### PR TITLE
refactor(core): allow readonly array of providers

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1514,7 +1514,7 @@ export function provideNgReflectAttributes(): EnvironmentProviders;
 export function providePlatformInitializer(initializerFn: () => void): StaticProvider;
 
 // @public
-export type Provider = TypeProvider | ValueProvider | ClassProvider | ConstructorProvider | ExistingProvider | FactoryProvider | any[];
+export type Provider = TypeProvider | ValueProvider | ClassProvider | ConstructorProvider | ExistingProvider | FactoryProvider | ReadonlyArray<any>;
 
 // @public
 export type ProviderToken<T> = Type<T> | AbstractType<T> | InjectionToken<T>;

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -340,7 +340,14 @@ export type Provider =
   | ConstructorProvider
   | ExistingProvider
   | FactoryProvider
-  | any[];
+  | ReadonlyArray<any>;
+
+// We use this override of `Array.isArray` to narrow the type of `ReadonlyArray` to `Array`
+declare global {
+  export interface ArrayConstructor {
+    isArray(arg: ReadonlyArray<any>): arg is ReadonlyArray<any>;
+  }
+}
 
 /**
  * Encapsulated `Provider`s that are only accepted during creation of an `EnvironmentInjector` (e.g.

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -386,7 +386,7 @@ function validateProvider(
 }
 
 function deepForEachProvider(
-  providers: Array<Provider | InternalEnvironmentProviders>,
+  providers: ReadonlyArray<Provider | InternalEnvironmentProviders>,
   fn: (provider: SingleProvider) => void,
 ): void {
   for (let provider of providers) {

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -723,7 +723,7 @@ function couldBeInjectableType(value: any): value is ProviderToken<any> {
 }
 
 function forEachSingleProvider(
-  providers: Array<Provider | EnvironmentProviders>,
+  providers: ReadonlyArray<Provider | EnvironmentProviders>,
   fn: (provider: SingleProvider) => void,
 ): void {
   for (const provider of providers) {

--- a/packages/core/src/render3/di_setup.ts
+++ b/packages/core/src/render3/di_setup.ts
@@ -253,7 +253,7 @@ function resolveProvider(
  */
 function registerDestroyHooksIfSupported(
   tView: TView,
-  provider: Exclude<Provider, any[]>,
+  provider: Exclude<Provider, ReadonlyArray<any>>,
   contextIndex: number,
   indexInFactory?: number,
 ) {

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -731,7 +731,10 @@ export class TestBedCompiler {
     this.existingComponentStyles.clear();
   }
 
-  private queueTypeArray(arr: any[], moduleType: Type<any> | TestingModuleOverride): void {
+  private queueTypeArray(
+    arr: ReadonlyArray<any>,
+    moduleType: Type<any> | TestingModuleOverride,
+  ): void {
     for (const value of arr) {
       if (Array.isArray(value)) {
         this.queueTypeArray(value, moduleType);
@@ -817,7 +820,7 @@ export class TestBedCompiler {
     // can skip ones that have already been seen encountered. In some test setups, this caching
     // resulted in 10X runtime improvement.
     const processedDefs = new Set();
-    const queueTypesFromModulesArrayRecur = (arr: any[]): void => {
+    const queueTypesFromModulesArrayRecur = (arr: ReadonlyArray<any>): void => {
       for (const value of arr) {
         if (Array.isArray(value)) {
           queueTypesFromModulesArrayRecur(value);
@@ -868,10 +871,10 @@ export class TestBedCompiler {
   // if we have the following module hierarchy: A -> B -> C (where `->` means `imports`) and module
   // `C` is overridden, we consider `A` and `B` as affected, since their scopes might become
   // invalidated with the override.
-  private collectModulesAffectedByOverrides(arr: any[]): Set<NgModuleType<any>> {
+  private collectModulesAffectedByOverrides(arr: ReadonlyArray<any>): Set<NgModuleType<any>> {
     const seenModules = new Set<NgModuleType<any>>();
     const affectedModules = new Set<NgModuleType<any>>();
-    const calcAffectedModulesRecur = (arr: any[], path: NgModuleType<any>[]): void => {
+    const calcAffectedModulesRecur = (arr: ReadonlyArray<any>, path: NgModuleType<any>[]): void => {
       for (const value of arr) {
         if (Array.isArray(value)) {
           // If the value is an array, just flatten it (by invoking this function recursively),
@@ -1181,7 +1184,7 @@ function maybeUnwrapFn<T>(maybeFn: (() => T) | T): T {
   return maybeFn instanceof Function ? maybeFn() : maybeFn;
 }
 
-function flatten<T>(values: any[]): T[] {
+function flatten<T>(values: ReadonlyArray<any>): T[] {
   const out: T[] = [];
   values.forEach((value) => {
     if (Array.isArray(value)) {
@@ -1198,12 +1201,14 @@ function identityFn<T>(value: T): T {
 }
 
 function flattenProviders<T>(
-  providers: Array<Provider | InternalEnvironmentProviders>,
+  providers: ReadonlyArray<Provider | InternalEnvironmentProviders>,
   mapFn: (provider: Provider) => T,
 ): T[];
-function flattenProviders(providers: Array<Provider | InternalEnvironmentProviders>): Provider[];
 function flattenProviders(
-  providers: Array<Provider | InternalEnvironmentProviders>,
+  providers: ReadonlyArray<Provider | InternalEnvironmentProviders>,
+): Provider[];
+function flattenProviders(
+  providers: ReadonlyArray<Provider | InternalEnvironmentProviders>,
   mapFn: (provider: Provider) => any = identityFn,
 ): any[] {
   const out: any[] = [];


### PR DESCRIPTION
 This commit changes the `Provider` type to allow for a readonly array of providers, in addition to the existing mutable array.  

fixes angular#69203