### PR TITLE
refactor(compiler-cli): Change indexComponent file to be fileUrl

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -928,9 +928,6 @@ export class NgCompiler {
       getFileName(node: DeclarationNode): string {
         return node.getSourceFile().fileName;
       },
-      getContent(node: DeclarationNode): string {
-        return node.getSourceFile().getFullText();
-      },
     };
 
     return generateAnalysis(context, adapter);

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -8,7 +8,6 @@
 
 import {
   AST,
-  ParseSourceFile,
   TmplAstComponent,
   TmplAstDirective,
   TmplAstElement,
@@ -182,10 +181,10 @@ export class AbsoluteSourceSpan {
 export interface IndexedComponent<T = DeclarationNode> {
   name: string;
   selector: string | null;
-  file: ParseSourceFile;
+  fileUrl: string;
   template: {
     identifiers: Set<TopLevelIdentifier<T>>;
-    file: ParseSourceFile;
+    fileUrl: string;
   };
   errors: Error[];
 }
@@ -219,5 +218,4 @@ export interface AbstractBoundTemplate<T> {
 export interface NodeAdapter<T> {
   getName(node: T): string;
   getFileName(node: T): string;
-  getContent(node: T): string;
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ParseSourceFile} from '@angular/compiler';
-
 import {DeclarationNode} from '../../reflection';
 
 import {IndexedComponent, NodeAdapter} from './api.js';
@@ -32,22 +30,21 @@ export function generateAnalysis<T = DeclarationNode>(
 
     // Get source files for the component and the template. If the template is inline, its source
     // file is the component's.
-    const componentFile = new ParseSourceFile(adapter.getContent(declaration), fileName);
-    let templateFile: ParseSourceFile;
+    let templateFileUrl: string;
     if (templateMeta.isInline) {
-      templateFile = componentFile;
+      templateFileUrl = fileName;
     } else {
-      templateFile = templateMeta.file;
+      templateFileUrl = templateMeta.file.url;
     }
 
     const {identifiers, errors} = getTemplateIdentifiers<T>(boundTemplate);
     analysis.set(declaration, {
       name,
       selector,
-      file: componentFile,
+      fileUrl: fileName,
       template: {
         identifiers,
-        file: templateFile,
+        fileUrl: templateFileUrl,
       },
       errors,
     });

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -46,9 +46,6 @@ const adapter: NodeAdapter<DeclarationNode> = {
   getFileName(node: DeclarationNode): string {
     return node.getSourceFile().fileName;
   },
-  getContent(node: DeclarationNode): string {
-    return node.getSourceFile().getFullText();
-  },
 };
 
 runInEachFileSystem(() => {
@@ -66,11 +63,11 @@ runInEachFileSystem(() => {
       expect(info).toEqual({
         name: 'C',
         selector: 'c-selector',
-        file: new ParseSourceFile('class C {}', decl.getSourceFile().fileName),
+        fileUrl: decl.getSourceFile().fileName,
         template: {
           identifiers: getTemplateIdentifiers(util.getBoundTemplate('<div>{{foo}}</div>'))
             .identifiers,
-          file: new ParseSourceFile('<div>{{foo}}</div>', decl.getSourceFile().fileName),
+          fileUrl: decl.getSourceFile().fileName,
         },
         errors: [],
       });
@@ -94,9 +91,7 @@ runInEachFileSystem(() => {
 
       const info = analysis.get(decl);
       expect(info).toBeDefined();
-      expect(info!.template.file).toEqual(
-        new ParseSourceFile('class C {}', decl.getSourceFile().fileName),
-      );
+      expect(info!.template.fileUrl).toEqual(decl.getSourceFile().fileName);
     });
 
     it('should give external templates their own source file', () => {
@@ -110,9 +105,7 @@ runInEachFileSystem(() => {
 
       const info = analysis.get(decl);
       expect(info).toBeDefined();
-      expect(info!.template.file).toEqual(
-        new ParseSourceFile('<div>{{foo}}</div>', decl.getSourceFile().fileName),
-      );
+      expect(info!.template.fileUrl).toEqual(decl.getSourceFile().fileName);
     });
   });
 });

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -13,7 +13,6 @@ import {
   IndexedComponent,
   TopLevelIdentifier,
 } from '../../src/ngtsc/indexer';
-import {ParseSourceFile} from '@angular/compiler';
 
 import {NgtscTestEnvironment} from './env';
 
@@ -54,7 +53,7 @@ runInEachFileSystem(() => {
           jasmine.objectContaining<IndexedComponent>({
             name: 'TestCmp',
             selector: 'test-cmp',
-            file: new ParseSourceFile(componentContent, testSourceFile),
+            fileUrl: testSourceFile,
           }),
         );
       });
@@ -83,7 +82,7 @@ runInEachFileSystem(() => {
               target: null,
             },
           ]),
-          file: new ParseSourceFile(componentContent, testSourceFile),
+          fileUrl: testSourceFile,
         });
       });
 
@@ -114,7 +113,7 @@ runInEachFileSystem(() => {
               target: null,
             },
           ]),
-          file: new ParseSourceFile('{{foo}}', testTemplateFile),
+          fileUrl: testTemplateFile,
         });
       });
 
@@ -149,7 +148,7 @@ runInEachFileSystem(() => {
               target: null,
             },
           ]),
-          file: new ParseSourceFile('  \n  {{foo}}', testTemplateFile),
+          fileUrl: testTemplateFile,
         });
       });
 


### PR DESCRIPTION
We do not need ParseSourceFile which contains the whole content. Only the file url is ever used.
