### PR TITLE
feat(docs-infra): add Compare button to tutorial editor for side-by-side answer view

### DIFF
--- a/adev/src/app/editor/code-editor/code-editor.component.html
+++ b/adev/src/app/editor/code-editor/code-editor.component.html
@@ -10,7 +10,12 @@
       @for (file of files(); track file) {
         <mat-tab #tab>
           <ng-template mat-tab-label>
-            @if (tab.isActive && isRenamingFile()) {
+            @if (file.filename.startsWith('answer:')) {
+              <span class="adev-answer-tab-label">
+                {{ file.filename.replace('answer:src/', '') }}
+                <span class="adev-answer-tab-badge">answer</span>
+              </span>
+            } @else if (tab.isActive && isRenamingFile()) {
               <form (submit)="renameFile($event, file.filename)">
                 <input
                   name="rename-file"
@@ -27,29 +32,31 @@
               {{ file.filename.replace('src/', '') }}
             }
 
-            @if (tab.isActive && canRenameFile(file.filename)) {
-              <button
-                type="button"
-                class="docs-rename-file"
-                aria-label="rename file"
-                matTooltip="Rename file"
-                matTooltipPosition="above"
-                (click)="onRenameButtonClick()"
-              >
-                <docs-icon>edit</docs-icon>
-              </button>
-            }
-            @if (tab.isActive && canDeleteFile(file.filename)) {
-              <button
-                type="button"
-                class="docs-delete-file"
-                aria-label="Delete file"
-                matTooltip="Delete file"
-                matTooltipPosition="above"
-                (click)="deleteFile(file.filename)"
-              >
-                <docs-icon>delete</docs-icon>
-              </button>
+            @if (!file.filename.startsWith('answer:')) {
+              @if (tab.isActive && canRenameFile(file.filename)) {
+                <button
+                  type="button"
+                  class="docs-rename-file"
+                  aria-label="rename file"
+                  matTooltip="Rename file"
+                  matTooltipPosition="above"
+                  (click)="onRenameButtonClick()"
+                >
+                  <docs-icon>edit</docs-icon>
+                </button>
+              }
+              @if (tab.isActive && canDeleteFile(file.filename)) {
+                <button
+                  type="button"
+                  class="docs-delete-file"
+                  aria-label="Delete file"
+                  matTooltip="Delete file"
+                  matTooltipPosition="above"
+                  (click)="deleteFile(file.filename)"
+                >
+                  <docs-icon>delete</docs-icon>
+                </button>
+              }
             }
           </ng-template>
         </mat-tab>

--- a/adev/src/app/editor/code-editor/code-editor.component.scss
+++ b/adev/src/app/editor/code-editor/code-editor.component.scss
@@ -314,3 +314,21 @@
     }
   }
 }
+
+.adev-answer-tab-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.adev-answer-tab-badge {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+  background: var(--bright-blue);
+  color: #fff;
+  line-height: 1.4;
+}

--- a/adev/src/app/editor/code-editor/code-mirror-editor.service.ts
+++ b/adev/src/app/editor/code-editor/code-mirror-editor.service.ts
@@ -422,6 +422,8 @@ export class CodeMirrorEditor {
   }
 
   private createEditorState(): EditorState {
+    const isAnswerTab = this.currentFile().filename.startsWith('answer:');
+
     const newEditorState = EditorState.create({
       doc: this.currentFile().content,
       extensions: [
@@ -431,7 +433,7 @@ export class CodeMirrorEditor {
 
         placeholderExtension('Type your code here...'),
 
-        ...this.getLanguageExtensions(),
+        ...(isAnswerTab ? [EditorState.readOnly.of(true)] : this.getLanguageExtensions()),
       ],
     });
 

--- a/adev/src/app/editor/embedded-tutorial-manager.service.ts
+++ b/adev/src/app/editor/embedded-tutorial-manager.service.ts
@@ -113,6 +113,45 @@ export class EmbeddedTutorialManager {
     this._shouldChangeTutorial$.next(true);
   }
 
+  /**
+   * Opens answer files as additional read-only tabs alongside the student's current
+   * work, prefixed with "answer:" so they are visually distinct. Does not replace or
+   * write any files to the sandbox, preserving the student's WIP code.
+   */
+  compareAnswer() {
+    const answerFilenames = Object.keys(this.answerFiles());
+    const compareKeys = answerFilenames.map((f) => `answer:${f}`);
+
+    const answerAsCompareFiles = Object.fromEntries(
+      answerFilenames.map((f) => [`answer:${f}`, this.answerFiles()[f]]),
+    );
+
+    const openFilesWithCompare = [
+      ...this.openFiles().filter((f) => !f.startsWith('answer:')),
+      ...compareKeys,
+    ];
+
+    this.tutorialFiles.update((existing) => ({...existing, ...answerAsCompareFiles}));
+    this.openFiles.set(openFilesWithCompare);
+    this._shouldChangeTutorial$.next(true);
+  }
+
+  /**
+   * Removes the answer comparison tabs and restores the original open-file list.
+   */
+  stopCompareAnswer() {
+    const openFilesWithoutCompare = this.openFiles().filter((f) => !f.startsWith('answer:'));
+    this.tutorialFiles.update((existing) => {
+      const withoutCompare = {...existing};
+      for (const key of Object.keys(withoutCompare)) {
+        if (key.startsWith('answer:')) delete withoutCompare[key];
+      }
+      return withoutCompare;
+    });
+    this.openFiles.set(openFilesWithoutCompare);
+    this._shouldChangeTutorial$.next(true);
+  }
+
   resetRevealAnswer() {
     const allFilesWithoutAnswer = this.metadata()!.allFiles;
     const filesToDelete = this.computeFilesToRemove(allFilesWithoutAnswer, this.allFiles());

--- a/adev/src/app/features/tutorial/tutorial-navigation.scss
+++ b/adev/src/app/features/tutorial/tutorial-navigation.scss
@@ -162,6 +162,23 @@
   width: 120px;
 }
 
+.docs-compare-answer-button {
+  height: 2.875rem;
+  width: 120px;
+  background: transparent;
+  border: 1px solid var(--quinary-contrast);
+  color: var(--primary-contrast);
+
+  &:hover:not(:disabled) {
+    background: var(--octonary-contrast);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
 .adev-reset-answer-button {
   background: var(--senary-contrast);
   transition:

--- a/adev/src/app/features/tutorial/tutorial.component.html
+++ b/adev/src/app/features/tutorial/tutorial.component.html
@@ -64,6 +64,16 @@
         >
           {{ answerRevealed() ? 'Reset' : 'Reveal Answer' }}
         </button>
+        <button
+          type="button"
+          (click)="compareRevealed() ? handleStopCompare() : handleCompareAnswer()"
+          [disabled]="!canRevealAnswer() || answerRevealed()"
+          class="docs-compare-answer-button adev-reveal-desktop-button docs-primary-btn"
+          [attr.aria-label]="compareRevealed() ? 'Stop Comparing' : 'Compare'"
+          [class.adev-reset-answer-button]="compareRevealed()"
+        >
+          {{ compareRevealed() ? 'Stop Comparing' : 'Compare' }}
+        </button>
       }
 
       <!-- Download code -->
@@ -117,6 +127,16 @@
             [class.adev-reset-answer-button]="answerRevealed()"
           >
             {{ answerRevealed() ? 'Reset' : 'Reveal Answer' }}
+          </button>
+          <button
+            type="button"
+            (click)="compareRevealed() ? handleStopCompare() : handleCompareAnswer()"
+            [disabled]="!canRevealAnswer() || answerRevealed()"
+            class="docs-compare-answer-button adev-reveal-mobile-button docs-primary-btn"
+            [attr.aria-label]="compareRevealed() ? 'Stop Comparing' : 'Compare'"
+            [class.adev-reset-answer-button]="compareRevealed()"
+          >
+            {{ compareRevealed() ? 'Stop Comparing' : 'Compare' }}
           </button>
         }
       </div>

--- a/adev/src/app/features/tutorial/tutorial.component.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.ts
@@ -99,6 +99,7 @@ export default class Tutorial {
 
   canRevealAnswer: Signal<boolean> = signal(false);
   readonly answerRevealed = signal<boolean>(false);
+  readonly compareRevealed = signal<boolean>(false);
 
   constructor() {
     this.route.data
@@ -180,12 +181,24 @@ export default class Tutorial {
     this.answerRevealed.set(false);
   }
 
+  handleCompareAnswer() {
+    if (!this.canRevealAnswer()) return;
+    this.embeddedTutorialManager.compareAnswer();
+    this.compareRevealed.set(true);
+  }
+
+  handleStopCompare() {
+    this.embeddedTutorialManager.stopCompareAnswer();
+    this.compareRevealed.set(false);
+  }
+
   /**
    * Set tutorial data based on current tutorial
    */
   private async setTutorialData(tutorialNavigationItem: TutorialNavigationItem): Promise<void> {
     this.showNavigationDropdown.set(false);
     this.answerRevealed.set(false);
+    this.compareRevealed.set(false);
     this.restrictedMode.set(tutorialNavigationItem.tutorialData.restrictedMode);
 
     this.setRouteData(tutorialNavigationItem);


### PR DESCRIPTION
## Which issue does this PR close?

Closes #52656

## Description

Currently, clicking "Reveal Answer" in the tutorial editor replaces the student's entire work-in-progress code with the answer, with no way to compare or revert. This PR adds a **Compare** button that lets students see the answer alongside their own code without losing their work.

### How it works

- Clicking **Compare** opens answer files as additional **read-only** tabs in the code editor, prefixed with `answer:` and labelled with a blue badge
- The student's WIP files remain untouched and editable
- Clicking **Stop Comparing** removes the answer tabs and restores the original file list
- The Compare button is disabled while "Reveal Answer" is active (and vice versa)
- State resets automatically when navigating to a new tutorial step

### Files changed

| File | Change |
|---|---|
| `embedded-tutorial-manager.service.ts` | `compareAnswer()` injects answer files as `answer:`-prefixed virtual tabs; `stopCompareAnswer()` removes them |
| `tutorial.component.ts` | `compareRevealed` signal, `handleCompareAnswer()`, `handleStopCompare()`, reset on navigation |
| `tutorial.component.html` | Compare button added in desktop and mobile nav |
| `tutorial-navigation.scss` | Outlined secondary button style for Compare |
| `code-editor.component.html` | Answer tabs show filename + blue "answer" badge; rename/delete buttons hidden |
| `code-mirror-editor.service.ts` | Answer tabs get `EditorState.readOnly.of(true)` |
| `code-editor.component.scss` | Styles for the answer tab badge |

## Type of change

- [x] New feature (non-breaking)

## Checklist

- [x] Commit message follows the [Angular commit guidelines](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md)
- [x] Does not affect the existing Reveal Answer / Reset flow