### PR TITLE
fix(core): allow static attributes for explicit input transforms

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1029,8 +1029,8 @@ export interface InputFunction {
     <T>(initialValue: undefined, opts: InputOptionsWithoutTransform<T>): InputSignal<T | undefined>;
     <T, TransformT>(initialValue: T, opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;
     <T, TransformT>(initialValue: undefined, opts: InputOptionsWithTransform<T | undefined, TransformT>): InputSignalWithTransform<T | undefined, TransformT>;
-    <T>(initialValue: T, opts: InputOptionsWithTransform<T, unknown>): InputSignalWithTransform<T, T>;
-    <T>(initialValue: undefined, opts: InputOptionsWithTransform<T | undefined, unknown>): InputSignalWithTransform<T | undefined, T | undefined>;
+    <T>(initialValue: T, opts: InputOptionsWithTransform<T, unknown>): InputSignalWithTransform<T, T | string>;
+    <T>(initialValue: undefined, opts: InputOptionsWithTransform<T | undefined, unknown>): InputSignalWithTransform<T | undefined, T | undefined | string>;
     required: {
         <T>(opts?: InputOptionsWithoutTransform<T>): InputSignal<T>;
         <T, TransformT>(opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;

--- a/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
@@ -320,6 +320,66 @@ runInEachFileSystem(() => {
         );
       });
 
+      it('should allow text attributes for explicit signal inputs with booleanAttribute transform', () => {
+        env.write(
+          'test.ts',
+          `
+          import {booleanAttribute, Component, Directive, input} from '@angular/core';
+
+          @Directive({
+            selector: '[directiveName]',
+          })
+          export class TestDir {
+            dismissible = input<boolean>(true, {transform: booleanAttribute});
+          }
+
+          @Component({
+            template: \`
+              <div directiveName [dismissible]="true"></div>
+              <div directiveName dismissible="true"></div>
+              <div directiveName dismissible></div>
+            \`,
+            imports: [TestDir],
+          })
+          export class TestComp {
+          }
+        `,
+        );
+
+        const diagnostics = env.driveDiagnostics();
+        expect(diagnostics).toEqual([]);
+      });
+
+      it('should allow text attributes for explicit signal inputs with numberAttribute transform', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive, input, numberAttribute} from '@angular/core';
+
+          @Directive({
+            selector: '[directiveName]',
+          })
+          export class TestDir {
+            count = input<number>(0, {transform: numberAttribute});
+          }
+
+          @Component({
+            template: \`
+              <div directiveName [count]="1"></div>
+              <div directiveName count="1"></div>
+              <div directiveName count=""></div>
+            \`,
+            imports: [TestDir],
+          })
+          export class TestComp {
+          }
+        `,
+        );
+
+        const diagnostics = env.driveDiagnostics();
+        expect(diagnostics).toEqual([]);
+      });
+
       it('should report unset required inputs', () => {
         env.write(
           'test.ts',

--- a/packages/core/src/authoring/input/input.ts
+++ b/packages/core/src/authoring/input/input.ts
@@ -79,17 +79,20 @@ export interface InputFunction {
   ): InputSignalWithTransform<T | undefined, TransformT>;
   /**
    * Declares an input of type `T` with an initial value and a transform function
-   * that accepts values of the same type.
+   * that accepts values of the same type, or string values from static attributes.
    */
-  <T>(initialValue: T, opts: InputOptionsWithTransform<T, unknown>): InputSignalWithTransform<T, T>;
+  <T>(
+    initialValue: T,
+    opts: InputOptionsWithTransform<T, unknown>,
+  ): InputSignalWithTransform<T, T | string>;
   /**
    * Declares an input of type `T|undefined` without an initial value and with a transform
-   * function that accepts values of the same type.
+   * function that accepts values of the same type, or string values from static attributes.
    */
   <T>(
     initialValue: undefined,
     opts: InputOptionsWithTransform<T | undefined, unknown>,
-  ): InputSignalWithTransform<T | undefined, T | undefined>;
+  ): InputSignalWithTransform<T | undefined, T | undefined | string>;
 
   /**
    * Initializes a required input.

--- a/packages/core/test/authoring/signal_input_signature_test.ts
+++ b/packages/core/test/authoring/signal_input_signature_test.ts
@@ -102,15 +102,15 @@ export class InputSignatureTest {
     transform: (v: string | boolean) => '',
   });
 
-  /** boolean, boolean */
+  /** boolean, string | boolean */
   explicitReadWithBooleanAttributeTransform = input<boolean>(false, {transform: booleanAttribute});
-  /** number, number */
+  /** number, string | number */
   explicitReadWithNumberAttributeTransform = input<number>(0, {transform: numberAttribute});
-  /** boolean | undefined, boolean | undefined */
+  /** boolean | undefined, string | boolean | undefined */
   explicitReadWithUndefinedInitialBooleanAttributeTransform = input<boolean>(undefined, {
     transform: booleanAttribute,
   });
-  /** number | undefined, number | undefined */
+  /** number | undefined, string | number | undefined */
   explicitReadWithUndefinedInitialNumberAttributeTransform = input<number>(undefined, {
     transform: numberAttribute,
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

This is a follow-up to #67997, which allowed explicit read generics with input transforms, such as `input<boolean>(false, {transform: booleanAttribute})`.

That fixed the declaration, but static template attributes like `dismissible="true"` and bare `dismissible` were still checked as strings against the read type. 

## What is the new behavior?

Allow the fallback write type to include static attribute strings so these template forms compile.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
