### PR TITLE
Respect cache directives and avoid request deduplication for unhashed assets

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -16,6 +16,22 @@ import {AssetGroupConfig} from './manifest';
 import {NamedCache} from './named-cache-storage';
 import {sha1Binary} from './sha1';
 
+const UNCACHEABLE_CACHE_CONTROL_DIRECTIVES = new Set(['no-store', 'private', 'no-cache']);
+
+function hasUncacheableCacheControl(headers: Headers): boolean {
+  const cacheControl = headers.get('cache-control');
+
+  if (!cacheControl) {
+    return false;
+  }
+
+  return cacheControl.split(',').some((directive) => {
+    const directiveName = directive.split('=', 1)[0].trim().toLowerCase();
+
+    return UNCACHEABLE_CACHE_CONTROL_DIRECTIVES.has(directiveName);
+  });
+}
+
 /**
  * A group of assets that are cached in a `Cache` and managed by a given policy.
  *
@@ -151,16 +167,20 @@ export abstract class AssetGroup {
           // the response.
           return cachedResponse;
         } else {
-          // This resource has no hash, and yet exists in the cache. Check how old this request is
-          // to make sure it's still usable.
-          if (await this.needToRevalidate(req, cachedResponse)) {
-            this.idle.schedule(`revalidate(${cache.name}): ${req.url}`, async () => {
-              await this.fetchAndCacheOnce(req);
-            });
-          }
+          if (hasUncacheableCacheControl(cachedResponse.headers)) {
+            await this.removeCachedResource(req, cache);
+          } else {
+            // This resource has no hash, and yet exists in the cache. Check how old this request
+            // is to make sure it's still usable.
+            if (await this.needToRevalidate(req, cachedResponse)) {
+              this.idle.schedule(`revalidate(${cache.name}): ${req.url}`, async () => {
+                await this.fetchAndCacheOnce(req);
+              });
+            }
 
-          // In either case (revalidation or not), the cached response must be good.
-          return cachedResponse;
+            // In either case (revalidation or not), the cached response must be good.
+            return cachedResponse;
+          }
         }
       }
 
@@ -298,6 +318,8 @@ export abstract class AssetGroup {
    * Fetch the given resource from the network, and cache it if able.
    */
   protected async fetchAndCacheOnce(req: Request, used: boolean = true): Promise<Response> {
+    const url = this.adapter.normalizeUrl(req.url);
+
     // The `inFlightRequests` map holds information about which caching operations are currently
     // underway for known resources. If this request appears there, another "thread" is already
     // in the process of caching it, and this work should not be duplicated.
@@ -327,6 +349,10 @@ export abstract class AssetGroup {
         throw new Error(
           `Response not Ok (fetchAndCacheOnce): request for ${req.url} returned response ${res.status} ${res.statusText}`,
         );
+      }
+
+      if (!this.hashes.has(url) && hasUncacheableCacheControl(res.headers)) {
+        return res;
       }
 
       try {
@@ -381,6 +407,15 @@ export abstract class AssetGroup {
     }
 
     return res;
+  }
+
+  private async removeCachedResource(req: Request, cache: Cache): Promise<void> {
+    await cache.delete(req, this.config.cacheQueryOptions);
+
+    if (!this.hashes.has(this.adapter.normalizeUrl(req.url))) {
+      const metaTable = await this.metadata;
+      await metaTable.delete(req.url);
+    }
   }
 
   /**
@@ -645,6 +680,10 @@ export class PrefetchAssetGroup extends AssetGroup {
           const res = await updateFrom.lookupResourceWithoutHash(url);
           if (res === null || res.metadata === undefined) {
             // Unexpected, but not harmful.
+            return;
+          }
+
+          if (hasUncacheableCacheControl(res.response.headers)) {
             return;
           }
 

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -319,11 +319,12 @@ export abstract class AssetGroup {
    */
   protected async fetchAndCacheOnce(req: Request, used: boolean = true): Promise<Response> {
     const url = this.adapter.normalizeUrl(req.url);
+    const shouldDeduplicate = this.hashes.has(url);
 
     // The `inFlightRequests` map holds information about which caching operations are currently
-    // underway for known resources. If this request appears there, another "thread" is already
+    // underway for hashed resources. If this request appears there, another "thread" is already
     // in the process of caching it, and this work should not be duplicated.
-    if (this.inFlightRequests.has(req.url)) {
+    if (shouldDeduplicate && this.inFlightRequests.has(req.url)) {
       // There is a caching operation already in progress for this request. Wait for it to
       // complete, and hopefully it will have yielded a useful response.
       return this.inFlightRequests.get(req.url)!;
@@ -335,7 +336,9 @@ export abstract class AssetGroup {
 
     // Save this operation in `inFlightRequests` so any other "thread" attempting to cache it
     // will block on this chain instead of duplicating effort.
-    this.inFlightRequests.set(req.url, fetchOp);
+    if (shouldDeduplicate) {
+      this.inFlightRequests.set(req.url, fetchOp);
+    }
 
     // Make sure this attempt is cleaned up properly on failure.
     try {
@@ -385,7 +388,9 @@ export abstract class AssetGroup {
     } finally {
       // Finally, it can be removed from `inFlightRequests`. This might result in a double-remove
       // if some other chain was already making this request too, but that won't hurt anything.
-      this.inFlightRequests.delete(req.url);
+      if (shouldDeduplicate) {
+        this.inFlightRequests.delete(req.url);
+      }
     }
   }
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1812,6 +1812,36 @@ import {envIsSupported} from '../testing/utils';
         server.assertNoOtherRequests();
       });
 
+      it('does not deduplicate concurrent unhashed requests', async () => {
+        server.pause();
+
+        const firstNetworkRequest = server.nextRequest;
+        const [firstResponse, firstDone] = scope.handleFetch(
+          new MockRequest('/unhashed/a.txt'),
+          'default',
+        );
+        await firstNetworkRequest;
+
+        const secondNetworkRequest = server.nextRequest;
+        const [secondResponse, secondDone] = scope.handleFetch(
+          new MockRequest('/unhashed/a.txt'),
+          'default',
+        );
+        let sawSecondNetworkRequest = false;
+        secondNetworkRequest.then(() => (sawSecondNetworkRequest = true));
+        await new Promise((resolve) => setTimeout(resolve)); // Wait for async operations to complete.
+        expect(sawSecondNetworkRequest).toBeTrue();
+
+        server.unpause();
+        await Promise.all([firstDone, secondDone]);
+
+        expect(await (await firstResponse)?.text()).toEqual('this is unhashed');
+        expect(await (await secondResponse)?.text()).toEqual('this is unhashed');
+        server.assertSawRequestFor('/unhashed/a.txt');
+        server.assertSawRequestFor('/unhashed/a.txt');
+        server.assertNoOtherRequests();
+      });
+
       const uncacheableUnhashedResponses: {
         description: string;
         url: string;

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -43,6 +43,14 @@ import {envIsSupported} from '../testing/utils';
     .addFile('/lazy/redirect-target.txt', 'this was a redirect too')
     .addUnhashedFile('/unhashed/a.txt', 'this is unhashed', {'Cache-Control': 'max-age=10'})
     .addUnhashedFile('/unhashed/b.txt', 'this is unhashed b', {'Cache-Control': 'no-cache'})
+    .addUnhashedFile('/unhashed/no-store.txt', 'this is no-store', {
+      'Cache-Control': 'no-store, max-age=60',
+      Pragma: 'no-cache',
+      Expires: '0',
+    })
+    .addUnhashedFile('/unhashed/private.txt', 'this is private', {
+      'Cache-Control': 'private, max-age=60',
+    })
     .addUnhashedFile('/api/foo', 'this is api foo', {'Cache-Control': 'no-cache'})
     .addUnhashedFile('/api-static/bar', 'this is static api bar', {'Cache-Control': 'no-cache'})
     .build();
@@ -58,6 +66,15 @@ import {envIsSupported} from '../testing/utils';
     .addFile('/lazy/unchanged1.txt', 'this is unchanged (1)')
     .addFile('/lazy/unchanged2.txt', 'this is unchanged (2)')
     .addUnhashedFile('/unhashed/a.txt', 'this is unhashed v2', {'Cache-Control': 'max-age=10'})
+    .addUnhashedFile('/unhashed/b.txt', 'this is unhashed b v2', {'Cache-Control': 'no-cache'})
+    .addUnhashedFile('/unhashed/no-store.txt', 'this is no-store v2', {
+      'Cache-Control': 'no-store, max-age=60',
+      Pragma: 'no-cache',
+      Expires: '0',
+    })
+    .addUnhashedFile('/unhashed/private.txt', 'this is private v2', {
+      'Cache-Control': 'private, max-age=60',
+    })
     .addUnhashedFile('/ignored/file1', 'this is not handled by the SW')
     .addUnhashedFile('/ignored/dir/file2', 'this is not handled by the SW either')
     .build();
@@ -1795,11 +1812,75 @@ import {envIsSupported} from '../testing/utils';
         server.assertNoOtherRequests();
       });
 
-      it(`don't error when 'Cache-Control' is 'no-cache'`, async () => {
-        expect(await makeRequest(scope, '/unhashed/b.txt')).toEqual('this is unhashed b');
-        server.assertSawRequestFor('/unhashed/b.txt');
-        expect(await makeRequest(scope, '/unhashed/b.txt')).toEqual('this is unhashed b');
-        server.assertNoOtherRequests();
+      const uncacheableUnhashedResponses: {
+        description: string;
+        url: string;
+        first: string;
+        second: string;
+        firstInit?: Object;
+        secondInit?: Object;
+      }[] = [
+        {
+          description: '`Cache-Control: no-cache`',
+          url: '/unhashed/b.txt',
+          first: 'this is unhashed b',
+          second: 'this is unhashed b v2',
+        },
+        {
+          description: '`Cache-Control: no-store`',
+          url: '/unhashed/no-store.txt',
+          first: 'this is no-store',
+          second: 'this is no-store v2',
+          secondInit: {cache: 'no-store'},
+        },
+        {
+          description: '`Cache-Control: private`',
+          url: '/unhashed/private.txt',
+          first: 'this is private',
+          second: 'this is private v2',
+        },
+      ];
+
+      uncacheableUnhashedResponses.forEach(
+        ({description, url, first, second, firstInit, secondInit}) => {
+          it(`do not cache responses with ${description}`, async () => {
+            expect(await makeRequest(scope, url, 'default', firstInit)).toEqual(first);
+            server.assertSawRequestFor(url);
+            server.assertNoOtherRequests();
+            expect(await scope.caches.original.match(new MockRequest(url))).toBeUndefined();
+
+            scope.updateServerState(serverUpdate);
+
+            expect(await makeRequest(scope, url, 'default', secondInit)).toEqual(second);
+            serverUpdate.assertSawRequestFor(url);
+            serverUpdate.assertNoOtherRequests();
+            expect(await scope.caches.original.match(new MockRequest(url))).toBeUndefined();
+          });
+        },
+      );
+
+      it(`does not serve a previously cached response with 'Cache-Control: no-store'`, async () => {
+        const cache = await scope.caches.open(`${manifestHash}:assets:assets:cache`);
+        await cache.put(
+          new MockRequest('/unhashed/no-store.txt'),
+          new MockResponse('stale no-store response', {
+            headers: {'Cache-Control': 'no-store'},
+          }),
+        );
+        expect(
+          await scope.caches.original.match(new MockRequest('/unhashed/no-store.txt')),
+        ).toBeDefined();
+
+        scope.updateServerState(serverUpdate);
+
+        expect(
+          await makeRequest(scope, '/unhashed/no-store.txt', 'default', {cache: 'no-store'}),
+        ).toEqual('this is no-store v2');
+        serverUpdate.assertSawRequestFor('/unhashed/no-store.txt');
+        serverUpdate.assertNoOtherRequests();
+        expect(
+          await scope.caches.original.match(new MockRequest('/unhashed/no-store.txt')),
+        ).toBeUndefined();
       });
 
       it('avoid opaque responses', async () => {


### PR DESCRIPTION
###  fix(service-worker): avoid caching private unhashed assets
Respect Cache-Control directives for unhashed asset resources and skip CacheStorage writes for responses marked no-store or private. Evict existing unsafe cached entries before fetching from the network.

More context https://issuetracker.google.com/u/1/issues/522520490

###  fix(service-worker): deduplicate only hashed asset fetches
Limit URL-based in-flight request deduplication to hashed asset resources. Unhashed runtime resources may vary by session, so concurrent requests should fetch independently.