### PR TITLE
docs: use the @service decorator in the first-app and signals tutorials

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing.service.ts
@@ -1,8 +1,6 @@
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 import {HousingLocationInfo} from './housinglocation';
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class HousingService {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing.service.ts
@@ -1,9 +1,7 @@
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 import {HousingLocationInfo} from './housinglocation';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class HousingService {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing.service.ts
@@ -1,9 +1,7 @@
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 import {HousingLocationInfo} from './housinglocation';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class HousingService {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/housing.service.ts
@@ -1,9 +1,7 @@
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 import {HousingLocationInfo} from './housinglocation';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class HousingService {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts
@@ -1,9 +1,7 @@
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 import {HousingLocationInfo} from './housinglocation';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class HousingService {
   url = 'http://localhost:3000/locations';
 

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/housing.service.ts
@@ -1,9 +1,7 @@
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 import {HousingLocationInfo} from './housinglocation';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class HousingService {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 

--- a/adev/src/content/tutorials/signals/steps/7-using-signals-with-services/README.md
+++ b/adev/src/content/tutorials/signals/steps/7-using-signals-with-services/README.md
@@ -13,7 +13,7 @@ Add readonly and computed signals to make the cart state reactive in `cart-store
 
 ```ts
 // Add the computed import
-import {Injectable, signal, computed} from '@angular/core';
+import {Service, signal, computed} from '@angular/core';
 
 // Then add these signals to the class:
 

--- a/adev/src/content/tutorials/signals/steps/7-using-signals-with-services/answer/src/app/cart-store.ts
+++ b/adev/src/content/tutorials/signals/steps/7-using-signals-with-services/answer/src/app/cart-store.ts
@@ -1,9 +1,7 @@
-import {Injectable, signal, computed} from '@angular/core';
+import {Service, signal, computed} from '@angular/core';
 import {CartItem} from './cart-types';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class CartStore {
   private items = signal<CartItem[]>([]);
 

--- a/adev/src/content/tutorials/signals/steps/7-using-signals-with-services/src/app/cart-store.ts
+++ b/adev/src/content/tutorials/signals/steps/7-using-signals-with-services/src/app/cart-store.ts
@@ -1,10 +1,8 @@
 // TODO: Import computed from @angular/core
-import {Injectable, signal} from '@angular/core';
+import {Service, signal} from '@angular/core';
 import {CartItem} from './cart-types';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class CartStore {
   private items = signal<CartItem[]>([]);
 


### PR DESCRIPTION
Update the services in the first-app and signals tutorials to use the
`@Service()` decorator instead of `@Injectable({providedIn: 'root'})`.
This affects `HousingService` (first-app steps 10-14) and `CartStore`
(signals step 7).

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other

## What is the current behavior?

The first-app tutorial (`HousingService`, steps 10-14) and the signals
tutorial (`CartStore`, step 7) still introduce services with
`@Injectable({providedIn: 'root'})`. The essentials guide, the in-depth
dependency injection guides, and the learn-angular DI tutorial have
already adopted the newer `@Service` decorator, leaving these tutorials
out of step with the rest of the docs.

## What is the new behavior?

Both tutorials use `@Service()`. Since `@Service()` is an ergonomic
shorthand for `@Injectable({providedIn: 'root'})` (it defaults to
`autoProvided: true`), the examples behave identically while teaching the
recommended modern API. The signals step 7 README snippet is updated to
match.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
