### PR TITLE
fix(forms): update status classes once deferred registration resolves the control

### DIFF
--- a/packages/forms/src/directives/abstract_control_directive.ts
+++ b/packages/forms/src/directives/abstract_control_directive.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {computed, signal} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {AbstractControl} from '../model/abstract_model';
@@ -35,6 +36,22 @@ export abstract class AbstractControlDirective {
    * @returns the control that backs this directive. Most properties fall through to that instance.
    */
   abstract get control(): AbstractControl | null;
+
+  /**
+   * Set once the underlying control has been resolved by a deferred registration
+   * (see `NgForm.addControl` and `NgForm.addFormGroup`). Status host bindings read
+   * this signal so that views are re-checked when the control becomes available,
+   * even if `control` was still `null` when the bindings were first evaluated.
+   *
+   * @internal
+   */
+  readonly _controlResolved = computed(() => this.controlResolvedReactive());
+  private readonly controlResolvedReactive = signal(false);
+
+  /** @internal */
+  _markControlResolved(): void {
+    this.controlResolvedReactive.set(true);
+  }
 
   /**
    * @description

--- a/packages/forms/src/directives/ng_control_status.ts
+++ b/packages/forms/src/directives/ng_control_status.ts
@@ -26,6 +26,8 @@ export class AbstractControlStatus {
   }
 
   protected get isTouched() {
+    // re-evaluate once a deferred registration resolves the control
+    this._cd?._controlResolved();
     // track the touched signal
     this._cd?.control?._touched?.();
     return !!this._cd?.control?.touched;
@@ -36,6 +38,8 @@ export class AbstractControlStatus {
   }
 
   protected get isPristine() {
+    // re-evaluate once a deferred registration resolves the control
+    this._cd?._controlResolved();
     // track the pristine signal
     this._cd?.control?._pristine?.();
     return !!this._cd?.control?.pristine;
@@ -47,6 +51,8 @@ export class AbstractControlStatus {
   }
 
   protected get isValid() {
+    // re-evaluate once a deferred registration resolves the control
+    this._cd?._controlResolved();
     // track the status signal
     this._cd?.control?._status?.();
     return !!this._cd?.control?.valid;

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -233,6 +233,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
       dir._setupWithForm(this.callSetDisabledState);
       dir.control.updateValueAndValidity({emitEvent: false});
       this._directives.add(dir);
+      dir._markControlResolved();
     });
   }
 
@@ -275,6 +276,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
       setUpFormContainer(group, dir);
       container.registerControl(dir.name, group);
       group.updateValueAndValidity({emitEvent: false});
+      dir._markControlResolved();
     });
   }
 

--- a/packages/forms/test/ng_control_status_spec.ts
+++ b/packages/forms/test/ng_control_status_spec.ts
@@ -6,8 +6,20 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, provideZonelessChangeDetection} from '@angular/core';
-import {FormControl, FormsModule, ReactiveFormsModule, Validators} from '../public_api';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  provideZonelessChangeDetection,
+  ViewChild,
+} from '@angular/core';
+import {
+  ControlContainer,
+  FormControl,
+  FormsModule,
+  NgForm,
+  ReactiveFormsModule,
+  Validators,
+} from '../public_api';
 import {TestBed} from '@angular/core/testing';
 
 describe('status host binding classes', () => {
@@ -43,5 +55,63 @@ describe('status host binding classes', () => {
     fixture.componentInstance.control.reset();
     await fixture.whenStable();
     expect(fixture.nativeElement.innerHTML).toContain('ng-untouched');
+  });
+
+  it('update on ngModelGroup hosts in OnPush components when the group has no rendered controls', async () => {
+    @Component({
+      selector: 'collapsed-group',
+      // A "collapsed section": the group host renders, its controls do not.
+      template: `<div class="group" ngModelGroup="section">collapsed</div>`,
+      imports: [FormsModule],
+      viewProviders: [{provide: ControlContainer, useExisting: NgForm}],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class CollapsedGroup {}
+
+    @Component({
+      selector: 'test-cmp',
+      template: `<form><collapsed-group /></form>`,
+      imports: [FormsModule, CollapsedGroup],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class App {
+      @ViewChild(NgForm) ngForm!: NgForm;
+    }
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    // The group is registered by `NgForm` in a deferred microtask; the host
+    // bindings must still pick the state up once it lands.
+    const group = fixture.nativeElement.querySelector('.group');
+    expect(group.classList.contains('ng-valid')).toBe(true);
+    expect(group.classList.contains('ng-untouched')).toBe(true);
+    expect(group.classList.contains('ng-pristine')).toBe(true);
+
+    // Later model-only changes must keep being reflected: nothing inside the
+    // group's view ever writes a tracked signal, so this only works if the
+    // first binding pass created a dependency.
+    fixture.componentInstance.ngForm.form.markAllAsTouched();
+    await fixture.whenStable();
+    expect(group.classList.contains('ng-touched')).toBe(true);
+    expect(group.classList.contains('ng-untouched')).toBe(false);
+  });
+
+  it('update on the form host in OnPush components before any control registers', async () => {
+    @Component({
+      selector: 'test-cmp',
+      template: `<form class="form"></form>`,
+      imports: [FormsModule],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    const form = fixture.nativeElement.querySelector('.form');
+    expect(form.classList.contains('ng-valid')).toBe(true);
+    expect(form.classList.contains('ng-untouched')).toBe(true);
+    expect(form.classList.contains('ng-pristine')).toBe(true);
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

`NgForm` registers `ngModel`/`ngModelGroup` controls in a deferred microtask (`resolvedPromise.then(...)` in `addControl`/`addFormGroup`) without notifying any view. When the `NgControlStatus`/`NgControlStatusGroup` host bindings are first checked before that registration lands, `control` is still `null`, the optional-chained signal reads in `AbstractControlStatus` short-circuit, and the view never establishes a reactive dependency.

In zoneless OnPush apps, an `[ngModelGroup]` host with no rendered controls (the collapsed accordion/section pattern) therefore never receives its `ng-*` status classes, and later model changes (`markAllAsTouched()` etc.) are never reflected — permanently stale DOM. The same stale binding throws NG0100 on every tick under `provideCheckNoChangesConfig({exhaustive: true})`.

Issue Number: #69310

## What is the new behavior?

`AbstractControlDirective` tracks an internal `_controlResolved` signal. The status host-binding getters read it, so the first binding pass always creates a reactive dependency even while `control` is `null`; `NgForm`'s deferred `addControl`/`addFormGroup` callbacks set it once the control is registered, which wakes the host view. This also covers `addControl` swapping the `NgModel` control instance for a previously registered one.

Status classes on group hosts now appear once the deferred registration lands and keep tracking the control's `_touched`/`_pristine`/`_status` signals from the second pass onward — with no behavior change for views that already worked (the signal flips once, causing at most one extra refresh per directive).

Verified against the issue's reproduction: the repro spec fails on stock 21.2.16 and passes with this change ported onto it. Live demo of the patched behavior: https://stackblitz.com/github/gregkaczan/ng69310-fix-demo (broken-state counterpart linked from #69310).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Side observation from the issue — `isUntouched`/`isDirty`/`isInvalid`/`isPending` not reading the corresponding signals — is left as-is: they are evaluated in the same host-binding pass as their signal-reading positive counterparts, which the existing comments rely on deliberately.