### PR TITLE
refactor(core): ɵɵgetInheritedFactory should accept abstract type

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
@@ -748,6 +748,16 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     selector: '[test-dir]',
                 }]
         }] });
+export class AbstractInherited extends AbstractDir {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AbstractInherited, deps: null, target: i0.ɵɵFactoryTarget.Directive });
+    static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: AbstractInherited, isStandalone: true, selector: "[dir2]", usesInheritance: true, ngImport: i0 });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AbstractInherited, decorators: [{
+            type: Directive,
+            args: [{
+                    selector: '[dir2]',
+                }]
+        }] });
 export class AbstractComp {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AbstractComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
     static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: AbstractComp, isStandalone: true, selector: "test-comp", ngImport: i0, template: '', isInline: true });
@@ -767,6 +777,10 @@ import * as i0 from "@angular/core";
 export declare abstract class AbstractDir {
     static ɵfac: i0.ɵɵFactoryDeclaration<AbstractDir, never>;
     static ɵdir: i0.ɵɵDirectiveDeclaration<AbstractDir, "[test-dir]", never, {}, {}, never, never, true, never>;
+}
+export declare abstract class AbstractInherited extends AbstractDir {
+    static ɵfac: i0.ɵɵFactoryDeclaration<AbstractInherited, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<AbstractInherited, "[dir2]", never, {}, {}, never, never, true, never>;
 }
 export declare abstract class AbstractComp {
     static ɵfac: i0.ɵɵFactoryDeclaration<AbstractComp, never>;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/abstract_directive.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/abstract_directive.js
@@ -14,6 +14,16 @@ export class AbstractDir {
   });
 }
 …
+export class AbstractInherited extends AbstractDir {
+  …
+  static ɵfac = /*@__PURE__*/ (() => { let ɵAbstractInherited_BaseFactory; return function AbstractInherited_Factory(__ngFactoryType__) { return (ɵAbstractInherited_BaseFactory || (ɵAbstractInherited_BaseFactory = i0.ɵɵgetInheritedFactory(AbstractInherited)))(__ngFactoryType__ || AbstractInherited); }; })();
+  static ɵdir = /*@__PURE__*/ i0.ɵɵdefineDirective({
+    type: AbstractInherited,
+    selectors: [["", "dir2", ""]],
+    features: [i0.ɵɵInheritDefinitionFeature]
+  });
+}
+…
 export class AbstractComp {
   …
   static ɵfac = function AbstractComp_Factory(__ngFactoryType__) {
@@ -22,4 +32,3 @@ export class AbstractComp {
   };
     …
 }
-…

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/abstract_directive.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/abstract_directive.ts
@@ -6,6 +6,12 @@ import {Component, Directive} from '@angular/core';
 export abstract class AbstractDir {
 }
 
+@Directive({
+  selector: '[dir2]',
+})
+export abstract class AbstractInherited extends AbstractDir {
+}
+
 @Component({
   selector: 'test-comp',
   template: ''

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -13,7 +13,7 @@ import {BackwardsCompatibleInjector, convertToBitFlags} from '../di/injector_com
 import {InjectorMarkers} from '../di/injector_marker';
 import {InjectOptions, InternalInjectFlags} from '../di/interface/injector';
 import {ProviderToken} from '../di/provider_token';
-import {Type} from '../interface/type';
+import {AbstractType, Type} from '../interface/type';
 import {assertDefined, assertEqual, assertIndexInRange} from '../util/assert';
 import {noSideEffects} from '../util/closure';
 
@@ -915,7 +915,9 @@ export function createNodeInjector(): Injector {
 /**
  * @codeGenApi
  */
-export function ɵɵgetInheritedFactory<T>(type: Type<any>): (type: Type<T>) => T {
+export function ɵɵgetInheritedFactory<T>(
+  type: Type<any> | AbstractType<any>,
+): (type: Type<T>) => T {
   return noSideEffects(() => {
     const ownConstructor = type.prototype.constructor;
     const ownFactory = ownConstructor[NG_FACTORY_DEF] || getFactoryOf(ownConstructor);


### PR DESCRIPTION
An abstract component or directive can extend another class, meaning ɵɵgetInheritedFactory needs to allow abstract
