### PR TITLE
fix(core): sanitize href/xlink:href on all SVG namespace elements

### DIFF
--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -107,7 +107,10 @@ export function SECURITY_SCHEMA(): SecuritySchema {
     ['object', ['codebase', 'data']],
   ]);
 
-  registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]]);
+  registerContext(SecurityContext.URL, SVG_NAMESPACE, [
+    ['a', ['href', 'xlink:href']],
+    ['*', ['href', 'xlink:href']],
+  ]);
 
   // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
   // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -185,9 +185,14 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     expect(registry.securityContext(':math:foobar', 'xlink:href', true)).toBe(SecurityContext.URL);
     expect(registry.securityContext(':math:foobar', 'href', false)).toBe(SecurityContext.URL);
     expect(registry.securityContext(':math:foobar', 'xlink:href', false)).toBe(SecurityContext.URL);
-    // Ensure MathML wildcard does not apply outside of the MathML namespace.
-    expect(registry.securityContext(':svg:foobar', 'href', false)).toBe(SecurityContext.NONE);
-    expect(registry.securityContext(':svg:foobar', 'xlink:href', false)).toBe(SecurityContext.NONE);
+    // SVG href/xlink:href should be sanitized as URL for all SVG elements.
+    expect(registry.securityContext(':svg:foobar', 'href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:foobar', 'xlink:href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:image', 'href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:image', 'xlink:href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:use', 'href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:use', 'xlink:href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:feImage', 'href', false)).toBe(SecurityContext.URL);
 
     expect(registry.securityContext('p', 'href', false)).toBe(SecurityContext.NONE);
   });

--- a/packages/core/src/sanitization/dom_security_schema.ts
+++ b/packages/core/src/sanitization/dom_security_schema.ts
@@ -107,7 +107,10 @@ export function SECURITY_SCHEMA(): SecuritySchema {
     ['object', ['codebase', 'data']],
   ]);
 
-  registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]]);
+  registerContext(SecurityContext.URL, SVG_NAMESPACE, [
+    ['a', ['href', 'xlink:href']],
+    ['*', ['href', 'xlink:href']],
+  ]);
 
   // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
   // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## Description

The DOM security schema registers `SecurityContext.URL` for `href` and `xlink:href` in the MathML namespace using a wildcard `*` (added in 3927a5b), but the SVG namespace only registers these attributes for `<a>` elements.

This means SVG elements such as `<image>`, `<use>`, and `<feImage>` that also accept `href`/`xlink:href` are not covered by the schema, resulting in an inconsistency with how the MathML namespace is handled.

This PR adds a wildcard `*` entry for the SVG namespace to match the MathML approach. Specific-element registrations (e.g. `animate` → `ATTRIBUTE_NO_BINDING`) take precedence over the wildcard in the schema lookup, so existing behavior for SVG animation attributes is preserved.

### Changes

- `packages/compiler/src/schema/dom_security_schema.ts` — added SVG wildcard
- `packages/core/src/sanitization/dom_security_schema.ts` — same change (kept in sync)
- `packages/compiler/test/schema/dom_element_schema_registry_spec.ts` — updated expectations, added test cases for `image`, `use`, `feImage`

## Issue Number: N/A

## What is the new behavior?

SVG elements that accept href/xlink:href (such as image, use, feImage) are now covered by SecurityContext.URL, matching the existing behavior for MathML namespace elements. Previously only SVG `<a>` elements had this coverage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This follows the same wildcard pattern introduced for MathML in commit 3927a5b. The schema lookup gives precedence to specific-element registrations over wildcards, so SVG animation elements (animate, set, animateMotion, animateTransform) continue to use ATTRIBUTE_NO_BINDING as before.