### PR TITLE
fix(docs-infra): correct select dropdown scrolling, sizing, and selec…

### DIFF
--- a/adev/shared-docs/components/select/select.component.html
+++ b/adev/shared-docs/components/select/select.component.html
@@ -57,7 +57,7 @@
                   [(value)]="selectedValues"
                   [multi]="false"
                   ngComboboxWidget
-                  class="example-listbox"
+                  class="docs-select-listbox"
                   focusMode="activedescendant"
                   tabindex="-1"
                   selectionMode="explicit"
@@ -74,12 +74,6 @@
                       class="docs-select-option"
                     >
                       <span class="docs-select-option-label">{{ option.label }}</span>
-                      <span
-                        class="material-symbols-outlined docs-select-check-icon"
-                        translate="no"
-                        aria-hidden="true"
-                        >check</span
-                      >
                     </div>
                   }
                 </div>

--- a/adev/shared-docs/components/select/select.component.scss
+++ b/adev/shared-docs/components/select/select.component.scss
@@ -5,8 +5,12 @@
   width: 100%;
   display: flex;
   flex-direction: column;
+}
+
+.docs-combobox-container {
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
+  overflow: hidden;
 }
 
 .docs-select-input-container {
@@ -69,6 +73,8 @@
 
 .docs-select-dialog {
   position: absolute;
+  box-sizing: border-box;
+  width: 100%;
   left: auto;
   right: auto;
   top: auto;
@@ -76,6 +82,7 @@
   padding: 0;
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
+  overflow: hidden;
   background-color: var(--septenary-contrast);
   color: inherit;
 
@@ -178,16 +185,8 @@
     color: var(--vivid-pink);
     background-color: color-mix(in srgb, var(--vivid-pink) 5%, transparent);
   }
-
-  &:not([aria-selected='true']) .docs-select-check-icon {
-    display: none;
-  }
 }
 
 .docs-select-option-label {
   flex: 1;
-}
-
-.docs-select-check-icon {
-  font-size: 0.9rem;
 }

--- a/adev/shared-docs/components/select/select.component.ts
+++ b/adev/shared-docs/components/select/select.component.ts
@@ -39,7 +39,6 @@ export class Select implements FormValueControl<string | null> {
   readonly id = input.required<string>({alias: 'selectId'});
   readonly name = input.required<string>();
   readonly options = input.required<SelectOption[]>();
-  readonly disabled = input(false);
 
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
@@ -76,7 +75,7 @@ export class Select implements FormValueControl<string | null> {
     const values = this.selectedValues();
     if (values.length) {
       this.value.set(values[0]);
-      //this.popupExpanded.set(false);
+      this.popupExpanded.set(false);
     }
   }
 


### PR DESCRIPTION
Several issues in the shared docs `Select` component (used by the API reference package filter):

- The options list never scrolled: its element used a class with no styles, so the intended max-height/overflow rule was dead. Point it at the styled class so long lists scroll within the popover.
- Selecting an option now closes the popup instead of leaving it open.
- Clip the trigger and popover corners (overflow: hidden) so their rounded borders render cleanly, and align the popover width with the trigger.
- Drop the selected-option checkmark. The component is single-select and already marks the selection with a highlight, so the tick was misleading.
- Remove the unused `disabled` input.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The package filter dropdown on the API reference page (the shared `docs-select`
component) has several issues: the options list doesn't scroll on short pages,
the popup stays open after picking an option, the trigger/popover corners and
widths don't line up, and a checkmark on the selected option makes the
single-select look like a multi-select.

https://github.com/user-attachments/assets/34d34936-3d66-4ca8-87c1-161a6a341b49

## What is the new behavior?

- Long option lists scroll inside the popover.
- Choosing an option closes the dropdown.
- Trigger and popover corners are clipped and their widths match.
- The misleading selected-option checkmark is removed (selection is shown by
  the highlight); the unused `disabled` input is dropped.

https://github.com/user-attachments/assets/eda928f4-9a4d-4f4b-92fb-e1d8415a0f98

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
