### PR TITLE
fix(docs-infra): support header values containing apostrophes

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-block.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-block.mts
@@ -38,7 +38,7 @@ export const docsCodeBlockExtension = {
     if (match) {
       const metadataStr = match[2].trim();
 
-      const headerRule = /header\s*:\s*(['"`])([^'"`]+)\1/; // The 2nd capture matters here
+      const headerRule = /header\s*:\s*(['"`])(.*?)\1/; // The 2nd capture matters here
       const highlightRule = /highlight\s*:\s*(.*)([^,])/;
       const hideCopyRule = /hideCopy/;
       const hideDollarRule = /hideDollar/;

--- a/adev/shared-docs/pipeline/shared/marked/test/code/code.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/code/code.spec.mts
@@ -7,15 +7,16 @@
  */
 
 import {readFile} from 'fs/promises';
-import {parseMarkdown} from '../../parse.mjs';
+import {parseMarkdown, parseMarkdownAsync} from '../../parse.mjs';
 import {resolve} from 'node:path';
-import {rendererContext} from '../renderer-context.mjs';
+import {rendererContext, setHighlighter} from '../renderer-context.mjs';
 
 describe('markdown to html', () => {
   let parsedMarkdown: string;
   beforeAll(async () => {
     const markdownContent = await readFile(resolve('./code.md'), {encoding: 'utf-8'});
     parsedMarkdown = await parseMarkdown(markdownContent, rendererContext);
+    await setHighlighter();
   });
 
   it('should render symbol with link', () => {
@@ -34,5 +35,14 @@ describe('markdown to html', () => {
     expect(parsedMarkdown).toContain(
       ' <a href="/api/angular/router/Router#lastSuccessfulNavigation"><code>Router.lastSuccessfulNavigation()</code></a>',
     );
+  });
+
+  it('should parse header with quotes inside', async () => {
+    const markdown = '```angular-ts {avoid, header: "Can\'t inject interface"}\nconst x = 1;\n```';
+    const parsed = await parseMarkdownAsync(markdown, rendererContext);
+
+    expect(parsed).toContain("Can't inject interface");
+    expect(parsed).toContain('<span class="docs-code-header-style ">Avoid</span>');
+    expect(parsed).toContain("<h3>Can't inject interface</h3>");
   });
 });

--- a/adev/src/content/guide/di/debugging-and-troubleshooting-di.md
+++ b/adev/src/content/guide/di/debugging-and-troubleshooting-di.md
@@ -440,7 +440,7 @@ TIP: Always export tokens from a shared file and import them everywhere they're 
 
 When you define a TypeScript interface, it only exists during compilation for type checking. TypeScript erases all interface definitions when it compiles to JavaScript, so at runtime there's no object for Angular to use as an injection token. If you try to inject an interface type, Angular has nothing to match against the provider configuration.
 
-```angular-ts {avoid, header: 'Can't inject interface'}
+```angular-ts {avoid, header: "Can't inject interface"}
 interface UserConfig {
   name: string;
   email: string;


### PR DESCRIPTION
Update the `headerRule` regex to capture the complete quoted header value. The previous pattern excluded quote characters from the content and failed to parse headers such as:

```angular-ts {avoid, header: "Can't inject interface"}
```

The new pattern matches everything between the opening and closing quote delimiters.

## What is the current behavior?
Showing Only "Can" not full text.
https://angular.dev/guide/di/debugging-and-troubleshooting-di#trying-to-inject-interfaces

<img width="1604" height="592" alt="image" src="https://github.com/user-attachments/assets/433e94b0-f7d1-4eac-ad0f-a8af1fc79f15" />

## What is the new behavior?
Showing full text "Can't inject interface"