### PR TITLE
fix(compiler-cli): report diagnostic instead of crashing on malformed…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -2046,7 +2046,16 @@ function evaluateHostExpressionBindings(
     }
   });
 
-  const bindings = parseHostBindings(hostMetadata);
+  let bindings: ParsedHostBindings;
+  try {
+    bindings = parseHostBindings(hostMetadata);
+  } catch (e) {
+    throw new FatalDiagnosticError(
+      ErrorCode.HOST_BINDING_PARSE_ERROR,
+      hostExpr,
+      (e as Error).message,
+    );
+  }
 
   const errors = verifyHostBindings(bindings, createSourceSpan(hostExpr));
   if (errors.length > 0) {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -3256,6 +3256,25 @@ runInEachFileSystem((os: string) => {
         );
       });
 
+      it('should report a diagnostic instead of crashing when a host property binding has a non-static value', () => {
+        env.tsconfig({});
+        env.write(
+          'test.ts',
+          `
+              import {Directive} from '@angular/core';
+
+              declare function getValue(): string;
+
+              @Directive({
+                selector: 'test-dir',
+                host: {'[class.foo]': getValue()}
+              })
+              export class TestDir {}
+            `,
+        );
+        verifyThrownError(ErrorCode.HOST_BINDING_PARSE_ERROR, 'Property binding must be string');
+      });
+
       it('should throw error if @Directive.queries field has wrong type', () => {
         env.tsconfig({});
         env.write(


### PR DESCRIPTION
`parseHostBindings` throws plain `Error`s for malformed host bindings (e.g. a property binding with a non-static value, as can happen while editing in the language service). These were uncaught during directive analysis, crashing the compiler and the Angular Language Service.

Wrap the call and surface the error as a `FatalDiagnosticError` so it becomes a diagnostic and analysis can complete normally.

Fixes #69106

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: #69106

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
