### PR TITLE
ci: add id-token: write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: read # Required to checkout the repository
+  id-token: write # Required for NPM provenance in reusable workflow
 
 jobs:
   release:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The release caller workflow lacks the `id-token: write` permission.

Issue Number: N/A

## What is the new behavior?

Adds the missing `id-token: write` permission to the release caller workflow. This is required because the called reusable workflow `reusable-release.yml` in dev-infra requires this permission to generate NPM provenance metadata during publishing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
