### PR TITLE
refactor(devtools): improve public API naming of the visualizers

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -62,6 +62,9 @@ const HIERARCHY_HOR_SIZE = 50;
 const INIT_SNAP_ZOOM_SCALE = 0.7;
 const SNAP_ZOOM_SCALE = 0.8;
 
+const HIGHLIGHTED_NODE_CLASS = 'it-highlighted';
+const SELECTED_NODE_CLASS = 'it-selected';
+
 @Component({
   selector: 'ng-injector-tree',
   imports: [
@@ -378,9 +381,9 @@ export class InjectorTreeComponent {
       return;
     }
     if (this.selectedNode()!.data.injector.id === id) {
-      node.classList.add('selected');
+      node.classList.add(SELECTED_NODE_CLASS);
     }
-    node.classList.add('highlighted');
+    node.classList.add(HIGHLIGHTED_NODE_CLASS);
   }
 
   private highlightEdgeById(tree: InjectorTreeVisualizer, id: string): void {
@@ -389,21 +392,21 @@ export class InjectorTreeComponent {
       return;
     }
 
-    edge.classList.add('highlighted');
+    edge.classList.add(HIGHLIGHTED_NODE_CLASS);
   }
 
   private unhighlightAllEdges(tree: InjectorTreeVisualizer): void {
     const edges = tree.svg.querySelectorAll('.link');
     for (const edge of edges) {
-      edge.classList.remove('highlighted');
+      edge.classList.remove(HIGHLIGHTED_NODE_CLASS);
     }
   }
 
   private unhighlightAllNodes(tree: InjectorTreeVisualizer): void {
     const nodes = tree.svg.querySelectorAll('.node');
     for (const node of nodes) {
-      node.classList.remove('selected');
-      node.classList.remove('highlighted');
+      node.classList.remove(SELECTED_NODE_CLASS);
+      node.classList.remove(HIGHLIGHTED_NODE_CLASS);
     }
   }
 

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.component.scss
@@ -61,7 +61,7 @@ $cluster-expand-anim-duration: 1s;
       }
 
       .edge {
-        &.highlighted {
+        &.highlighted-dep {
           .path {
             stroke: var(--purple-03);
             stroke-width: 1.75px;
@@ -153,32 +153,32 @@ $cluster-expand-anim-duration: 1s;
         }
       }
 
-      .selected rect,
-      .highlighted-origin rect,
-      .highlighted rect {
+      .highlighted rect,
+      .highlighted-dep-origin rect,
+      .highlighted-dep rect {
         ry: 8px;
         rx: 8px;
       }
 
-      .selected rect {
+      .highlighted rect {
         stroke-width: 3px;
       }
 
-      .highlighted-origin rect,
-      .highlighted rect {
+      .highlighted-dep-origin rect,
+      .highlighted-dep rect {
         stroke-width: 6px;
       }
 
-      .highlighted rect {
+      .highlighted-dep rect {
         stroke: var(--purple-03);
       }
 
-      .highlighted-origin rect {
+      .highlighted-dep-origin rect {
         stroke: var(--purple-02);
       }
 
       /* Note: It's important to keep the following `<class> rect` order to achieve the intended coloring. */
-      .selected rect {
+      .highlighted rect {
         stroke: var(--blue-03);
       }
 

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.component.ts
@@ -104,7 +104,7 @@ export class SignalsVisualizerComponent {
 
           effect(() => {
             const selected = this.selectedNodeId();
-            this.signalsVisualizer!.setSelected(selected);
+            this.signalsVisualizer!.highlightNode(selected);
           });
 
           let lastElement: ElementPosition | undefined;
@@ -204,7 +204,7 @@ export class SignalsVisualizerComponent {
       this.navigateMatchedNode('next');
     } else {
       // Unhighlight the last selected node, if there isn't a match.
-      this.signalsVisualizer?.setSelected(null);
+      this.signalsVisualizer?.highlightNode(null);
     }
   }
 
@@ -218,7 +218,7 @@ export class SignalsVisualizerComponent {
 
     // Snap to the node and highlight it.
     this.signalsVisualizer?.snapToNode(newMatchId);
-    this.signalsVisualizer?.setSelected(newMatchId);
+    this.signalsVisualizer?.highlightNode(newMatchId);
 
     this.currentSearchMatchIdx.set(newMatchedIdx);
     this.searchedNodeFound.emit();

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.ts
@@ -60,8 +60,9 @@ const CLUSTER_EDGE_CLASS = 'cluster-edge';
 const CLUSTER_CHILD_CLASS = 'cluster-child';
 const CLOSE_BTN_CLASS = 'cluster-close-btn';
 const NODE_EPOCH_UPDATE_ANIM_CLASS = 'node-epoch-anim';
-const HIGHLIGHTED_CLASS = 'highlighted';
-const HIGHLIGHTED_ORIGIN_CLASS = 'highlighted-origin';
+const HIGHLIGHTED_NODE_CLASS = 'highlighted';
+const HIGHLIGHTED_DEP_CLASS = 'highlighted-dep';
+const HIGHLIGHTED_DEP_ORIGIN_CLASS = 'highlighted-dep-origin';
 
 // Keep in sync with signals-visualizer.component.scss
 const NODE_WIDTH = 100;
@@ -126,6 +127,7 @@ export class SignalsGraphVisualizer {
     d3svg.call(this.zoomController);
   }
 
+  /** Snaps to a provided node. */
   snapToNode(nodeId: string): void;
   snapToNode(node: DevtoolsSignalGraphNode): void;
   snapToNode(node: string | DevtoolsSignalGraphNode) {
@@ -160,11 +162,15 @@ export class SignalsGraphVisualizer {
     }
   }
 
-  setSelected(selectedId: string | null) {
+  /**
+   * Adds a standard outline to the provided node.
+   * Using `null`, clears the highlighted node.
+   */
+  highlightNode(nodeId: string | null) {
     d3.select(this.svg)
       .select('.output .nodes')
       .selectAll<SVGGElement, string>(`.${NODE_CLASS}`)
-      .classed('selected', (d) => d === selectedId);
+      .classed(HIGHLIGHTED_NODE_CLASS, (d) => d === nodeId);
   }
 
   zoomScale(scale: number) {
@@ -679,7 +685,7 @@ export class SignalsGraphVisualizer {
           const edgeSelector = group[idx];
           const edgeSelection = d3.select(edgeSelector);
           this.highlightedPath.edges.push(edgeSelection);
-          appendClasses(edgeSelection, HIGHLIGHTED_CLASS);
+          appendClasses(edgeSelection, HIGHLIGHTED_DEP_CLASS);
         }
       });
   }
@@ -700,10 +706,10 @@ export class SignalsGraphVisualizer {
           let className: string;
 
           if (isOriginNode) {
-            className = HIGHLIGHTED_ORIGIN_CLASS;
+            className = HIGHLIGHTED_DEP_ORIGIN_CLASS;
             this.highlightedPath.originNode = nodeSelection;
           } else {
-            className = HIGHLIGHTED_CLASS;
+            className = HIGHLIGHTED_DEP_CLASS;
             this.highlightedPath.pathNodes.push(nodeSelection);
           }
 
@@ -717,13 +723,13 @@ export class SignalsGraphVisualizer {
     const {originNode, pathNodes, edges} = this.highlightedPath;
 
     if (originNode) {
-      removeClasses(originNode, HIGHLIGHTED_ORIGIN_CLASS);
+      removeClasses(originNode, HIGHLIGHTED_DEP_ORIGIN_CLASS);
     }
     for (const node of pathNodes) {
-      removeClasses(node, HIGHLIGHTED_CLASS);
+      removeClasses(node, HIGHLIGHTED_DEP_CLASS);
     }
     for (const edge of edges) {
-      removeClasses(edge, HIGHLIGHTED_CLASS);
+      removeClasses(edge, HIGHLIGHTED_DEP_CLASS);
     }
 
     this.highlightedPath = {

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.scss
@@ -68,7 +68,7 @@
         border-width: 2px;
         font-weight: 300;
 
-        &.node-highlighted {
+        &.highlighted {
           outline: 4px solid var(--blue-03);
         }
 
@@ -119,17 +119,15 @@
           }
         }
 
-        /* TODO(hawkgs): Rename to something more context-specific. */
-        &.highlighted,
-        &.highlighted:hover {
+        &.it-highlighted,
+        &.it-highlighted:hover {
           background: var(--blue-02);
           border-color: white;
           color: white;
         }
 
-        /* TODO(hawkgs): Rename to something more context-specific. */
-        &.selected,
-        &.selected:hover {
+        &.it-selected,
+        &.it-selected:hover {
           color: var(--blue-02);
           background: white;
           border-width: 3px;

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
@@ -103,7 +103,7 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
     }
   }
 
-  /** Snaps to root node. NOTE: Relies on container size. */
+  /** Snaps to the root node. NOTE: Relies on container size. */
   override snapToRoot(scale = 1): void {
     if (this.root) {
       this.snapToD3Node(this.root, scale);
@@ -118,12 +118,12 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
     }
   }
 
-  /** Adds an outline to the provided node. Using `null`, clear the highlighted node. */
+  /** Adds an outline to the provided node. Using `null`, clears the highlighted node. */
   override highlightNode(node: T | null) {
     this.highlightedNode = node;
     d3.select(this.containerElement)
       .selectAll<HTMLElement, TreeD3Node<T>>('.node-wrapper .node')
-      .classed('node-highlighted', (n) => (node ? n.data === node : false));
+      .classed('highlighted', (n) => n.data === node);
   }
 
   override getInternalNodeById(id: string): TreeD3Node<T> | null {


### PR DESCRIPTION
Improve the name of the public methods of the visualizers by using common terms like "highlighted". This should, hopefully, clear up some ambiguities that came with the term "selected". Additionally, clean up some CSS class names.