### PR TITLE
fix(vscode-extension): resolve relative workspace tsdk paths to absolute

### DIFF
--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -649,6 +649,18 @@ export class AngularLanguageClient implements vscode.Disposable {
         const isApproved = this.context.workspaceState.get<boolean>(stateKey);
 
         if (isApproved) {
+          if (!path.isAbsolute(workspaceTsdk)) {
+            const workspaceFolders = vscode.workspace.workspaceFolders || [];
+            for (const folder of workspaceFolders) {
+              const absolutePath = path.join(folder.uri.fsPath, workspaceTsdk);
+              if (fs.existsSync(path.join(absolutePath, 'tsserverlibrary.js'))) {
+                return absolutePath;
+              }
+            }
+            if (workspaceFolders.length > 0) {
+              return path.join(workspaceFolders[0].uri.fsPath, workspaceTsdk);
+            }
+          }
           return workspaceTsdk;
         }
 

--- a/vscode-ng-language-service/server/src/version_provider.ts
+++ b/vscode-ng-language-service/server/src/version_provider.ts
@@ -53,6 +53,8 @@ function resolveWithMinVersion(
 /**
  * Resolve `typescript/lib/tsserverlibrary` from the given locations.
  * @param probeLocations
+ * TODO: Remove probeLocations entirely and require the client to pass the exact TypeScript path
+ * to load (either the bundled version or the user-configured tsdk version as an absolute path).
  */
 export function resolveTsServer(probeLocations: string[], tsdk: string | null): NodeModule {
   if (tsdk !== null) {


### PR DESCRIPTION
Resolve the approved relative workspace tsdk path to an absolute path by checking workspace folders. This ensures the path is correctly resolved on the server side.

Fixes #69276
