### PR TITLE
refactor(forms): widen `AsyncValidatorOptions.factory`

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -17,7 +17,7 @@ import { InputSignalWithTransform } from '@angular/core';
 import { ModelSignal } from '@angular/core';
 import { OutputRef } from '@angular/core';
 import { Provider } from '@angular/core';
-import { ResourceRef } from '@angular/core';
+import { Resource } from '@angular/core';
 import { Signal } from '@angular/core';
 import { StandardSchemaV1 } from '@standard-schema/spec';
 import { WritableSignal } from '@angular/core';
@@ -46,7 +46,7 @@ export type AsyncValidationResult<E extends ValidationError = ValidationError> =
 // @public
 export interface AsyncValidatorOptions<TValue, TParams, TResult, TPathKind extends PathKind = PathKind.Root> {
     readonly debounce?: DebounceTimer<TParams | undefined>;
-    readonly factory: (params: Signal<TParams | undefined>) => ResourceRef<TResult | undefined>;
+    readonly factory: (params: Signal<TParams | undefined>) => Resource<TResult | undefined>;
     readonly onError: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
     readonly onSuccess: MapToErrorsFn<TValue, TResult, TPathKind>;
     readonly params: (ctx: FieldContext<TValue, TPathKind>) => TParams;

--- a/packages/forms/signals/src/api/rules/validation/validate_async.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_async.ts
@@ -6,15 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  computed,
-  DebounceTimer,
-  ResourceRef,
-  ResourceSnapshot,
-  Signal,
-  debounced,
-  ɵchain,
-} from '@angular/core';
+import {DebounceTimer, Resource, Signal, computed, debounced, ɵchain} from '@angular/core';
 import {FieldNode} from '../../../field/node';
 import {addDefaultField} from '../../../field/validation';
 import {FieldPathNode} from '../../../schema/path_node';
@@ -90,7 +82,7 @@ export interface AsyncValidatorOptions<
    * @param params The params to use for constructing the resource
    * @returns A reference to the constructed resource.
    */
-  readonly factory: (params: Signal<TParams | undefined>) => ResourceRef<TResult | undefined>;
+  readonly factory: (params: Signal<TParams | undefined>) => Resource<TResult | undefined>;
   /**
    * A function to handle errors thrown by httpResource (HTTP errors, network errors, etc.).
    * Receives the error and the field context, returns a list of validation errors.


### PR DESCRIPTION
This is to accept `Resource` and not only `ResourceRef`.

fixes #69443
