### PR TITLE
fix(docs-infra): center social and theme menus under their triggers o…

### DIFF
--- a/adev/src/app/core/layout/navigation/mini-menu.scss
+++ b/adev/src/app/core/layout/navigation/mini-menu.scss
@@ -20,9 +20,30 @@
     animation: none;
   }
 
+  // Tablet drop-down: anchor the menu centered under its trigger. The
+  // `--social`/`--theme`/`--version` modifiers select which trigger to anchor to.
   @include mq.for-tablet {
-    top: 75px;
-    left: 5px;
+    position: fixed;
+    inset-block-start: calc(anchor(bottom) + 8px);
+    justify-self: anchor-center;
+  }
+
+  &--social {
+    @include mq.for-tablet {
+      position-anchor: --social-trigger;
+    }
+  }
+
+  &--theme {
+    @include mq.for-tablet {
+      position-anchor: --theme-trigger;
+    }
+  }
+
+  &--version {
+    @include mq.for-tablet {
+      position-anchor: --version-trigger;
+    }
   }
 
   li {
@@ -99,10 +120,6 @@
   }
 
   @include mq.for-tablet {
-    position: fixed;
-    position-anchor: --version-trigger;
-    inset-block-start: calc(anchor(bottom) + 8px);
-    justify-self: anchor-center;
     margin-inline-start: 0;
   }
 }

--- a/adev/src/app/core/layout/navigation/navigation.component.html
+++ b/adev/src/app/core/layout/navigation/navigation.component.html
@@ -170,7 +170,7 @@
           </button>
 
           <ng-template #docsVersionMiniMenu>
-            <ul class="adev-mini-menu adev-version-picker" cdkMenu>
+            <ul class="adev-mini-menu adev-mini-menu--version adev-version-picker" cdkMenu>
               @for (item of versions(); track item) {
                 <li>
                   <a type="button" cdkMenuItem [href]="item.url" [aria-label]="item.displayName">
@@ -300,12 +300,13 @@
           aria-label="Open social media links"
           (cdkMenuClosed)="closeMenu()"
           (cdkMenuOpened)="openMenu('social')"
+          aria-controls="social-mini-menu"
         >
           <docs-icon role="presentation">more_horiz</docs-icon>
         </button>
 
         <ng-template #socialMiniMenu>
-          <ul class="adev-mini-menu" cdkMenu>
+          <ul class="adev-mini-menu adev-mini-menu--social" cdkMenu id="social-mini-menu">
             <li>
               <a
                 [href]="ngLinks.YOUTUBE"
@@ -491,7 +492,7 @@
 
         <ng-template #themeMiniMenu>
           <ul
-            class="adev-mini-menu"
+            class="adev-mini-menu adev-mini-menu--theme"
             cdkMenu
             id="theme-mini-menu"
             role="menu"

--- a/adev/src/app/core/layout/navigation/navigation.component.scss
+++ b/adev/src/app/core/layout/navigation/navigation.component.scss
@@ -261,6 +261,14 @@
         padding-inline: 0.5rem;
       }
 
+      &[aria-controls='social-mini-menu'] {
+        anchor-name: --social-trigger;
+      }
+
+      &[aria-controls='theme-mini-menu'] {
+        anchor-name: --theme-trigger;
+      }
+
       docs-icon {
         color: var(--quaternary-contrast);
         font-size: 1.5rem;


### PR DESCRIPTION
On tablet the social and theme mini-menus shared a fixed `top/left` offset, so their dropdowns didn't line up with the buttons that open them.

They now anchor to their triggers and center beneath them via the same CSS anchor positioning the version picker uses. The social trigger also gains `aria-controls` + a matching menu `id` for a11y parity with the theme trigger.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

On tablet widths (701–900px), the social-links and theme-picker mini-menus were positioned with a fixed `top: 75px; left: 5px` offset, so their dropdown panels did not line up with the buttons that open them.

<img width="441" height="405" alt="image" src="https://github.com/user-attachments/assets/660601c5-e06d-4b24-afd0-9e0e3eb6bd01" />

<img width="259" height="287" alt="image" src="https://github.com/user-attachments/assets/37f94f8f-23c2-4ac6-85cd-a5371248124f" />



## What is the new behavior?

The social and theme dropdowns now anchor to their trigger buttons and center beneath them on tablet, using the same CSS anchor positioning the version picker already used. The shared tablet positioning is consolidated onto `.adev-mini-menu`, with `--social` / `--theme` / `--version` modifiers selecting each trigger, so all three mini-menus share one rule. The version picker's on-screen behavior is unchanged. The social trigger also gains `aria-controls` and a matching menu `id`, bringing it to accessibility parity with the theme trigger.

<img width="822" height="521" alt="image" src="https://github.com/user-attachments/assets/ade04883-fde6-47f4-857d-958afbce0ec8" />

<img width="818" height="332" alt="image" src="https://github.com/user-attachments/assets/90cc9e52-469d-4987-a0ce-d82287c06db6" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No