### PR TITLE
docs(forms): update package docs for Signal Forms graduation

### DIFF
--- a/packages/forms/PACKAGE.md
+++ b/packages/forms/PACKAGE.md
@@ -12,12 +12,15 @@ Angular forms allow you to:
 - Validate the correctness of user input.
 - Create custom validators and input elements.
 
-You can build forms in one of two ways:
+You can build forms in one of three ways:
 
 - _Reactive forms_ use existing instances of a `FormControl` or `FormGroup` to build a form model. This form
   model is synced with form input elements through directives to track and communicate changes back to the form model. Changes
   to the value and status of the controls are provided as observables.
 - _Template-driven forms_ rely on directives such as `NgModel` and `NgModelGroup` create the form model for you,
   so any changes to the form are communicated through the template.
+- _Signal forms_ use the `form()` function to build a form model from a signal that holds your data, with a
+  `schema()` that declares validation and other logic. This form model is synced with form input elements
+  through the `[formField]` directive. The value and status of the form are exposed as signals.
 
 @see Find out more in the [Forms Overview](guide/forms).

--- a/packages/forms/signals/PACKAGE.md
+++ b/packages/forms/signals/PACKAGE.md
@@ -1,37 +1,11 @@
-# 🚧 Experimental Signal-Based Forms API 🏗️
+# Signal-based forms API
 
-This directory contains an experimental new Angular Forms API built on top of
-[signals](https://angular.dev/guide/signals). We're using this experimental API to explore potential
-designs for such a system, to play with new ideas, identify challenges, and to demonstrate
-interoperability with the existing version of `@angular/forms`.
+This directory contains the signal-based Angular forms API, built on top of
+[signals](https://angular.dev/guide/signals). It is an alternative to template-driven and reactive
+forms that keeps signals at its core, and interoperates with the existing `@angular/forms` APIs.
 
 ## Not yet supported
 
 - Debouncing validation
 - Dynamic objects
 - Tuples
-- Interop with Reactive/Template forms
-- Strongly-typed binding to UI controls
-
-## FAQs
-
-### Why are you working on this?
-
-We've been exploring ways that we can integrate signals into Angular's forms package. We've looked
-at several options, including integrating signals into template and reactive forms, and designing a
-new flavor of forms with signals at the core. Our hope is that we can leverage this work to close
-the gap between template and reactive forms, which often inspires debate in the Angular ecosystem.
-
-### What does this mean for the future of template and/or reactive forms?
-
-Nothing is changing yet with template and reactive forms. This API is early and still highly experimental.
-
-Even if we achieve our goals, we will roll out any changes to forms incrementally. Like with NgModules
-and `standalone`, we don't intend to deprecate template or reactive forms without a clear sign from
-our community that the ecosystem is fully on board.
-
-### Will I need to rewrite my application code to use the new forms system?
-
-No - a non-negotiable design goal of a new signal-based forms system is interoperability with
-existing forms code and applications. It should be possible to incrementally start using the new
-system in existing applications, and as always we will explore the possibility of automated migrations.


### PR DESCRIPTION
After #68581 graduated the Signal Forms APIs to public API and #68654 removed the experimental warnings from the Signal Forms documentation in adev, the package READMEs still framed the API as experimental.

Update `packages/forms/signals/PACKAGE.md`: drop the experimental title and intro, remove the now-shipped entries from "Not yet supported" (interop with reactive/template forms and strongly-typed binding to UI controls), and remove the remaining experimental and exploratory wording from the FAQ.

Update `packages/forms/PACKAGE.md`: it listed only two ways to build forms (reactive and template-driven). Add signal forms as the third.

Fixes #68724

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Fixes #68724. Post-graduation (#68581, #68654), the forms package READMEs still
framed Signal Forms as experimental, and `packages/forms/PACKAGE.md` listed only
two ways to build forms.

## What is the new behavior?

- `packages/forms/signals/PACKAGE.md` de-experimentalized (title, intro,
  "Not yet supported" list, FAQ).
- `packages/forms/PACKAGE.md` now lists three ways to build forms, adding signal
  forms with its `form()` / `schema()` / `[formField]` primitives.

Authored and verified with: adev-writing-guide, reference-signal-forms, pr_review,

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
