### PR TITLE
fix(forms): prevent stale CVA writeback during debounce

### DIFF
--- a/packages/forms/signals/src/directive/control_cva.ts
+++ b/packages/forms/signals/src/directive/control_cva.ts
@@ -88,12 +88,12 @@ export function cvaControlCreate(
 
   return () => {
     const fieldState = parent.state();
-    const value = fieldState.value();
+    const controlValue = fieldState.controlValue();
 
-    if (bindingUpdated(bindings, 'controlValue', value)) {
+    if (bindingUpdated(bindings, 'controlValue', controlValue)) {
       // We don't know if the interop control has underlying signals, so we must use `untracked` to
       // prevent writing to a signal in a reactive context.
-      untracked(() => parent.controlValueAccessor!.writeValue(value));
+      untracked(() => parent.controlValueAccessor!.writeValue(controlValue));
     }
 
     for (const name of CONTROL_BINDING_NAMES) {

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -607,6 +607,62 @@ describe('ControlValueAccessor', () => {
     expect(field().value()).toBe('initial');
   });
 
+  it('should not write stale model values back to a CVA while debounce is pending', () => {
+    let writeValues: string[] = [];
+
+    @Component({
+      selector: 'custom-control-writeback-test',
+      template: `<input [value]="value" (input)="onInput($event.target.value)" />`,
+    })
+    class CustomControlWritebackTest implements ControlValueAccessor {
+      value = '';
+
+      private onChangeFn?: (value: string) => void;
+
+      writeValue(newValue: string): void {
+        writeValues.push(newValue);
+        this.value = newValue;
+      }
+
+      registerOnChange(fn: (value: string) => void): void {
+        this.onChangeFn = fn;
+      }
+
+      registerOnTouched(fn: () => void): void {}
+
+      onInput(newValue: string) {
+        this.value = newValue;
+        this.onChangeFn?.(newValue);
+      }
+    }
+
+    @Component({
+      imports: [CustomControlWritebackTest, FormField],
+      template: `<custom-control-writeback-test [formField]="f" />`,
+    })
+    class TestCmp {
+      readonly f = form(signal('initial'), (p) => {
+        debounce(p, 'blur');
+      });
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+
+    const debugEl = fixture.debugElement.query(
+      (el) => el.componentInstance instanceof CustomControlWritebackTest,
+    );
+
+    const cvaInstance = debugEl.componentInstance as CustomControlWritebackTest;
+
+    writeValues = [];
+
+    act(() => cvaInstance.onInput('updated'));
+
+    expect(cvaInstance.value).toBe('updated');
+
+    expect(writeValues).toEqual([]);
+  });
+
   describe('properties', () => {
     describe('disabled', () => {
       it('should bind to directive input', () => {

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -613,6 +613,13 @@ describe('ControlValueAccessor', () => {
     @Component({
       selector: 'custom-control-writeback-test',
       template: `<input [value]="value" (input)="onInput($event.target.value)" />`,
+      providers: [
+        {
+          provide: NG_VALUE_ACCESSOR,
+          useExisting: CustomControlWritebackTest,
+          multi: true,
+        },
+      ],
     })
     class CustomControlWritebackTest implements ControlValueAccessor {
       value = '';
@@ -659,7 +666,7 @@ describe('ControlValueAccessor', () => {
     act(() => cvaInstance.onInput('updated'));
 
     expect(cvaInstance.value).toBe('updated');
-
+    expect(fixture.componentInstance.f().value()).toBe('initial');
     expect(writeValues).toEqual([]);
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (not required for this bug fix)

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

When a Signal Forms field uses `debounce()`, `ControlValueAccessor` synchronization reads from `fieldState.value()`. During the debounce period, this value can still contain the previous model value even though the control has already received a newer user-entered value.

As a result, the stale model value may be written back to the CVA before the debounced update is flushed.

Issue Number: #69387

## What is the new behavior?

`ControlValueAccessor` synchronization now uses `fieldState.controlValue()` instead of `fieldState.value()`.

This ensures that CVAs receive the latest control value while a debounce is pending, preventing stale values from being written back to the control.

A regression test has been added to verify that no stale write-back occurs when debounce is active.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

The change aligns CVA synchronization behavior with the existing implementations in `control_custom.ts` and `control_native.ts`, which already use `controlValue()`.
