### PR TITLE
fix(core): preserve leave animation for sibling instances sharing a TNode

### DIFF
--- a/packages/core/src/animation/utils.ts
+++ b/packages/core/src/animation/utils.ts
@@ -16,7 +16,7 @@ import {
   LeaveNodeAnimations,
   AnimationClassBindingFn,
 } from './interfaces';
-import {INJECTOR, LView, ANIMATIONS} from '../render3/interfaces/view';
+import {INJECTOR, LView, ANIMATIONS, DECLARATION_VIEW} from '../render3/interfaces/view';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {Renderer} from '../render3/interfaces/renderer';
 import {RElement} from '../render3/interfaces/renderer_dom';
@@ -110,10 +110,37 @@ export const enterClassMap = new WeakMap<
 >();
 export const longestAnimations = new WeakMap<HTMLElement, LongestAnimation>();
 
+/**
+ * A node that is currently animating away, tracked alongside the view that
+ * declares its template. The declaration view lets us tell apart two distinct
+ * instances of the same template (which share a `TNode`) from the same logical
+ * view being re-rendered.
+ */
+interface LeavingNode {
+  el: HTMLElement;
+  // The view that declares the template the leaving element belongs to. For two
+  // separate component instances of the same template this differs; for the same
+  // logical view re-rendered (e.g. a dynamic component repeatedly created from the
+  // same `ViewContainerRef`) it is identical. `null` when no owning view is known.
+  declarationView: LView | null;
+}
+
 // Tracks nodes that are animating away for the duration of the animation. This is
 // used to prevent duplicate nodes from showing up when nodes have been toggled quickly
 // from an `@if` or `@for`.
-export const leavingNodes = new WeakMap<TNode, HTMLElement[]>();
+export const leavingNodes = new WeakMap<TNode, LeavingNode[]>();
+
+/**
+ * Resolves the view that declares the template a node belongs to. We use the
+ * declaration view (rather than the rendered `LView` itself, which is a fresh
+ * object on every re-render) so that the same logical insertion point compares
+ * equal across re-renders, while distinct instances of a shared template compare
+ * unequal.
+ */
+function getDeclarationView(lView: LView | undefined): LView | null {
+  if (!lView) return null;
+  return lView[DECLARATION_VIEW] ?? lView;
+}
 
 // Tracks nodes that have scheduled leave animations but were re-inserted into the DOM
 // before the animation completed, thus rescuing them from being physically removed.
@@ -125,7 +152,7 @@ export const reusedNodes = new WeakSet<HTMLElement>();
 export function clearLeavingNodes(tNode: TNode, el: HTMLElement): void {
   const nodes = leavingNodes.get(tNode);
   if (nodes && nodes.length > 0) {
-    const ix = nodes.findIndex((node) => node === el);
+    const ix = nodes.findIndex((node) => node.el === el);
     if (ix > -1) nodes.splice(ix, 1);
   }
   if (nodes?.length === 0) {
@@ -141,16 +168,23 @@ export function clearLeavingNodes(tNode: TNode, el: HTMLElement): void {
  *
  * Leaving elements in the same parent are left alone — their leave
  * animation will complete naturally and remove them from the DOM.
+ *
+ * @param tNode The `TNode` of the entering element.
+ * @param newElement The element being inserted.
+ * @param newLView The view the entering element is being rendered into. Used to
+ *   tell apart two separate instances of the same template (which share a
+ *   `TNode`) from the same logical view being re-rendered into a new DOM parent.
  */
-export function cancelLeavingNodes(tNode: TNode, newElement: HTMLElement): void {
+export function cancelLeavingNodes(tNode: TNode, newElement: HTMLElement, newLView?: LView): void {
   const nodes = leavingNodes.get(tNode);
   if (!nodes || nodes.length === 0) return;
 
   const newParent = newElement.parentNode;
   const prevSibling = newElement.previousSibling;
+  const newDeclarationView = getDeclarationView(newLView);
 
   for (let i = nodes.length - 1; i >= 0; i--) {
-    const leavingEl = nodes[i];
+    const {el: leavingEl, declarationView: leavingDeclarationView} = nodes[i];
     const leavingParent = leavingEl.parentNode;
     // Cancel if the leaving element is:
     // - The direct previousSibling of the new element. This is reliable
@@ -164,13 +198,30 @@ export function cancelLeavingNodes(tNode: TNode, newElement: HTMLElement): void 
       nodes.splice(i, 1);
       reusedNodes.add(leavingEl);
       leavingEl.dispatchEvent(new CustomEvent('animationend', {detail: {cancel: true}}));
-    } else if (
-      (prevSibling && leavingEl === prevSibling) ||
-      (leavingParent && newParent && leavingParent !== newParent)
-    ) {
+    } else if (prevSibling && leavingEl === prevSibling) {
       nodes.splice(i, 1);
       leavingEl.dispatchEvent(new CustomEvent('animationend', {detail: {cancel: true}}));
       leavingEl.parentNode?.removeChild(leavingEl);
+    } else if (leavingParent && newParent && leavingParent !== newParent) {
+      // The leaving element is in a different DOM parent than the entering one.
+      // This is ambiguous: it can be the same logical view re-rendered into a new
+      // container (e.g. a dynamic component re-created in a fresh CDK overlay
+      // pane), which must be de-duplicated by removing it immediately; or it can
+      // be a *distinct* instance of the same template (accordions, exclusive-
+      // expansion menus, master/detail nav) that merely shares this `TNode` and
+      // is legitimately leaving in its own parent. Only force-remove when the
+      // entering element belongs to the SAME declaration view as the leaving one
+      // — i.e. a true re-render of the same logical view. Distinct instances are
+      // left alone so their `animate.leave` runs to completion.
+      const sameLogicalView =
+        newDeclarationView === null ||
+        leavingDeclarationView === null ||
+        newDeclarationView === leavingDeclarationView;
+      if (sameLogicalView) {
+        nodes.splice(i, 1);
+        leavingEl.dispatchEvent(new CustomEvent('animationend', {detail: {cancel: true}}));
+        leavingEl.parentNode?.removeChild(leavingEl);
+      }
     }
   }
 }
@@ -180,17 +231,20 @@ export function cancelLeavingNodes(tNode: TNode, newElement: HTMLElement): void 
  * and remove the node before adding a new entering instance of the DOM node. This prevents
  * duplicates from showing up on screen mid-animation.
  */
-export function trackLeavingNodes(tNode: TNode, el: HTMLElement): void {
+export function trackLeavingNodes(tNode: TNode, el: HTMLElement, lView?: LView): void {
   // We need to track this tNode's element just to be sure we don't add
   // a new RNode for this TNode while this one is still animating away.
   // once the animation is complete, we remove this reference.
+  // The declaration view is recorded so `cancelLeavingNodes` can tell apart two
+  // separate instances of the same template from the same view re-rendered.
+  const declarationView = getDeclarationView(lView);
   const nodes = leavingNodes.get(tNode);
   if (nodes) {
-    if (!nodes.includes(el)) {
-      nodes.push(el);
+    if (!nodes.some((node) => node.el === el)) {
+      nodes.push({el, declarationView});
     }
   } else {
-    leavingNodes.set(tNode, [el]);
+    leavingNodes.set(tNode, [{el, declarationView}]);
   }
 }
 

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -151,10 +151,10 @@ function applyToElementOrContainer(
     } else if (action === WalkTNodeTreeAction.Insert && parent !== null) {
       maybeQueueEnterAnimation(parentLView, parent, tNode, injector);
       nativeInsertBefore(renderer, parent, rNode, beforeNode || null, true);
-      cancelLeavingNodes(tNode, rNode as HTMLElement);
+      cancelLeavingNodes(tNode, rNode as HTMLElement, parentLView);
     } else if (action === WalkTNodeTreeAction.Detach) {
       if (parentLView?.[ANIMATIONS]?.leave?.has(tNode.index)) {
-        trackLeavingNodes(tNode, rNode as HTMLElement);
+        trackLeavingNodes(tNode, rNode as HTMLElement, parentLView);
       }
       reusedNodes.delete(rNode as HTMLElement);
       runLeaveAnimationsWithCallback(

--- a/packages/core/test/acceptance/animation_spec.ts
+++ b/packages/core/test/acceptance/animation_spec.ts
@@ -23,6 +23,7 @@ import {
   EnvironmentInjector,
   ErrorHandler,
   inject,
+  input,
   NgModule,
   OnDestroy,
   provideZonelessChangeDetection,
@@ -2600,6 +2601,115 @@ describe('Animation', () => {
 
       // Clean up overlay panes
       document.querySelectorAll('.overlay-pane').forEach((p) => p.remove());
+    }));
+
+    it('should run animate.leave for a sibling instance when another instance of the same template enters', fakeAsync(() => {
+      // Regression test for a case where two *separate* instances of the same
+      // component (which therefore share a `TNode`) are toggled in the same
+      // change-detection tick: one panel collapses (`animate.leave`) while a
+      // sibling panel expands (`animate.enter`). Because the leaving and entering
+      // elements live in different DOM parents (each instance has its own host),
+      // the cross-parent de-duplication in `cancelLeavingNodes` used to rip the
+      // leaving element out synchronously, skipping its leave animation. The two
+      // elements belong to different declaration views, so it must be left alone.
+      const animateStyles = `
+        .panel {
+          overflow: hidden;
+        }
+        .enter {
+          animation: grow 10ms;
+        }
+        .leave {
+          animation: shrink 10ms forwards;
+        }
+        @keyframes grow {
+          from { height: 0; }
+          to { height: 60px; }
+        }
+        @keyframes shrink {
+          from { height: 60px; }
+          to { height: 0; }
+        }
+      `;
+
+      @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
+        selector: 'expandable-cmp',
+        styles: [animateStyles],
+        template: `
+          @if (open()) {
+            <div class="panel" animate.enter="enter" animate.leave="leave">Panel {{ id }}</div>
+          }
+        `,
+        encapsulation: ViewEncapsulation.None,
+      })
+      class ExpandableComponent {
+        id = '';
+        open = signal(false);
+      }
+
+      @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
+        selector: 'test-cmp',
+        imports: [ExpandableComponent],
+        // Two instances of the SAME template; only one open at a time.
+        template: `
+          <expandable-cmp #a />
+          <expandable-cmp #b />
+        `,
+        encapsulation: ViewEncapsulation.None,
+      })
+      class TestComponent {
+        @ViewChild('a', {read: ExpandableComponent}) a!: ExpandableComponent;
+        @ViewChild('b', {read: ExpandableComponent}) b!: ExpandableComponent;
+      }
+
+      TestBed.configureTestingModule({animationsEnabled: true});
+      const fixture = TestBed.createComponent(TestComponent);
+      const cmp = fixture.componentInstance;
+      fixture.detectChanges();
+      cmp.a.id = 'A';
+      cmp.b.id = 'B';
+      // Initially only A is open.
+      cmp.a.open.set(true);
+      fixture.detectChanges();
+      tickAnimationFrames(1);
+
+      const panels = () => Array.from(fixture.nativeElement.querySelectorAll('.panel'));
+      const panelByText = (text: string) =>
+        panels().find((el) => (el as HTMLElement).textContent?.includes(text)) as
+          | HTMLElement
+          | undefined;
+
+      expect(panels().length).toBe(1);
+      expect(panelByText('Panel A')).toBeTruthy();
+
+      const leavingPanelA = panelByText('Panel A')!;
+
+      // Open B (and close A) in the same change-detection tick. A and B are two
+      // separate instances of the same component, so their panels share a `TNode`
+      // but live in different DOM parents (their respective hosts).
+      cmp.a.open.set(false);
+      cmp.b.open.set(true);
+      fixture.detectChanges();
+      tickAnimationFrames(1);
+
+      // B's panel should have entered.
+      expect(panelByText('Panel B')).toBeTruthy();
+
+      // A's panel must NOT have been removed synchronously — its leave animation
+      // should still be running, so the element stays connected to the DOM.
+      expect(leavingPanelA.isConnected).toBe(true);
+      expect(panelByText('Panel A')).toBeTruthy();
+
+      // Once A's leave animation completes, it is removed as usual.
+      leavingPanelA.dispatchEvent(new AnimationEvent('animationend', {animationName: 'shrink'}));
+      tickAnimationFrames(1);
+      fixture.detectChanges();
+
+      expect(leavingPanelA.isConnected).toBe(false);
+      expect(panelByText('Panel A')).toBeUndefined();
+      expect(panelByText('Panel B')).toBeTruthy();
     }));
   });
 

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -501,6 +501,7 @@
       "getCurrentTNodePlaceholderOk",
       "getDOM",
       "getDeclarationTNode",
+      "getDeclarationView",
       "getDirectiveDef",
       "getDocument",
       "getElementDepthCount",

--- a/packages/core/test/bundling/create_component/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/create_component/bundle.golden_symbols.json
@@ -404,6 +404,7 @@
       "getCurrentTNodePlaceholderOk",
       "getDOM",
       "getDeclarationTNode",
+      "getDeclarationView",
       "getDirectiveDef",
       "getDocument",
       "getFactoryDef",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -446,6 +446,7 @@
       "getCurrentTNode",
       "getCurrentTNodePlaceholderOk",
       "getDeclarationTNode",
+      "getDeclarationView",
       "getDeferBlockDataIndex",
       "getDirectiveDef",
       "getDocument",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -591,6 +591,7 @@
       "getCurrentTNodePlaceholderOk",
       "getDOM",
       "getDeclarationTNode",
+      "getDeclarationView",
       "getDirectiveDef",
       "getDocument",
       "getElementDepthCount",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -587,6 +587,7 @@
       "getCurrentTNodePlaceholderOk",
       "getDOM",
       "getDeclarationTNode",
+      "getDeclarationView",
       "getDirectiveDef",
       "getDocument",
       "getElementDepthCount",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -564,6 +564,7 @@
       "getCurrentTNodePlaceholderOk",
       "getDOM",
       "getDeclarationTNode",
+      "getDeclarationView",
       "getDeferBlockDataIndex",
       "getDirectiveDef",
       "getDocument",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -663,6 +663,7 @@
       "getData",
       "getDataKeys",
       "getDeclarationTNode",
+      "getDeclarationView",
       "getDirectiveDef",
       "getDocument",
       "getElementDepthCount",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -372,6 +372,7 @@
       "getCurrentTNodePlaceholderOk",
       "getDOM",
       "getDeclarationTNode",
+      "getDeclarationView",
       "getDirectiveDef",
       "getDocument",
       "getFactoryDef",


### PR DESCRIPTION
Fixes #69291

## Summary

`animate.leave` is skipped — the element is removed from the DOM synchronously instead of running its leave animation — whenever a **sibling instance of the same template enters in a different DOM parent during the same change-detection tick**. This is the common "close section A while opening section B" pattern: accordions, tab groups, exclusive-expansion menus, master/detail navigation, where A and B are two instances of the same child component. It is a regression introduced in 21.2.0; it worked in 21.1.x.

## Root cause

`leavingNodes` (`packages/core/src/animation/utils.ts`) is keyed by `TNode`, which is part of the compiled `TView` and is therefore **shared by every instance** of a template. So the animated element in instance A and the one in instance B map to the same `TNode` bucket.

On insert, `applyToElementOrContainer` calls `cancelLeavingNodes(tNode, enteringEl)`. Its cross-parent branch:

```ts
} else if (
  (prevSibling && leavingEl === prevSibling) ||
  (leavingParent && newParent && leavingParent !== newParent)   // ← the problem
) {
  nodes.splice(i, 1);
  leavingEl.dispatchEvent(new CustomEvent('animationend', {detail: {cancel: true}}));
  leavingEl.parentNode?.removeChild(leavingEl);                 // ← synchronous removal
}
```

The `leavingParent !== newParent` removal was added in #67032 to de-duplicate a single dynamic component re-rendered into a fresh overlay/portal parent (e.g. CDK Overlay). But "different parent" is *also* the normal situation for two legitimate sibling instances, so it produces a false positive: A's still-animating element is force-removed because its host differs from B's host. (#67361 later rescued the node-move case via `leavingEl === newElement`, but the cross-parent removal for *distinct* sibling elements was untouched.)

## The fix

The collision is purely a matter of tracking by `TNode` with no instance identity. We add instance identity:

- `leavingNodes` now stores `{el, declarationView}` per leaving node instead of a bare `HTMLElement`.
- `trackLeavingNodes` (called from the Detach branch, which has the leaving node's `LView`) records the **declaration view** (`lView[DECLARATION_VIEW] ?? lView`) of the leaving element.
- `cancelLeavingNodes` (called from the Insert branch, which has the entering node's `LView`) resolves the entering node's declaration view and only performs the **cross-parent** removal when it matches the leaving node's declaration view — i.e. the *same logical view* re-rendered. Distinct instances of a shared template have different declaration views, so they are left alone and their `animate.leave` runs to completion.

The declaration view (rather than the rendered `LView`, which is a fresh object on every re-render) is used so the same logical insertion point compares equal across re-renders while distinct instances compare unequal. When no owning view is known on either side, the original (conservative) removal behavior is kept.

The `prevSibling` (same-position `@if`/VCR toggle) branch and the `leavingEl === newElement` (drag-and-drop node move, #67361) branch are unchanged.

### Why this preserves #67032 and #67361

- **#67032 (dynamic component in overlay-like containers):** each `open()` re-creates the embedded view from the *same* `ViewContainerRef` on the *same* component instance, so every embedded view's `DECLARATION_VIEW` is the same component `LView`. `newDeclarationView === leavingDeclarationView` holds, so the cross-parent removal still fires and the duplicate is removed. Its acceptance test ("should not duplicate elements when using dynamic components in overlay-like containers") passes.
- **#67361 (drag-and-drop node move):** handled by the earlier `leavingEl === newElement` branch, which is untouched.

## New regression test

Added to `packages/core/test/acceptance/animation_spec.ts` in the existing `animation element duplication` suite: *"should run animate.leave for a sibling instance when another instance of the same template enters"*. It renders two instances of one component (panels sharing a `TNode`), closes A and opens B in the same tick, and asserts A's panel stays connected to the DOM (leave animation running) until its `animationend`, instead of being removed synchronously.

I verified this test **fails on `main`** ("Expected false to be true" at the `leavingPanelA.isConnected` assertion — A removed synchronously) and **passes with the fix**.

## Local verification

Built and tested with Bazel locally (Node 22.22.3, pnpm 11.5.2):

- `//packages/core/test/acceptance:acceptance_web_chromium` — **PASS** (2658 passed incl. the new test; the existing #67032 overlay-dedup test green)
- `//packages/core/test/acceptance:acceptance_web_firefox` — **PASS**
- `//packages/core/test/acceptance:acceptance` (Node/jasmine) — **PASS**
- Confirmed the new test **fails without** the source fix and **passes with** it.
- Bundle-size golden symbol tests: the new internal helper `getDeclarationView` survives tree-shaking, so the 8 affected `bundle.golden_symbols.json` files were updated via the `:symbol_test.accept` targets; all 8 `symbol_test`s pass.
- `prettier --check` passes on all changed source/test files.

Not run locally: the full repository test matrix and the `integration/animations` e2e harness (could not bring up the integration browser tooling in this environment). CI will cover those.

## Uncertainty for reviewers

- The discriminator is the **declaration view**. I confirmed empirically (via the two acceptance tests passing simultaneously) that it distinguishes the overlay re-render case from distinct sibling instances. If there is an overlay/portal scenario where the duplicate is re-rendered from a *different* declaring view than the leaving one, the cross-parent removal would no longer fire for it; I could not construct such a case, and the existing #67032 test does not exercise one, but maintainers may know of one.
- The new helper adds one symbol (`getDeclarationView`) to the animation-containing bundles. The golden updates are mechanical, but flagging the size delta explicitly.