### PR TITLE
Revert "fix(core): escape overlapping comment delimiters in escapeCom…

### DIFF
--- a/packages/core/src/util/dom.ts
+++ b/packages/core/src/util/dom.ts
@@ -11,7 +11,7 @@
  *
  * see: https://html.spec.whatwg.org/multipage/syntax.html#comments
  */
-const COMMENT_DISALLOWED = />|->|<!--|-->|--!>|<!-$/g;
+const COMMENT_DISALLOWED = /^>|^->|<!--|-->|--!>|<!-$/g;
 /**
  * Delimiter in the disallowed strings which needs to be wrapped with zero with character.
  */

--- a/packages/core/test/util/dom_spec.ts
+++ b/packages/core/test/util/dom_spec.ts
@@ -40,35 +40,10 @@ describe('comment node text escaping', () => {
       expect(escapeCommentText('--!>')).toEqual('--!\u200b>\u200b');
       expect(escapeCommentText('<!-')).toEqual('\u200b<\u200b!-');
 
-      // A standalone `>` or `->` is escaped regardless of position so that a delimiter which
-      // overlaps an earlier match (e.g. the `-->` in `<!-->`) can't survive a single pass.
-      expect(escapeCommentText('.>')).toEqual('.\u200b>\u200b');
-      expect(escapeCommentText('.->')).toEqual('.-\u200b>\u200b');
+      // Things which are OK
+      expect(escapeCommentText('.>')).toEqual('.>');
+      expect(escapeCommentText('.->')).toEqual('.->');
       expect(escapeCommentText('<!-.')).toEqual('<!-.');
-    });
-
-    it('should escape delimiters that overlap an earlier match', () => {
-      // `<!-->` contains both `<!--` and a `-->` that shares its `--`; both must be neutralized.
-      expect(escapeCommentText('<!-->')).toEqual('\u200b<\u200b!--\u200b>\u200b');
-      expect(escapeCommentText('<!--!>')).toEqual('\u200b<\u200b!--!\u200b>\u200b');
-      expect(escapeCommentText('a<!-->b')).toEqual('a\u200b<\u200b!--\u200b>\u200bb');
-    });
-
-    it('should keep an injected payload inside a programmatically created comment', () => {
-      // `<!-->` closes a comment immediately (the `-->` overlaps the `<!--`), so without escaping
-      // the trailing markup leaks out of the comment and runs. Round-trip a comment node through
-      // serialization + re-parsing to confirm the payload stays inert comment text.
-      const host = document.createElement('div');
-      host.appendChild(
-        document.createComment(escapeCommentText('<!--><img src=x onerror="alert(1)">')),
-      );
-
-      const reparsed = document.createElement('div');
-      reparsed.innerHTML = host.innerHTML;
-
-      expect(reparsed.childNodes.length).toBe(1);
-      expect(reparsed.firstChild!.nodeType).toBe(Node.COMMENT_NODE);
-      expect(reparsed.getElementsByTagName('img').length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
…mentText"

This reverts commit ea1a3ed64c538fa768fff586796ece6ffb8b6598.

This change caused several targets to break in G3.