### PR TITLE
docs(docs-infra): remove deprecated ts flags

### DIFF
--- a/adev/shared-docs/pipeline/examples/template/tsconfig.json
+++ b/adev/shared-docs/pipeline/examples/template/tsconfig.json
@@ -2,11 +2,9 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,

--- a/adev/shared-docs/pipeline/tutorials/common/tsconfig.json
+++ b/adev/shared-docs/pipeline/tutorials/common/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
@@ -12,7 +11,6 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,

--- a/adev/src/content/examples/angular-compiler-options/tsconfig.json
+++ b/adev/src/content/examples/angular-compiler-options/tsconfig.json
@@ -4,7 +4,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     // #enddocregion angular-compiler-options
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
@@ -15,16 +14,12 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "es2020",
     "module": "es2020",
-    "lib": [
-      "es2020",
-      "dom"
-    ]
+    "lib": ["es2020", "dom"]
     // #docregion angular-compiler-options
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
This fixes the playground & tutorials 