### PR TITLE
fix(docs-infra): pin learn-angular tutorial to an Angular version wit…

### DIFF
--- a/adev/src/content/tutorials/learn-angular/common/package-lock.json
+++ b/adev/src/content/tutorials/learn-angular/common/package-lock.json
@@ -8,12 +8,12 @@
       "name": "angular.dev",
       "version": "0.0.0",
       "dependencies": {
-        "@angular/common": "^22.1.0-next",
-        "@angular/compiler": "^22.1.0-next",
-        "@angular/core": "^22.1.0-next",
-        "@angular/forms": "^22.1.0-next",
-        "@angular/platform-browser": "^22.1.0-next",
-        "@angular/router": "^22.1.0-next",
+        "@angular/common": "^22.1.0-next.1",
+        "@angular/compiler": "^22.1.0-next.1",
+        "@angular/core": "^22.1.0-next.1",
+        "@angular/forms": "^22.1.0-next.1",
+        "@angular/platform-browser": "^22.1.0-next.1",
+        "@angular/router": "^22.1.0-next.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.16.0"
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@angular/build": "^22.1.0-next",
         "@angular/cli": "^22.1.0-next",
-        "@angular/compiler-cli": "^22.1.0-next",
+        "@angular/compiler-cli": "^22.1.0-next.1",
         "typescript": "~6.0.3"
       }
     },
@@ -452,9 +452,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "22.1.0-next.0",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.1.0-next.0.tgz",
-      "integrity": "sha512-d6hYNsG73xouc0kON+p0Hw8DqDgQwllh8xATxjCkjHtu551eMGptRy1+vUIcZJEZbM8BQNXt+/VuHS2rVLlEBA==",
+      "version": "22.1.0-next.1",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.1.0-next.1.tgz",
+      "integrity": "sha512-tNyKQ8BQyFOUbtZnNbAjkICkATppr5Z+6l2u6R9bwiMVjdqmMX42oY32Z1Sc7i/iOZig7vTuEuNcSISUmL6qIw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -463,14 +463,14 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "22.1.0-next.0",
+        "@angular/core": "22.1.0-next.1",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "22.1.0-next.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.1.0-next.0.tgz",
-      "integrity": "sha512-ghmJI+tuVYUbkvrovWmv1/9g2u94H3kcFRnGVOmI58j6gCBxOxuUeLujTGQzDtgz7wXjkekpsgml5hxRwIOGBg==",
+      "version": "22.1.0-next.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.1.0-next.1.tgz",
+      "integrity": "sha512-RXbWTFVCT5TwszURCM6U6PigosvNO3wtG33mXQ5UrXV0oO4srhltJrcqx+okekQebgCz8FTzkHQ0/ksUmAMfSA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -480,9 +480,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "22.1.0-next.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.1.0-next.0.tgz",
-      "integrity": "sha512-vZiE7QVG7pMLyoBiSpFWzDtXqCBCZCo3QdgbTEqIym2/bVCPLcZ32HIBsbmbJG4O311OIfpsmxLNPlUojw1QCw==",
+      "version": "22.1.0-next.1",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.1.0-next.1.tgz",
+      "integrity": "sha512-yebPqQ2Tl6pwyiafRz6Y5wBnD2cydkr2WkBfiaLGLRymhhRhOc4hqMtYuFfDi3sfC4RylkMAmAUtc7NCcyPB7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -503,7 +503,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.1.0-next.0",
+        "@angular/compiler": "22.1.0-next.1",
         "typescript": ">=6.0 <6.1"
       },
       "peerDependenciesMeta": {
@@ -513,9 +513,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "22.1.0-next.0",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.1.0-next.0.tgz",
-      "integrity": "sha512-SfGaPijz4D/GGlOK0UpGRAVA/Ri3W1tu06ASOn/Hcan39n2Wq733ot4NUPTEaxZOr91FYMaXZ1bPdriDM9vTag==",
+      "version": "22.1.0-next.1",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.1.0-next.1.tgz",
+      "integrity": "sha512-mkkcPoDP74+AwEzTLyp9iV9x4HbFByKTv+qPyNr60BeA3S+472I7DwZk7JxTRF9ifZwjmA3ab/wGsR2zg1hsEg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -524,7 +524,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.1.0-next.0",
+        "@angular/compiler": "22.1.0-next.1",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -538,9 +538,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "22.1.0-next.0",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.1.0-next.0.tgz",
-      "integrity": "sha512-4IzC7IBKnXXNlukBs6d8r8MaxB6CCQlRyDglSQPilVnwy4Qht1jHDZWIt5hOI3fFj/1dOl/ccB2zHPxbKTHglA==",
+      "version": "22.1.0-next.1",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.1.0-next.1.tgz",
+      "integrity": "sha512-OFMeTNc6LGMzii5FOfkNIp7p1A05DlKVDOLAF4yyCrBZ+EsIk+7w1kP7dnd7VdKkriRSi3+JFMDVJtduIwyNkw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -551,16 +551,16 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.1.0-next.0",
-        "@angular/core": "22.1.0-next.0",
-        "@angular/platform-browser": "22.1.0-next.0",
+        "@angular/common": "22.1.0-next.1",
+        "@angular/core": "22.1.0-next.1",
+        "@angular/platform-browser": "22.1.0-next.1",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "22.1.0-next.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.1.0-next.0.tgz",
-      "integrity": "sha512-xTZZOA5j0CNXm94rfX6FPtVAvbrutRAwD6RkNn+V8vBljZmj4VY/RZZFvhWx6EvcQe0vkOs/2nAtibx38PHxZQ==",
+      "version": "22.1.0-next.1",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.1.0-next.1.tgz",
+      "integrity": "sha512-+4a17IdLml643281UGoxd+N9BpzDh2Ge8EkEq4efcHDDLdK9oAQhA09YPzj+T3Fsf2XYq4j2KWuLvljV6VooAQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -569,9 +569,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "22.1.0-next.0",
-        "@angular/common": "22.1.0-next.0",
-        "@angular/core": "22.1.0-next.0"
+        "@angular/animations": "22.1.0-next.1",
+        "@angular/common": "22.1.0-next.1",
+        "@angular/core": "22.1.0-next.1"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -580,9 +580,9 @@
       }
     },
     "node_modules/@angular/router": {
-      "version": "22.1.0-next.0",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.1.0-next.0.tgz",
-      "integrity": "sha512-GvYwRQeuPLcYP/7S0FwdbeFDvGnzmuPD7P/8oMO36hKSreUZ9UEL7V+rM3FR+AvY5mj0t2onzbLGY7UgM0itDw==",
+      "version": "22.1.0-next.1",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.1.0-next.1.tgz",
+      "integrity": "sha512-bbD8SM/T1AFXQ7C32Dy18xuGM5IjHmyaeISnaa5QAKnofHYdjG8YYzvG/rNpASjPnjLYbqA9LgvVoLHkbz7P7g==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -591,9 +591,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.1.0-next.0",
-        "@angular/core": "22.1.0-next.0",
-        "@angular/platform-browser": "22.1.0-next.0",
+        "@angular/common": "22.1.0-next.1",
+        "@angular/core": "22.1.0-next.1",
+        "@angular/platform-browser": "22.1.0-next.1",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2154,9 +2154,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2174,9 +2171,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2194,9 +2188,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2214,9 +2205,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2234,9 +2222,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2254,9 +2239,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2274,9 +2256,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2778,9 +2757,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2802,9 +2778,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2826,9 +2799,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2850,9 +2820,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2874,9 +2841,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2898,9 +2862,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3077,9 +3038,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3094,9 +3052,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3111,9 +3066,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3128,9 +3080,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3145,9 +3094,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3162,9 +3108,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3179,9 +3122,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3196,9 +3136,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3213,9 +3150,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3230,9 +3164,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3247,9 +3178,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3264,9 +3192,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3281,9 +3206,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/adev/src/content/tutorials/learn-angular/common/package.json
+++ b/adev/src/content/tutorials/learn-angular/common/package.json
@@ -9,12 +9,12 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/common": "^22.1.0-next",
-    "@angular/compiler": "^22.1.0-next",
-    "@angular/core": "^22.1.0-next",
-    "@angular/forms": "^22.1.0-next",
-    "@angular/platform-browser": "^22.1.0-next",
-    "@angular/router": "^22.1.0-next",
+    "@angular/common": "^22.1.0-next.1",
+    "@angular/compiler": "^22.1.0-next.1",
+    "@angular/core": "^22.1.0-next.1",
+    "@angular/forms": "^22.1.0-next.1",
+    "@angular/platform-browser": "^22.1.0-next.1",
+    "@angular/router": "^22.1.0-next.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.16.0"
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@angular/build": "^22.1.0-next",
     "@angular/cli": "^22.1.0-next",
-    "@angular/compiler-cli": "^22.1.0-next",
+    "@angular/compiler-cli": "^22.1.0-next.1",
     "typescript": "~6.0.3"
   }
 }


### PR DESCRIPTION
The learn-angular steps 19 & 20 import the @Service decorator, but the lockfile pinned @angular/core to 22.1.0-next.0, which predates the stable @Service export, so the tutorial failed with "no exported member 'Service'".

Floor the framework deps at ^22.1.0-next.1 and regenerate the lockfile so the WebContainer installs a version that exports Service. Tooling stays at ^22.1.0-next; its peer ranges already accept the next.1 framework.

Fixes #69438 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

learn-angular steps 19 & 20 import `@Service` from `@angular/core`, but the lockfile
pinned `@angular/core` to `22.1.0-next.0`, which predates the stable `@Service` export.
The tutorial fails with `TS2305: ... has no exported member 'Service'`.

Issue Number: #69438

## What is the new behavior?

Floor the learn-angular framework deps at `^22.1.0-next.1` and regenerate the lockfile,
so the WebContainer installs a version that exports `Service`. Steps 19 & 20 (same
`common/package.json`) now compile. Tooling (`@angular/build`/`cli`) stays at
`^22.1.0-next` — peer ranges already accept the `next.1` framework. Verified with
`ng build` (no `TS2305`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No