### PR TITLE
fix(docs-infra): align and highlight external-link icon in nav sidebar

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.scss
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.scss
@@ -162,11 +162,12 @@ a,
   }
 }
 
-.docs-external-link {
+.docs-external-link.docs-faceted-list-item-text {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
+  max-width: 100%;
   gap: 0.5rem;
   &::after {
     content: 'open_in_new';
@@ -174,7 +175,11 @@ a,
     font-size: 1.1rem;
     color: var(--quinary-contrast);
     transition: color 0.3s ease;
-    margin-inline-end: 0.4rem;
+    margin-inline-end: 0.2rem;
+  }
+
+  a:hover &::after {
+    color: var(--primary-contrast);
   }
 }
 


### PR DESCRIPTION
The open_in_new icon on external navigation items stayed grey on hover and sat inset from the chevron column, so it never matched the chevron items visually.

- Add a hover rule so the icon brightens to --primary-contrast along with the label, matching the chevron/text behaviour.
- Override the 1rem max-width reserve inherited from .docs-faceted-list-item-text by chaining both classes the span carries (.docs-external-link.docs-faceted-list-item-text), so the icon lines up with the chevrons at the link's end-padding. Using :host was avoided because it breaks the nested `a:hover &` selector.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

On external navigation items in the docs sidebar, the `open_in_new` icon stayed grey on hover (while the label brightened) and sat inset from the chevron column, so external items did not align with the chevron items above them.

<img width="572" height="900" alt="image" src="https://github.com/user-attachments/assets/0968d88d-e0cc-479d-8957-32ac548df9a1" />

## What is the new behavior?

The external-link icon now brightens to `--primary-contrast` on hover along with its label, and its right edge aligns with the chevron column at the link's end-padding.

<img width="270" height="415" alt="image" src="https://github.com/user-attachments/assets/a4c39fdc-30bd-4885-9fdf-ea083a09d0df" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No