### PR TITLE
fix: use safe hasOwnProperty when parsing query params

### DIFF
--- a/packages/common/upgrade/src/params.ts
+++ b/packages/common/upgrade/src/params.ts
@@ -271,7 +271,7 @@ function parseKeyValue(keyValue: string): {[k: string]: unknown} {
       key = tryDecodeURIComponent(key);
       if (typeof key !== 'undefined') {
         val = typeof val !== 'undefined' ? tryDecodeURIComponent(val) : true;
-        if (!obj.hasOwnProperty(key)) {
+        if (!Object.hasOwn(obj, key)) {
           obj[key] = val;
         } else if (Array.isArray(obj[key])) {
           (obj[key] as unknown[]).push(val);

--- a/packages/common/upgrade/test/params.spec.ts
+++ b/packages/common/upgrade/test/params.spec.ts
@@ -76,4 +76,13 @@ describe('AngularJSUrlCodec', () => {
       }).toThrowError('Invalid URL (http://foo.bar) with base (abc)');
     });
   });
+
+  describe('decodeSearch', () => {
+    it('should decode a search param named like an Object.prototype member', () => {
+      expect(codec.decodeSearch('hasOwnProperty=foo&bar=baz')).toEqual({
+        hasOwnProperty: 'foo',
+        bar: 'baz',
+      });
+    });
+  });
 });

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -745,7 +745,7 @@ class UrlParser {
     const decodedKey = decodeQuery(key);
     const decodedVal = decodeQuery(value);
 
-    if (params.hasOwnProperty(decodedKey)) {
+    if (Object.hasOwn(params, decodedKey)) {
       // Append to existing values
       let currentVal = params[decodedKey];
       if (!Array.isArray(currentVal)) {

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -39,6 +39,11 @@ describe('UrlTree', () => {
       expect(tree.queryParams).toEqual({'first': 'http://foo/bar?baz=true', 'second': '123'});
     });
 
+    it('should parse a query param named like an Object.prototype member', () => {
+      const tree = serializer.parse('/path/to?hasOwnProperty=foo&bar=baz');
+      expect(tree.queryParams).toEqual({'hasOwnProperty': 'foo', 'bar': 'baz'});
+    });
+
     it('create, serialize, parse, serialize results in same serialized tree with outlet and no primary children', () => {
       const router = TestBed.inject(Router);
       const th = router.createUrlTree(['/', {outlets: {a: ['a'], b: [{outlets: {a: ['b1']}}]}}]);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other

## What is the current behavior?

Issue Number: N/A

`parseQueryParam` in the router and `parseKeyValue` in `@angular/common/upgrade` check for an existing key by calling `hasOwnProperty` directly on the object they accumulate parsed query params into, whose keys come straight from the URL. A query string like `?hasOwnProperty=x&a=b` overwrites that method with a string, so the existence check for the next param throws `TypeError: params.hasOwnProperty is not a function` and the whole parse fails on otherwise valid input reachable from any crafted link.

## What is the new behavior?

Both call sites use the non-clobberable `Object.prototype.hasOwnProperty.call(...)`, which `router/src/shared.ts` already uses for param lookups, so a `hasOwnProperty` query key parses like any other key and the repeated-key array handling is unchanged. Spotted while auditing the query-string parsers for the unsafe `obj.hasOwnProperty(userKey)` shape.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
