### PR TITLE
refactor: optimize dom security schema lookups

### DIFF
--- a/packages/compiler/src/schema/dom_element_schema_registry.ts
+++ b/packages/compiler/src/schema/dom_element_schema_registry.ts
@@ -10,7 +10,7 @@ import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata, SecurityContex
 import {isNgContainer, isNgContent, splitNsName} from '../ml_parser/tags';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from '../template/pipeline/src/namespaces';
 import {dashCaseToCamelCase} from '../util';
-import {checkSecurityContext, SECURITY_SCHEMA} from './dom_security_schema';
+import {checkSecurityContext} from './dom_security_schema';
 import {ElementSchemaRegistry} from './element_schema_registry';
 
 const BOOLEAN = 'boolean';

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -36,89 +36,96 @@ export enum SecurityContext {
 // =================================================================================================
 
 /**
- *  Map from tagName|propertyName to SecurityContext. Properties applying to all tags use '*'.
+ * Map from property name to namespace and tag name to SecurityContext.
+ * Properties applying to all tags use '*'.
+ * Properties applying to all namespaces use ''.
  */
-let _SECURITY_SCHEMA!: {[k: string]: SecurityContext};
+let _SECURITY_SCHEMA!: Record<string, Record<string, Record<string, SecurityContext>>>;
 const SVG_NAMESPACE = 'svg';
 const MATH_ML_NAMESPACE = 'math';
+const NO_NAMESPACE = '';
+const MATCH_ALL_ELEMENTS = '*';
 
 /**
  * @remarks Keep is a copy of DOM Security Schema.
  * @see [SECURITY_SCHEMA](../../../compiler/src/schema/dom_security_schema.ts)
  */
-export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
-  if (!_SECURITY_SCHEMA) {
-    _SECURITY_SCHEMA = {};
-    // Case is insignificant below, all element and attribute names are lower-cased for lookup.
-
-    registerContext(SecurityContext.HTML, /** Namespace */ undefined, [
-      ['iframe', ['srcdoc']],
-      ['*', ['innerHTML', 'outerHTML']],
-    ]);
-    registerContext(SecurityContext.STYLE, /** Namespace */ undefined, [['*', ['style']]]);
-    // NB: no SCRIPT contexts here, they are never allowed due to the parser stripping them.
-    registerContext(SecurityContext.URL, /** Namespace */ undefined, [
-      ['*', ['formAction']],
-      ['area', ['href']],
-      ['a', ['href', 'xlink:href']],
-      ['form', ['action']],
-
-      // The below two items are safe and should be removed but they require a G3 clean-up as a small number of tests fail.
-      ['img', ['src']],
-      ['video', ['src']],
-    ]);
-
-    registerContext(SecurityContext.URL, MATH_ML_NAMESPACE, [
-      // MathML namespace
-      // https://crsrc.org/c/third_party/blink/renderer/core/sanitizer/sanitizer.cc;l=753-768;drc=b3eb16372dcd3317d65e9e0265015e322494edcd;bpv=1;bpt=1
-      ['*', ['href', 'xlink:href']],
-    ]);
-
-    registerContext(SecurityContext.RESOURCE_URL, /** Namespace */ undefined, [
-      ['base', ['href']],
-      ['embed', ['src']],
-      ['frame', ['src']],
-      ['iframe', ['src']],
-      ['link', ['href']],
-      ['object', ['codebase', 'data']],
-    ]);
-
-    registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]]);
-
-    // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
-    // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)
-    // and the directive can be applied to multiple different elements (with different tag names). In this case we generate
-    // a special instruction that an attribute might potentially be security-sensitive and defer the actual security check
-    // to runtime, when we apply that directive to a concrete elements, thus we can check the combination of tag+attribute
-    // against the set that requires sanitization.
-    // These are unsafe as `attributeName` can be `href` or `xlink:href`
-    // See: http://b/463880509#comment7
-    registerContext(SecurityContext.ATTRIBUTE_NO_BINDING, SVG_NAMESPACE, [
-      ['animate', ['attributeName', 'values', 'to', 'from']],
-      ['set', ['to', 'attributeName']],
-      ['animateMotion', ['attributeName']],
-      ['animateTransform', ['attributeName']],
-    ]);
-
-    registerContext(SecurityContext.ATTRIBUTE_NO_BINDING, /** Namespace */ undefined, [
-      [
-        'unknown',
-        [
-          'attributeName',
-          'values',
-          'to',
-          'from',
-          'sandbox',
-          'allow',
-          'allowFullscreen',
-          'referrerPolicy',
-          'csp',
-          'fetchPriority',
-        ],
-      ],
-      ['iframe', ['sandbox', 'allow', 'allowFullscreen', 'referrerPolicy', 'csp', 'fetchPriority']],
-    ]);
+export function SECURITY_SCHEMA(): Record<string, Record<string, Record<string, SecurityContext>>> {
+  if (_SECURITY_SCHEMA) {
+    return _SECURITY_SCHEMA;
   }
+
+  _SECURITY_SCHEMA = {};
+
+  // Case is insignificant below, all element and attribute names are lower-cased for lookup.
+
+  registerContext(SecurityContext.HTML, /** Namespace */ undefined, [
+    ['iframe', ['srcdoc']],
+    ['*', ['innerHTML', 'outerHTML']],
+  ]);
+  registerContext(SecurityContext.STYLE, /** Namespace */ undefined, [['*', ['style']]]);
+  // NB: no SCRIPT contexts here, they are never allowed due to the parser stripping them.
+  registerContext(SecurityContext.URL, /** Namespace */ undefined, [
+    ['*', ['formAction']],
+    ['area', ['href']],
+    ['a', ['href', 'xlink:href']],
+    ['form', ['action']],
+
+    // The below two items are safe and should be removed but they require a G3 clean-up as a small number of tests fail.
+    ['img', ['src']],
+    ['video', ['src']],
+  ]);
+
+  registerContext(SecurityContext.URL, MATH_ML_NAMESPACE, [
+    // MathML namespace
+    // https://crsrc.org/c/third_party/blink/renderer/core/sanitizer/sanitizer.cc;l=753-768;drc=b3eb16372dcd3317d65e9e0265015e322494edcd;bpv=1;bpt=1
+    ['*', ['href', 'xlink:href']],
+  ]);
+
+  registerContext(SecurityContext.RESOURCE_URL, /** Namespace */ undefined, [
+    ['base', ['href']],
+    ['embed', ['src']],
+    ['frame', ['src']],
+    ['iframe', ['src']],
+    ['link', ['href']],
+    ['object', ['codebase', 'data']],
+  ]);
+
+  registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]]);
+
+  // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
+  // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)
+  // and the directive can be applied to multiple different elements (with different tag names). In this case we generate
+  // a special instruction that an attribute might potentially be security-sensitive and defer the actual security check
+  // to runtime, when we apply that directive to a concrete elements, thus we can check the combination of tag+attribute
+  // against the set that requires sanitization.
+  // These are unsafe as `attributeName` can be `href` or `xlink:href`
+  // See: http://b/463880509#comment7
+  registerContext(SecurityContext.ATTRIBUTE_NO_BINDING, SVG_NAMESPACE, [
+    ['animate', ['attributeName', 'values', 'to', 'from']],
+    ['set', ['to', 'attributeName']],
+    ['animateMotion', ['attributeName']],
+    ['animateTransform', ['attributeName']],
+  ]);
+
+  registerContext(SecurityContext.ATTRIBUTE_NO_BINDING, /** Namespace */ undefined, [
+    [
+      'unknown',
+      [
+        'attributeName',
+        'values',
+        'to',
+        'from',
+        'sandbox',
+        'allow',
+        'allowFullscreen',
+        'referrerPolicy',
+        'csp',
+        'fetchPriority',
+      ],
+    ],
+    ['iframe', ['sandbox', 'allow', 'allowFullscreen', 'referrerPolicy', 'csp', 'fetchPriority']],
+  ]);
 
   return _SECURITY_SCHEMA;
 }
@@ -128,15 +135,15 @@ function registerContext(
   namespace: string | undefined,
   specs: readonly [tagName: string, attributeNames: readonly string[]][],
 ): void {
+  const nsKey = namespace ?? NO_NAMESPACE;
   for (const [element, attributeNames] of specs) {
-    let tagName = element;
-    if (namespace && element !== 'unknown') {
-      tagName = `:${namespace}:${element}`;
-    }
-    tagName = tagName.toLowerCase();
+    const tagName = element.toLowerCase();
 
     for (const attr of attributeNames) {
-      _SECURITY_SCHEMA[`${tagName}|${attr.toLowerCase()}`] = ctx;
+      const attrLower = attr.toLowerCase();
+      const attrSchema = (_SECURITY_SCHEMA[attrLower] ??= {});
+      const nsSchema = (attrSchema[nsKey] ??= {});
+      nsSchema[tagName] = ctx;
     }
   }
 }
@@ -153,21 +160,27 @@ export function checkSecurityContext(
   namespace?: string | null,
 ): SecurityContext {
   const securitySchema = SECURITY_SCHEMA();
-  propName = propName.toLowerCase();
-  tagName = tagName.toLowerCase();
-
-  let namespacedTag = tagName;
-  let nsWildcardTag: string | undefined;
-
-  if (namespace === SVG_NAMESPACE || namespace === MATH_ML_NAMESPACE) {
-    namespacedTag = `:${namespace}:${tagName}`;
-    nsWildcardTag = `:${namespace}:*`;
+  const attrSchema = securitySchema[propName.toLowerCase()];
+  if (!attrSchema) {
+    return SecurityContext.NONE;
   }
 
-  return (
-    securitySchema[namespacedTag + '|' + propName] ??
-    (nsWildcardTag !== undefined ? securitySchema[nsWildcardTag + '|' + propName] : undefined) ??
-    securitySchema['*|' + propName] ??
-    SecurityContext.NONE
-  );
+  const tagLower = tagName.toLowerCase();
+  let context: SecurityContext | undefined;
+
+  if (namespace) {
+    const nsSchema = attrSchema[namespace];
+    if (nsSchema) {
+      context = nsSchema[tagLower] ?? nsSchema[MATCH_ALL_ELEMENTS];
+    }
+  }
+
+  if (context === undefined) {
+    const defaultSchema = attrSchema[NO_NAMESPACE];
+    if (defaultSchema) {
+      context = defaultSchema[tagLower] ?? defaultSchema[MATCH_ALL_ELEMENTS];
+    }
+  }
+
+  return context ?? SecurityContext.NONE;
 }

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -36,11 +36,26 @@ export enum SecurityContext {
 // =================================================================================================
 
 /**
- * Map from property name to namespace and tag name to SecurityContext.
- * Properties applying to all tags use '*'.
- * Properties applying to all namespaces use ''.
+ * A security schema mapping property or attribute names to namespaces,
+ * tag names, and finally their corresponding `SecurityContext`.
+ *
+ * - The first level keys are lowercase property or attribute names (e.g., `'href'`, `'srcdoc'`).
+ * - The second level keys are lowercase namespaces (e.g., `''` for HTML/default, `'svg'`, `'math'`).
+ * - The third level keys are lowercase tag names (e.g., `'a'`, `'iframe'`, or `'*'` for all elements)
+ *   mapping to the appropriate `SecurityContext` value.
  */
-let _SECURITY_SCHEMA!: Record<string, Record<string, Record<string, SecurityContext>>>;
+type SecuritySchema = Record<
+  string, // Property/Attribute Name
+  Record<
+    string, // Namespace
+    Record<
+      string, // Tag Name
+      SecurityContext
+    >
+  >
+>;
+
+let _SECURITY_SCHEMA!: SecuritySchema;
 const SVG_NAMESPACE = 'svg';
 const MATH_ML_NAMESPACE = 'math';
 const NO_NAMESPACE = '';
@@ -50,7 +65,7 @@ const MATCH_ALL_ELEMENTS = '*';
  * @remarks Keep is a copy of DOM Security Schema.
  * @see [SECURITY_SCHEMA](../../../compiler/src/schema/dom_security_schema.ts)
  */
-export function SECURITY_SCHEMA(): Record<string, Record<string, Record<string, SecurityContext>>> {
+export function SECURITY_SCHEMA(): SecuritySchema {
   if (_SECURITY_SCHEMA) {
     return _SECURITY_SCHEMA;
   }

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -60,6 +60,7 @@ const SVG_NAMESPACE = 'svg';
 const MATH_ML_NAMESPACE = 'math';
 const NO_NAMESPACE = '';
 const MATCH_ALL_ELEMENTS = '*';
+const createNullObj = () => Object.create(null);
 
 /**
  * @remarks Keep is a copy of DOM Security Schema.
@@ -70,7 +71,7 @@ export function SECURITY_SCHEMA(): SecuritySchema {
     return _SECURITY_SCHEMA;
   }
 
-  _SECURITY_SCHEMA = {};
+  _SECURITY_SCHEMA = createNullObj();
 
   // Case is insignificant below, all element and attribute names are lower-cased for lookup.
 
@@ -156,8 +157,8 @@ function registerContext(
 
     for (const attr of attributeNames) {
       const attrLower = attr.toLowerCase();
-      const attrSchema = (_SECURITY_SCHEMA[attrLower] ??= {});
-      const nsSchema = (attrSchema[nsKey] ??= {});
+      const attrSchema = (_SECURITY_SCHEMA[attrLower] ??= createNullObj());
+      const nsSchema = (attrSchema[nsKey] ??= createNullObj());
       nsSchema[tagName] = ctx;
     }
   }

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -1003,7 +1003,7 @@ function splitNsName(elementName: string, fatal: boolean = true): [string | null
 }
 
 function i18nResolveSanitizer(attrName: string, tagName?: string): SanitizerFn | null {
-  let schemaContext = SecurityContext.NONE;
+  let schemaContext: SecurityContext;
 
   if (tagName) {
     const [ns, name] = splitNsName(tagName, false);

--- a/packages/core/src/sanitization/dom_security_schema.ts
+++ b/packages/core/src/sanitization/dom_security_schema.ts
@@ -36,89 +36,96 @@ export enum SecurityContext {
 // =================================================================================================
 
 /**
- *  Map from tagName|propertyName to SecurityContext. Properties applying to all tags use '*'.
+ * Map from property name to namespace and tag name to SecurityContext.
+ * Properties applying to all tags use '*'.
+ * Properties applying to all namespaces use ''.
  */
-let _SECURITY_SCHEMA!: {[k: string]: SecurityContext};
+let _SECURITY_SCHEMA!: Record<string, Record<string, Record<string, SecurityContext>>>;
 const SVG_NAMESPACE = 'svg';
 const MATH_ML_NAMESPACE = 'math';
+const NO_NAMESPACE = '';
+const MATCH_ALL_ELEMENTS = '*';
 
 /**
  * @remarks Keep is a copy of DOM Security Schema.
  * @see [SECURITY_SCHEMA](../../../compiler/src/schema/dom_security_schema.ts)
  */
-export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
-  if (!_SECURITY_SCHEMA) {
-    _SECURITY_SCHEMA = {};
-    // Case is insignificant below, all element and attribute names are lower-cased for lookup.
-
-    registerContext(SecurityContext.HTML, /** Namespace */ undefined, [
-      ['iframe', ['srcdoc']],
-      ['*', ['innerHTML', 'outerHTML']],
-    ]);
-    registerContext(SecurityContext.STYLE, /** Namespace */ undefined, [['*', ['style']]]);
-    // NB: no SCRIPT contexts here, they are never allowed due to the parser stripping them.
-    registerContext(SecurityContext.URL, /** Namespace */ undefined, [
-      ['*', ['formAction']],
-      ['area', ['href']],
-      ['a', ['href', 'xlink:href']],
-      ['form', ['action']],
-
-      // The below two items are safe and should be removed but they require a G3 clean-up as a small number of tests fail.
-      ['img', ['src']],
-      ['video', ['src']],
-    ]);
-
-    registerContext(SecurityContext.URL, MATH_ML_NAMESPACE, [
-      // MathML namespace
-      // https://crsrc.org/c/third_party/blink/renderer/core/sanitizer/sanitizer.cc;l=753-768;drc=b3eb16372dcd3317d65e9e0265015e322494edcd;bpv=1;bpt=1
-      ['*', ['href', 'xlink:href']],
-    ]);
-
-    registerContext(SecurityContext.RESOURCE_URL, /** Namespace */ undefined, [
-      ['base', ['href']],
-      ['embed', ['src']],
-      ['frame', ['src']],
-      ['iframe', ['src']],
-      ['link', ['href']],
-      ['object', ['codebase', 'data']],
-    ]);
-
-    registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]]);
-
-    // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
-    // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)
-    // and the directive can be applied to multiple different elements (with different tag names). In this case we generate
-    // a special instruction that an attribute might potentially be security-sensitive and defer the actual security check
-    // to runtime, when we apply that directive to a concrete elements, thus we can check the combination of tag+attribute
-    // against the set that requires sanitization.
-    // These are unsafe as `attributeName` can be `href` or `xlink:href`
-    // See: http://b/463880509#comment7
-    registerContext(SecurityContext.ATTRIBUTE_NO_BINDING, SVG_NAMESPACE, [
-      ['animate', ['attributeName', 'values', 'to', 'from']],
-      ['set', ['to', 'attributeName']],
-      ['animateMotion', ['attributeName']],
-      ['animateTransform', ['attributeName']],
-    ]);
-
-    registerContext(SecurityContext.ATTRIBUTE_NO_BINDING, /** Namespace */ undefined, [
-      [
-        'unknown',
-        [
-          'attributeName',
-          'values',
-          'to',
-          'from',
-          'sandbox',
-          'allow',
-          'allowFullscreen',
-          'referrerPolicy',
-          'csp',
-          'fetchPriority',
-        ],
-      ],
-      ['iframe', ['sandbox', 'allow', 'allowFullscreen', 'referrerPolicy', 'csp', 'fetchPriority']],
-    ]);
+export function SECURITY_SCHEMA(): Record<string, Record<string, Record<string, SecurityContext>>> {
+  if (_SECURITY_SCHEMA) {
+    return _SECURITY_SCHEMA;
   }
+
+  _SECURITY_SCHEMA = {};
+
+  // Case is insignificant below, all element and attribute names are lower-cased for lookup.
+
+  registerContext(SecurityContext.HTML, /** Namespace */ undefined, [
+    ['iframe', ['srcdoc']],
+    ['*', ['innerHTML', 'outerHTML']],
+  ]);
+  registerContext(SecurityContext.STYLE, /** Namespace */ undefined, [['*', ['style']]]);
+  // NB: no SCRIPT contexts here, they are never allowed due to the parser stripping them.
+  registerContext(SecurityContext.URL, /** Namespace */ undefined, [
+    ['*', ['formAction']],
+    ['area', ['href']],
+    ['a', ['href', 'xlink:href']],
+    ['form', ['action']],
+
+    // The below two items are safe and should be removed but they require a G3 clean-up as a small number of tests fail.
+    ['img', ['src']],
+    ['video', ['src']],
+  ]);
+
+  registerContext(SecurityContext.URL, MATH_ML_NAMESPACE, [
+    // MathML namespace
+    // https://crsrc.org/c/third_party/blink/renderer/core/sanitizer/sanitizer.cc;l=753-768;drc=b3eb16372dcd3317d65e9e0265015e322494edcd;bpv=1;bpt=1
+    ['*', ['href', 'xlink:href']],
+  ]);
+
+  registerContext(SecurityContext.RESOURCE_URL, /** Namespace */ undefined, [
+    ['base', ['href']],
+    ['embed', ['src']],
+    ['frame', ['src']],
+    ['iframe', ['src']],
+    ['link', ['href']],
+    ['object', ['codebase', 'data']],
+  ]);
+
+  registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]]);
+
+  // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
+  // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)
+  // and the directive can be applied to multiple different elements (with different tag names). In this case we generate
+  // a special instruction that an attribute might potentially be security-sensitive and defer the actual security check
+  // to runtime, when we apply that directive to a concrete elements, thus we can check the combination of tag+attribute
+  // against the set that requires sanitization.
+  // These are unsafe as `attributeName` can be `href` or `xlink:href`
+  // See: http://b/463880509#comment7
+  registerContext(SecurityContext.ATTRIBUTE_NO_BINDING, SVG_NAMESPACE, [
+    ['animate', ['attributeName', 'values', 'to', 'from']],
+    ['set', ['to', 'attributeName']],
+    ['animateMotion', ['attributeName']],
+    ['animateTransform', ['attributeName']],
+  ]);
+
+  registerContext(SecurityContext.ATTRIBUTE_NO_BINDING, /** Namespace */ undefined, [
+    [
+      'unknown',
+      [
+        'attributeName',
+        'values',
+        'to',
+        'from',
+        'sandbox',
+        'allow',
+        'allowFullscreen',
+        'referrerPolicy',
+        'csp',
+        'fetchPriority',
+      ],
+    ],
+    ['iframe', ['sandbox', 'allow', 'allowFullscreen', 'referrerPolicy', 'csp', 'fetchPriority']],
+  ]);
 
   return _SECURITY_SCHEMA;
 }
@@ -128,15 +135,15 @@ function registerContext(
   namespace: string | undefined,
   specs: readonly [tagName: string, attributeNames: readonly string[]][],
 ): void {
+  const nsKey = namespace ?? NO_NAMESPACE;
   for (const [element, attributeNames] of specs) {
-    let tagName = element;
-    if (namespace && element !== 'unknown') {
-      tagName = `:${namespace}:${element}`;
-    }
-    tagName = tagName.toLowerCase();
+    const tagName = element.toLowerCase();
 
     for (const attr of attributeNames) {
-      _SECURITY_SCHEMA[`${tagName}|${attr.toLowerCase()}`] = ctx;
+      const attrLower = attr.toLowerCase();
+      const attrSchema = (_SECURITY_SCHEMA[attrLower] ??= {});
+      const nsSchema = (attrSchema[nsKey] ??= {});
+      nsSchema[tagName] = ctx;
     }
   }
 }
@@ -153,21 +160,27 @@ export function checkSecurityContext(
   namespace?: string | null,
 ): SecurityContext {
   const securitySchema = SECURITY_SCHEMA();
-  propName = propName.toLowerCase();
-  tagName = tagName.toLowerCase();
-
-  let namespacedTag = tagName;
-  let nsWildcardTag: string | undefined;
-
-  if (namespace === SVG_NAMESPACE || namespace === MATH_ML_NAMESPACE) {
-    namespacedTag = `:${namespace}:${tagName}`;
-    nsWildcardTag = `:${namespace}:*`;
+  const attrSchema = securitySchema[propName.toLowerCase()];
+  if (!attrSchema) {
+    return SecurityContext.NONE;
   }
 
-  return (
-    securitySchema[namespacedTag + '|' + propName] ??
-    (nsWildcardTag !== undefined ? securitySchema[nsWildcardTag + '|' + propName] : undefined) ??
-    securitySchema['*|' + propName] ??
-    SecurityContext.NONE
-  );
+  const tagLower = tagName.toLowerCase();
+  let context: SecurityContext | undefined;
+
+  if (namespace) {
+    const nsSchema = attrSchema[namespace];
+    if (nsSchema) {
+      context = nsSchema[tagLower] ?? nsSchema[MATCH_ALL_ELEMENTS];
+    }
+  }
+
+  if (context === undefined) {
+    const defaultSchema = attrSchema[NO_NAMESPACE];
+    if (defaultSchema) {
+      context = defaultSchema[tagLower] ?? defaultSchema[MATCH_ALL_ELEMENTS];
+    }
+  }
+
+  return context ?? SecurityContext.NONE;
 }

--- a/packages/core/src/sanitization/dom_security_schema.ts
+++ b/packages/core/src/sanitization/dom_security_schema.ts
@@ -36,11 +36,26 @@ export enum SecurityContext {
 // =================================================================================================
 
 /**
- * Map from property name to namespace and tag name to SecurityContext.
- * Properties applying to all tags use '*'.
- * Properties applying to all namespaces use ''.
+ * A security schema mapping property or attribute names to namespaces,
+ * tag names, and finally their corresponding `SecurityContext`.
+ *
+ * - The first level keys are lowercase property or attribute names (e.g., `'href'`, `'srcdoc'`).
+ * - The second level keys are lowercase namespaces (e.g., `''` for HTML/default, `'svg'`, `'math'`).
+ * - The third level keys are lowercase tag names (e.g., `'a'`, `'iframe'`, or `'*'` for all elements)
+ *   mapping to the appropriate `SecurityContext` value.
  */
-let _SECURITY_SCHEMA!: Record<string, Record<string, Record<string, SecurityContext>>>;
+type SecuritySchema = Record<
+  string, // Property/Attribute Name
+  Record<
+    string, // Namespace
+    Record<
+      string, // Tag Name
+      SecurityContext
+    >
+  >
+>;
+
+let _SECURITY_SCHEMA!: SecuritySchema;
 const SVG_NAMESPACE = 'svg';
 const MATH_ML_NAMESPACE = 'math';
 const NO_NAMESPACE = '';
@@ -50,7 +65,7 @@ const MATCH_ALL_ELEMENTS = '*';
  * @remarks Keep is a copy of DOM Security Schema.
  * @see [SECURITY_SCHEMA](../../../compiler/src/schema/dom_security_schema.ts)
  */
-export function SECURITY_SCHEMA(): Record<string, Record<string, Record<string, SecurityContext>>> {
+export function SECURITY_SCHEMA(): SecuritySchema {
   if (_SECURITY_SCHEMA) {
     return _SECURITY_SCHEMA;
   }

--- a/packages/core/src/sanitization/dom_security_schema.ts
+++ b/packages/core/src/sanitization/dom_security_schema.ts
@@ -60,6 +60,7 @@ const SVG_NAMESPACE = 'svg';
 const MATH_ML_NAMESPACE = 'math';
 const NO_NAMESPACE = '';
 const MATCH_ALL_ELEMENTS = '*';
+const createNullObj = () => Object.create(null);
 
 /**
  * @remarks Keep is a copy of DOM Security Schema.
@@ -70,7 +71,7 @@ export function SECURITY_SCHEMA(): SecuritySchema {
     return _SECURITY_SCHEMA;
   }
 
-  _SECURITY_SCHEMA = {};
+  _SECURITY_SCHEMA = createNullObj();
 
   // Case is insignificant below, all element and attribute names are lower-cased for lookup.
 
@@ -156,8 +157,8 @@ function registerContext(
 
     for (const attr of attributeNames) {
       const attrLower = attr.toLowerCase();
-      const attrSchema = (_SECURITY_SCHEMA[attrLower] ??= {});
-      const nsSchema = (attrSchema[nsKey] ??= {});
+      const attrSchema = (_SECURITY_SCHEMA[attrLower] ??= createNullObj());
+      const nsSchema = (attrSchema[nsKey] ??= createNullObj());
       nsSchema[tagName] = ctx;
     }
   }

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -116,20 +116,27 @@ describe('sanitization', () => {
       [SecurityContext.URL, ɵɵsanitizeUrl],
       [SecurityContext.RESOURCE_URL, ɵɵsanitizeResourceUrl],
     ]);
-    Object.entries(schema).forEach(([key, context]) => {
-      if (context === SecurityContext.URL || context === SecurityContext.RESOURCE_URL) {
-        const [tag, prop] = key.split('|');
-        const contexts = contextsByProp.get(prop) || new Set<number>();
-        contexts.add(context);
-        contextsByProp.set(prop, contexts);
-        // check only in case a prop can be a part of both URL contexts
-        if (contexts.size === 2) {
-          expect(getUrlSanitizer(tag, prop))
-            .withContext(`key: ${key}, context: ${context}`)
-            .toEqual(sanitizerNameByContext.get(context)!);
+
+    for (const [prop, nsSchema] of Object.entries(schema)) {
+      for (const [ns, tagSchema] of Object.entries(nsSchema)) {
+        for (const [tag, context] of Object.entries(tagSchema)) {
+          if (context !== SecurityContext.URL && context !== SecurityContext.RESOURCE_URL) {
+            continue;
+          }
+
+          const contexts = contextsByProp.get(prop) || new Set<number>();
+          contexts.add(context);
+          contextsByProp.set(prop, contexts);
+
+          // check only in case a prop can be a part of both URL contexts
+          if (contexts.size === 2) {
+            expect(getUrlSanitizer(tag, prop))
+              .withContext(`ns: ${ns}, tag: ${tag}, prop: ${prop}, context: ${context}`)
+              .toEqual(sanitizerNameByContext.get(context)!);
+          }
         }
       }
-    });
+    }
   });
 
   it('should select URL sanitizer case-insensitively', () => {


### PR DESCRIPTION
Restructure the security schema map to index by property name instead of tag name, improving lookup efficiency.

Reviwer note: use `hidewhite space` https://github.com/angular/angular/pull/69307/changes?w=1