### PR TITLE
fix(zone.js): harden zoneSymbolEventNames against __proto__ key (defense-in-depth)

### DIFF
--- a/packages/zone.js/lib/common/events.ts
+++ b/packages/zone.js/lib/common/events.ts
@@ -85,7 +85,8 @@ const OPTIMIZED_ZONE_EVENT_TASK_DATA: EventTaskData = {
   useG: true,
 };
 
-export const zoneSymbolEventNames: any = {};
+// tslint:disable-next-line:no-toplevel-property-access
+export const zoneSymbolEventNames: any = Object.create(null);
 export const globalSources: any = {};
 
 const EVENT_NAME_SYMBOL_REGX = new RegExp('^' + ZONE_SYMBOL_PREFIX + '(\\w+)(true|false)$');
@@ -96,9 +97,10 @@ function prepareEventNames(eventName: string, eventNameToString?: (eventName: st
   const trueEventName = (eventNameToString ? eventNameToString(eventName) : eventName) + TRUE_STR;
   const symbol = ZONE_SYMBOL_PREFIX + falseEventName;
   const symbolCapture = ZONE_SYMBOL_PREFIX + trueEventName;
-  zoneSymbolEventNames[eventName] = {};
-  zoneSymbolEventNames[eventName][FALSE_STR] = symbol;
-  zoneSymbolEventNames[eventName][TRUE_STR] = symbolCapture;
+  zoneSymbolEventNames[eventName] = {
+    [FALSE_STR]: symbol,
+    [TRUE_STR]: symbolCapture,
+  };
 }
 
 export interface PatchEventTargetOptions {


### PR DESCRIPTION
Initialize zoneSymbolEventNames with Object.create(null) instead of {}.

This is hardening only. addEventListener('__proto__', fn) is not
directly attacker-controllable — its presence in an application is
itself an application bug and a prerequisite for any issue here.

Without this change, if that application bug exists, two unexpected
behaviors follow depending on environment:

Browser: zoneSymbolEventNames['__proto__'] reads the __proto__ getter
and returns Object.prototype (truthy), bypassing prepareEventNames.
symbolEventName resolves to undefined and window['undefined'] = []
throws TypeError.

Node.js + --disable-proto=throw: the assignment
zoneSymbolEventNames['__proto__'] = {} inside prepareEventNames
triggers the disabled __proto__ setter and throws.

Using Object.create(null) removes the __proto__ accessor from the
map so the key is treated as a plain missing property in both cases.