### PR TITLE
refactor(compiler): Remove 80 char limit on AbstractEmitterVisitor

### DIFF
--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -661,27 +661,11 @@ export abstract class AbstractEmitterVisitor
     ctx: EmitterVisitorContext,
     separator: string,
   ): void {
-    let incrementedIndent = false;
     for (let i = 0; i < expressions.length; i++) {
       if (i > 0) {
-        if (ctx.lineLength() > 80) {
-          ctx.print(null, separator, true);
-          if (!incrementedIndent) {
-            // continuation are marked with double indent.
-            ctx.incIndent();
-            ctx.incIndent();
-            incrementedIndent = true;
-          }
-        } else {
-          ctx.print(null, separator, false);
-        }
+        ctx.print(null, separator, false);
       }
       handler(expressions[i]);
-    }
-    if (incrementedIndent) {
-      // continuation are marked with double indent.
-      ctx.decIndent();
-      ctx.decIndent();
     }
   }
 


### PR DESCRIPTION
This limit breaks ts-ignore comments when using this for our source->source transform. Rather than overridding it there, it's just removed here since we don't care about the limit
