### PR TITLE
fix(docs-infra): load cross-origin video embeds under COEP credential…

### DIFF
--- a/adev/angular.json
+++ b/adev/angular.json
@@ -70,7 +70,7 @@
             "buildTarget": "web-ui:build",
             "headers": {
               "Cross-Origin-Opener-Policy": "same-origin",
-              "Cross-Origin-Embedder-Policy": "require-corp"
+              "Cross-Origin-Embedder-Policy": "credentialless"
             }
           }
         },

--- a/adev/firebase.json
+++ b/adev/firebase.json
@@ -49,7 +49,7 @@
         "headers": [
           {
             "key": "Cross-Origin-Embedder-Policy",
-            "value": "require-corp"
+            "value": "credentialless"
           }
         ]
       },
@@ -71,7 +71,7 @@
           },
           {
             "key": "Cross-Origin-Embedder-Policy",
-            "value": "require-corp"
+            "value": "credentialless"
           }
         ]
       }


### PR DESCRIPTION
adev is cross-origin isolated (COOP same-origin + COEP require-corp) so the embedded WebContainer editor can use SharedArrayBuffer. Under require-corp the cross-origin YouTube iframe in `<docs-video>` only loaded in Chromium, leaving the player blank in Safari.

Switch COEP from `require-corp` to `credentialless`. The page stays cross-origin isolated, so the editor keeps working, but cross-origin frames are now allowed to load, which restores the inline player in Safari as well.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

adev sets `COOP: same-origin` + `COEP: require-corp` on every response so the
embedded WebContainer editor can use `SharedArrayBuffer`. Under `require-corp`,
the cross-origin YouTube iframe in `<docs-video>` only loads in Chromium (via
the `credentialless` iframe attribute). In Safari the player is blank.

## What is the new behavior?

Switches COEP from `require-corp` to `credentialless` in `adev/angular.json` and
`adev/firebase.json`. The page stays cross-origin isolated (the editor keeps
working), but cross-origin frames are now allowed to load, which fixes the
inline player in Safari as well as Chromium.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

