### PR TITLE
fix(upgrade): guard window.angular access against DOM clobbering

### DIFF
--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -341,7 +341,7 @@ export class UpgradeModule {
     );
 
     // Make sure resumeBootstrap() only exists if the current bootstrap is deferred
-    const windowAngular = (window as any)['angular'];
+    const windowAngular = ɵangular1.getAngularJSGlobal();
     windowAngular.resumeBootstrap = undefined;
 
     // Bootstrap the AngularJS application inside our zone


### PR DESCRIPTION
`UpgradeModule.bootstrap` was accessing `window['angular']` directly to
patch `resumeBootstrap`, bypassing the `hasOwnProperty` guard in `angular1.ts`
that protects against DOM clobbering (e.g. `<div id="angular">`).

Replace the raw window access with `ɵangular1.getAngularJSGlobal()`, which
returns the already-validated AngularJS reference.