### PR TITLE
docs: remove space before question mark in landing page heading

### DIFF
--- a/adev/src/app/features/home/home.component.html
+++ b/adev/src/app/features/home/home.component.html
@@ -228,7 +228,7 @@
   <section class="learn-more-bottom-section" id="bottom">
     <div class="pattern"></div>
     <div class="content">
-      <h2>Want to learn more about Angular ?</h2>
+      <h2>Want to learn more about Angular?</h2>
       <button
         class="docs-primary-btn"
         [attr.text]="'Learn more'"


### PR DESCRIPTION
The bottom CTA heading on the landing page read "Want to learn more about Angular ?" with a space before the question mark, while the matching heading higher up the page correctly had no space. Removed the space so both read "Want to learn more about Angular?".

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The bottom call-to-action heading on the landing page reads "Want to learn
more about Angular ?" with a space before the question mark. The identical
heading earlier on the page has no space, so the two are inconsistent, and a
space before "?" is incorrect in English typography.

## What is the new behavior?

The space is removed so the heading reads "Want to learn more about Angular?",
matching the other heading on the page.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
