### PR TITLE
fix(docs-infra): use a facade for docs-video to fix Firefox embeds

### DIFF
--- a/adev/shared-docs/components/viewers/BUILD.bazel
+++ b/adev/shared-docs/components/viewers/BUILD.bazel
@@ -71,6 +71,7 @@ ts_project(
         "//adev/shared-docs/interfaces",
         "//adev/shared-docs/providers",
         "//adev/shared-docs/services",
+        "//adev/shared-docs/utils",
     ],
 )
 

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
@@ -20,6 +20,7 @@ import {CopySourceCodeButton} from '../../copy-source-code-button/copy-source-co
 import {CopyLinkButton} from '../../copy-link-anchor/copy-link-anchor.component';
 import {TableOfContents} from '../../table-of-contents/table-of-contents.component';
 import {Clipboard} from '@angular/cdk/clipboard';
+import {isFirefox} from '../../../utils';
 
 describe('DocViewer', () => {
   let exampleContentSpy: jasmine.SpyObj<ExampleViewerContentLoader>;
@@ -62,6 +63,23 @@ describe('DocViewer', () => {
         <code>
           <div class="hljs-ln-line"></div>
         </code>
+    </div>
+  `;
+
+  const exampleContentWithVideoFacade = `
+    <div class="docs-video-container">
+      <a
+        class="docs-video-facade"
+        href="https://www.youtube.com/watch?v=abc123&autoplay=1"
+        target="_blank"
+        rel="noopener"
+        aria-label="Play video: Test video"
+        data-video-src="https://www.youtube.com/embed/abc123"
+        data-video-title="Test video"
+      >
+        <img class="docs-video-thumbnail" src="https://i.ytimg.com/vi/abc123/maxresdefault.jpg" alt="" loading="lazy" />
+        <span class="docs-video-play-button" aria-hidden="true"></span>
+      </a>
     </div>
   `;
 
@@ -236,5 +254,26 @@ describe('DocViewer', () => {
     // Because the copyButton click bubbles up to an anchor tag, causing a navigation, it is
     // necessary to undo this location change by going back in the history.
     window.history.back();
+  });
+
+  it('should upgrade a video facade to an iframe in browsers that can embed it', async () => {
+    const fixture = TestBed.createComponent(DocViewer);
+    fixture.componentRef.setInput('docContent', exampleContentWithVideoFacade);
+
+    await fixture.whenStable();
+
+    const iframe = fixture.nativeElement.querySelector('iframe.docs-video');
+    const facade = fixture.nativeElement.querySelector('a.docs-video-facade');
+
+    if (isFirefox) {
+      // Firefox can't load the cross-origin embed under COEP, so the facade stays a link.
+      expect(facade).toBeTruthy();
+      expect(iframe).toBeNull();
+    } else {
+      expect(iframe).toBeTruthy();
+      expect(iframe.getAttribute('src')).toContain('youtube.com/embed/abc123');
+      expect(iframe.hasAttribute('credentialless')).toBeTrue();
+      expect(facade).toBeNull();
+    }
   });
 });

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -31,7 +31,7 @@ import {Router} from '@angular/router';
 import {fromEvent} from 'rxjs';
 import {Snippet} from '../../../interfaces';
 import {NavigationState, TOC_SKIP_CONTENT_MARKER} from '../../../services';
-import {handleHrefClickEventWithRouter} from '../../../utils';
+import {handleHrefClickEventWithRouter, isFirefox} from '../../../utils';
 import {IconComponent} from '../../icon/icon.component';
 import {TableOfContents} from '../../table-of-contents/table-of-contents.component';
 
@@ -124,6 +124,7 @@ export class DocViewer {
       // In case when content contains tabs, create tabs component and move
       // content in a tab into tab panel.
       this.constructTabs(contentContainer);
+      this.setupVideoFacades(contentContainer);
     }
 
     // Display Breadcrumb component if the `<docs-breadcrumb>` element exists
@@ -410,6 +411,38 @@ export class DocViewer {
       const tabGroupRef = this.viewContainer.createComponent(TabGroup);
       tabGroupRef.setInput('tabs', tabs);
       tabGroup.parentElement!.replaceChild(tabGroupRef.location.nativeElement, tabGroup);
+    }
+  }
+
+  private setupVideoFacades(element: HTMLElement): void {
+    const facades = element.querySelectorAll<HTMLAnchorElement>('a.docs-video-facade');
+
+    for (const facade of Array.from(facades)) {
+      const src = facade.getAttribute('data-video-src');
+      if (!src) {
+        continue;
+      }
+
+      if (isFirefox) {
+        const thumbnail = facade.querySelector<HTMLImageElement>('img.docs-video-thumbnail');
+        thumbnail?.addEventListener(
+          'error',
+          () => {
+            thumbnail.src = thumbnail.src.replace('maxresdefault', 'hqdefault');
+          },
+          {once: true},
+        );
+        continue;
+      }
+
+      const iframe = this.document.createElement('iframe');
+      iframe.className = 'docs-video';
+      iframe.src = src;
+      iframe.title = facade.getAttribute('data-video-title') ?? 'Video player';
+      iframe.setAttribute('allow', 'accelerometer; encrypted-media; gyroscope; picture-in-picture');
+      iframe.setAttribute('allowfullscreen', '');
+      iframe.setAttribute('credentialless', '');
+      facade.replaceWith(iframe);
     }
   }
 }

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-video.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-video.mts
@@ -53,17 +53,33 @@ export const docsVideoExtension = {
       );
     }
 
+    const videoId = /\/embed\/([^/?#]+)/.exec(token.src)?.[1];
+    const watchUrl = videoId ? `https://www.youtube.com/watch?v=${videoId}&autoplay=1` : token.src;
+    const thumbnail = videoId ? `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg` : '';
+    const label = token.title ? `Play video: ${token.title}` : 'Play video';
+
     return `
     <div class="docs-video-container">
-      <iframe
-      class="docs-video"
-      src="${token.src}"
-      ${token.title ? `title="${token.title}"` : ''}
-      allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
-      allowfullscreen
-      credentialless
-      title="Video player"
-      ></iframe>
+      <a
+        class="docs-video-facade"
+        href="${watchUrl}"
+        target="_blank"
+        rel="noopener"
+        aria-label="${label}"
+        data-video-src="${token.src}"
+        ${token.title ? `data-video-title="${token.title}"` : ''}
+      >
+        <img class="docs-video-thumbnail" src="${thumbnail}" alt="" loading="lazy" />
+        <span class="docs-video-play-button" aria-hidden="true">
+          <svg viewBox="0 0 68 48" width="68" height="48">
+            <path
+              class="docs-video-play-button-bg"
+              d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z"
+            />
+            <path d="M45 24 27 14v20z" fill="#fff" />
+          </svg>
+        </span>
+      </a>
     </div>
     `;
   },

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-video/docs-video.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-video/docs-video.spec.mts
@@ -20,15 +20,20 @@ describe('markdown to html', () => {
     markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, rendererContext));
   });
 
-  it('should create an iframe in a container', () => {
+  it('should create a video facade in a container', () => {
     const videoContainerEl = markdownDocument.querySelector('.docs-video-container')!;
-    const iframeEl = videoContainerEl.children[0];
+    const facadeEl = videoContainerEl.children[0];
 
     expect(videoContainerEl.children.length).toBe(1);
 
-    expect(iframeEl.nodeName).toBe('IFRAME');
-    expect(iframeEl.getAttribute('src')).toBeTruthy();
-    expect(iframeEl.classList.contains('docs-video')).toBeTrue();
-    expect(iframeEl.getAttribute('title')).toBeTruthy();
+    expect(facadeEl.nodeName).toBe('A');
+    expect(facadeEl.classList.contains('docs-video-facade')).toBeTrue();
+    expect(facadeEl.getAttribute('href')).toContain('youtube.com/watch?v=');
+    expect(facadeEl.getAttribute('data-video-src')).toBeTruthy();
+
+    const thumbnailEl = facadeEl.querySelector('img.docs-video-thumbnail');
+    expect(thumbnailEl?.getAttribute('src')).toContain('i.ytimg.com');
+
+    expect(facadeEl.querySelector('.docs-video-play-button')).toBeTruthy();
   });
 });

--- a/adev/shared-docs/styles/_colors.scss
+++ b/adev/shared-docs/styles/_colors.scss
@@ -32,6 +32,7 @@ $gray-50: oklch(98.81% 0 0); // #fbfbfb
   --hot-pink-header: oklch(59.91% 0.239 8.14); // #e90464
   --hot-red: oklch(61.42% 0.238 15.34); // #f11653
   --orange-red: oklch(63.32% 0.24 31.68); // #fa2c04
+  --always-red: oklch(62.8% 0.2577 29.23); // #ff0000
   --super-green: oklch(79.12% 0.257 155.13); // #00c572 // Used for success, merge additions, etc.
 
   --deprecated-light: oklch(95% 0.02 304.04); // Base color

--- a/adev/shared-docs/styles/docs/_video.scss
+++ b/adev/shared-docs/styles/docs/_video.scss
@@ -1,3 +1,5 @@
+@use '../colors' as colors;
+
 @mixin docs-video() {
   .docs-video-container {
     iframe {
@@ -6,6 +8,49 @@
       border-radius: 0.25rem;
       overflow: hidden;
       aspect-ratio: 16 / 9;
+    }
+
+    .docs-video-facade {
+      position: relative;
+      display: block;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      border-radius: 0.25rem;
+      overflow: hidden;
+      cursor: pointer;
+    }
+
+    .docs-video-thumbnail {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      object-fit: cover;
+      display: block;
+    }
+
+    .docs-video-play-button {
+      position: absolute;
+      inset: 0;
+      margin: auto;
+      width: 68px;
+      height: 48px;
+
+      svg {
+        width: 100%;
+        height: 100%;
+      }
+
+      .docs-video-play-button-bg {
+        fill: colors.$gray-800;
+        fill-opacity: 0.8;
+        transition: fill-opacity 0.2s ease;
+      }
+    }
+
+    .docs-video-facade:hover .docs-video-play-button-bg,
+    .docs-video-facade:focus-visible .docs-video-play-button-bg {
+      fill: var(--always-red);
+      fill-opacity: 1;
     }
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/angular/angular/pull/69205. After switching adev's COEP to `credentialless`, the
cross-origin YouTube iframe in `<docs-video>` loads in Chromium and Safari but
not Firefox, whose `credentialless` policy does not extend to nested frames. The
result was a COEP error screen instead of the player.

Render `<docs-video>` as a lightweight thumbnail facade instead of embedding the
iframe directly. The thumbnail is a cross-origin subresource, so it loads under
`credentialless` in every browser. `DocViewer` then upgrades the facade to the
inline player on hydration in browsers that can load the embed (Chromium,
Safari), preserving the previous behavior there. On Firefox the facade stays a
plain link that opens the video on YouTube (with autoplay), which replaces the
error screen.

The thumbnail uses `maxresdefault` and falls back to `hqdefault` when a video
has no max-resolution image.
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Follow-up to #69205 (see also #55310). adev is cross-origin isolated with
`COEP: credentialless`. The cross-origin YouTube iframe in `<docs-video>` loads
in Chromium and Safari, but Firefox's `credentialless` policy does not cover
nested frames, so the embed is blocked and the reader sees a COEP error screen
instead of the video.

## What is the new behavior?

`<docs-video>` now renders a lightweight thumbnail facade (a YouTube poster
image plus a play button) rather than embedding the iframe directly:

- The thumbnail is a cross-origin subresource, so it loads under
  `credentialless` in every browser, including Firefox.
- On hydration, `DocViewer` swaps the facade for the inline iframe in browsers
  that can load the embed (Chromium, Safari), using the same iframe attributes
  as before, so their behavior is unchanged.
- On Firefox the facade remains a link that opens the video on YouTube (with
  `autoplay=1`), replacing the error screen.
- The thumbnail requests `maxresdefault` and falls back to `hqdefault` when a
  video lacks a max-resolution image.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
