### PR TITLE
fix(service-worker): validate redirected hashed asset responses

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -363,7 +363,14 @@ export abstract class AssetGroup {
     }
   }
 
-  protected async fetchFromNetwork(req: Request, redirectLimit: number = 3): Promise<Response> {
+  protected async fetchFromNetwork(
+    req: Request,
+    redirectLimit: number = 3,
+    hashToVerify?: string,
+  ): Promise<Response> {
+    const originalUrl = this.adapter.normalizeUrl(req.url);
+    const canonicalHash = hashToVerify ?? this.hashes.get(originalUrl);
+
     // Make a cache-busted request for the resource.
     const res = await this.cacheBustedFetchFromNetwork(req);
 
@@ -377,7 +384,22 @@ export abstract class AssetGroup {
       }
 
       // Unwrap the redirect directly.
-      return this.fetchFromNetwork(this.newRequestWithMetadata(res.url, req), redirectLimit - 1);
+      const redirectedResponse = await this.fetchFromNetwork(
+        this.newRequestWithMetadata(res.url, req),
+        redirectLimit - 1,
+        canonicalHash,
+      );
+
+      if (canonicalHash !== undefined && redirectedResponse.ok) {
+        const redirectedHash = sha1Binary(await redirectedResponse.clone().arrayBuffer());
+        if (canonicalHash !== redirectedHash) {
+          throw new SwCriticalError(
+            `Hash mismatch (fetchFromNetwork redirect): ${req.url}: expected ${canonicalHash}, got ${redirectedHash} after redirect to ${res.url}`,
+          );
+        }
+      }
+
+      return redirectedResponse;
     }
 
     return res;

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -7,8 +7,10 @@
  */
 
 import {processNavigationUrls} from '../../config/src/generator';
+import {LazyAssetGroup} from '../src/assets';
 import {CacheDatabase} from '../src/db-cache';
 import {Driver, DriverReadyState} from '../src/driver';
+import {IdleScheduler} from '../src/idle';
 import {Manifest} from '../src/manifest';
 import {sha1} from '../src/sha1';
 import {clearAllCaches, MockCache} from '../testing/cache';
@@ -376,6 +378,57 @@ import {envIsSupported} from '../testing/utils';
       server.clearRequests();
       expect(await makeRequest(scope, '/redirected.txt')).toEqual('this was a redirect');
       server.assertNoOtherRequests();
+    });
+
+    it('rejects a re-fetched redirected hashed response with mismatched bytes', async () => {
+      class TestAssetGroup extends LazyAssetGroup {
+        fetchFromNetworkForTest(req: Request): Promise<Response> {
+          return this.fetchFromNetwork(req);
+        }
+      }
+
+      const expectedBody = 'expected redirected body';
+      const redirectedFs = new MockFileSystemBuilder()
+        .addFile('/redirect-target.txt', 'unexpected redirected body')
+        .build();
+      const redirectedAssetGroup = {
+        name: 'assets',
+        installMode: 'lazy' as const,
+        updateMode: 'lazy' as const,
+        urls: ['/hashed-redirected.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
+      };
+      const redirectedManifest: Manifest = {
+        configVersion: 1,
+        timestamp: 1234567890123,
+        index: '/hashed-redirected.txt',
+        assetGroups: [redirectedAssetGroup],
+        navigationUrls: [],
+        navigationRequestStrategy: 'performance',
+        hashTable: {'/hashed-redirected.txt': sha1(expectedBody)},
+      };
+      const redirectedServer = new MockServerStateBuilder()
+        .withStaticFiles(redirectedFs)
+        .withManifest(redirectedManifest)
+        .withRedirectedResponse('/hashed-redirected.txt', '/redirect-target.txt', expectedBody)
+        .build();
+      const redirectedScope = new SwTestHarnessBuilder().withServerState(redirectedServer).build();
+      const assetGroup = new TestAssetGroup(
+        redirectedScope,
+        redirectedScope,
+        new IdleScheduler(redirectedScope, 0, 0, {log: () => undefined}),
+        redirectedAssetGroup,
+        new Map([['/hashed-redirected.txt', sha1(expectedBody)]]),
+        new CacheDatabase(redirectedScope),
+        'test',
+      );
+
+      await expectAsync(
+        assetGroup.fetchFromNetworkForTest(redirectedScope.newRequest('/hashed-redirected.txt')),
+      ).toBeRejectedWithError(/Hash mismatch \(fetchFromNetwork redirect\)/);
+      redirectedServer.assertSawRequestFor('/hashed-redirected.txt');
+      redirectedServer.assertSawRequestFor('/redirect-target.txt');
     });
 
     it('caches lazy content on-request', async () => {

--- a/packages/service-worker/worker/testing/mock.ts
+++ b/packages/service-worker/worker/testing/mock.ts
@@ -115,6 +115,11 @@ export class MockServerStateBuilder {
     return this;
   }
 
+  withRedirectedResponse(from: string, to: string, body: string): MockServerStateBuilder {
+    this.resources.set(from, new MockResponse(body, {redirected: true, url: to}));
+    return this;
+  }
+
   withError(url: string): MockServerStateBuilder {
     this.errors.add(url);
     return this;


### PR DESCRIPTION
Carry the expected asset hash through redirected network fetches so a hashed manifest entry cannot cache bytes from a different redirect target.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
When a hashed service-worker asset request is fulfilled through a redirect, the final redirected response can be returned to the caching path without validating the final response body against the original manifest hash.

Issue Number: N/A

## What is the new behavior?

The expected manifest hash is carried through redirected network fetches. If the final successful redirected response body does not match the original hash, Angular raises a service-worker critical error instead of returning the mismatched response for caching.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Tested with:

  - `bazelisk test //packages/service-worker/worker/test:test --test_output=errors --cache_test_results=no`
  - `git diff --check main..HEAD`
  - `pnpm ng-dev commit-message validate-range main HEAD`
  - `pnpm ng-dev format changed --check main`
  - `pnpm tslint`
  - `pnpm ts-circular-deps:check`