### PR TITLE
fix(compiler-cli): include toSignal in debugName transform

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/implicit_signal_debug_name_transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/implicit_signal_debug_name_transform.ts
@@ -231,6 +231,7 @@ const signalFunctions: ReadonlyMap<string, PackageName> = new Map([
   ['contentChild', 'core'],
   ['contentChildren', 'core'],
   ['effect', 'core'],
+  ['toSignal', 'core'],
   ['resource', 'core'],
   ['httpResource', 'common'],
 ]);

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -30,6 +30,7 @@ jasmine_test(
     timeout = "long",
     data = [
         ":ngtsc_lib",
+        "//:node_modules/rxjs",
         "//:node_modules/yargs",
         "//packages/compiler-cli/src/ngtsc/testing/fake_common:npm_package",
         "//packages/core:npm_package",

--- a/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
@@ -2992,6 +2992,7 @@ runInEachFileSystem(() => {
         env.write(
           'test.ts',
           `
+            import {Component} from '@angular/core';
             import {of} from 'rxjs';
             declare function toSignal(source: any): any;
 
@@ -3012,6 +3013,7 @@ runInEachFileSystem(() => {
         env.write(
           'test.ts',
           `
+            import {Component} from '@angular/core';
             import {toSignal} from '@angular/core/rxjs-interop';
             import {of} from 'rxjs';
 

--- a/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
@@ -14,6 +14,7 @@ import {NgtscTestEnvironment} from './env';
 
 const testFiles = loadStandardTestFiles({
   fakeCommon: true,
+  rxjs: true,
 });
 
 const minifiedDevBuildOptions = {
@@ -2981,6 +2982,342 @@ runInEachFileSystem(() => {
           const contentWoNewLines = cleanNewLines(builtContent);
           expect(contentWoNewLines).toContain(
             'testHttpResource = httpResource( () => "/api", { debugName: "testHttpResource" } )',
+          );
+        });
+      });
+    });
+
+    describe('toSignal', () => {
+      it('should not insert debug info into toSignal function if not imported from angular core', () => {
+        env.write(
+          'test.ts',
+          `
+            import {of} from 'rxjs';
+            declare function toSignal(source: any): any;
+
+            @Component({
+                template: ''
+            }) class MyComponent {
+                testSignal = toSignal(of(0));
+            }
+          `,
+        );
+        env.driveMain();
+
+        const jsContents = env.getContents('test.js');
+        expect(jsContents).not.toContain('debugName');
+      });
+
+      it('should insert debug info into toSignal function if imported from angular core', () => {
+        env.write(
+          'test.ts',
+          `
+            import {toSignal} from '@angular/core/rxjs-interop';
+            import {of} from 'rxjs';
+
+            @Component({
+                template: ''
+            }) class MyComponent {
+                testSignal = toSignal(of(0));
+            }
+          `,
+        );
+        env.driveMain();
+
+        const jsContents = env.getContents('test.js');
+        expect(cleanNewLines(jsContents)).toContain(
+          `toSignal(of(0), /* @ts-ignore */ ...(ngDevMode ? [{ debugName: "testSignal" }] : /* istanbul ignore next */ []))`,
+        );
+      });
+
+      describe('Property Declaration Case', () => {
+        it('should tree-shake away debug info if in prod mode', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0));
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
+          expect(builtContent).not.toContain('debugName');
+          expect(cleanNewLines(builtContent)).toContain('toSignal( of(0) )');
+        });
+
+        it('should not tree-shake away debug info if in dev mode', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0));
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedDevBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(
+            `toSignal( of(0), { debugName: "testSignal" } )`,
+          );
+        });
+
+        it('should insert debug info into toSignal function that already has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0), { initialValue: 0 });
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          expect(cleanNewLines(jsContents)).toContain(
+            `toSignal(of(0), { ...(ngDevMode ? { debugName: "testSignal" } : /* istanbul ignore next */ {}), initialValue: 0 })`,
+          );
+        });
+
+        it('should tree-shake away debug info if in prod mode for toSignal function that has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0), { initialValue: 0 });
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(`toSignal(of(0), { initialValue: 0 })`);
+          expect(builtContent).not.toContain('ngDevMode');
+          expect(builtContent).not.toContain('debugName');
+        });
+
+        it('should not tree-shake away debug info if in dev mode and has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0), { initialValue: 0 });
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedDevBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(
+            `toSignal(of(0), { debugName: "testSignal", initialValue: 0 })`,
+          );
+        });
+      });
+
+      describe('Property Assignment Case', () => {
+        it('should insert debug info into toSignal function', () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number|undefined>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0));
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          expect(cleanNewLines(jsContents)).toContain(
+            `toSignal(of(0), /* @ts-ignore */ ...(ngDevMode ? [{ debugName: "testSignal" }] : /* istanbul ignore next */ [])`,
+          );
+        });
+
+        it('should tree-shake away debug info if in prod mode', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number|undefined>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0));
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
+          expect(builtContent).not.toContain('debugName');
+          expect(cleanNewLines(builtContent)).toContain('toSignal( of(0) )');
+        });
+
+        it('should not tree-shake away debug info if in dev mode', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number|undefined>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0));
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedDevBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(
+            `toSignal( of(0), { debugName: "testSignal" } )`,
+          );
+        });
+
+        it('should insert debug info into toSignal function that already has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0), { initialValue: 0 });
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          expect(cleanNewLines(jsContents)).toContain(
+            `toSignal(of(0), { ...(ngDevMode ? { debugName: "testSignal" } : /* istanbul ignore next */ {}), initialValue: 0 })`,
+          );
+        });
+
+        it('should tree-shake away debug info if in prod mode for toSignal function that has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0), { initialValue: 0 });
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(`toSignal(of(0), { initialValue: 0 })`);
+          expect(builtContent).not.toContain('ngDevMode');
+          expect(builtContent).not.toContain('debugName');
+        });
+
+        it('should not tree-shake away debug info if in dev mode and has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0), { initialValue: 0 });
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedDevBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(
+            `toSignal(of(0), { debugName: "testSignal", initialValue: 0 })`,
           );
         });
       });


### PR DESCRIPTION
the toSignal function received a debugName option in 0812ac3bec9b9f2fabba5a379e6626aa641a97c9, but was not covered by the signalMetadataTransform which sets the debugName in dev mode automatically.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
when running under `ng serve`, toSignal does not have the `debugName` set automatically like the other functions (signal, computed, httpResource, etc.)

## What is the new behavior?
toSignal gets the same treatment as other functions with `debugName`:
```ts
test = toSignal(of(0));
```
is transformed into
```ts
test = toSignal(of(0), ...(ngDevMode ? [{ debugName: "test" }] : /* istanbul ignore next */ []));
```
which adds a `debugName` in dev mode, and gets optimized away in prod mode.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
