### PR TITLE
refactor(compiler): correct TcbInvalidReferenceOp initializer

### DIFF
--- a/packages/compiler/src/typecheck/ops/references.ts
+++ b/packages/compiler/src/typecheck/ops/references.ts
@@ -118,7 +118,7 @@ export class TcbInvalidReferenceOp extends TcbOp {
 
   override execute(): TcbExpr {
     const id = new TcbExpr(this.tcb.allocateId());
-    this.scope.addStatement(new TcbExpr(`var ${id.print()} = any`));
+    this.scope.addStatement(new TcbExpr(`var ${id.print()} = null! as any`));
     return id;
   }
 }


### PR DESCRIPTION
initializer should use null! as any rather than simply '= any'
