### PR TITLE
fix(core): preserve MathML elements during DOM sanitization

### DIFF
--- a/packages/core/src/sanitization/html_sanitizer.ts
+++ b/packages/core/src/sanitization/html_sanitizer.ts
@@ -68,11 +68,18 @@ const INLINE_ELEMENTS = merge(
   ),
 );
 
+// MathML Elements - W3C MathML Core
+// https://w3c.github.io/mathml-core/
+const MATHML_ELEMENTS = tagSet(
+  'math,merror,mfrac,mi,mmultiscripts,mn,mo,mover,mpadded,mphantom,mprescripts,mroot,mrow,ms,mspace,msqrt,mstyle,msub,msubsup,msup,mtable,mtd,mtext,mtr,munder,munderover,semantics'
+);
+
 export const VALID_ELEMENTS: BooleanRecord = merge(
   VOID_ELEMENTS,
   BLOCK_ELEMENTS,
   INLINE_ELEMENTS,
   OPTIONAL_END_TAG_ELEMENTS,
+  MATHML_ELEMENTS,
 );
 
 // Attributes that have href and hence need to be sanitized

--- a/packages/core/test/sanitization/html_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/html_sanitizer_spec.ts
@@ -55,6 +55,15 @@ describe('HTML sanitizer', () => {
     );
   });
 
+  it('supports MathML elements', () => {
+    expect(sanitizeHtml(defaultDoc, '<math><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></math>')).toEqual(
+      '<math><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></math>',
+    );
+    expect(sanitizeHtml(defaultDoc, '<math><mfrac><mn>1</mn><mn>2</mn></mfrac></math>')).toEqual(
+      '<math><mfrac><mn>1</mn><mn>2</mn></mfrac></math>',
+    );
+  });
+
   it('supports HTML5 elements', () => {
     expect(sanitizeHtml(defaultDoc, '<main><summary>Works</summary></main>')).toEqual(
       '<main><summary>Works</summary></main>',


### PR DESCRIPTION
Sanitization previously removed all MathML elements, breaking formulas rendered in Angular. This adds W3C MathML Core elements to the list of valid HTML elements.

Fixes #61013