### PR TITLE
build: introduce GHA release publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+.x'
+  workflow_dispatch: # Allow manual trigger for verification
 
 # Ensure only one release runs at a time PER BRANCH to avoid race conditions.
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,6 @@ permissions:
 jobs:
   release:
     # Reference the reusable workflow on the development branch in dev-infra.
-    uses: angular/dev-infra/.github/workflows/reusable-release.yml@task-3.1-reusable-workflow
+    uses: josephperrott/dev-infra/.github/workflows/reusable-release.yml@task-3.1-reusable-workflow
     secrets:
       wombot-token: ${{ secrets.WOMBOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+.x'
+
+# Ensure only one release runs at a time PER BRANCH to avoid race conditions.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # Required for the reusable workflow to create releases and tags
+
+jobs:
+  release:
+    # Reference the reusable workflow on the development branch in dev-infra.
+    uses: angular/dev-infra/.github/workflows/reusable-release.yml@task-3.1-reusable-workflow
+    secrets:
+      wombot-token: ${{ secrets.WOMBOT_TOKEN }}


### PR DESCRIPTION
This PR introduces the caller GitHub Actions workflow for release publishing, which delegates the build and publish steps to the centralized reusable workflow in dev-infra. This is part of the secure CI release migration. Note: This currently references the dev-infra branch task-3.1-reusable-workflow for testing and must be updated to @main before merging.