### PR TITLE
fix(http): pass down the `reportUploadProgress` and `reportDownloadProgress` on post/patch requests

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -43,24 +43,7 @@ export interface HttpClientCommonOptions extends Omit<HttpRequestOptions, 'heade
 function addBody<T>(options: HttpClientCommonOptions, body: T | null): any {
   return {
     body,
-    headers: options.headers,
-    context: options.context,
-    observe: options.observe,
-    params: options.params,
-    reportProgress: options.reportProgress,
-    responseType: options.responseType,
-    withCredentials: options.withCredentials,
-    credentials: options.credentials,
-    transferCache: options.transferCache,
-    timeout: options.timeout,
-    keepalive: options.keepalive,
-    priority: options.priority,
-    cache: options.cache,
-    mode: options.mode,
-    redirect: options.redirect,
-    integrity: options.integrity,
-    referrer: options.referrer,
-    referrerPolicy: options.referrerPolicy,
+    ...options,
   };
 }
 

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -144,6 +144,16 @@ describe('HttpClient', () => {
       expect(req.request.reportDownloadProgress).toBe(true);
       req.flush({});
     });
+
+    it('post with a split progress events enabled', (done) => {
+      client
+        .post('/test', {}, {reportUploadProgress: true, reportDownloadProgress: true})
+        .subscribe(() => done());
+      const req = backend.expectOne('/test');
+      expect(req.request.reportUploadProgress).toBe(true);
+      expect(req.request.reportDownloadProgress).toBe(true);
+      req.flush({});
+    });
   });
   describe('makes a POST request', () => {
     it('with text data', (done) => {


### PR DESCRIPTION
The `addBody` function did not pass the argument correctly

fixes #69241
