### PR TITLE
fix(docs-infra): remove white flash on example viewer tab labels

### DIFF
--- a/adev/shared-docs/styles/_resets.scss
+++ b/adev/shared-docs/styles/_resets.scss
@@ -312,13 +312,17 @@
         padding-inline: 15px !important;
       }
 
+      .mdc-tab__text-label {
+        transition: none;
+      }
+
       .mdc-tab--active {
         border: 0;
         border-block-end-width: 2px;
         border-style: solid;
         border-image: var(--purple-to-blue-horizontal-gradient) 1;
 
-        span {
+        .mdc-tab__text-label {
           background-image: var(--purple-to-blue-horizontal-gradient);
           background-clip: text;
           -webkit-background-clip: text;

--- a/adev/src/content/introduction/installation.md
+++ b/adev/src/content/introduction/installation.md
@@ -55,7 +55,6 @@ Open a terminal (if you're using [Visual Studio Code](https://code.visualstudio.
     >
     bun install -g @angular/cli
     </docs-code>
-
 </docs-code-multifile>
 
 If you are having issues running this command in Windows or Unix, check out the [CLI docs](/tools/cli/setup-local#install-the-angular-cli) for more info.


### PR DESCRIPTION
The code tabs rendered by the example viewer (e.g. the npm/pnpm/yarn/bun install tabs) paint their active label as transparent text clipped to a gradient. Material's MDC tab styles add `transition: color 0.15s linear` to `.mdc-tab__text-label`, plus a 100ms delay on the active tab. Because that transition animates `color` from the solid label color to transparent, the solid color stays visible on top of the gradient for ~100ms when a tab is activated, which reads as a white flash.

Disable the transition on these labels so the color switches instantly, and target `.mdc-tab__text-label` directly (instead of a generic `span`) so `color: transparent` drives the gradient clip cleanly.

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

When switching between the code tabs in an example viewer (for example the
npm/pnpm/yarn/bun tabs on the Installation page), the newly activated tab
label briefly flashes its solid label color before settling into the
gradient text. The cause is Material's MDC `transition: color 0.15s linear`
on `.mdc-tab__text-label` (with a 100ms delay on the active tab): the label
color animates to transparent, so the solid color is visible on top of the
gradient for ~100ms during activation.

https://github.com/user-attachments/assets/a631349d-53a8-4b64-bbd6-0793eda9fe47

## What is the new behavior?

The active tab label shows its gradient immediately with no color flash. The
transition on these labels is disabled so the switch is instant, and the
gradient rule targets `.mdc-tab__text-label` directly so `color: transparent`
cleanly drives the gradient clip.

https://github.com/user-attachments/assets/65fa62df-25f9-418d-9af4-6a18f2f299e5

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No