### PR TITLE
fix(docs-infra): keep version picker dropdown within the viewport

### DIFF
--- a/adev/src/app/core/layout/navigation/mini-menu.scss
+++ b/adev/src/app/core/layout/navigation/mini-menu.scss
@@ -87,10 +87,6 @@
 .adev-version-picker {
   overflow-y: auto;
   max-height: 90vh;
-  top: 30px;
-  left: 10px;
-  position: absolute;
-  bottom: auto;
 
   li {
     padding-inline: 0;
@@ -98,12 +94,6 @@
 
   li a {
     line-height: 1em;
-  }
-
-  @include mq.for-tablet {
-    top: 30px;
-    left: auto;
-    bottom: auto;
   }
 }
 

--- a/adev/src/app/core/layout/navigation/navigation.component.ts
+++ b/adev/src/app/core/layout/navigation/navigation.component.ts
@@ -57,12 +57,12 @@ export class Navigation {
 
   protected miniMenuPositions = [
     new ConnectionPositionPair(
-      {originX: 'end', originY: 'center'},
-      {overlayX: 'start', overlayY: 'center'},
-    ),
-    new ConnectionPositionPair(
       {originX: 'end', originY: 'top'},
       {overlayX: 'start', overlayY: 'top'},
+    ),
+    new ConnectionPositionPair(
+      {originX: 'end', originY: 'bottom'},
+      {overlayX: 'start', overlayY: 'bottom'},
     ),
   ];
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (N/A — purely a CSS/overlay-positioning fix in the docs site)
- [ ] Docs have been added / updated (N/A)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other

## What is the current behavior?

On angular.dev, opening the version picker dropdown (the `vNN ▾` control in the navigation) can render the version list overflowing the viewport, so some versions are clipped and unreachable without scrolling — the newest/current versions can be hidden above the fold on tall screens, and the oldest hidden below on shorter screens.

**Root cause:** `.adev-version-picker` is styled with `position: absolute`, which takes the `<ul>` out of the CDK overlay pane's flow. As a result the `.cdk-overlay-pane` measures a height of `0`, so the CDK overlay cannot size or constrain the menu to the viewport. The `90vh`-tall version list then overflows.

This was confirmed by inspecting the live site — the overlay pane reports `height: 0` and the menu extends past the viewport edge.

Issue Number: N/A

## What is the new behavior?

- Removed the `position: absolute` (and the `top` / `left` / `bottom` overrides) from `.adev-version-picker` so the menu participates in the overlay pane's layout. The pane now measures the real menu height, allowing CDK to constrain the overlay to the viewport.
- Changed the preferred `miniMenuPositions` entry to a top-aligned overlay position so the list opens downward from the button with the newest versions first, with a bottom-aligned fallback for tight space below.

Verified by building the docs site locally and measuring the overlay before/after at the same viewport:

| | `.cdk-overlay-pane` height | picker `position` | picker bottom vs 736px viewport |
| --- | --- | --- | --- |
| Before | `0` | `absolute` | `808` (overflows by 72px) |
| After | `692` | `static` | `722` (fully within viewport) |

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Scoped entirely to the docs site navigation (`adev/src/app/core/layout/navigation/`). No application/runtime code is affected.