### PR TITLE
fix(docs-infra): add explicit font styles to docs-primary-btn

### DIFF
--- a/adev/shared-docs/styles/_button.scss
+++ b/adev/shared-docs/styles/_button.scss
@@ -43,6 +43,12 @@
     color: transparent;
     user-select: none;
 
+    // We explicitly apply font styles since the class
+    // may be used for non-button elements (e.g. <a>) as well.
+    font-family: var(--inter-font);
+    font-size: 0.875rem;
+    font-weight: 600;
+
     // border gradient / background
     --angle: 90deg;
     background: linear-gradient(


### PR DESCRIPTION
Add font family, size and weight to the `.docs-primary-btn`. This guarantees that applying the class to non-button elements, like anchors, will result in the same visual representation.

More specifically, the lack of those styles results in a discrepancy between the buttons in the cookies popup (quite severe in Safari):

<img width="320" height="153" alt="Screenshot 2026-06-12 at 16 55 56" src="https://github.com/user-attachments/assets/3efe3644-56f3-48d8-a23d-51017c04c59a" />
