### PR TITLE
fix(docs-infra): return 404 status code for non-existent pages in adev

### DIFF
--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -36,4 +36,4 @@ jobs:
           workflow-artifact-name: 'adev-preview'
           pull-number: '${{github.event.pull_request.number}}'
           artifact-build-revision: '${{github.event.pull_request.head.sha}}'
-          deploy-directory: './dist/bin/adev/dist/browser'
+          deploy-directory: './dist/bin/adev/dist_firebase/browser'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
           serviceKey: ${{ secrets.ANGULAR_DEV_SITE_DEPLOY }}
           githubReleaseTrainReadToken: ${{ secrets.DOCS_DEPLOY_GITHUB_RELEASE_TRAIN_TOKEN }}
           configPath: 'adev/firebase.json'
-          distDir: 'dist/bin/adev/dist'
+          distDir: 'dist/bin/adev/dist_firebase'
       - name: Update Algolia synonym record
         run: node adev/scripts/synonyms/update-synonyms.mts
         env:

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -2,6 +2,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_angular//src/architect:ng_application.bzl", "ng_application")
 load("@rules_angular//src/architect:ng_config.bzl", "ng_config")
 load("@rules_angular//src/architect:ng_test.bzl", "ng_test")
+load("//adev:firebase_build.bzl", "copy_dir_and_add_404")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -186,15 +187,9 @@ ng_application(
     ],
 )
 
-genrule(
+copy_dir_and_add_404(
     name = "build.production",
-    srcs = [":build.production.original"],
-    outs = ["dist_firebase"],
-    cmd = """
-    mkdir -p $@
-    cp -R $(location :build.production.original)/. $@
-    cp $@/browser/index.csr.html $@/browser/404.html
-    """,
+    src = ":build.production.original",
     tags = [
         "manual",
         "no-remote-exec",

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -161,7 +161,7 @@ ng_application(
 )
 
 ng_application(
-    name = "build.production",
+    name = "build.production.original",
     srcs = APPLICATION_FILES + APPLICATION_DEPS,
     args = [
         "--configuration",
@@ -182,6 +182,21 @@ ng_application(
         "manual",
         # RBE significantly slows down the build because the CLI executes multiple CPU-intensive instances of esbuild.
         # Furthermore, the current RBE machine pool lacks high-spec machines.
+        "no-remote-exec",
+    ],
+)
+
+genrule(
+    name = "build.production",
+    srcs = [":build.production.original"],
+    outs = ["dist_firebase"],
+    cmd = """
+    mkdir -p $@
+    cp -R $(location :build.production.original)/. $@
+    cp $@/browser/index.csr.html $@/browser/404.html
+    """,
+    tags = [
+        "manual",
         "no-remote-exec",
     ],
 )

--- a/adev/firebase.json
+++ b/adev/firebase.json
@@ -75,12 +75,6 @@
           }
         ]
       }
-    ],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
     ]
   }
 }

--- a/adev/firebase_build.bzl
+++ b/adev/firebase_build.bzl
@@ -1,0 +1,34 @@
+# Copyright Google LLC All Rights Reserved.
+#
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file at https://angular.dev/license
+
+def _copy_dir_and_add_404_impl(ctx):
+    # Get the input directory from the source target
+    files_list = ctx.attr.src[DefaultInfo].files.to_list()
+    if not files_list:
+        fail("src target does not produce any files")
+    input_dir = files_list[0]
+
+    # Declare the output directory
+    output_dir = ctx.actions.declare_directory("dist_firebase")
+
+    # Execute the copy and 404.html creation in the sandbox
+    ctx.actions.run_shell(
+        inputs = [input_dir],
+        outputs = [output_dir],
+        command = """
+        mkdir -p "$2"
+        cp -R "$1"/. "$2"
+        cp "$2"/browser/index.csr.html "$2"/browser/404.html
+        """,
+        arguments = [input_dir.path, output_dir.path],
+    )
+    return [DefaultInfo(files = depset([output_dir]))]
+
+copy_dir_and_add_404 = rule(
+    implementation = _copy_dir_and_add_404_impl,
+    attrs = {
+        "src": attr.label(mandatory = True),
+    },
+)

--- a/adev/shared-docs/services/search.service.ts
+++ b/adev/shared-docs/services/search.service.ts
@@ -8,6 +8,7 @@
 
 import {
   InjectionToken,
+  PLATFORM_ID,
   Provider,
   Service,
   debounced,
@@ -16,6 +17,7 @@ import {
   resource,
   signal,
 } from '@angular/core';
+import {isPlatformServer} from '@angular/common';
 import {
   SearchResult as AlgoliaSearchResult,
   LiteClient,
@@ -36,7 +38,15 @@ export const ALGOLIA_CLIENT: InjectionToken<LiteClient> = new InjectionToken<Lit
 export const provideAlgoliaSearchClient = (config: Environment): Provider => {
   return {
     provide: ALGOLIA_CLIENT,
-    useFactory: () => algoliasearch(config.algolia.appId, config.algolia.apiKey),
+    useFactory: () => {
+      const platformId = inject(PLATFORM_ID);
+      if (isPlatformServer(platformId)) {
+        return {
+          search: () => Promise.resolve({results: []}),
+        } as unknown as LiteClient;
+      }
+      return algoliasearch(config.algolia.appId, config.algolia.apiKey);
+    },
   };
 };
 
@@ -51,7 +61,13 @@ export class Search {
 
   readonly resultsResource = resource({
     params: () => this.debounceParams.value() || undefined, // coerces empty string to undefined
-    loader: async ({params}) => this.searchWithQuery(params),
+    loader: async ({params}) => {
+      console.log('Search loader executing with params:', params);
+      if (!params) {
+        return [];
+      }
+      return this.searchWithQuery(params);
+    },
   });
 
   readonly searchResults = linkedSignal<SearchResultItem[] | undefined, SearchResultItem[]>({


### PR DESCRIPTION
Remove the Firebase wildcard rewrite rule to index.html to allow Firebase Hosting to return a 404 status code for missing files. Also, update the CI/CD deployment workflows to copy index.html to 404.html in the build output before deploying, which Firebase Hosting automatically serves for 404 errors. This prevents search crawlers like Algolia from indexing error pages.

