### PR TITLE
refactor(devtools): minor improvements of the transfer state UI

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/BUILD.bazel
@@ -6,6 +6,7 @@ sass_binary(
     name = "transfer_state_component_styles",
     src = "transfer-state.component.scss",
     deps = [
+        "//devtools/projects/ng-devtools/src/styles:material_sass_deps",
         "//devtools/projects/ng-devtools/src/styles:typography",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.html
@@ -57,6 +57,7 @@
           </div>
         </div>
         <div class="filter">
+          <!-- TODO(hawkgs): Consider substituting with ng-filter -->
           <input
             type="text"
             class="ng-input filter-input"
@@ -138,8 +139,12 @@
             </td>
           </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
           <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+          <tr *matNoDataRow>
+            <td [attr.colspan]="displayedColumns.length">No such key</td>
+          </tr>
         </table>
       </div>
     </div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.scss
@@ -1,4 +1,5 @@
 @use '../../../styles/typography';
+@use '@angular/material' as mat;
 
 .transfer-state-container {
   padding: 1rem;
@@ -150,27 +151,38 @@
       }
 
       .filter {
-        display: flex;
-        align-items: center;
-        gap: 0.25rem;
+        position: relative;
         min-width: 12rem;
-        flex: 1;
         max-width: 20rem;
 
         .filter-input {
-          flex: 1;
+          display: block;
+          width: 100%;
+          padding-right: 1.75rem;
+        }
+
+        button {
+          position: absolute;
+          top: 5px;
+          right: 7px;
+
+          mat-icon {
+            width: 18px;
+            height: 18px;
+            font-size: 18px;
+          }
         }
       }
     }
 
     .table-container {
-      flex: 1;
       min-height: 0;
       border: 1px solid var(--color-separator);
       border-radius: 0.25rem;
       overflow-y: auto;
 
       .transfer-state-table {
+        @include mat.table-density(-2);
         width: 100%;
         background: var(--color-background);
 
@@ -180,7 +192,7 @@
           @extend %body-01;
           text-transform: uppercase;
           letter-spacing: 0.03rem;
-          padding: 0.75rem 1rem;
+          padding: 0.5rem 0.75rem;
           border-bottom: 2px solid var(--color-separator);
         }
 
@@ -191,11 +203,12 @@
           color: var(--secondary-contrast);
           display: inline-block;
           vertical-align: bottom;
+          margin-left: 0.125rem;
         }
 
         tr {
           td {
-            padding: 0.75rem 1rem;
+            padding: 0.625rem 0.75rem;
           }
 
           &:not(:last-of-type) {
@@ -252,10 +265,9 @@
           display: inline-block;
           padding: 0.125rem 0.5rem;
           border-radius: 0.75rem;
-          @extend %body-01;
+          @extend %caption-text;
           font-weight: 500;
           text-transform: uppercase;
-          letter-spacing: 0.03rem;
           background: transparent;
           border: 1px solid currentColor;
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.spec.ts
@@ -12,8 +12,6 @@ import {Clipboard} from '@angular/cdk/clipboard';
 import {Events, MessageBus, TransferStateValue} from '../../../../../protocol';
 import {LOADING_TIMEOUT, TransferStateComponent} from './transfer-state.component';
 
-type DataCallback = (data: Record<string, TransferStateValue> | null) => void;
-
 class MessageBusMock implements Pick<MessageBus<Events>, 'on' | 'emit' | 'once' | 'destroy'> {
   readonly emit = jasmine.createSpy('emit');
   readonly once = jasmine.createSpy('once');

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
@@ -21,6 +21,7 @@ import {
   MatCellDef,
   MatHeaderRowDef,
   MatRowDef,
+  MatNoDataRow,
 } from '@angular/material/table';
 import {MatSort, MatSortHeader, Sort} from '@angular/material/sort';
 import {FormsModule} from '@angular/forms';
@@ -77,6 +78,7 @@ function getByteSize(key: string, value: TransferStateValue): number | null {
     MatHeaderCellDef,
     MatCellDef,
     MatHeaderRowDef,
+    MatNoDataRow,
     MatRowDef,
     MatSort,
     MatSortHeader,


### PR DESCRIPTION
The change can be treated as a continuation of #68535.

- Make the table header sticky
- Reduce slightly the table density in order to equalize it with the rest of the UI
- Reduce the font size of the type pills
- Change the position of the filter clear button to match with the rest of the filter inputs
- Add a "No such key" label when there are no data rows as a result of filtering


<img width="826" height="469" alt="Screenshot 2026-06-11 at 17 11 35" src="https://github.com/user-attachments/assets/1ef91f56-e024-460f-9891-6aea213a21ce" />
