### PR TITLE
docs(core): improve Signals conceptual guidance

### DIFF
--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -178,7 +178,7 @@ effect(() => {
 });
 ```
 
-A simple guideline is:
+In general, you'll want to follow the general guidelines:
 
 - If you're calculating a value, use `computed`.
 - If you need to synchronize signal state to an external non-reactive system, use `effect`.

--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -124,6 +124,65 @@ If you set `showCount` to `true` and then read `conditionalCount` again, the der
 
 Note that dependencies can be removed during a derivation as well as added. If you later set `showCount` back to `false`, then `count` will no longer be considered a dependency of `conditionalCount`.
 
+## Mental model
+
+Signals are best understood as a reactive state graph.
+
+Each signal represents a piece of state. Computed values derive state from other state. Effects react to state changes and interact with the outside world.
+
+A useful rule of thumb is:
+
+- Use `signal` for state.
+- Use `computed` for derived state.
+- Use `effect` for side effects.
+
+When working with signals, prefer deriving values over synchronizing values. If one value can be calculated from another, represent that relationship with `computed` instead of manually keeping multiple signals in sync.
+
+### Prefer derivation over synchronization
+
+When a value can be expressed as a function of other state, model it as a derivation instead of maintaining multiple sources of truth.
+
+Prefer:
+
+```ts
+const fullName = computed(() => `${firstName()} ${lastName()}`);
+```
+
+Over:
+
+```ts
+const fullName = signal('');
+
+effect(() => {
+  fullName.set(`${firstName()} ${lastName()}`);
+});
+```
+
+Derived state stays consistent automatically and avoids unnecessary mutable state.
+
+### Choosing between computed and effect
+
+Both `computed` and `effect` react to signal changes, but they serve different purposes.
+
+Use `computed` when you need to calculate a value from other signals:
+
+```ts
+const total = computed(() => price() * quantity());
+```
+
+Use `effect` when you need to interact with APIs, browser storage, logging, analytics, or other non-reactive systems:
+
+```ts
+effect(() => {
+  localStorage.setItem('theme', theme());
+});
+```
+
+A simple guideline is:
+
+- If you're calculating a value, use `computed`.
+- If you're causing something to happen, use `effect`.
+
 ## Reactive contexts
 
 A **reactive context** is a runtime state where Angular monitors signal reads to establish a dependency. The code reading the signal is the _consumer_, and the signal being read is the _producer_.
@@ -273,6 +332,37 @@ const doubled = computed(() => count() * 2);
 isWritableSignal(count); // true
 isWritableSignal(doubled); // false
 ```
+
+## Signals and RxJS
+
+Signals and RxJS solve different problems and are often used together.
+Signals model state and relationships between values.
+RxJS models events and asynchronous streams over time.
+
+A signal answers:
+
+> What is the current value?
+
+An Observable answers:
+
+> What values may be emitted over time?
+
+Signals are typically a good fit for:
+
+- Component state
+- UI state
+- Derived state
+- Relationships between values
+
+RxJS is typically a better fit for:
+
+- Event streams
+- WebSocket messages
+- Request orchestration
+- Cancellation and retry logic
+- Complex asynchronous workflows
+
+Signals are not intended to replace RxJS. Instead, they provide a simpler model for representing and deriving application state.
 
 ## Using signals with RxJS
 

--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -170,7 +170,7 @@ Use `computed` when you need to calculate a value from other signals:
 const total = computed(() => price() * quantity());
 ```
 
-Use `effect` when you need to interact with APIs, browser storage, logging, analytics, or other non-reactive systems:
+Use `effect` when you need to update something outside Angular’s signal model, such as browser storage, logging, analytics, or a third-party UI library.
 
 ```ts
 effect(() => {

--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -181,7 +181,7 @@ effect(() => {
 A simple guideline is:
 
 - If you're calculating a value, use `computed`.
-- If you're causing something to happen, use `effect`.
+- If you need to synchronize signal state to an external non-reactive system, use `effect`.
 
 ## Reactive contexts
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The Signals overview guide explains the core APIs and reactive concepts, but it provides limited guidance on how to reason about Signals when designing applications.

In particular, the guide does not clearly explain:

- The mental model behind Signals as a reactive state graph.
- When to use computed versus effect.
- Why derived state should generally be modeled with computed.
- The conceptual distinction between Signals and RxJS.


Issue Number: N/A

## What is the new behavior?

This PR adds conceptual guidance to the Signals overview guide, including:

A new "Mental model" section.
Guidance on preferring derivation over synchronization.
Recommendations for choosing between computed and effect.
A conceptual comparison between Signals and RxJS focused on use cases rather than APIs.

The goal is to help developers adopt the Signals programming model more effectively and avoid common architectural misunderstandings.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This is a documentation-only change.