### PR TITLE
fix(common): include minutes in the short GMT timezone format

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -458,7 +458,7 @@ function getDateTranslation(
 
 /**
  * Returns a date formatter that transforms a date and an offset into a timezone with ISO8601 or
- * GMT format depending on the width (eg: short = +0430, short:GMT = GMT+4, long = GMT+04:30,
+ * GMT format depending on the width (eg: short = +0430, short:GMT = GMT+4:30, long = GMT+04:30,
  * extended = +04:30)
  */
 function timeZoneGetter(width: ZoneWidth): DateFormatter {
@@ -473,8 +473,18 @@ function timeZoneGetter(width: ZoneWidth): DateFormatter {
           padNumber(hours, 2, minusSign) +
           padNumber(Math.abs(zone % 60), 2, minusSign)
         );
-      case ZoneWidth.ShortGMT:
-        return 'GMT' + (zone >= 0 ? '+' : '') + padNumber(hours, 1, minusSign);
+      case ZoneWidth.ShortGMT: {
+        // The short localized GMT format omits a leading zero on the hours but,
+        // per CLDR, still includes the minutes when they are non-zero (e.g.
+        // `GMT+5:30` for India, `GMT-4` for New York).
+        const minutes = Math.abs(zone % 60);
+        return (
+          'GMT' +
+          (zone >= 0 ? '+' : '') +
+          padNumber(hours, 1, minusSign) +
+          (minutes ? ':' + padNumber(minutes, 2, minusSign) : '')
+        );
+      }
       case ZoneWidth.Long:
         return (
           'GMT' +

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -174,7 +174,7 @@ export const DATE_PIPE_DEFAULT_OPTIONS = new InjectionToken<DatePipeConfig>(
  *  | Zone                    | z, zz & zzz | Short specific non location format (fallback to O)            | GMT-8                                                      |
  *  |                         | zzzz        | Long specific non location format (fallback to OOOO)          | GMT-08:00                                                  |
  *  |                         | Z, ZZ & ZZZ | ISO8601 basic format                                          | -0800                                                      |
- *  |                         | ZZZZ        | Long localized GMT format                                     | GMT-8:00                                                   |
+ *  |                         | ZZZZ        | Long localized GMT format                                     | GMT-08:00                                                  |
  *  |                         | ZZZZZ       | ISO8601 extended format + Z indicator for offset 0 (= XXXXX)  | -08:00                                                     |
  *  |                         | O, OO & OOO | Short localized GMT format                                    | GMT-8                                                      |
  *  |                         | OOOO        | Long localized GMT format                                     | GMT-08:00                                                  |

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -287,24 +287,28 @@ describe('Format date', () => {
 
     it('should format with timezones', () => {
       const dateFixtures: any = {
-        z: /GMT(\+|-)\d/,
-        zz: /GMT(\+|-)\d/,
-        zzz: /GMT(\+|-)\d/,
+        z: /GMT(\+|-)\d\:30/,
+        zz: /GMT(\+|-)\d\:30/,
+        zzz: /GMT(\+|-)\d\:30/,
         zzzz: /GMT(\+|-)\d{2}\:30/,
         Z: /(\+|-)\d{2}30/,
         ZZ: /(\+|-)\d{2}30/,
         ZZZ: /(\+|-)\d{2}30/,
         ZZZZ: /GMT(\+|-)\d{2}\:30/,
         ZZZZZ: /(\+|-)\d{2}\:30/,
-        O: /GMT(\+|-)\d/,
+        O: /GMT(\+|-)\d\:30/,
         OOOO: /GMT(\+|-)\d{2}\:30/,
       };
 
-      Object.keys(dateFixtures).forEach((pattern: string) => {
-        expect(formatDate(date, pattern, ɵDEFAULT_LOCALE_ID, '+0430')).toMatch(
-          dateFixtures[pattern],
-        );
-      });
+      // Both a positive and a negative fractional offset, so the short GMT
+      // format is exercised for each sign with non-zero minutes.
+      for (const offset of ['+0430', '-0330']) {
+        Object.keys(dateFixtures).forEach((pattern: string) => {
+          expect(formatDate(date, pattern, ɵDEFAULT_LOCALE_ID, offset)).toMatch(
+            dateFixtures[pattern],
+          );
+        });
+      }
     });
 
     it('should format common multi component patterns', () => {
@@ -527,6 +531,13 @@ describe('Format date', () => {
 
       const dateEst = formatDate(isoDate, 'long', 'en', 'EST');
       expect(dateEst).toBe('February 17, 2024, 7:00:00 AM GMT-5');
+
+      // Short GMT (`O`) keeps non-zero minutes for fractional zones, drops them
+      // for whole-hour zones, for both signs.
+      expect(formatDate(isoDate, 'O', 'en', '+0530')).toBe('GMT+5:30');
+      expect(formatDate(isoDate, 'O', 'en', '+0545')).toBe('GMT+5:45');
+      expect(formatDate(isoDate, 'O', 'en', '-0330')).toBe('GMT-3:30');
+      expect(formatDate(isoDate, 'O', 'en', '-0500')).toBe('GMT-5');
 
       const dateOffset = formatDate(isoDate, 'long', 'en', '+0500');
       expect(dateOffset).toBe('February 17, 2024, 5:00:00 PM GMT+5');


### PR DESCRIPTION
The short localized GMT format (`z`, `zz`, `zzz`, `O`) returned the hours only, so in zones with a non-zero minute offset it dropped them, for example `GMT+5` in India instead of `GMT+5:30`. Per CLDR (UTS #35), the short localized GMT format omits the leading zero on the hours but still includes the minutes when they are non-zero; this also affects the named `long` and `longTime` formats, which use `z`. The format now appends the minutes when they are non-zero, leaving whole-hour zones (such as `GMT-4`) unchanged.

While in the same timezone-format area, this also corrects the `DatePipe` JSDoc format table, where the `ZZZZ` ("Long localized GMT format") example showed `GMT-8:00` instead of the zero-padded `GMT-08:00` that the format actually produces (and that the `OOOO` row already shows).

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other

## What is the current behavior?

`formatDate` / `DatePipe` renders the short localized GMT timezone format (`z`, `zz`, `zzz`, `O`, and the named `long` / `longTime` formats that use `z`) with the hours only. In a timezone whose offset has non-zero minutes, the minutes are dropped:

- India `+5:30` renders `GMT+5` (should be `GMT+5:30`)
- Nepal `+5:45` renders `GMT+5` (should be `GMT+5:45`)

This diverges from CLDR / `Intl`, whose short localized GMT format keeps non-zero minutes (`Intl.DateTimeFormat('en', {timeZoneName: 'shortOffset', timeZone: 'Asia/Kolkata'})` → `GMT+5:30`).

## What is the new behavior?

The short GMT format appends the minutes when they are non-zero:

- India `+5:30` → `GMT+5:30`
- Nepal `+5:45` → `GMT+5:45`
- Newfoundland `-3:30` → `GMT-3:30`
- Whole-hour zones unchanged (`GMT-4`, `GMT-5`)

The PR also fixes a small typo in the `DatePipe` JSDoc format table (`ZZZZ` example `GMT-8:00` → `GMT-08:00`) in the same timezone-format area.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No