### PR TITLE
docs(forms): correct signal field access in form model example

### DIFF
--- a/adev/src/content/guide/forms/signals/designing-your-form-model.md
+++ b/adev/src/content/guide/forms/signals/designing-your-form-model.md
@@ -380,7 +380,7 @@ class MyForm {
 
   handleSubmit() {
     submit(this.myForm, async () => {
-      await this.myDataService.update(formModelToDomainModel(this.myForm.value()));
+      await this.myDataService.update(formModelToDomainModel(this.myForm().value()));
     });
   };
 }
@@ -402,7 +402,7 @@ class MyForm {
     effect(() => {
       // When the form model changes to a valid value, update the domain model.
       if (this.myForm().valid()) {
-        this.domainModel.set(formModelToDomainModel(this.myForm.value()));
+        this.domainModel.set(formModelToDomainModel(this.myForm().value()));
       }
     });
   };


### PR DESCRIPTION
The `myForm` field is a callable `FieldTree`, so its value must be read via `this.myForm().value()`. Fixes two examples that incorrectly used `this.myForm.value()`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #69498

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
