### PR TITLE
refactor(core): ComponentDef should allow abstract types too

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
@@ -736,7 +736,7 @@ export {};
 /****************************************************************************************************
  * PARTIAL FILE: abstract_directive.js
  ****************************************************************************************************/
-import { Directive } from '@angular/core';
+import { Component, Directive } from '@angular/core';
 import * as i0 from "@angular/core";
 export class AbstractDir {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AbstractDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
@@ -748,6 +748,17 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     selector: '[test-dir]',
                 }]
         }] });
+export class AbstractComp {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AbstractComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: AbstractComp, isStandalone: true, selector: "test-comp", ngImport: i0, template: '', isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AbstractComp, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'test-comp',
+                    template: ''
+                }]
+        }] });
 
 /****************************************************************************************************
  * PARTIAL FILE: abstract_directive.d.ts
@@ -756,5 +767,9 @@ import * as i0 from "@angular/core";
 export declare abstract class AbstractDir {
     static ɵfac: i0.ɵɵFactoryDeclaration<AbstractDir, never>;
     static ɵdir: i0.ɵɵDirectiveDeclaration<AbstractDir, "[test-dir]", never, {}, {}, never, never, true, never>;
+}
+export declare abstract class AbstractComp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<AbstractComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<AbstractComp, "test-comp", never, {}, {}, never, never, true, never>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/abstract_directive.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/abstract_directive.js
@@ -1,4 +1,4 @@
-import { Directive } from '@angular/core';
+import { Component, Directive } from '@angular/core';
 import * as i0 from "@angular/core";
 
 …
@@ -12,5 +12,14 @@ export class AbstractDir {
     type: AbstractDir,
     selectors: [["", "test-dir", ""]]
   });
+}
+…
+export class AbstractComp {
+  …
+  static ɵfac = function AbstractComp_Factory(__ngFactoryType__) {
+    …
+    return new (__ngFactoryType__ || AbstractComp)();
+  };
+    …
 }
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/abstract_directive.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/abstract_directive.ts
@@ -1,7 +1,14 @@
-import {Directive} from '@angular/core';
+import {Component, Directive} from '@angular/core';
 
 @Directive({
   selector: '[test-dir]',
 })
 export abstract class AbstractDir {
+}
+
+@Component({
+  selector: 'test-comp',
+  template: ''
+})
+export abstract class AbstractComp {
 }

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -16,7 +16,7 @@ import {
 import {Injector} from '../di/injector';
 import {EnvironmentInjector} from '../di/r3_injector';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
-import {Type} from '../interface/type';
+import {AbstractType, Type} from '../interface/type';
 import {ComponentRef as AbstractComponentRef} from '../linker/component_factory';
 import {createElementRef, ElementRef} from '../linker/element_ref';
 import {NgModuleRef} from '../linker/ng_module_factory';
@@ -111,7 +111,7 @@ function verifyNotAnOrphanComponent(componentDef: ComponentDef<unknown>) {
     (typeof ngJitMode === 'undefined' || ngJitMode) &&
     componentDef.debugInfo?.forbidOrphanRendering
   ) {
-    if (depsTracker.isOrphanComponent(componentDef.type)) {
+    if (depsTracker.isOrphanComponent(componentDef.type as Type<any>)) {
       throw new RuntimeError(
         RuntimeErrorCode.RUNTIME_DEPS_ORPHAN_COMPONENT,
         `Orphan component found! Trying to render the component ${debugStringifyTypeForError(
@@ -234,7 +234,7 @@ export class ComponentFactory<T> {
     private componentDef: ComponentDef<any>,
     private ngModule?: NgModuleRef<any>,
   ) {
-    this.componentType = componentDef.type;
+    this.componentType = componentDef.type as Type<any>;
     this.selector = stringifyCSSSelectorList(componentDef.selectors);
     this.ngContentSelectors = componentDef.ngContentSelectors ?? [];
     this.isBoundToModule = !!ngModule;

--- a/packages/core/src/render3/debug/set_debug_info.ts
+++ b/packages/core/src/render3/debug/set_debug_info.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Type} from '../../interface/type';
+import {AbstractType, Type} from '../../interface/type';
 import {getComponentDef} from '../def_getters';
 import {ClassDebugInfo} from '../interfaces/definition';
 
@@ -15,7 +15,10 @@ import {ClassDebugInfo} from '../interfaces/definition';
  *
  * This runtime is guarded by ngDevMode flag.
  */
-export function ɵsetClassDebugInfo(type: Type<any>, debugInfo: ClassDebugInfo): void {
+export function ɵsetClassDebugInfo(
+  type: Type<any> | AbstractType<any>,
+  debugInfo: ClassDebugInfo,
+): void {
   const def = getComponentDef(type);
   if (def !== null) {
     def.debugInfo = debugInfo;

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -215,9 +215,6 @@ interface DirectiveDefinition<T> {
 }
 
 interface ComponentDefinition<T> extends Omit<DirectiveDefinition<T>, 'features'> {
-  /** Component type, needed to configure the injector. */
-  type: Type<T>;
-
   /**
    * The number of nodes, local refs, and pipes in this component template.
    *
@@ -347,7 +344,6 @@ export function ɵɵdefineComponent<T>(
     const baseDef = getNgDirectiveDef(componentDefinition as DirectiveDefinition<T>);
     const def: Writable<ComponentDef<T>> = {
       ...baseDef,
-      type: componentDefinition.type,
       decls: componentDefinition.decls,
       vars: componentDefinition.vars,
       template: componentDefinition.template,
@@ -680,7 +676,7 @@ export function extractDefListOrFactory<T>(
 /**
  * A map that contains the generated component IDs and type.
  */
-export const GENERATED_COMP_IDS = new Map<string, Type<unknown>>();
+export const GENERATED_COMP_IDS = new Map<string, Type<unknown> | AbstractType<unknown>>();
 
 /**
  * A method can returns a component ID from the component definition using a variant of DJB2 hash

--- a/packages/core/src/render3/errors.ts
+++ b/packages/core/src/render3/errors.ts
@@ -7,7 +7,7 @@
  */
 
 import {RuntimeError, RuntimeErrorCode} from '../errors';
-import {Type} from '../interface/type';
+import {AbstractType, Type} from '../interface/type';
 
 import {getComponentDef} from './def_getters';
 import {getDeclarationComponentDef} from './instructions/element_validation';
@@ -37,7 +37,7 @@ export function assertStandaloneComponentType(type: Type<unknown>) {
 }
 
 /** Verifies whether a given type is a component */
-export function assertComponentDef(type: Type<unknown>) {
+export function assertComponentDef(type: Type<unknown> | AbstractType<unknown>) {
   if (!getComponentDef(type)) {
     throw new RuntimeError(
       RuntimeErrorCode.MISSING_GENERATED_DEF,
@@ -50,8 +50,8 @@ export function assertComponentDef(type: Type<unknown>) {
 /** Called when there are multiple component selectors that match a given node */
 export function throwMultipleComponentError(
   tNode: TNode,
-  first: Type<unknown>,
-  second: Type<unknown>,
+  first: Type<unknown> | AbstractType<unknown>,
+  second: Type<unknown> | AbstractType<unknown>,
 ): never {
   throw new RuntimeError(
     RuntimeErrorCode.MULTIPLE_COMPONENTS_MATCH,

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -295,9 +295,6 @@ export interface DirectiveDef<T> {
  * See: {@link defineComponent}
  */
 export interface ComponentDef<T> extends DirectiveDef<T> {
-  /** Token representing the component. Used by DI. */
-  readonly type: Type<T>;
-
   /**
    * Unique ID for the component. Used in view encapsulation and
    * to keep track of the injector in standalone components.

--- a/packages/core/src/render3/jit/partial.ts
+++ b/packages/core/src/render3/jit/partial.ts
@@ -19,7 +19,7 @@ import {
   R3DeclarePipeFacade,
   R3DeclareServiceFacade,
 } from '../../compiler/compiler_facade';
-import {Type} from '../../interface/type';
+import {AbstractType, Type} from '../../interface/type';
 import {setClassMetadata, setClassMetadataAsync} from '../metadata';
 
 import {angularCoreEnv} from './environment';
@@ -75,10 +75,14 @@ export function ɵɵngDeclareClassMetadataAsync(decl: {
     propDecorators: {[field: string]: any} | null;
   };
 }): void {
-  setClassMetadataAsync(decl.type, decl.resolveDeferredDeps, (...types: Type<unknown>[]) => {
-    const meta = decl.resolveMetadata(...types);
-    setClassMetadata(decl.type, meta.decorators, meta.ctorParameters, meta.propDecorators);
-  });
+  setClassMetadataAsync(
+    decl.type,
+    decl.resolveDeferredDeps,
+    (...types: (Type<unknown> | AbstractType<unknown>)[]) => {
+      const meta = decl.resolveMetadata(...(types as Type<unknown>[]));
+      setClassMetadata(decl.type, meta.decorators, meta.ctorParameters, meta.propDecorators);
+    },
+  );
 }
 
 /**

--- a/packages/core/src/render3/metadata.ts
+++ b/packages/core/src/render3/metadata.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Type} from '../interface/type';
+import {AbstractType, Type} from '../interface/type';
 import {noSideEffects} from '../util/closure';
 
 interface TypeWithMetadata extends Type<any> {
@@ -58,10 +58,10 @@ export function hasAsyncClassMetadata(type: Type<unknown>): boolean {
  * @param metadataSetterFn Function that forms a scope in which the `setClassMetadata` is invoked
  */
 export function setClassMetadataAsync(
-  type: Type<any>,
-  dependencyLoaderFn: () => Array<Promise<Type<unknown>>>,
-  metadataSetterFn: (...types: Type<unknown>[]) => void,
-): () => Promise<Array<Type<unknown>>> {
+  type: Type<any> | AbstractType<any>,
+  dependencyLoaderFn: () => Array<Promise<Type<unknown> | AbstractType<unknown>>>,
+  metadataSetterFn: (...types: (Type<unknown> | AbstractType<unknown>)[]) => void,
+): () => Promise<Array<Type<unknown> | AbstractType<unknown>>> {
   const componentClass = type as any; // cast to `any`, so that we can monkey-patch it
   componentClass[ASYNC_COMPONENT_METADATA_FN] = () =>
     Promise.all(dependencyLoaderFn()).then((dependencies) => {


### PR DESCRIPTION
d1539a8513402877357887d62304ffb4b45091b4 incorrectly assumed components wouldn't be abstract but it is still possible (though probably should be an abstract directive instead).
