### PR TITLE
fix(docs-infra): align the page title with its edit action

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -132,6 +132,7 @@
 .docs-page-title {
   display: flex;
   justify-content: space-between;
+  align-items: baseline;
 
   h1 {
     margin-block: 0;


### PR DESCRIPTION
The page title row (`.docs-page-title`) relied on the default flex alignment, so the edit icon next to the title did not line up with the title text. Add `align-items: baseline` so the icon sits on the title's baseline.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The edit (pencil) icon next to a page title is not vertically aligned with the
title text, because .docs-page-title uses the default flex alignment.

<img width="451" height="62" alt="image" src="https://github.com/user-attachments/assets/945c5cd3-c9a1-48cf-ad61-ca1f0fcafb00" />

<img width="458" height="225" alt="image" src="https://github.com/user-attachments/assets/74dcbfff-85fa-43bd-b4d7-8632f0ead541" />


## What is the new behavior?

The edit icon aligns to the title's baseline via align-items: baseline.

<img width="660" height="82" alt="image" src="https://github.com/user-attachments/assets/b2077736-47cd-4405-bb9c-a45da86979e2" />

<img width="456" height="269" alt="image" src="https://github.com/user-attachments/assets/cd56e2dd-c270-4927-8c9d-c77d6cf7753f" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
