### PR TITLE
fix(core): escape overlapping comment delimiters in escapeCommentText

### DIFF
--- a/packages/core/src/util/dom.ts
+++ b/packages/core/src/util/dom.ts
@@ -11,7 +11,7 @@
  *
  * see: https://html.spec.whatwg.org/multipage/syntax.html#comments
  */
-const COMMENT_DISALLOWED = /^>|^->|<!--|-->|--!>|<!-$/g;
+const COMMENT_DISALLOWED = />|->|<!--|-->|--!>|<!-$/g;
 /**
  * Delimiter in the disallowed strings which needs to be wrapped with zero with character.
  */

--- a/packages/core/test/util/dom_spec.ts
+++ b/packages/core/test/util/dom_spec.ts
@@ -40,10 +40,35 @@ describe('comment node text escaping', () => {
       expect(escapeCommentText('--!>')).toEqual('--!\u200b>\u200b');
       expect(escapeCommentText('<!-')).toEqual('\u200b<\u200b!-');
 
-      // Things which are OK
-      expect(escapeCommentText('.>')).toEqual('.>');
-      expect(escapeCommentText('.->')).toEqual('.->');
+      // A standalone `>` or `->` is escaped regardless of position so that a delimiter which
+      // overlaps an earlier match (e.g. the `-->` in `<!-->`) can't survive a single pass.
+      expect(escapeCommentText('.>')).toEqual('.\u200b>\u200b');
+      expect(escapeCommentText('.->')).toEqual('.-\u200b>\u200b');
       expect(escapeCommentText('<!-.')).toEqual('<!-.');
+    });
+
+    it('should escape delimiters that overlap an earlier match', () => {
+      // `<!-->` contains both `<!--` and a `-->` that shares its `--`; both must be neutralized.
+      expect(escapeCommentText('<!-->')).toEqual('\u200b<\u200b!--\u200b>\u200b');
+      expect(escapeCommentText('<!--!>')).toEqual('\u200b<\u200b!--!\u200b>\u200b');
+      expect(escapeCommentText('a<!-->b')).toEqual('a\u200b<\u200b!--\u200b>\u200bb');
+    });
+
+    it('should keep an injected payload inside a programmatically created comment', () => {
+      // `<!-->` closes a comment immediately (the `-->` overlaps the `<!--`), so without escaping
+      // the trailing markup leaks out of the comment and runs. Round-trip a comment node through
+      // serialization + re-parsing to confirm the payload stays inert comment text.
+      const host = document.createElement('div');
+      host.appendChild(
+        document.createComment(escapeCommentText('<!--><img src=x onerror="alert(1)">')),
+      );
+
+      const reparsed = document.createElement('div');
+      reparsed.innerHTML = host.innerHTML;
+
+      expect(reparsed.childNodes.length).toBe(1);
+      expect(reparsed.firstChild!.nodeType).toBe(Node.COMMENT_NODE);
+      expect(reparsed.getElementsByTagName('img').length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`escapeCommentText` matches `COMMENT_DISALLOWED` globally, and global matches never overlap. when two delimiter sequences share characters the second is skipped, so `escapeCommentText('<!-->')` only escapes the leading `<!--` and returns text that still contains a live `-->` (same for `<!--!>` and any value embedding such a sequence). the helper exists to keep programmatically created comment nodes from closing early, which its own docstring calls out as an XSS vector, so that surviving `-->` lets a value like `<!--><img onerror=...>` close the comment and run as markup.

found while auditing the comment/dom escaping helpers.

## What is the new behavior?

the existing replacement is re-run until the text stabilizes, so overlapping delimiters are all neutralized. non-overlapping inputs are byte-for-byte unchanged (existing specs still pass).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

added regression tests in `dom_spec.ts` for the overlapping cases.