### PR TITLE
fix(docs-infra): improve Retro clear button visibility in dark mode

### DIFF
--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.css
@@ -155,12 +155,21 @@
   font-family: 'Press Start 2P';
   font-size: 0.6rem;
   user-select: none;
+
+  .docs-dark-mode & {
+    color: var(--win95-dark-gray);
+  }
 }
 
 .clear-button:hover {
   background: #e0e0e0;
   outline: 1px dashed var(--win95-dark-gray);
   outline-offset: 1px;
+  color: var(--win95-shadow);
+
+  .docs-dark-mode & {
+    color: var(--win95-dark-gray);
+  }
 }
 
 .clear-button:active {

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.css
@@ -155,12 +155,21 @@
   font-family: 'Press Start 2P';
   font-size: 0.6rem;
   user-select: none;
+
+  .docs-dark-mode & {
+    color: var(--win95-dark-gray);
+  }
 }
 
 .clear-button:hover {
   background: #e0e0e0;
   outline: 1px dashed var(--win95-dark-gray);
   outline-offset: 1px;
+  color: var(--win95-shadow);
+
+  .docs-dark-mode & {
+    color: var(--win95-dark-gray);
+  }
 }
 
 .clear-button:active {

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.css
@@ -155,12 +155,21 @@
   font-family: 'Press Start 2P';
   font-size: 0.6rem;
   user-select: none;
+
+  .docs-dark-mode & {
+    color: var(--win95-dark-gray);
+  }
 }
 
 .clear-button:hover {
   background: #e0e0e0;
   outline: 1px dashed var(--win95-dark-gray);
   outline-offset: 1px;
+  color: var(--win95-shadow);
+
+  .docs-dark-mode & {
+    color: var(--win95-dark-gray);
+  }
 }
 
 .clear-button:active {


### PR DESCRIPTION
## PR Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (not applicable)
* [ ] Docs have been added / updated (not applicable)

## PR Type

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no API changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] angular.dev application / infrastructure changes
* [ ] Other

## What is the current behavior?

In the Retro theme variants of the ARIA Autocomplete examples, the clear ("X") button uses `--win95-shadow` as its text color. This can result in poor contrast and reduced visibility, particularly in dark mode.

<img width="642" height="432" alt="Screenshot 2026-06-18 220327" src="https://github.com/user-attachments/assets/dde9bffc-3529-4693-b8a3-360dc36bfd58" />

Issue Number: N/A

## What is the new behavior?

* Replaces `--win95-shadow` with `--win95-dark-gray` for the clear button text color.
* Adds a `--win95-dark-gray` token to the Retro theme scope.
* Updates the hover state to maintain consistent icon contrast.
* Applies the change consistently across:

  * `basic/retro`
  * `highlight/retro`
  * `manual/retro`

<img width="677" height="427" alt="Screenshot 2026-06-18 220310" src="https://github.com/user-attachments/assets/6243965a-645c-49ff-9999-3d33d7736119" />

This improves visibility of the clear button while preserving the Retro theme appearance.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This is a visual accessibility fix only. No Autocomplete functionality or behavior has been changed.
