### PR TITLE
fix(docs-infra): increase SSR fetch limit to prevent 404 on page reload #69377

### DIFF
--- a/adev/src/app/app.config.server.ts
+++ b/adev/src/app/app.config.server.ts
@@ -11,7 +11,12 @@ import {provideServerRendering, withRoutes, RenderMode} from '@angular/ssr';
 import {appConfig} from './app.config';
 
 const serverConfig: ApplicationConfig = {
-  providers: [provideServerRendering(withRoutes([{path: '**', renderMode: RenderMode.Prerender}]))],
+  providers: [
+    provideServerRendering(
+      {maxResponseBodySize: 2 * 1024 * 1024},
+      withRoutes([{path: '**', renderMode: RenderMode.Prerender}]),
+    ),
+  ],
 };
 
 export const config: ApplicationConfig = mergeApplicationConfig(appConfig, serverConfig);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Directly navigating to or refreshing (F5) certain documentation pages with large content, such as `/guide/aria/combobox` and `/guide/aria/autocomplete`, results in a 404 error page. This occurs because the content payload exceeds the default HTTP fetch response size limit during Server-Side Rendering (SSR).

Issue Number: #69377 

## What is the new behavior?
This PR resolves the issue by explicitly providing larger limit 2MB (2 * 1024 * 1024). The affected pages now render successfully on initial load and after a hard refresh without redirecting to 404.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
hotfix