### PR TITLE
refactor(core): add context support for foreign components

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/foreign_component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/foreign_component.ts
@@ -347,7 +347,7 @@ class ForeignComponentFeatureAnalyzer extends TmplAstRecursiveVisitor {
       );
     }
 
-    // Explicitly defining a `@content(children)` block without parameters is unnecessary because
+    // Explicitly defining a `@content (children)` block without parameters is unnecessary because
     // child nodes are implicitly passed to the `children` property.
     if (block.name === CHILDREN && block.variables.length === 0) {
       this.diagnostics.push(

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
@@ -421,10 +421,10 @@ export class TestCmpChildren {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmpChildren, deps: [], target: i0.ɵɵFactoryTarget.Component });
     static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmpChildren, isStandalone: true, selector: "main-children", ngImport: i0, template: `
     <FancyButton [label]="title">
-      @content(icon) {
+      @content (icon) {
         <span>Icon!</span>
       }
-      @content(description) {
+      @content (description) {
         <span>Description text</span>
       }
       <span>Other children</span>
@@ -437,10 +437,10 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     selector: 'main-children',
                     template: `
     <FancyButton [label]="title">
-      @content(icon) {
+      @content (icon) {
         <span>Icon!</span>
       }
-      @content(description) {
+      @content (description) {
         <span>Description text</span>
       }
       <span>Other children</span>
@@ -458,7 +458,7 @@ export class TestCmpRenderProps {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmpRenderProps, deps: [], target: i0.ɵɵFactoryTarget.Component });
     static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmpRenderProps, isStandalone: true, selector: "main-render-props", ngImport: i0, template: `
     <FancyButton [label]="title">
-      @content(items; let item, index) {
+      @content (items; let item, index) {
         <span>#{{index}}: {{item}}</span>
       }
     </FancyButton>
@@ -470,7 +470,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     selector: 'main-render-props',
                     template: `
     <FancyButton [label]="title">
-      @content(items; let item, index) {
+      @content (items; let item, index) {
         <span>#{{index}}: {{item}}</span>
       }
     </FancyButton>

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
@@ -31,10 +31,10 @@ export class TestCmp {
   selector: 'main-children',
   template: `
     <FancyButton [label]="title">
-      @content(icon) {
+      @content (icon) {
         <span>Icon!</span>
       }
-      @content(description) {
+      @content (description) {
         <span>Description text</span>
       }
       <span>Other children</span>
@@ -54,7 +54,7 @@ export class TestCmpChildren {
   selector: 'main-render-props',
   template: `
     <FancyButton [label]="title">
-      @content(items; let item, index) {
+      @content (items; let item, index) {
         <span>#{{index}}: {{item}}</span>
       }
     </FancyButton>

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -2329,7 +2329,7 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test',
-            template: '<FancyButton> @content(icon) {} </FancyButton>',
+            template: '<FancyButton> @content (icon) {} </FancyButton>',
             foreignImports: [frameworkImport(FancyButton)],
           })
           export class TestCmp {}
@@ -2347,7 +2347,7 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test',
-            template: '<div> @content(icon) {} </div>',
+            template: '<div> @content (icon) {} </div>',
             foreignImports: [frameworkImport(FancyButton)],
           })
           export class TestCmp {}
@@ -2369,7 +2369,7 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test',
-            template: '<FancyButton> <div> @content(icon) {} </div> </FancyButton>',
+            template: '<FancyButton> <div> @content (icon) {} </div> </FancyButton>',
             foreignImports: [frameworkImport(FancyButton)],
           })
           export class TestCmp {}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -112,6 +112,7 @@ export {
   outputBinding,
   twoWayBinding,
 } from './render3/dynamic_bindings';
+// g3-only export {provideForeignRootContext} from './render3/foreign_context';
 // g3-only export {foreignImport} from './render3/foreign_import';
 export {createEnvironmentInjector, createNgModule} from './render3/ng_module_ref';
 export {publishNonCoreGlobalUtil as ɵpublishNonCoreGlobalUtil} from './render3/util/global_utils';

--- a/packages/core/src/interface/foreign_component.ts
+++ b/packages/core/src/interface/foreign_component.ts
@@ -15,16 +15,30 @@ export const ON_DESTROY: unique symbol = Symbol('ON_DESTROY');
 /** Symbol used to store and retrieve the content adapter function for a foreign component. */
 export const CONTENT_ADAPTER: unique symbol = Symbol('CONTENT_ADAPTER');
 
+/** Symbol used to store and retrieve the context retrieval function for a foreign component. */
+export const GET_CONTEXT: unique symbol = Symbol('GET_CONTEXT');
+
 /**
  * A function used to render a foreign component in an Angular template.
  *
- * The function accepts the component's properties as its only argument. It should return an array
+ * The function accepts the component's properties and optional context. It should return an array
  * of nodes rendered and owned by the foreign component. It may also return a callback to perform
  * any necessary cleanup when the component is destroyed.
  *
  * @template TProps The properties of the foreign component.
+ * @template TContext The context passed to the foreign component.
  */
-export type ForeignRenderFn<TProps> = (props: TProps) => [Node[], VoidFunction?];
+export type ForeignRenderFn<TProps, TContext> = (
+  props: TProps,
+  context?: TContext,
+) => [Node[], VoidFunction?];
+
+/**
+ * A function that captures the runtime context of a foreign component.
+ *
+ * @template TContext The captured context type.
+ */
+export type ForeignGetContextFn<TContext> = () => TContext;
 
 /**
  * A function that allows a foreign component to register a destroy callback.
@@ -46,9 +60,11 @@ export type ForeignContentAdapterFn = (producer: () => Node[]) => any;
  * Represents a component from another framework that Angular can import and render.
  *
  * @template TProps The properties of the foreign component.
+ * @template TContext The context passed to the foreign component.
  */
-export interface ForeignComponent<TProps> {
-  readonly [RENDER]: ForeignRenderFn<TProps>;
+export interface ForeignComponent<TProps = {}, TContext = unknown> {
+  readonly [RENDER]: ForeignRenderFn<TProps, TContext>;
   readonly [ON_DESTROY]: ForeignOnDestroyFn;
   readonly [CONTENT_ADAPTER]: ForeignContentAdapterFn;
+  readonly [GET_CONTEXT]?: ForeignGetContextFn<TContext>;
 }

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -648,7 +648,7 @@ export interface Component extends Directive {
    *
    * @internal // 3p-only
    */
-  foreignImports?: ForeignComponent<any>[];
+  foreignImports?: ForeignComponent<any, any>[];
 
   /**
    * The `deferredImports` property specifies a standalone component's template dependencies,

--- a/packages/core/src/render3/foreign_context.ts
+++ b/packages/core/src/render3/foreign_context.ts
@@ -19,9 +19,8 @@ export const FOREIGN_CONTEXT = new InjectionToken<unknown>('FOREIGN_CONTEXT');
  * hierarchy.
  *
  * @param contextFactory The factory function that creates the root context object.
- * @template TContext The foreign context type.
  */
-export function provideForeignRootContext<TContext>(contextFactory: () => TContext): Provider {
+export function provideForeignRootContext(contextFactory: () => unknown): Provider {
   return {
     provide: FOREIGN_CONTEXT,
     useFactory: contextFactory,

--- a/packages/core/src/render3/foreign_context.ts
+++ b/packages/core/src/render3/foreign_context.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken} from '../di/injection_token';
+import {Provider} from '../di/interface/provider';
+
+/**
+ * Internal token used to resolve foreign framework context providers.
+ */
+export const FOREIGN_CONTEXT = new InjectionToken<unknown>('FOREIGN_CONTEXT');
+
+/**
+ * Configures an opaque root context for a foreign framework within Angular's dependency injection
+ * hierarchy.
+ *
+ * @param contextFactory The factory function that creates the root context object.
+ * @template TContext The foreign context type.
+ */
+export function provideForeignRootContext<TContext>(contextFactory: () => TContext): Provider {
+  return {
+    provide: FOREIGN_CONTEXT,
+    useFactory: contextFactory,
+  };
+}

--- a/packages/core/src/render3/foreign_import.ts
+++ b/packages/core/src/render3/foreign_import.ts
@@ -10,29 +10,35 @@ import {
   ForeignComponent,
   ForeignRenderFn,
   ForeignOnDestroyFn,
+  ForeignGetContextFn,
   ForeignContentAdapterFn,
   RENDER,
   ON_DESTROY,
+  GET_CONTEXT,
   CONTENT_ADAPTER,
 } from '../interface/foreign_component';
 
 /**
  * Returns a {@link ForeignComponent} for use in Angular components.
  *
- * @template TProps The properties of the foreign component.
  * @param render A function that renders a foreign component.
  * @param onDestroy A function for foreign content to register a destroy callback.
  * @param contentAdapter A function that adapts Angular content to a representation expected by the
  * foreign component.
+ * @param getContext An optional function that captures runtime context.
+ * @template TProps The properties of the foreign component.
+ * @template TContext The context passed to the foreign component.
  */
-export function foreignImport<TProps>(
-  render: ForeignRenderFn<TProps>,
+export function foreignImport<TProps, TContext = unknown>(
+  render: ForeignRenderFn<TProps, TContext>,
   onDestroy: ForeignOnDestroyFn,
   contentAdapter: ForeignContentAdapterFn,
-): ForeignComponent<TProps> {
+  getContext?: ForeignGetContextFn<TContext>,
+): ForeignComponent<TProps, TContext> {
   return {
     [RENDER]: render,
     [ON_DESTROY]: onDestroy,
     [CONTENT_ADAPTER]: contentAdapter,
+    [GET_CONTEXT]: getContext,
   };
 }

--- a/packages/core/src/render3/instructions/foreign_component.ts
+++ b/packages/core/src/render3/instructions/foreign_component.ts
@@ -6,33 +6,36 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {Injector} from '../../di/injector';
+import {InternalInjectFlags} from '../../di/interface/injector';
 import {
-  ForeignComponent,
-  RENDER,
-  ON_DESTROY,
   CONTENT_ADAPTER,
+  ForeignComponent,
+  GET_CONTEXT,
+  ON_DESTROY,
+  RENDER,
 } from '../../interface/foreign_component';
+import {assertDefined, assertNotSame} from '../../util/assert';
+import {assertLContainer} from '../assert';
+import {collectNativeNodes} from '../collect_native_nodes';
 import {attachPatchData} from '../context_discovery';
+import {getOrCreateInjectable} from '../di';
 import {nativeInsertBefore} from '../dom_node_manipulation';
+import {FOREIGN_CONTEXT} from '../foreign_context';
 import {createForeignView} from '../foreign_view';
+import {CONTAINER_HEADER_OFFSET, LContainer, LContainerFlags} from '../interfaces/container';
 import {TContainerNode, TNodeType} from '../interfaces/node';
-import {HEADER_OFFSET, RENDERER, TVIEW, FLAGS} from '../interfaces/view';
+import {Renderer} from '../interfaces/renderer';
+import {RNode} from '../interfaces/renderer_dom';
+import {isDestroyed} from '../interfaces/type_checks';
+import {FLAGS, HEADER_OFFSET, LView, RENDERER, TVIEW} from '../interfaces/view';
 import {appendChild} from '../node_manipulation';
 import {getLView, getTView, setCurrentTNode, setCurrentTNodeAsNotParent} from '../state';
 import {getOrCreateTNode} from '../tnode_manipulation';
-import {addToEndOfViewTree} from '../view/construction';
-import {createLContainer, addLViewToLContainer, removeLViewFromLContainer} from '../view/container';
-import {NodeInjector} from '../di';
-import {runInInjectionContext} from '../../di';
-import {Renderer} from '../interfaces/renderer';
-import {RNode} from '../interfaces/renderer_dom';
-import {createAndRenderEmbeddedLView} from '../view_manipulation';
-import {collectNativeNodes} from '../collect_native_nodes';
-import {assertLContainer} from '../assert';
-import {CONTAINER_HEADER_OFFSET, LContainer, LContainerFlags} from '../interfaces/container';
 import {getConstant} from '../util/view_utils';
-import {isDestroyed} from '../interfaces/type_checks';
-import {assertNotSame} from '../../util/assert';
+import {addToEndOfViewTree} from '../view/construction';
+import {addLViewToLContainer, createLContainer, removeLViewFromLContainer} from '../view/container';
+import {createAndRenderEmbeddedLView} from '../view_manipulation';
 
 /**
  * Creation phase instruction to render a foreign component.
@@ -50,7 +53,10 @@ export function ɵɵforeignComponent(
   const lView = getLView();
   const tView = getTView();
   const adjustedIndex = index + HEADER_OFFSET;
-  const foreignComponent = getConstant<ForeignComponent<any>>(tView.consts, foreignComponentIndex)!;
+  const foreignComponent = getConstant<ForeignComponent<any, any>>(
+    tView.consts,
+    foreignComponentIndex,
+  )!;
 
   // 1. Get or create TNode for this container slot
   let tNode: TContainerNode;
@@ -77,9 +83,16 @@ export function ɵɵforeignComponent(
   // 4. Create the Foreign View and insert it at index 0 of the container
   const viewRef = createForeignView(lContainer, 0);
 
-  // 5. Call the RENDER function to get the nodes and DisposeFn
-  const injector = new NodeInjector(tNode, lView);
-  const [nodes, dispose] = runInInjectionContext(injector, () => foreignComponent[RENDER](props));
+  // 5. Resolve context and call the RENDER function to get the nodes and DisposeFn
+  // Context is optional because foreign components may not require context or a FOREIGN_CONTEXT
+  // provider might not be configured in the component/element injector hierarchy.
+  const context = getOrCreateInjectable(
+    tNode,
+    lView,
+    FOREIGN_CONTEXT,
+    InternalInjectFlags.Optional,
+  );
+  const [nodes, dispose] = foreignComponent[RENDER](props, context ?? undefined);
 
   // 6. Insert the returned nodes into the foreign view, between its head and tail comment anchors.
   const tail = viewRef.tail as RNode;
@@ -97,14 +110,24 @@ export function ɵɵforeignComponent(
 }
 
 /**
- * Creation phase instruction to render foreign content (children of a foreign component)
- * and extract its root DOM nodes.
- *
- * @param index The index of the container in the data array.
- * @param foreignComponentConstIndex The index of the matched foreign component in the constant pool.
- * @codeGenApi
+ * Reusable injector class that intercepts requests for {@link FOREIGN_CONTEXT} during
+ * embedded view creation and returns the captured runtime context.
  */
-export function ɵɵforeignContent(index: number, foreignComponentConstIndex: number): any {
+class ForeignContextInjector implements Injector {
+  constructor(private context: unknown) {}
+
+  get(token: any, notFoundValue?: any): any {
+    return token === FOREIGN_CONTEXT ? this.context : notFoundValue;
+  }
+}
+
+/**
+ * Resolves container and foreign component metadata for foreign content projection instructions.
+ */
+function resolveForeignContentContainer(
+  index: number,
+  foreignComponentConstIndex: number,
+): [LView, LContainer, TContainerNode, ForeignComponent<any, any>] {
   const lView = getLView();
   const adjustedIndex = index + HEADER_OFFSET;
 
@@ -115,15 +138,41 @@ export function ɵɵforeignContent(index: number, foreignComponentConstIndex: nu
 
   const tView = getTView();
   const tNode = tView.data[adjustedIndex] as TContainerNode;
-  const foreignComponent = getConstant<ForeignComponent<any>>(
+  const foreignComponent = getConstant<ForeignComponent<any, any>>(
     tView.consts,
     foreignComponentConstIndex,
   )!;
+  ngDevMode &&
+    assertDefined(foreignComponent, 'Foreign component must be defined in constant pool.');
+
+  return [lView, lContainer, tNode, foreignComponent];
+}
+
+/**
+ * Creation phase instruction to render foreign content (children of a foreign component)
+ * and extract its root DOM nodes.
+ *
+ * @param index The index of the container in the data array.
+ * @param foreignComponentConstIndex The index of the matched foreign component in the constant pool.
+ * @codeGenApi
+ */
+export function ɵɵforeignContent(index: number, foreignComponentConstIndex: number): any {
+  const [lView, lContainer, tNode, foreignComponent] = resolveForeignContentContainer(
+    index,
+    foreignComponentConstIndex,
+  );
   const adapter = foreignComponent[CONTENT_ADAPTER];
   const onDestroy = foreignComponent[ON_DESTROY];
+  const getContext = foreignComponent[GET_CONTEXT];
 
   const producer = () => {
-    const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, null);
+    const options = getContext
+      ? {embeddedViewInjector: new ForeignContextInjector(getContext())}
+      : undefined;
+
+    // Instantiate and render the embedded view inside the container, but do not add its elements to
+    // the DOM at the container anchor since the nodes will be projected into a foreign view.
+    const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, null, options);
     addLViewToLContainer(
       lContainer,
       embeddedLView,
@@ -139,6 +188,7 @@ export function ɵɵforeignContent(index: number, foreignComponentConstIndex: nu
       }
     });
 
+    // Extract and return the root nodes of the created view
     const embeddedTView = embeddedLView[TVIEW];
     return collectNativeNodes(embeddedTView, embeddedLView, embeddedTView.firstChild, []);
   };
@@ -158,26 +208,23 @@ export function ɵɵforeignContentFn(
   index: number,
   foreignComponentConstIndex: number,
 ): (...args: any[]) => any {
-  const lView = getLView();
-  const adjustedIndex = index + HEADER_OFFSET;
-
-  // The template is already declared at adjustedIndex, so lContainer must exist.
-  const lContainer = lView[adjustedIndex] as LContainer;
-  ngDevMode && assertLContainer(lContainer);
-  lContainer[FLAGS] |= LContainerFlags.LogicalOnly;
-
-  const tView = getTView();
-  const tNode = tView.data[adjustedIndex] as TContainerNode;
-  const foreignComponent = getConstant<ForeignComponent<any>>(
-    tView.consts,
+  const [lView, lContainer, tNode, foreignComponent] = resolveForeignContentContainer(
+    index,
     foreignComponentConstIndex,
-  )!;
+  );
   const adapter = foreignComponent[CONTENT_ADAPTER];
   const onDestroy = foreignComponent[ON_DESTROY];
+  const getContext = foreignComponent[GET_CONTEXT];
 
   return (...args: any[]) => {
     const producer = () => {
-      const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, args);
+      const options = getContext
+        ? {embeddedViewInjector: new ForeignContextInjector(getContext())}
+        : undefined;
+
+      // When the function is called, instantiate and render a new embedded view inside the container.
+      // The arguments are passed directly as the context of the view.
+      const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, args, options);
 
       addLViewToLContainer(
         lContainer,

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -229,7 +229,7 @@ export type TAttributes = (string | AttributeMarker | CssSelector)[];
  * - Translated messages (i18n).
  * - Foreign components.
  */
-export type TConstants = (TAttributes | string | ForeignComponent<any>)[];
+export type TConstants = (TAttributes | string | ForeignComponent<any, any>)[];
 
 /**
  * Factory function that returns an array of consts. Consts can be represented as a function in

--- a/packages/core/test/acceptance/foreign_component/foreign_component_context_spec.ts
+++ b/packages/core/test/acceptance/foreign_component/foreign_component_context_spec.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {ForeignComponent} from '../../../src/interface/foreign_component';
+import {foreignImport} from '../../../src/render3/foreign_import';
+import {provideForeignRootContext} from '../../../src/render3/foreign_context';
+
+/** A minimal framework for testing purposes. */
+const microFramework = {
+  context: undefined as string | undefined,
+
+  pushContext(context: string | undefined): string | undefined {
+    const previousContext = microFramework.context;
+    microFramework.context = context;
+    return previousContext;
+  },
+
+  popContext(context: string | undefined) {
+    microFramework.context = context;
+  },
+};
+
+interface Content {
+  render(): Node[];
+}
+
+function microImport<TProps>(
+  component: (props: TProps) => Node[],
+): ForeignComponent<TProps, string | undefined> {
+  return foreignImport(
+    (props, context) => {
+      const previousContext = microFramework.pushContext(context);
+      try {
+        return [component(props)];
+      } finally {
+        microFramework.popContext(previousContext);
+      }
+    },
+    () => {}, // No cleanup necessary.
+    (producer) => ({render: producer}),
+    () => microFramework.context,
+  );
+}
+
+function Provider(props: {context: string; children: Content}): Node[] {
+  const previousContext = microFramework.pushContext(props.context);
+  try {
+    return props.children.render();
+  } finally {
+    microFramework.popContext(previousContext);
+  }
+}
+
+function Consumer(): Node[] {
+  return [document.createTextNode(microFramework.context ?? '<no context>')];
+}
+
+describe('foreign component context', () => {
+  it('should be undefined when not provided', async () => {
+    @Component({
+      selector: 'no-ctx-cmp',
+      template: `<Consumer />`,
+      // @ts-ignore
+      foreignImports: [microImport(Consumer)],
+    })
+    class NoCtxApp {}
+
+    const fixture = TestBed.createComponent(NoCtxApp);
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.textContent).toBe('<no context>');
+  });
+
+  it('should receive root context when provided', async () => {
+    @Component({
+      selector: 'test-cmp',
+      // @ts-ignore
+      foreignImports: [microImport(Consumer)],
+      providers: [provideForeignRootContext(() => 'Hello, world!')],
+      template: `<Consumer />`,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.textContent).toBe('Hello, world!');
+  });
+
+  it('should pass parent context to static children', async () => {
+    @Component({
+      selector: 'test-app',
+      template: `
+        <Provider context="Parent context">
+          <Consumer />
+        </Provider>
+      `,
+      // @ts-ignore
+      foreignImports: [microImport(Provider), microImport(Consumer)],
+    })
+    class TestApp {}
+
+    const fixture = TestBed.createComponent(TestApp);
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.textContent).toBe('Parent context');
+  });
+
+  it('should pass parent context to dynamic children', async () => {
+    function DynamicProvider(props: {context: string; children: () => Content}): Node[] {
+      const previousContext = microFramework.pushContext(props.context);
+      try {
+        return props.children().render();
+      } finally {
+        microFramework.popContext(previousContext);
+      }
+    }
+
+    @Component({
+      selector: 'test-app',
+      template: `
+        <DynamicProvider context="Parent context">
+          @content (children; let _) {
+            <Consumer />
+          }
+        </DynamicProvider>
+      `,
+      // @ts-ignore
+      foreignImports: [microImport(DynamicProvider), microImport(Consumer)],
+    })
+    class TestApp {}
+
+    const fixture = TestBed.createComponent(TestApp);
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.textContent).toBe('Parent context');
+  });
+
+  it('should receive context from nearest ancestor', async () => {
+    @Component({
+      selector: 'test-app',
+      template: `
+        <Provider context="Outer context">
+          <Provider context="Inner context">
+            <Consumer />
+          </Provider>
+        </Provider>
+      `,
+      // @ts-ignore
+      foreignImports: [microImport(Provider), microImport(Consumer)],
+    })
+    class TestApp {}
+
+    const fixture = TestBed.createComponent(TestApp);
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.textContent).toBe('Inner context');
+  });
+});

--- a/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
+++ b/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
@@ -226,11 +226,11 @@ describe('foreign components', () => {
         selector: 'test-cmp',
         template: `
           <Card>
-            @content(header) {
+            @content (header) {
               <h1>My Title</h1>
             }
             <p>Card body content</p>
-            @content(footer) {
+            @content (footer) {
               <button>Close</button>
             }
           </Card>
@@ -377,10 +377,10 @@ describe('foreign components', () => {
 
       expect(fixture.nativeElement.innerHTML).toBe(
         '' +
-          '<!--container-->' + // @content(children) (implicit)
+          '<!--container-->' + // @content (children) (implicit)
           '<!--foreign-view-head-->' + // <SimpleWrapper>
           '<div class="wrapper">' +
-          '<!--container-->' + // @content(children) (implicit)
+          '<!--container-->' + // @content (children) (implicit)
           '<!--foreign-view-head-->' + // <FancyButton>
           '<button>' +
           '<span id="text">Inside wrapper button</span>' +
@@ -448,7 +448,7 @@ describe('foreign components', () => {
         selector: 'test-cmp',
         template: `
           <FancyList>
-            @content(renderHeader; let _) {
+            @content (renderHeader; let _) {
               <span>Header Content</span>
             }
           </FancyList>
@@ -463,7 +463,7 @@ describe('foreign components', () => {
 
       expect(fixture.nativeElement.innerHTML).toBe(
         '' +
-          '<!--container-->' + // for @content(renderHeader)
+          '<!--container-->' + // for @content (renderHeader)
           '<!--foreign-view-head-->' +
           '<div><span>Header Content</span></div>' +
           '<!--foreign-view-tail-->' +
@@ -487,7 +487,7 @@ describe('foreign components', () => {
         selector: 'test-cmp',
         template: `
           <FancyList>
-            @content(renderItem; let item) {
+            @content (renderItem; let item) {
               <span>{{ item }}</span>
             }
           </FancyList>
@@ -502,7 +502,7 @@ describe('foreign components', () => {
 
       expect(fixture.nativeElement.innerHTML).toBe(
         '' +
-          '<!--container-->' + // for @content(renderItem)
+          '<!--container-->' + // for @content (renderItem)
           '<!--foreign-view-head-->' +
           '<div><span>Hello Single</span></div>' +
           '<!--foreign-view-tail-->' +
@@ -528,7 +528,7 @@ describe('foreign components', () => {
         selector: 'test-cmp',
         template: `
           <FancyTable>
-            @content(renderRow; let row, idx, isLast) {
+            @content (renderRow; let row, idx, isLast) {
               <span>{{ idx }} - {{ row }} (Last: {{ isLast }})</span>
             }
           </FancyTable>
@@ -543,7 +543,7 @@ describe('foreign components', () => {
 
       expect(fixture.nativeElement.innerHTML).toBe(
         '' +
-          '<!--container-->' + // for @content(renderRow)
+          '<!--container-->' + // for @content (renderRow)
           '<!--foreign-view-head-->' +
           '<div><span>0 - RowA (Last: false)</span></div>' +
           '<!--foreign-view-tail-->' +
@@ -591,9 +591,9 @@ describe('foreign components', () => {
         selector: 'test-cmp',
         template: `
           <OuterComp>
-            @content(renderContent; let message) {
+            @content (renderContent; let message) {
               <InnerComp>
-                @content(renderHeader; let innerMessage) {
+                @content (renderHeader; let innerMessage) {
                   {{ message }} - {{ innerMessage }}
                 }
                 Body Content
@@ -611,11 +611,11 @@ describe('foreign components', () => {
 
       expect(fixture.nativeElement.innerHTML).toBe(
         '' +
-          '<!--container-->' + // @content(renderContent)
+          '<!--container-->' + // @content (renderContent)
           '<!--foreign-view-head-->' + // <OuterComp>
           '<div class="outer">' +
-          '<!--container-->' + // @content(renderHeader)
-          '<!--container-->' + // @content(children) (implicit)
+          '<!--container-->' + // @content (renderHeader)
+          '<!--container-->' + // @content (children) (implicit)
           '<!--foreign-view-head-->' + // <InnerComp>
           '<div class="inner">' +
           '<div class="inner-header"> Outer Msg - Inner Msg </div>' +
@@ -887,7 +887,7 @@ describe('foreign components', () => {
       @Component({
         template: `
           <DynamicIf [injector]="injector" [cond]="visible">
-            @content(children; let result) {
+            @content (children; let result) {
               <child>{{ result }}</child>
             }
           </DynamicIf>

--- a/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
+++ b/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
@@ -9,8 +9,10 @@
 import {
   Component,
   ElementRef,
+  Injector,
   computed,
   effect,
+  inject,
   signal,
   untracked,
   viewChildren,
@@ -753,22 +755,25 @@ describe('foreign components', () => {
     }
 
     it('should integrate lifecycle of static content', async () => {
-      function StaticIf(props: {cond: () => boolean; children: () => Node[]}) {
+      function StaticIf(props: {injector: Injector; cond: () => boolean; children: () => Node[]}) {
         const container = document.createElement('div');
         const context = new Context();
 
-        effect((onCleanup) => {
-          onCleanup(() => context.destroy());
+        effect(
+          (onCleanup) => {
+            onCleanup(() => context.destroy());
 
-          if (props.cond()) {
-            context.run(() => {
-              const nodes = untracked(() => props.children());
-              for (const node of nodes) {
-                container.appendChild(node);
-              }
-            });
-          }
-        });
+            if (props.cond()) {
+              context.run(() => {
+                const nodes = untracked(() => props.children());
+                for (const node of nodes) {
+                  container.appendChild(node);
+                }
+              });
+            }
+          },
+          {injector: props.injector},
+        );
 
         return [container];
       }
@@ -789,7 +794,7 @@ describe('foreign components', () => {
 
       @Component({
         template: `
-          <StaticIf [cond]="visible">
+          <StaticIf [injector]="injector" [cond]="visible">
             <child />
           </StaticIf>
         `,
@@ -798,6 +803,7 @@ describe('foreign components', () => {
         foreignImports: [frameworkImport(StaticIf)],
       })
       class App {
+        readonly injector = inject(Injector);
         readonly visible = signal(false);
       }
 
@@ -835,24 +841,31 @@ describe('foreign components', () => {
     });
 
     it('should integrate lifecycle of dynamic content', async () => {
-      function DynamicIf(props: {cond: () => boolean; children: (value: boolean) => () => Node[]}) {
+      function DynamicIf(props: {
+        injector: Injector;
+        cond: () => boolean;
+        children: (value: boolean) => () => Node[];
+      }) {
         const container = document.createElement('div');
         const context = new Context();
 
-        effect((onCleanup) => {
-          onCleanup(() => context.destroy());
+        effect(
+          (onCleanup) => {
+            onCleanup(() => context.destroy());
 
-          const result = props.cond();
-          if (result) {
-            context.run(() => {
-              const children = untracked(() => props.children(result));
-              const nodes = children();
-              for (const node of nodes) {
-                container.appendChild(node);
-              }
-            });
-          }
-        });
+            const result = props.cond();
+            if (result) {
+              context.run(() => {
+                const children = untracked(() => props.children(result));
+                const nodes = children();
+                for (const node of nodes) {
+                  container.appendChild(node);
+                }
+              });
+            }
+          },
+          {injector: props.injector},
+        );
 
         return [container];
       }
@@ -873,7 +886,7 @@ describe('foreign components', () => {
 
       @Component({
         template: `
-          <DynamicIf [cond]="visible">
+          <DynamicIf [injector]="injector" [cond]="visible">
             @content(children; let result) {
               <child>{{ result }}</child>
             }
@@ -884,6 +897,7 @@ describe('foreign components', () => {
         foreignImports: [frameworkImport(DynamicIf)],
       })
       class App {
+        readonly injector = inject(Injector);
         readonly visible = signal(false);
       }
 

--- a/packages/core/test/render3/foreign_component_spec.ts
+++ b/packages/core/test/render3/foreign_component_spec.ts
@@ -19,9 +19,6 @@ import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../src/render3/i
 import {ɵɵtext} from '../../src/render3/instructions/text';
 import {ɵɵadvance} from '../../src/render3/instructions/advance';
 import {ɵɵtextInterpolate2} from '../../src/render3/instructions/text_interpolation';
-import {inject, InjectionToken} from '../../src/di';
-import {ɵɵdefineDirective} from '../../src/render3/definition';
-import {ɵɵProvidersFeature} from '../../src/render3/features/providers_feature';
 import {createLView} from '../../src/render3/view/construction';
 import {renderView} from '../../src/render3/instructions/render';
 import {LView, LViewFlags, PARENT, RENDERER, T_HOST} from '../../src/render3/interfaces/view';
@@ -66,7 +63,7 @@ describe('ɵɵforeignComponent', () => {
       },
     });
 
-    expect(render).toHaveBeenCalledOnceWith({name: 'Angular'});
+    expect(render).toHaveBeenCalledOnceWith({name: 'Angular'}, /* context= */ undefined);
   });
 
   it('should call the dispose function when the containing view is destroyed', () => {
@@ -159,45 +156,6 @@ describe('ɵɵforeignComponent', () => {
         '<!--foreign-component-->' +
         '</div>',
     );
-  });
-
-  it('should execute the RENDER function inside the template injection context', () => {
-    const TEST_TOKEN = new InjectionToken<string>('test-token');
-
-    const foreignComp = foreignImport(
-      () => {
-        const value = inject(TEST_TOKEN, {optional: true}) ?? 'null';
-        const el = document.createElement('div');
-        el.id = 'foreign-el';
-        el.textContent = value;
-        return [[el]];
-      },
-      noopOnDestroy,
-      eagerContentAdapter,
-    );
-
-    class ProviderDirective {
-      static ɵfac = () => new ProviderDirective();
-      static ɵdir = ɵɵdefineDirective({
-        type: ProviderDirective,
-        selectors: [['', 'provider-dir', '']],
-        features: [ɵɵProvidersFeature([{provide: TEST_TOKEN, useValue: 'templated-value'}])],
-      });
-    }
-
-    const fixture = new ViewFixture({
-      decls: 2,
-      vars: 0,
-      consts: [['provider-dir', ''], foreignComp],
-      directives: [ProviderDirective],
-      create: () => {
-        ɵɵelementStart(0, 'div', 0);
-        ɵɵforeignComponent(1, 1);
-        ɵɵelementEnd();
-      },
-    });
-
-    expect(fixture.host.innerHTML).toContain('<div id="foreign-el">templated-value</div>');
   });
 
   it('should support reusing the same template between multiple view instances', () => {


### PR DESCRIPTION
Enable foreign components to receive and propagate contextual data across framework boundaries.

Previously, foreign render functions only accepted component properties, and foreign content projection instructions (`ɵɵforeignContent` / `ɵɵforeignContentFn`) did not provide any mechanism to expose foreign framework context to projected Angular embedded views.

With this change:

- Update `ForeignRenderFn` and `ForeignComponent` interfaces to accept an optional context parameter and an optional `GET_CONTEXT` symbol method.

- Introduce `FOREIGN_CONTEXT` injection token and `provideForeignRootContext` helper to configure root context in Angular's DI hierarchy.

- Update `ɵɵforeignComponent` instruction to resolve `FOREIGN_CONTEXT` from the injection tree and pass it to the foreign component's render function.

- Update `ɵɵforeignContent` and `ɵɵforeignContentFn` instructions to wrap embedded view creation with a `ForeignContextInjector` when `GET_CONTEXT` is present.

Furthermore, foreign render functions are no longer run inside an Angular injection context, since it's expected they use the foreign context support directly.