### PR TITLE
fix(adev): validate postMessage origin in code editor iframe handler

### DIFF
--- a/adev/src/app/editor/code-editor/code-editor.component.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.ts
@@ -176,6 +176,8 @@ export class CodeEditor {
     // Track the trusted preview origin once the WebContainer dev server starts.
     // The preview runs on a dynamic *.webcontainer.io subdomain (cross-origin)
     let trustedPreviewOrigin: string | null = null;
+    
+    if (this.nodeRuntimeSandbox) {
     this.nodeRuntimeSandbox.previewUrl$
        .pipe(
          filter((url): url is string => !!url),
@@ -185,12 +187,11 @@ export class CodeEditor {
         .subscribe((url) => {
           trustedPreviewOrigin = new URL(url).origin;
        });
-  
+    }
     const handlePostMessage = (event: MessageEvent) => {
       if (
         !trustedPreviewOrigin || 
         event.origin !== trustedPreviewOrigin ||
-        event.source !== iframe.contentWindow
       ) {
         return;
       }

--- a/adev/src/app/editor/code-editor/code-editor.component.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.ts
@@ -23,7 +23,7 @@ import {
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {MatTab, MatTabGroup, MatTabLabel} from '@angular/material/tabs';
 import {Title} from '@angular/platform-browser';
-import {debounceTime, from, map, switchMap} from 'rxjs';
+import {debounceTime, filter, from, map, switchMap, take} from 'rxjs';
 
 import {TerminalType} from '../terminal/terminal-handler.service';
 
@@ -37,6 +37,7 @@ import {NodeRuntimeState} from '../node-runtime-state.service';
 import {StackBlitzOpener} from '../stackblitz-opener.service';
 import {CodeMirrorEditor} from './code-mirror-editor.service';
 import {DiagnosticWithLocation, DiagnosticsState} from './services/diagnostics-state.service';
+import {NodeRuntimeSandbox} from '../node-runtime-sandbox.service';
 
 export const REQUIRED_FILES = new Set([
   'src/main.ts',
@@ -81,6 +82,7 @@ export class CodeEditor {
   private readonly title = inject(Title);
   private readonly location = inject(Location);
   private readonly environmentInjector = inject(EnvironmentInjector);
+  private readonly nodeRuntimeSandbox = inject(NodeRuntimeSandbox);
 
   private readonly errors$ = this.diagnosticsState.diagnostics$.pipe(
     // Display errors one second after code update
@@ -169,8 +171,23 @@ export class CodeEditor {
     };
 
     // Listen for postMessage from preview iframe (Vite error overlay)
+    // Track the trusted preview origin once the WebContainer dev server starts.
+    // The preview runs on a dynamic *.webcontainer.io subdomain (cross-origin)
+    let trustedPreviewOrigin: string | null = null;
+    this.nodeRuntimeSandbox.previewUrl$
+       .pipe(
+         filter((url): url is string => !!url),
+         take(1),
+         takeUntilDestroyed(this.destroyRef),
+        )
+        .subscribe((url) => {
+          trustedPreviewOrigin = new URL(url).origin;
+       });
+  
     const handlePostMessage = (event: MessageEvent) => {
-      // Check if this is an openFileAtLocation message
+      if (!trustedPreviewOrigin || event.origin !== trustedPreviewOrigin) {
+        return;
+      }
       if (event.data?.type === 'openFileAtLocation') {
         const {file, line, character} = event.data;
         openFile(file, line, character);

--- a/adev/src/app/editor/code-editor/code-editor.component.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.ts
@@ -82,7 +82,9 @@ export class CodeEditor {
   private readonly title = inject(Title);
   private readonly location = inject(Location);
   private readonly environmentInjector = inject(EnvironmentInjector);
-  private readonly nodeRuntimeSandbox = inject(NodeRuntimeSandbox);
+  private readonly nodeRuntimeSandbox = inject(NodeRuntimeSandbox, {
+    optional: true,
+  });
 
   private readonly errors$ = this.diagnosticsState.diagnostics$.pipe(
     // Display errors one second after code update
@@ -185,7 +187,11 @@ export class CodeEditor {
        });
   
     const handlePostMessage = (event: MessageEvent) => {
-      if (!trustedPreviewOrigin || event.origin !== trustedPreviewOrigin) {
+      if (
+        !trustedPreviewOrigin || 
+        event.origin !== trustedPreviewOrigin ||
+        event.source !== iframe.contentWindow
+      ) {
         return;
       }
       if (event.data?.type === 'openFileAtLocation') {

--- a/adev/src/app/editor/error-filename-handler.ts
+++ b/adev/src/app/editor/error-filename-handler.ts
@@ -24,7 +24,7 @@ function errorFilenameHandler() {
             line: parseInt(line, 10),
             character: parseInt(column, 10),
           },
-          '*',
+          'https://angular.dev',
         );
       }
       return new Response(null, {status: 200});


### PR DESCRIPTION
## Description

The `postMessage` handler in `CodeEditorComponent` accepted messages from any origin without validating `event.origin`. This allowed any cross-origin page to silently trigger `openFileAtLocation` actions in the editor by sending crafted `postMessage` events.

Additionally, `error-filename-handler.ts` used a wildcard targetOrigin
(`'*'`) when posting messages from the WebContainer preview iframe to the parent frame, which is a postMessage security best practice
violation.

## Changes

- **`code-editor.component.ts`**: Captures the trusted preview origin from `NodeRuntimeSandbox.previewUrl$` once the WebContainer dev server starts, then validates `event.origin` against it in the `handlePostMessage` handler. Messages from any other origin are silently dropped.

- **`error-filename-handler.ts`**: Replaces the wildcard `'*'`
  targetOrigin with the explicit `'https://angular.dev'` origin. This
  matches the existing `ANGULAR_DEV` constant used elsewhere in   the component.

## Notes

The preview iframe runs on a dynamic `*.webcontainer.io` subdomain (cross-origin), so `window.location.origin` cannot be used directly as the trusted origin. The origin is instead derived at runtime from the URL emitted by `previewUrl$` after the dev server becomes ready.

