### PR TITLE
fix(compiler): account for NgModule dependencies in JIT-compiled part…

### DIFF
--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -21,6 +21,7 @@ import {
   R3DeclareFactoryFacade,
   R3DeclareInjectableFacade,
   R3DeclareInjectorFacade,
+  R3DeclareNgModuleDependencyFacade,
   R3DeclareNgModuleFacade,
   R3DeclarePipeDependencyFacade,
   R3DeclarePipeFacade,
@@ -87,6 +88,7 @@ import {
   R3DirectiveMetadata,
   R3HostMetadata,
   R3InputMetadata,
+  R3NgModuleDependencyMetadata,
   R3PipeDependencyMetadata,
   R3QueryMetadata,
   R3TemplateDependency,
@@ -678,6 +680,9 @@ function convertDeclareComponentFacadeToMetadata(
         case 'pipe':
           declarations.push(convertPipeDeclarationToMetadata(innerDep));
           break;
+        case 'ngmodule':
+          declarations.push(convertNgModuleDeclarationToMetadata(innerDep));
+          break;
       }
     }
   } else if (decl.components || decl.directives || decl.pipes) {
@@ -769,6 +774,15 @@ function convertPipeDeclarationToMetadata(
     kind: R3TemplateDependencyKind.Pipe,
     name: pipe.name,
     type: new WrappedNodeExpr(pipe.type),
+  };
+}
+
+function convertNgModuleDeclarationToMetadata(
+  ngModule: R3DeclareNgModuleDependencyFacade,
+): R3NgModuleDependencyMetadata {
+  return {
+    kind: R3TemplateDependencyKind.NgModule,
+    type: new WrappedNodeExpr(ngModule.type),
   };
 }
 

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -116,6 +116,32 @@ describe('render3 jit', () => {
     expect(directiveDefs[0].type).toBe(InnerCmp);
   });
 
+  it('compiles a partially compiled component with ngmodule dependency', () => {
+    @NgModule()
+    class InnerMod {}
+
+    class OuterCmp {
+      static ɵcmp = ngDeclareComponent({
+        template: '<inner-cmp></inner-cmp>',
+        type: OuterCmp,
+        version: '21.0.0',
+        dependencies: [
+          {
+            kind: 'ngmodule',
+            type: InnerMod,
+          },
+        ],
+      });
+    }
+
+    const rawDependencies = (OuterCmp.ɵcmp as ComponentDef<OuterCmp>).dependencies;
+    expect(rawDependencies).not.toBeNull();
+    const dependencies =
+      rawDependencies! instanceof Function ? rawDependencies!() : rawDependencies!;
+    expect(dependencies.length).toBe(1);
+    expect(dependencies[0]).toBe(InnerMod);
+  });
+
   it('compiles an injectable with a type provider', () => {
     @Injectable({providedIn: 'root'})
     class Service {}


### PR DESCRIPTION
…ial declarations

When partial declarations are not preprocessed to AOT by the linker, the `ngDeclareComponent` call causes them to be compiled ad-hoc. In this mode, NgModule imports in standalone components would be dropped, deviating from the linker. This commit changes the ad-hoc compilation of component declarations to pass the NgModule imports along just like the linker does.

Fixes #69451