### PR TITLE
ci: introduce GHA release publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,11 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write # Required for the reusable workflow to create releases and tags
+  contents: read # Required to checkout the repository
 
 jobs:
   release:
-    uses: angular/dev-infra/.github/workflows/reusable-release.yml@11ee1f5400aa3220ff42546c8e1fe75ea0041e6b
+    uses: angular/dev-infra/.github/workflows/reusable-release.yml@e9faacd5b4df391f59989b6fb448b2c24115d592
     secrets:
       wombot-token: ${{ secrets.WOMBOT_TOKEN }}
+      angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+.x'
+  workflow_dispatch: # Allow manual trigger for verification
+
+# Ensure only one release runs at a time PER BRANCH to avoid race conditions.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # Required for the reusable workflow to create releases and tags
+
+jobs:
+  release:
+    uses: angular/dev-infra/.github/workflows/reusable-release.yml@11ee1f5400aa3220ff42546c8e1fe75ea0041e6b
+    secrets:
+      wombot-token: ${{ secrets.WOMBOT_TOKEN }}


### PR DESCRIPTION
This PR introduces the caller GitHub Actions workflow for release publishing, which delegates the build and publish steps to the centralized reusable workflow in dev-infra. It targets the merged reusable workflow in dev-infra by SHA: 11ee1f5400aa3220ff42546c8e1fe75ea0041e6b. Part of the secure CI release migration.