### PR TITLE
fix(docs-infra): restore adev build under stricter ts_project deps

### DIFF
--- a/adev/shared-docs/pipeline/_navigation.bzl
+++ b/adev/shared-docs/pipeline/_navigation.bzl
@@ -1,3 +1,5 @@
+load("@aspect_rules_js//js:providers.bzl", "js_info")
+
 def _generate_nav_items(ctx):
     """Implementation of the navigation items data generator rule"""
 
@@ -33,9 +35,18 @@ def _generate_nav_items(ctx):
         },
     )
 
-    # The return value describes what the rule is producing. In this case we need to specify
-    # the "DefaultInfo" with the output json file.
-    return [DefaultInfo(files = depset([json_output]))]
+    # The return value describes what the rule is producing. We expose the generated JSON via
+    # both DefaultInfo and JsInfo so it can be consumed as a `ts_project` dependency (the new
+    # rules_angular `ts_project` requires deps to provide JsInfo).
+    outputs = depset([json_output])
+    return [
+        DefaultInfo(files = outputs),
+        js_info(
+            target = ctx.label,
+            sources = outputs,
+            transitive_sources = outputs,
+        ),
+    ]
 
 generate_nav_items = rule(
     # Point to the starlark function that will execute for this rule.

--- a/adev/src/context/BUILD.bazel
+++ b/adev/src/context/BUILD.bazel
@@ -27,7 +27,6 @@ ts_project(
     name = "llms_lib",
     srcs = ["llms.mts"],
     tsconfig = ":tsconfig_build",
-    deps = [":llms_src"],
 )
 
 js_binary(

--- a/devtools/tools/esbuild/BUILD.bazel
+++ b/devtools/tools/esbuild/BUILD.bazel
@@ -8,7 +8,6 @@ ts_project(
     deps = [
         "//:node_modules/@angular/compiler-cli",
         "//devtools/tools/angular-optimization:js_lib",
-        "//packages:package_json",
     ],
 )
 


### PR DESCRIPTION
The cross-repo dependency update in #69410 bumped rules_angular, whose ts_project now requires every entry in `deps` to provide the JsInfo provider. Two adev targets passed deps that don't, so `bazel build //adev:build` fails analysis and the adev CI check has been red on main since that PR.

Make generate_nav_items return JsInfo (with the generated routes.json as its sources) so navigation-entries can keep importing routes.json through its deps. Also drop the spurious deps entry on llms_lib: llms.mts reads llms-list.md at runtime via readFile rather than importing it, and the file is already provided to the binary via data.

Fixes #69429

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other

## What is the current behavior?

`bazel build //adev:build` fails analysis after #69410 bumped
rules_angular. Its ts_project now requires `deps` to provide JsInfo, which
`//adev/src/context:llms_lib` (dep on a markdown filegroup) and
`//adev/src/app/routing/navigation-entries:navigation-entries` (deps on
`route-nav-items`, outputs of generate_nav_items) do not. The adev CI
check on main has been failing since that PR.

Issue Number: #69429

## What is the new behavior?

generate_nav_items returns JsInfo alongside DefaultInfo, so its routes.json
output is a valid ts_project dependency. The unnecessary `deps` on llms_lib
is removed. `bazel build //adev:build` passes again (verified locally).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No