### PR TITLE
refactor(compiler): disable the legacy template syntax

### DIFF
--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -25,6 +25,7 @@ import {BindingParser} from '../template_parser/binding_parser';
 import {PreparsedElementType, preparseElement} from '../template_parser/template_preparser';
 
 import * as t from './r3_ast';
+import {createContentBlock} from './r3_content_blocks';
 import {
   createForLoop,
   createIfBlock,
@@ -33,7 +34,6 @@ import {
   isConnectedIfLoopBlock,
 } from './r3_control_flow';
 import {createDeferredBlock, isConnectedDeferLoopBlock} from './r3_deferred_blocks';
-import {createContentBlock} from './r3_content_blocks';
 import {I18N_ICU_VAR_PREFIX} from './view/i18n/util';
 
 const BIND_NAME_REGEXP = /^(?:(bind-)|(let-)|(ref-|#)|(on-)|(bindon-)|(@))(.*)$/;
@@ -729,6 +729,7 @@ class HtmlAstToIvyAst implements html.Visitor {
 
     if (bindParts) {
       if (bindParts[KW_BIND_IDX] != null) {
+        // 3p-only-start
         const identifier = bindParts[IDENT_KW_IDX];
         const keySpan = createKeySpan(srcSpan, bindParts[KW_BIND_IDX], identifier);
         this.bindingParser.parsePropertyBinding(
@@ -743,6 +744,7 @@ class HtmlAstToIvyAst implements html.Visitor {
           parsedProperties,
           keySpan,
         );
+        // 3p-only-end
       } else if (bindParts[KW_LET_IDX]) {
         if (isTemplateElement) {
           const identifier = bindParts[IDENT_KW_IDX];
@@ -756,6 +758,7 @@ class HtmlAstToIvyAst implements html.Visitor {
         const keySpan = createKeySpan(srcSpan, bindParts[KW_REF_IDX], identifier);
         this.parseReference(identifier, value, srcSpan, keySpan, attribute.valueSpan, references);
       } else if (bindParts[KW_ON_IDX]) {
+        // 3p-only-start
         const events: ParsedEvent[] = [];
         const identifier = bindParts[IDENT_KW_IDX];
         const keySpan = createKeySpan(srcSpan, bindParts[KW_ON_IDX], identifier);
@@ -770,7 +773,9 @@ class HtmlAstToIvyAst implements html.Visitor {
           keySpan,
         );
         addEvents(events, boundEvents);
+        // 3p-only-end
       } else if (bindParts[KW_BINDON_IDX]) {
+        // 3p-only-start
         const identifier = bindParts[IDENT_KW_IDX];
         const keySpan = createKeySpan(srcSpan, bindParts[KW_BINDON_IDX], identifier);
         this.bindingParser.parsePropertyBinding(
@@ -795,6 +800,7 @@ class HtmlAstToIvyAst implements html.Visitor {
           keySpan,
           absoluteOffset,
         );
+        // 3p-only-end
       } else if (bindParts[KW_AT_IDX]) {
         const keySpan = createKeySpan(srcSpan, '', name);
         this.bindingParser.parseLiteralAttr(


### PR DESCRIPTION
This disables the legacy `bind`, `bindon-`, `on-`, `ref-` syntax in g3 ONLY. This is mostly to evaluate the blast radius
