### PR TITLE
docs: fix malformed prettier-ignore comment in whitespace guide

### DIFF
--- a/adev/src/content/guide/templates/whitespace.md
+++ b/adev/src/content/guide/templates/whitespace.md
@@ -18,7 +18,7 @@ Most developers prefer to format their templates with newlines and indentation t
 
 This template contains whitespace between all of the elements. The following snippet shows the same HTML with each whitespace character replaced with the hash (`#`) character to highlight how much whitespace is present:
 
-<!-- prettier-ignore>
+<!-- prettier-ignore -->
 ```html
 <!-- Total Whitespace: 20 -->
 <section>###<h3>User profile</h3>###<label>#####User name#####<input>###</label>#</section>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (not applicable)
* [x] Docs have been added / updated

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The whitespace guide contains a malformed HTML comment:

`<!-- prettier-ignore>`

Issue Number: N/A

## What is the new behavior?

Updates the malformed comment to valid HTML comment syntax:

`<!-- prettier-ignore -->`

This makes the comment syntax valid and consistent with the other `prettier-ignore` comment in the same document.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This is a documentation-only change and does not affect application behavior.
