### PR TITLE
docs: add Signal Forms and v22 guidance to AI best-practices and llms…

### DIFF
--- a/adev/src/llms.txt
+++ b/adev/src/llms.txt
@@ -64,6 +64,7 @@ Angular — Deliver web apps with confidence 🚀
 - [Setting up the HttpClient](https://angular.dev/guide/http/setup)
 - [Making requests](https://angular.dev/guide/http/making-requests)
 - [Intercepting requests](https://angular.dev/guide/http/interceptors)
+- [Reactive data fetching with httpResource](https://angular.dev/guide/http/http-resource)
 - [Testing](https://angular.dev/guide/http/testing)
 
 ## Forms
@@ -73,6 +74,10 @@ Angular — Deliver web apps with confidence 🚀
 - [Template driven forms](https://angular.dev/guide/forms/template-driven-forms)
 - [Validate forms input](https://angular.dev/guide/forms/form-validation)
 - [Building dynamic forms](https://angular.dev/guide/forms/dynamic-forms)
+- [Signal Forms](https://angular.dev/guide/forms/signals/overview)
+
+## Accessibility
+- [Angular Aria overview](https://angular.dev/guide/aria/overview)
 
 ## Routing
 - [Routing overview](https://angular.dev/guide/routing)

--- a/packages/core/resources/best-practices.md
+++ b/packages/core/resources/best-practices.md
@@ -10,6 +10,7 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 - Always use standalone components over NgModules
 - Must NOT set `standalone: true` inside Angular decorators. It's the default in Angular v20+.
+- Do NOT set `changeDetection: ChangeDetectionStrategy.OnPush` explicitly. `OnPush` is the default in Angular v22+.
 - Use signals for state management
 - Implement lazy loading for feature routes
 - Do NOT use the `@HostBinding` and `@HostListener` decorators. Put host bindings inside the `host` object of the `@Component` or `@Directive` decorator instead
@@ -27,7 +28,8 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
 - Prefer inline templates for small components
-- Prefer Reactive forms instead of Template-driven ones
+- Prefer Signal Forms (`@angular/forms/signals`) for new forms. They are stable in Angular v22+ and provide signal-based state, type-safe field access, and schema-based validation
+- When not using Signal Forms, prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead
 - Do NOT use `ngStyle`, use `style` bindings instead
 - When using external templates/styles, use paths relative to the component TS file.
@@ -50,4 +52,5 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 - Design services around a single responsibility
 - Use the `providedIn: 'root'` option for singleton services
+- Prefer the `@Service` decorator over `@Injectable({providedIn: 'root'})` for new singleton services (Angular v22+)
 - Use the `inject()` function instead of constructor injection


### PR DESCRIPTION
Update the AI codegen resources for Angular v22:
- **best-practices.md**: note that `OnPush` is the default in v22+ (don't set it explicitly), recommend Signal Forms, and recommend the `@Service` decorator.
- **llms.txt**: add a Signal Forms reference, the `httpResource` guide, and an Accessibility section linking the Angular Aria overview.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The "Build with AI" resources (`best-practices.md` and `llms.txt`) predate Angular v22. They don't mention that `OnPush` is now the default change detection strategy, don't reference Signal Forms or the `@Service` decorator, and `llms.txt` has no links to Signal Forms, `httpResource`, or Angular Aria.

Issue Number: N/A

## What is the new behavior?

The resources are updated for Angular v22:
- `best-practices.md` notes `OnPush` is the v22+ default (don't set it explicitly), recommends Signal Forms for new forms, and recommends the `@Service` decorator over `@Injectable({providedIn: 'root'})`.
- `llms.txt` adds a Signal Forms reference under Forms, the `httpResource` guide under Loading Data, and a new Accessibility section linking the Angular Aria overview.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

All added links were verified against `adev/src/app/routing/navigation-entries/index.ts`.

I focused on the most obvious v22 additions (Signal Forms, the `OnPush` default, the `@Service` decorator, `httpResource`, and Angular Aria) and intentionally kept both files minimal — `best-practices.md` as a short rules file and `llms.txt` as references only. If the team thinks other v22 features belong here (e.g. additional template enhancements, router updates, or AI tooling references), I'm happy to add them.