### PR TITLE
fix(core): guard against DOM clobbering in declareExperimentalWebMcpTool

### DIFF
--- a/packages/core/src/webmcp/declare_tool.ts
+++ b/packages/core/src/webmcp/declare_tool.ts
@@ -41,8 +41,10 @@ export function declareExperimentalWebMcpTool<const InputSchema extends JsonSche
     (globalThis.document as {modelContext?: ModelContext}).modelContext ??
     (globalThis.navigator as unknown as {modelContext?: ModelContext}).modelContext;
 
-  // Verify WebMCP is supported in this client.
-  if (!modelContext) return;
+  // Verify WebMCP is supported in this client. The typeof check guards against
+  // DOM clobbering (e.g. <form id="modelContext">), which would produce a truthy
+  // Element instead of a ModelContext object.
+  if (!modelContext || typeof modelContext.registerTool !== 'function') return;
 
   if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     if (!injector) assertInInjectionContext(declareExperimentalWebMcpTool);


### PR DESCRIPTION
Previously, the modelContext truthiness check could be bypassed via DOM clobbering (e.g. `<form id="modelContext">`), causing a truthy HTMLElement to pass the guard and then throw when `registerTool` was called on it.

Replace the truthiness check with a duck-type check that asserts `registerTool` is a function, rejecting both absent and clobbered values.
