### PR TITLE
fix(platform-server): validate allowed hosts by authority

### DIFF
--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -383,9 +383,9 @@ function validateAllowedHosts(url: string | undefined, allowedHosts: string[] | 
   if (typeof url === 'string') {
     const parsedUrl = resolveUrl(url);
     if (parsedUrl !== null) {
-      const hostname = parsedUrl.hostname;
+      const host = parsedUrl.host;
       const allowedHostsSet: ReadonlySet<string> = new Set(allowedHosts);
-      if (!isHostAllowed(hostname, allowedHostsSet)) {
+      if (!isHostAllowed(host, allowedHostsSet)) {
         throw new RuntimeError(
           RuntimeErrorCode.HOST_NOT_ALLOWED,
           typeof ngDevMode === 'undefined' || ngDevMode
@@ -398,15 +398,15 @@ function validateAllowedHosts(url: string | undefined, allowedHosts: string[] | 
 }
 
 /**
- * Checks if the hostname is allowed.
- * @param hostname - The hostname to check.
- * @param allowedHosts - A set of allowed hostnames.
- * @returns `true` if the hostname is allowed, `false` otherwise.
+ * Checks if the host is allowed.
+ * @param host - The host to check.
+ * @param allowedHosts - A set of allowed hosts.
+ * @returns `true` if the host is allowed, `false` otherwise.
  * @note Used also in `@angular/ssr`.
  * @private
  */
-export function isHostAllowed(hostname: string, allowedHosts: ReadonlySet<string>): boolean {
-  if (allowedHosts.has('*') || allowedHosts.has(hostname)) {
+export function isHostAllowed(host: string, allowedHosts: ReadonlySet<string>): boolean {
+  if (allowedHosts.has('*') || allowedHosts.has(host)) {
     return true;
   }
 
@@ -416,7 +416,7 @@ export function isHostAllowed(hostname: string, allowedHosts: ReadonlySet<string
     }
 
     const domain = allowedHost.slice(1);
-    if (hostname.endsWith(domain)) {
+    if (host.endsWith(domain)) {
       return true;
     }
   }

--- a/packages/platform-server/test/utils_spec.ts
+++ b/packages/platform-server/test/utils_spec.ts
@@ -76,6 +76,16 @@ describe('allowedHosts validation in renderApplication', () => {
     }
   });
 
+  it('should reject URLs on ports that are not in the allowedHosts list', async () => {
+    await expectAsync(
+      renderApplication(bootstrap, {
+        document: '<app></app>',
+        url: 'http://test.com:4201/deep/path',
+        allowedHosts: ['test.com'],
+      }),
+    ).toBeRejectedWithError(/Host .+ is not allowed/);
+  });
+
   it('should not throw a host validation error on bootstrap if host is allowed', async () => {
     try {
       await renderApplication(bootstrap, {


### PR DESCRIPTION
Validate allowedHosts against the full URL authority so a configured hostname does not implicitly allow arbitrary ports during SSR.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`allowedHosts` validation during server-side rendering compares the parsed URL `hostname` against the configured allowlist. Since `hostname` does not include the port, a configuration such as `allowedHosts: ['test.com']` also allows `test.com:<non-default-port>`.

Issue Number: N/A

## What is the new behavior?

`allowedHosts` validation compares against the parsed URL `host`, which includes the port when present. This makes the allowlist match the full URL authority. Deployments that intentionally allow a non-default port can list that host authority explicitly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Tested with:

  - `bazelisk test //packages/platform-server/test:test --test_output=errors --cache_test_results=no`
  - `git diff --check main..HEAD`
  - `pnpm ng-dev commit-message validate-range main HEAD`
  - `pnpm ng-dev format changed --check main`
  - `pnpm tslint`
  - `pnpm ts-circular-deps:check`
