### PR TITLE
fix(zone.js): harden zoneSymbolEventNames and patches against __proto__ key

### DIFF
--- a/packages/zone.js/lib/common/utils.ts
+++ b/packages/zone.js/lib/common/utils.ts
@@ -129,7 +129,8 @@ export const isMix: boolean =
   !isWebWorker &&
   !!(isWindowExists && internalWindow['HTMLElement']);
 
-const zoneSymbolEventNames: {[eventName: string]: string} = {};
+// tslint:disable-next-line:no-toplevel-property-access
+const zoneSymbolEventNames: {[eventName: string]: string} = Object.create(null);
 
 const enableBeforeunloadSymbol = zoneSymbol('enable_beforeunload');
 

--- a/packages/zone.js/lib/zone-impl.ts
+++ b/packages/zone.js/lib/zone-impl.ts
@@ -814,7 +814,7 @@ export function initZone(): ZoneType {
     }
 
     static __load_patch(name: string, fn: PatchFn, ignoreDuplicate = false): void {
-      if (patches.hasOwnProperty(name)) {
+      if (Object.hasOwn(patches, name)) {
         // `checkDuplicate` option is defined from global variable
         // so it works for all modules.
         // `ignoreDuplicate` can work for the specified module
@@ -1601,7 +1601,7 @@ export function initZone(): ZoneType {
     macroTask: 'macroTask' = 'macroTask',
     eventTask: 'eventTask' = 'eventTask';
 
-  const patches: {[key: string]: any} = {};
+  const patches: {[key: string]: any} = Object.create(null);
   const _api: ZonePrivate = {
     symbol: __symbol__,
     currentZoneFrame: () => _currentZoneFrame,

--- a/packages/zone.js/test/typings/tsconfig.json
+++ b/packages/zone.js/test/typings/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmitOnError": false,
     "stripInternal": false,
     "strict": true,
-    "lib": ["es5", "dom", "es2015.collection", "es2015.iterable", "es2015.promise"]
+    "lib": ["es5", "dom", "es2015.collection", "es2015.iterable", "es2015.promise", "es2022.object"]
   },
   "files": ["./type.test.ts", "./node_modules/zone.js/zone.ts"]
 }

--- a/packages/zone.js/tsconfig.json
+++ b/packages/zone.js/tsconfig.json
@@ -18,7 +18,8 @@
       "es2015.iterable",
       "es2015.promise",
       "es2015.symbol",
-      "es2015.symbol.wellknown"
-    ],
-  },
+      "es2015.symbol.wellknown",
+      "es2022.object"
+    ]
+  }
 }


### PR DESCRIPTION
Initialize `zoneSymbolEventNames` and `patches` with `Object.create(null)` instead of `{}`.

This is a hardening change rather than a fix for an exploitable vulnerability. Calling `addEventListener('__proto__', fn)` is not directly attacker-controlled; its presence already implies an application bug. However, if such a call does occur, the current implementation can behave unexpectedly depending on the environment.

For `zoneSymbolEventNames`, accessing `zoneSymbolEventNames['__proto__']` on a plain object invokes the inherited `__proto__` accessor and returns `Object.prototype`, which is truthy. This causes `prepareEventNames()` to be skipped, leaving `symbolEventName` undefined and eventually leading to a runtime error when `window['undefined'] = []` is executed.

In Node.js environments running with `--disable-proto=throw`, the assignment:

```ts
zoneSymbolEventNames['__proto__'] = {};
```

throws immediately because it triggers the disabled `__proto__` setter.

The `patches` registry has a similar issue. A `__proto__` key passed to `__load_patch()` bypasses the duplicate-patch check and reaches:

```ts
patches['__proto__'] = fn(...);
```

which invokes the `__proto__` setter and changes the prototype of the `patches` object.

Using `Object.create(null)` removes the inherited `__proto__` accessor entirely, causing these keys to behave like ordinary properties rather than interacting with JavaScript's prototype machinery.

As part of this change, `patches.hasOwnProperty(name)` is also updated to:

```ts
Object.prototype.hasOwnProperty.call(patches, name)
```

since null-prototype objects do not inherit `hasOwnProperty`.