### PR TITLE
docs: add missing space before decorator link in components guide

### DIFF
--- a/adev/src/content/introduction/essentials/components.md
+++ b/adev/src/content/introduction/essentials/components.md
@@ -8,7 +8,7 @@ Components are the main building blocks of Angular applications. Each component 
 
 Every component has a few main parts:
 
-1. A `@Component`[decorator](https://www.typescriptlang.org/docs/handbook/decorators.html) that contains some configuration used by Angular.
+1. A `@Component` [decorator](https://www.typescriptlang.org/docs/handbook/decorators.html) that contains some configuration used by Angular.
 2. An HTML template that controls what renders into the DOM.
 3. A [CSS selector](https://developer.mozilla.org/docs/Learn/CSS/Building_blocks/Selectors) that defines how the component is used in HTML.
 4. A TypeScript class with behaviors, such as handling user input or making requests to a server.


### PR DESCRIPTION
The `@Component` inline-code span was directly adjacent to the `[decorator](...)` link, rendering as a mashed-together token in the source. Added a space so it reads "A `@Component` [decorator] that..." as intended.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

In the "Defining a component" essentials guide, `` `@Component`[decorator](...) ``
had no space between the inline-code span and the link, so the source reads as
one mashed-together token. It only appears spaced in the rendered page because
of the inline-code background padding.

<img width="683" height="159" alt="image" src="https://github.com/user-attachments/assets/b90d976f-2814-4319-bca7-97f3b59a1a56" />

## What is the new behavior?

Added a single space so the source reads `` `@Component` [decorator](...) ``.
Renders identically/cleaner and is correct in the markdown source.

<img width="698" height="159" alt="image" src="https://github.com/user-attachments/assets/706e0667-0eef-4e00-9d7d-374661cd3a45" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
