### PR TITLE
fix(core): update comment for Default change detection

### DIFF
--- a/packages/core/src/change_detection/constants.ts
+++ b/packages/core/src/change_detection/constants.ts
@@ -34,8 +34,7 @@ export enum ChangeDetectionStrategy {
   Eager = 1,
 
   /**
-   * Use the default `CheckAlways` strategy, in which change detection is automatic until
-   * explicitly deactivated.
+   * This value is equivalent to setting `Eager` and is due to be removed.
    * @deprecated Use `Eager` instead.
    */
   // 3p-only-start


### PR DESCRIPTION
Updates the comment on `ChangeDetectionStrategy.Default` to mention that it's the same as `Eager`.

Fixes #69253.
