### PR TITLE
fix(forms): delay mcp reading the form model by a `tick`

### DIFF
--- a/packages/forms/signals/src/webmcp/registration.ts
+++ b/packages/forms/signals/src/webmcp/registration.ts
@@ -8,28 +8,48 @@
 
 import {
   declareExperimentalWebMcpTool,
+  effect,
   EnvironmentProviders,
+  inject,
+  Injector,
   makeEnvironmentProviders,
   untracked,
 } from '@angular/core';
 import type {JsonSchemaForInference} from '@mcp-b/webmcp-types';
 import {submit} from '../api/structure';
+import {FieldTree} from '../api/types';
 import {FieldNode} from '../field/node';
 import {REGISTER_WEBMCP_FORM, RegisterWebMcpForm} from './tokens';
 
-const registerWebMcpForm: RegisterWebMcpForm = (formTree, options) => {
-  untracked(() => {
-    const node = formTree() as FieldNode;
-    const inputSchema = inferSchemaFromFieldNode(node);
+const registerWebMcpForm: RegisterWebMcpForm = async (formTree, options) => {
+  const injector = inject(Injector);
 
-    if (!inputSchema) {
-      throw new Error(
-        `Could not accurately infer WebMCP schema for form "${options.name}". ` +
-          `Ensure that the form model does not contain null, undefined, empty arrays, or unsupported types.`,
-      );
-    }
+  // we want to defer the registration until the context is fully initialized,
+  // This is especially useful if the form model is a derivation of a required input
+  effect(() => {
+    untracked(() => {
+      initWebMcpForm(formTree, options, injector);
+    });
+  });
+};
 
-    declareExperimentalWebMcpTool({
+function initWebMcpForm(
+  formTree: FieldTree<unknown>,
+  options: {name: string; description?: string},
+  injector: Injector,
+) {
+  const node = formTree() as FieldNode;
+  const inputSchema = inferSchemaFromFieldNode(node);
+
+  if (!inputSchema) {
+    throw new Error(
+      `Could not accurately infer WebMCP schema for form "${options.name}". ` +
+        `Ensure that the form model does not contain null, undefined, empty arrays, or unsupported types.`,
+    );
+  }
+
+  declareExperimentalWebMcpTool(
+    {
       name: options.name,
       description: options.description,
       inputSchema,
@@ -54,9 +74,10 @@ const registerWebMcpForm: RegisterWebMcpForm = (formTree, options) => {
           return {content: [{type: 'text', text: `Form submission failed:\n${errorMessages}`}]};
         }
       },
-    });
-  });
-};
+    },
+    injector,
+  );
+}
 
 /** Infers the JSON schema from a specific form field. */
 function inferSchemaFromFieldNode(node: FieldNode): JsonSchemaForInference | undefined {

--- a/packages/forms/signals/test/web/webmcp.spec.ts
+++ b/packages/forms/signals/test/web/webmcp.spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {initializeWebMCPPolyfill, cleanupWebMCPPolyfill} from '@mcp-b/webmcp-polyfill';
-import {signal} from '@angular/core';
-import {form, required, provideExperimentalWebMcpForms} from '@angular/forms/signals';
+import {ApplicationRef, Component, input, linkedSignal, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {form, provideExperimentalWebMcpForms, required} from '@angular/forms/signals';
+import {cleanupWebMCPPolyfill, initializeWebMCPPolyfill} from '@mcp-b/webmcp-polyfill';
 
 describe('Signal Forms WebMCP Integration', () => {
   beforeEach(() => {
@@ -27,7 +27,7 @@ describe('Signal Forms WebMCP Integration', () => {
       });
     });
 
-    it('should infer schema and register form as a tool', () => {
+    it('should infer schema and register form as a tool', async () => {
       const model = signal({
         name: 'John',
         age: 30,
@@ -47,6 +47,7 @@ describe('Signal Forms WebMCP Integration', () => {
           },
         });
       });
+      await TestBed.inject(ApplicationRef).whenStable();
 
       const registeredTools = globalThis.navigator.modelContextTesting!.listTools();
       expect(registeredTools[0].name).toBe('testFormTool');
@@ -76,7 +77,7 @@ describe('Signal Forms WebMCP Integration', () => {
       });
     });
 
-    it('should infer required validators in schema', () => {
+    it('should infer required validators in schema', async () => {
       const model = signal({
         name: 'John',
         age: 30,
@@ -101,6 +102,7 @@ describe('Signal Forms WebMCP Integration', () => {
           },
         );
       });
+      await TestBed.inject(ApplicationRef).whenStable();
 
       const registeredTools = globalThis.navigator.modelContextTesting!.listTools();
       const tool = registeredTools.find((t) => t.name === 'requiredTestTool')!;
@@ -143,6 +145,7 @@ describe('Signal Forms WebMCP Integration', () => {
           },
         });
       });
+      await TestBed.inject(ApplicationRef).whenStable();
 
       const result = await globalThis.navigator.modelContextTesting!.executeTool(
         'testFormSubmitTool',
@@ -184,6 +187,7 @@ describe('Signal Forms WebMCP Integration', () => {
           },
         );
       });
+      await TestBed.inject(ApplicationRef).whenStable();
 
       const result = await globalThis.navigator.modelContextTesting!.executeTool(
         'testFormInvalidTool',
@@ -219,6 +223,7 @@ describe('Signal Forms WebMCP Integration', () => {
           },
         });
       });
+      await TestBed.inject(ApplicationRef).whenStable();
 
       const result = await globalThis.navigator.modelContextTesting!.executeTool(
         'testFormSubmitFailTool',
@@ -251,6 +256,7 @@ describe('Signal Forms WebMCP Integration', () => {
           },
         });
       });
+      await TestBed.inject(ApplicationRef).whenStable();
 
       await expectAsync(
         globalThis.navigator.modelContextTesting!.executeTool(
@@ -270,6 +276,7 @@ describe('Signal Forms WebMCP Integration', () => {
               description: 'A null tool',
             },
           });
+          TestBed.inject(ApplicationRef).tick();
         }).toThrowError(/Could not accurately infer WebMCP schema/);
       });
       expect(
@@ -285,6 +292,7 @@ describe('Signal Forms WebMCP Integration', () => {
               description: 'An empty array tool',
             },
           });
+          TestBed.inject(ApplicationRef).tick();
         }).toThrowError(/Could not accurately infer WebMCP schema/);
       });
       expect(
@@ -302,11 +310,30 @@ describe('Signal Forms WebMCP Integration', () => {
               description: 'A symbol tool',
             },
           });
+          TestBed.inject(ApplicationRef).tick();
         }).toThrowError(/Could not accurately infer WebMCP schema/);
       });
       expect(
         globalThis.navigator.modelContextTesting!.listTools().some((t) => t.name === 'symbolTool'),
       ).toBeFalse();
+    });
+
+    it('should not throw an error when reading the model', async () => {
+      @Component({
+        selector: 'app-root',
+        template: ``,
+      })
+      class App {
+        id = input.required<string>();
+        model = linkedSignal(() => ({id: this.id()}));
+
+        form = form(this.model, () => {}, {
+          experimentalWebMcpTool: {description: 'foo', name: 'foo'},
+        });
+      }
+
+      await TestBed.inject(ApplicationRef).whenStable();
+      expect(() => TestBed.createComponent(App)).not.toThrow();
     });
   });
 


### PR DESCRIPTION
Reading the form model on init is unsafe as it could depend on inputs (eg a required input). We need to delay the read by a tick (after the inputs are set) to ensure that values can be safely read.

fixes #69262
