### PR TITLE
fix(docs-infra): keep footer headings on a single line

### DIFF
--- a/adev/src/app/core/layout/footer/footer.component.scss
+++ b/adev/src/app/core/layout/footer/footer.component.scss
@@ -1,11 +1,13 @@
 @use '@angular/docs/styles/media-queries' as mq;
 
+$columns-breakpoint: 600px;
+
 .adev-footer-columns {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 2rem;
 
-  @container footer (max-width: 600px) {
+  @container footer (max-width: #{$columns-breakpoint}) {
     grid-template-columns: repeat(2, 1fr) !important;
   }
 }
@@ -33,6 +35,10 @@
     font-weight: 600;
     margin-block-end: 1.75rem;
     letter-spacing: -0.00875rem;
+
+    @container footer (min-width: #{$columns-breakpoint + 1px}) {
+      white-space: nowrap;
+    }
   }
 
   ul {


### PR DESCRIPTION
The "Community translations" column heading wrapped to two lines while the other footer headings stayed on one. Add a `white-space: nowrap` rule on the footer headings, scoped to the wide (4-column) layout. The breakpoint is driven by a shared `$columns-breakpoint` variable so the nowrap rule and the grid's 2-column collapse stay in sync.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

In the angular.dev footer, the "Community translations" heading wraps to
two lines while the other column headings ("Social Media", "Community",
"Resources") stay on one, making the heading row look uneven.

<img width="809" height="463" alt="image" src="https://github.com/user-attachments/assets/ecc7dd08-4262-480f-8d5b-2f3cb6085778" />

## What is the new behavior?

Footer headings stay on a single line in the wide (4-column) layout via a
`white-space: nowrap` rule. The rule is gated on `$columns-breakpoint + 1px`
so it only applies above the point where the grid collapses to 2 columns;
in the narrow 2-column layout the headings still wrap to avoid overflow.

<img width="896" height="380" alt="image" src="https://github.com/user-attachments/assets/9630d5d0-b3e8-45e5-b0d1-e5e3a62c8f34" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
