### PR TITLE
docs: fix CurrencyPipe locale override example

### DIFF
--- a/adev/src/content/guide/i18n/format-data-locale.md
+++ b/adev/src/content/guide/i18n/format-data-locale.md
@@ -25,7 +25,7 @@ Add the `locale` parameter to the pipe to override the current value of `LOCALE_
 To force the currency to use American English \(`en-US`\), use the following format for the `CurrencyPipe`
 
 ```angular-html
-{{ amount | currency: 'en-US' }}
+{{ amount | currency: 'USD' : 'symbol' : '1.2-2' : 'en-US' }}
 ```
 
 HELPFUL: The locale specified for the `CurrencyPipe` overrides the global `LOCALE_ID` token of your application.


### PR DESCRIPTION
The "Override current locale for CurrencyPipe" example used `{{ amount | currency: 'en-US' }}`, but the first `CurrencyPipe` argument is the currency code, not the locale, so `'en-US'` was treated as an invalid currency code (rendered literally as the symbol) and the locale was never overridden. Since `locale` is the fourth positional argument, the example now passes a valid currency code, display, and digits before it (`'USD' : 'symbol' : '1.2-2' : 'en-US'`), matching the parameter order shown on the CurrencyPipe API page.

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other

## What is the current behavior?

On the [Format data based on locale](https://angular.dev/guide/i18n/format-data-locale) page, the "Override current locale for CurrencyPipe" section shows `{{ amount | currency: 'en-US' }}`. The first [`CurrencyPipe`](https://angular.dev/api/common/CurrencyPipe) argument is the currency code, not the locale, so `'en-US'` is treated as a (non-existent) currency code, rendered literally as the symbol (e.g. `en-US1,234.50`), and the locale is never overridden. The example does not do what the section describes.

<img width="837" height="296" alt="image" src="https://github.com/user-attachments/assets/013b7fee-6990-4135-94d2-eafbafdd4a29" />


## What is the new behavior?

The example passes the locale as the fourth positional argument with valid preceding arguments: `{{ amount | currency: 'USD' : 'symbol' : '1.2-2' : 'en-US' }}`, which actually overrides the locale. This matches the parameter order on the [`CurrencyPipe` API page](https://angular.dev/api/common/CurrencyPipe) and its canonical example, [`packages/examples/common/pipes/ts/currency_pipe.ts`](https://github.com/angular/angular/blob/main/packages/examples/common/pipes/ts/currency_pipe.ts), which uses the same shape (`{{ b | currency: 'CAD' : 'symbol' : '4.2-2' : 'fr' }}`). Only the code example changed; the surrounding prose is unchanged.

<img width="848" height="310" alt="image" src="https://github.com/user-attachments/assets/f07037da-68d0-4787-8657-de1371701ee1" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No