### PR TITLE
fix(docs-infra): prevent inline code in table headers from wrapping m…

### DIFF
--- a/adev/shared-docs/styles/docs/_table.scss
+++ b/adev/shared-docs/styles/docs/_table.scss
@@ -20,6 +20,10 @@
       border-block: 1px solid var(--senary-contrast);
       font-size: 0.75rem;
       font-weight: 600;
+
+      code {
+        white-space: nowrap;
+      }
     }
 
     tr {


### PR DESCRIPTION
When a documentation table has a wide content column, the narrow header columns get squeezed and inline-code header labels break mid-word at their hyphens. On the MCP server tools page this rendered the `local-only` and `read-only` column headers as `local-` / `only` and `read-` / `only`.

Apply `white-space: nowrap` to `code` inside `th` so header tokens stay on a single line. The rule is scoped to headers, whose labels are always short, so long code signatures in body cells continue to wrap and no table gains a horizontal scrollbar.

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other

## What is the current behavior?

In documentation tables with a wide content column, the narrower header
columns are squeezed and inline-code header labels break mid-word at
their hyphens. For example, on https://angular.dev/ai/mcp#available-tools
the `local-only` and `read-only` column headers render as `local-` /
`only` and `read-` / `only`.

<img width="796" height="320" alt="image" src="https://github.com/user-attachments/assets/b3b07c2f-b94f-4766-9976-1ab76712c9c1" />

## What is the new behavior?

Inline `code` inside table headers (`th`) is set to `white-space: nowrap`,
so header tokens stay on a single line. The rule is scoped to headers
only, so long code signatures in body cells still wrap and no table gains
a horizontal scrollbar.

<img width="823" height="285" alt="image" src="https://github.com/user-attachments/assets/ec7307a9-8d34-4c0a-8c0c-c0ed976f4848" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
