### PR TITLE
docs(core): document resource chaining with chain() in params context

### DIFF
--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -140,6 +140,53 @@ The `id` value must be unique within your application and identical on the serve
 
 IMPORTANT: Because the cached value is serialized into the page's HTML, avoid setting `id` on resources that load data specific to the user who triggered the server-side render, especially if the rendered HTML can be cached or shared between users.
 
+## Chaining resources
+
+Sometimes one resource depends on the result of another. You can express this dependency using the `chain` function available in the `params` context object.
+
+```typescript
+import {resource} from '@angular/core';
+
+const userResource = resource({
+  params: () => ({id: getUserId()}),
+  loader: ({params}) => fetchUser(params),
+});
+
+const companyResource = resource({
+  params: ({chain}) => chain(userResource)?.companyId,
+  loader: ({params: companyId}) => fetchCompany(companyId),
+});
+```
+
+Here `companyResource` depends on the user's `companyId`, which is only known once `userResource` has loaded. `chain(userResource)` reads the value of `userResource` and automatically propagates its status to `companyResource`:
+
+- If `userResource` is **idle**, `companyResource` also becomes `idle`.
+- If `userResource` is **loading** or **reloading**, `companyResource` enters the `loading` state and its loader does not run. Note that during `reloading`, `chain` does not return the previously resolved value.
+- If `userResource` is in an **error** state, `companyResource` also enters the `error` state.
+- If `userResource` is **resolved** or **local**, `chain` returns its current value, which `companyResource` then uses as its params.
+
+When `chain` propagates a status from `userResource` (`idle`, `loading`, `reloading`, or `error`), the params function does not continue. When `userResource` is `resolved` or `local`, `chain` returns its value, which can itself be `undefined`. The example handles this with `chain(userResource)?.companyId`, so an `undefined` value results in `undefined` params and `companyResource` becomes `idle`.
+
+NOTE: Pass the chained value directly as the params value rather than wrapping it in an object. A params value like `{companyId: undefined}` is still a defined value, so the loader would run with an `undefined` `companyId` instead of the resource becoming `idle`.
+
+### Chaining vs. reading resource values directly
+
+You might be tempted to read a resource's value directly inside `params`:
+
+```typescript {avoid, header: 'reads value() directly without status propagation'}
+const companyResource = resource({
+  params: () => {
+    const user = userResource.value(); // may be undefined
+    return user ? {companyId: user.companyId} : undefined;
+  },
+  loader: ({params}) => fetchCompany(params.companyId),
+});
+```
+
+While this works, returning `undefined` from `params` makes the resource go `idle` rather than reflecting the actual state of the upstream resource. Using `chain` is preferred because it correctly mirrors `loading` and `error` states.
+
+Reach for `chain` only when the downstream resource performs its own async work that depends on the upstream value. If you only need to derive a value synchronously from a resource, use `computed` instead.
+
 ## Reactive data fetching with `httpResource`
 
 [`httpResource`](/guide/http/http-resource) is a wrapper around `HttpClient` that gives you the request status and response as signals. It makes HTTP requests through the Angular HTTP stack, including interceptors.

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -39,7 +39,11 @@ export class ResourceParamsStatus extends Error {
   static readonly LOADING = new ResourceParamsStatus('LOADING');
 }
 
-/** Context received by a resource's `params` or `request` function. */
+/**
+ * Context received by a resource's `params` or `request` function.
+ *
+ * @see [Chaining resources](guide/signals/resource#chaining-resources)
+ */
 export interface ResourceParamsContext {
   /**
    * Chains the current params off of the value of another resource, returning the value


### PR DESCRIPTION
## Which issue does this PR close?

Closes #69329

## Description

Angular 22 introduced resource chaining via the `chain` function in `ResourceParamsContext`. This feature had no documentation in the signals resource guide.

This PR adds a **"Chaining resources"** section to `adev/src/content/guide/signals/resource.md` covering:

- Basic usage of `chain(resource)` inside `params` to make one resource depend on another
- Automatic status propagation — when the upstream is `loading` / `idle` / `error`, the downstream mirrors that status so the loader never runs with missing data
- **Chaining vs reading `.value()` directly** — explains why `chain` is preferred: reading `.value()` collapses any non-resolved state to `idle`, whereas `chain` correctly propagates `loading` and `error`
- **Synchronous value transformation** — covers the common pattern of mapping a resource's value synchronously and notes when `computed` is a better fit

## Type of change

- [x] Documentation content changes

## Checklist

- [x] Commit message follows the [Angular commit guidelines](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md)
- [x] No code changes — documentation only