### PR TITLE
fix(docs-infra): align homepage banner and search field

### DIFF
--- a/adev/src/app/features/home/home.component.scss
+++ b/adev/src/app/features/home/home.component.scss
@@ -191,6 +191,8 @@ section {
   }
 
   .search-field {
+    display: flex;
+
     @include mq.for-tablet-landscape-down() {
       display: none;
     }


### PR DESCRIPTION
The homepage hero lays out the announcement banner and the search field on the same flex row. The `.search-field` wrapper was a plain block, so its `docs-text-field` kept its intrinsic height instead of filling the row, leaving the two pills at different heights and vertically misaligned.

Make `.search-field` a flex container so the search control stretches to the row height and matches the banner.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (not applicable, CSS-only)
- [ ] Docs have been added / updated (not applicable)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other

## What is the current behavior?

On the homepage hero, the announcement banner ("Angular vX is here") and the
search field share the same flex row. Because the `.search-field` wrapper is a
block element, the inner `docs-text-field` keeps its intrinsic height and does
not fill the row, so the banner and search pills render at different heights
and look vertically misaligned.

<img width="359" height="251" alt="image" src="https://github.com/user-attachments/assets/3e90e0a1-a92c-4f4b-b0e6-99cbde37ffa8" />

<img width="375" height="258" alt="image" src="https://github.com/user-attachments/assets/1b00e71a-a097-4d52-bbc7-8a0b556816a4" />


## What is the new behavior?

`.search-field` is now a flex container, so the search control stretches to the
row height and matches the banner. The two pills are now the same height and
aligned.

<img width="356" height="251" alt="image" src="https://github.com/user-attachments/assets/fb9a03b5-25ed-42e6-aee6-e0880551f06e" />

<img width="375" height="258" alt="image" src="https://github.com/user-attachments/assets/fd4a5175-f552-47fd-b1b7-af561291be6a" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
