### PR TITLE
docs(docs-infra): add missing readonly property to combobox guide

### DIFF
--- a/adev/src/content/guide/aria/combobox.md
+++ b/adev/src/content/guide/aria/combobox.md
@@ -243,15 +243,16 @@ Coordinates an interactive trigger element (such as a text input, button, or div
 
 #### Inputs / Model
 
-| Property           | Type                   | Default | Description                                                         |
-| ------------------ | ---------------------- | ------- | ------------------------------------------------------------------- |
-| `value`            | `ModelSignal<string>`  | `''`    | Two-way bindable text value of the combobox                         |
-| `expanded`         | `ModelSignal<boolean>` | `false` | Two-way bindable open/closed expanded state of the popup            |
-| `disabled`         | `boolean`              | `false` | Disables the combobox trigger element                               |
-| `softDisabled`     | `boolean`              | `true`  | Disables interaction while keeping the element keyboard focusable   |
-| `alwaysExpanded`   | `boolean`              | `false` | Forces the popup to always remain open                              |
-| `inlineSuggestion` | `string \| undefined`  | -       | Sets an inline suggestion to be highlighted at the end of the input |
-| `tabIndex`         | `number \| undefined`  | -       | Tabindex of the combobox element (aliased to `tabindex`)            |
+| Property           | Type                   | Default | Description                                                                                                          |
+| ------------------ | ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `value`            | `ModelSignal<string>`  | `''`    | Two-way bindable text value of the combobox                                                                          |
+| `expanded`         | `ModelSignal<boolean>` | `false` | Two-way bindable open/closed expanded state of the popup                                                             |
+| `disabled`         | `boolean`              | `false` | Disables the combobox trigger element                                                                                |
+| `softDisabled`     | `boolean`              | `true`  | Disables interaction while keeping the element keyboard focusable                                                    |
+| `readonly`         | `boolean`              | `false` | Makes the combobox read-only. Prevents the user from changing the value while keeping the element keyboard focusable |
+| `alwaysExpanded`   | `boolean`              | `false` | Forces the popup to always remain open                                                                               |
+| `inlineSuggestion` | `string \| undefined`  | -       | Sets an inline suggestion to be highlighted at the end of the input                                                  |
+| `tabIndex`         | `number \| undefined`  | -       | Tabindex of the combobox element (aliased to `tabindex`)                                                             |
 
 All keyboard events, focus coordination, and ARIA state properties (including `role="combobox"`, `aria-autocomplete`, and `aria-expanded`) are handled automatically on the host element.
 


### PR DESCRIPTION
PR angular/components#33364 restored the `readonly` property for the combobox, but the documentation was not updated to reflect this change. This commit adds the missing `readonly` input and its description to the Inputs / Model table in the combobox guide.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
missing readonly property in API

Issue Number: N/A

## What is the new behavior?
`readonly` property for combobox docs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
