### PR TITLE
docs: show selected menu item visually in context menu example

### DIFF
--- a/adev/src/content/examples/aria/menu/src/menu-context/app/app.css
+++ b/adev/src/content/examples/aria/menu/src/menu-context/app/app.css
@@ -76,6 +76,34 @@
   font-size: 0.875rem;
 }
 
+.last-action {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-color);
+  font-size: 0.875rem;
+  animation: fade-in 0.2s ease;
+}
+
+.last-action .material-symbols-outlined {
+  font-size: 1.1rem;
+  color: var(--vivid-pink);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 [ngMenu] .separator {
   border-top: 1px solid var(--border-color);
   margin: 0.25rem 0;

--- a/adev/src/content/examples/aria/menu/src/menu-context/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-context/app/app.html
@@ -3,6 +3,13 @@
   Right-click inside this area to open the context menu.
 </div>
 
+@if (lastAction()) {
+  <p class="last-action">
+    <span class="material-symbols-outlined" translate="no" aria-hidden="true">check_circle</span>
+    Action performed: <strong>{{ lastAction() }}</strong>
+  </p>
+}
+
 <!-- Hidden trigger positioned dynamically at cursor coordinates -->
 <div
   #triggerEl

--- a/adev/src/content/examples/aria/menu/src/menu-context/app/app.ts
+++ b/adev/src/content/examples/aria/menu/src/menu-context/app/app.ts
@@ -25,8 +25,10 @@ export class App {
     this.trigger().open();
   }
 
+  lastAction = signal<string | null>(null);
+
   onItemSelected(value: string) {
-    console.log(`Action selected: ${value}`);
+    this.lastAction.set(value);
   }
 
   onOverlayKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
Replace console.log with a lastAction signal and render the result in a styled <p> element with a fade-in animation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The selected item is printed to the console, providing no clear documentation to the user.

## What is the new behavior?

<img width="807" height="422" alt="Screenshot 2026-06-20 alle 00 41 45" src="https://github.com/user-attachments/assets/e2d86313-36c6-4339-9a2d-75ae1ecb22bc" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
