### PR TITLE
preserve `referrer` & `referrerPolicy ` metadata in asset requests

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -501,10 +501,10 @@ export abstract class AssetGroup {
    * Create a new `Request` based on the specified URL and `RequestInit` options, preserving only
    * metadata that are known to be safe.
    *
-   * Currently, headers, redirect policy, an explicit `credentials: 'omit'`, and the HTTP cache
-   * mode are preserved. On cross-origin redirects, sensitive headers are removed. This includes
-   * `Authorization`, as required by the Fetch redirect algorithm, and forbidden request headers
-   * that could contain credentials.
+   * Currently, headers, referrer, redirect policy, an explicit `credentials: 'omit'`, and the HTTP
+   * cache mode are preserved. On cross-origin redirects, sensitive headers are removed. This
+   * includes `Authorization`, as required by the Fetch redirect algorithm, and forbidden request
+   * headers that could contain credentials.
    *
    * NOTE:
    *   `credentials: 'same-origin'` and `credentials: 'include'` are intentionally not preserved.
@@ -532,6 +532,7 @@ export abstract class AssetGroup {
 
     const init: RequestInit = {
       headers,
+      referrer: options.referrer,
       redirect: options.redirect,
     };
 

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -501,10 +501,10 @@ export abstract class AssetGroup {
    * Create a new `Request` based on the specified URL and `RequestInit` options, preserving only
    * metadata that are known to be safe.
    *
-   * Currently, headers, referrer, redirect policy, an explicit `credentials: 'omit'`, and the HTTP
-   * cache mode are preserved. On cross-origin redirects, sensitive headers are removed. This
-   * includes `Authorization`, as required by the Fetch redirect algorithm, and forbidden request
-   * headers that could contain credentials.
+   * Currently, headers, referrer, referrer policy, redirect policy, an explicit
+   * `credentials: 'omit'`, and the HTTP cache mode are preserved. On cross-origin redirects,
+   * sensitive headers are removed. This includes `Authorization`, as required by the Fetch redirect
+   * algorithm, and forbidden request headers that could contain credentials.
    *
    * NOTE:
    *   `credentials: 'same-origin'` and `credentials: 'include'` are intentionally not preserved.
@@ -533,6 +533,7 @@ export abstract class AssetGroup {
     const init: RequestInit = {
       headers,
       referrer: options.referrer,
+      referrerPolicy: options.referrerPolicy,
       redirect: options.redirect,
     };
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1688,6 +1688,14 @@ import {envIsSupported} from '../testing/utils';
         expect(bazReq.referrer).toBe('');
       });
 
+      it(`passes 'referrerPolicy' through to the server`, async () => {
+        const reqInit = {referrerPolicy: 'no-referrer'};
+        expect(await makeRequest(scope, '/baz.txt', undefined, reqInit)).toBe('this is baz');
+
+        const [bazReq] = server.getRequestsFor('/baz.txt');
+        expect(bazReq.referrerPolicy).toBe('no-referrer');
+      });
+
       it(`passes 'cache' through to the server`, async () => {
         // Request a lazy-cached asset (so that it is fetched from the network) and provide an
         // explicit HTTP cache mode.
@@ -1799,6 +1807,16 @@ import {envIsSupported} from '../testing/utils';
 
           const [redirectReq] = server.getRequestsFor('/lazy/redirect-target.txt');
           expect(redirectReq.referrer).toBe('');
+        });
+
+        it(`passes 'referrerPolicy' through to the server`, async () => {
+          const reqInit = {referrerPolicy: 'no-referrer'};
+          expect(await makeRequest(scope, '/lazy/redirected.txt', undefined, reqInit)).toBe(
+            'this was a redirect too',
+          );
+
+          const [redirectReq] = server.getRequestsFor('/lazy/redirect-target.txt');
+          expect(redirectReq.referrerPolicy).toBe('no-referrer');
         });
 
         it(`passes 'cache' through to the server`, async () => {

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1672,6 +1672,22 @@ import {envIsSupported} from '../testing/utils';
         expect(bazReq.credentials).toBe('omit');
       });
 
+      it(`passes 'referrer' through to the server`, async () => {
+        const reqInit = {referrer: 'http://localhost/profile?token=secret'};
+        expect(await makeRequest(scope, '/baz.txt', undefined, reqInit)).toBe('this is baz');
+
+        const [bazReq] = server.getRequestsFor('/baz.txt');
+        expect(bazReq.referrer).toBe('http://localhost/profile?token=secret');
+      });
+
+      it(`passes 'referrer: ""' through to the server`, async () => {
+        const reqInit = {referrer: ''};
+        expect(await makeRequest(scope, '/baz.txt', undefined, reqInit)).toBe('this is baz');
+
+        const [bazReq] = server.getRequestsFor('/baz.txt');
+        expect(bazReq.referrer).toBe('');
+      });
+
       it(`passes 'cache' through to the server`, async () => {
         // Request a lazy-cached asset (so that it is fetched from the network) and provide an
         // explicit HTTP cache mode.
@@ -1763,6 +1779,26 @@ import {envIsSupported} from '../testing/utils';
           // reconstruction (instead of being replaced by the default `'same-origin'`).
           const [redirectReq] = server.getRequestsFor('/lazy/redirect-target.txt');
           expect(redirectReq.credentials).toBe('omit');
+        });
+
+        it(`passes 'referrer' through to the server`, async () => {
+          const reqInit = {referrer: 'http://localhost/profile?token=secret'};
+          expect(await makeRequest(scope, '/lazy/redirected.txt', undefined, reqInit)).toBe(
+            'this was a redirect too',
+          );
+
+          const [redirectReq] = server.getRequestsFor('/lazy/redirect-target.txt');
+          expect(redirectReq.referrer).toBe('http://localhost/profile?token=secret');
+        });
+
+        it(`passes 'referrer: ""' through to the server`, async () => {
+          const reqInit = {referrer: ''};
+          expect(await makeRequest(scope, '/lazy/redirected.txt', undefined, reqInit)).toBe(
+            'this was a redirect too',
+          );
+
+          const [redirectReq] = server.getRequestsFor('/lazy/redirect-target.txt');
+          expect(redirectReq.referrer).toBe('');
         });
 
         it(`passes 'cache' through to the server`, async () => {

--- a/packages/service-worker/worker/testing/fetch.ts
+++ b/packages/service-worker/worker/testing/fetch.ts
@@ -131,7 +131,7 @@ export class MockRequest extends MockBody implements Request {
   readonly mode: RequestMode = 'cors';
   readonly redirect: RequestRedirect = 'follow';
   readonly referrer: string = 'about:client';
-  readonly referrerPolicy: ReferrerPolicy = 'no-referrer';
+  readonly referrerPolicy: ReferrerPolicy = '';
   readonly signal: AbortSignal = null as any;
 
   url: string;
@@ -166,6 +166,9 @@ export class MockRequest extends MockBody implements Request {
     if (init.referrer !== undefined) {
       this.referrer = init.referrer;
     }
+    if (init.referrerPolicy !== undefined) {
+      this.referrerPolicy = init.referrerPolicy;
+    }
     if (init.destination !== undefined) {
       this.destination = init.destination;
     }
@@ -183,6 +186,7 @@ export class MockRequest extends MockBody implements Request {
       headers: this.headers,
       redirect: this.redirect,
       referrer: this.referrer,
+      referrerPolicy: this.referrerPolicy,
     });
   }
 }

--- a/packages/service-worker/worker/testing/fetch.ts
+++ b/packages/service-worker/worker/testing/fetch.ts
@@ -130,7 +130,7 @@ export class MockRequest extends MockBody implements Request {
   readonly method: string = 'GET';
   readonly mode: RequestMode = 'cors';
   readonly redirect: RequestRedirect = 'follow';
-  readonly referrer: string = '';
+  readonly referrer: string = 'about:client';
   readonly referrerPolicy: ReferrerPolicy = 'no-referrer';
   readonly signal: AbortSignal = null as any;
 
@@ -163,6 +163,9 @@ export class MockRequest extends MockBody implements Request {
     if (init.redirect !== undefined) {
       this.redirect = init.redirect;
     }
+    if (init.referrer !== undefined) {
+      this.referrer = init.referrer;
+    }
     if (init.destination !== undefined) {
       this.destination = init.destination;
     }
@@ -179,6 +182,7 @@ export class MockRequest extends MockBody implements Request {
       credentials: this.credentials,
       headers: this.headers,
       redirect: this.redirect,
+      referrer: this.referrer,
     });
   }
 }


### PR DESCRIPTION
### fix(service-worker): preserve empty referrer in asset requests

Preserve explicit referrer: '' when the service worker reconstructs asset requests for cache-busted and redirected asset fetches.

For example, an attacker with access to asset host logs could receive a reset token embedded in a page URL if the reconstructed request falls back to the default referrer behavior.

Also, we can see a similar behavior in the recent fix for the HTTP client

See  https://github.com/angular/angular/pull/69171#issuecomment-4632271457

### fix(service-worker): preserve referrer policy in asset requests

Preserve explicit referrer policy when the service worker reconstructs asset requests for cache-busted and redirected asset fetches.

For example, an application can load a script or image with referrerPolicy: 'same-origin' or 'origin' to limit referrer data. Dropping that policy can expose more of the current URL to that resource host.

