### PR TITLE
fix(docs-infra): add fallback submenu positions in menubar example

### DIFF
--- a/adev/src/content/examples/aria/menubar/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/app/app.html
@@ -60,6 +60,7 @@
           [cdkConnectedOverlay]="{origin: shareEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -277,6 +278,7 @@
           [cdkConnectedOverlay]="{origin: imageEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -328,6 +330,7 @@
           [cdkConnectedOverlay]="{origin: chartEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -410,6 +413,7 @@
           [cdkConnectedOverlay]="{origin: textEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -461,6 +465,7 @@
                 [cdkConnectedOverlay]="{origin: sizeEl, usePopover: 'inline'}"
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+                  {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
                 ]"
                 cdkAttachPopoverAsChild
               >
@@ -497,6 +502,7 @@
           [cdkConnectedOverlay]="{origin: paragraphEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -524,6 +530,7 @@
           [cdkConnectedOverlay]="{origin: alignEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >

--- a/adev/src/content/examples/aria/menubar/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/material/app/app.html
@@ -60,6 +60,7 @@
           [cdkConnectedOverlay]="{origin: shareEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -277,6 +278,7 @@
           [cdkConnectedOverlay]="{origin: imageEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -328,6 +330,7 @@
           [cdkConnectedOverlay]="{origin: chartEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -410,6 +413,7 @@
           [cdkConnectedOverlay]="{origin: textEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -461,6 +465,7 @@
                 [cdkConnectedOverlay]="{origin: sizeEl, usePopover: 'inline'}"
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+                  {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
                 ]"
                 cdkAttachPopoverAsChild
               >
@@ -497,6 +502,7 @@
           [cdkConnectedOverlay]="{origin: paragraphEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -524,6 +530,7 @@
           [cdkConnectedOverlay]="{origin: alignEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >

--- a/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.html
@@ -60,6 +60,7 @@
           [cdkConnectedOverlay]="{origin: shareEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -277,6 +278,7 @@
           [cdkConnectedOverlay]="{origin: imageEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -328,6 +330,7 @@
           [cdkConnectedOverlay]="{origin: chartEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -410,6 +413,7 @@
           [cdkConnectedOverlay]="{origin: textEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -461,6 +465,7 @@
                 [cdkConnectedOverlay]="{origin: sizeEl, usePopover: 'inline'}"
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+                  {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
                 ]"
                 cdkAttachPopoverAsChild
               >
@@ -497,6 +502,7 @@
           [cdkConnectedOverlay]="{origin: paragraphEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >
@@ -524,6 +530,7 @@
           [cdkConnectedOverlay]="{origin: alignEl, usePopover: 'inline'}"
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
+            {originX: 'start', originY: 'top', overlayY: 'top', overlayX: 'end', offsetX: -6},
           ]"
           cdkAttachPopoverAsChild
         >


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (not applicable for this template/example update)
* [ ] Docs have been added / updated (not applicable)

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Nested submenus in the ARIA menubar examples only define a single overlay position that opens to the right of the trigger element. When there is insufficient space on the right side of the viewport, the submenu can overflow off-screen instead of repositioning.

Issue Number: N/A

## What is the new behavior?

Adds fallback overlay positions for nested submenus in the ARIA menubar examples. If there is not enough space to render the submenu on the right side, the CDK overlay can fall back to opening on the left side of the trigger element, helping keep submenu content visible within the viewport.

The update is applied consistently across the basic, material, and retro menubar examples.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This change only updates overlay positioning configuration in the example templates and does not affect framework APIs or runtime behavior outside of the examples.
