### PR TITLE
fix(zone.js): harden against frozen intrinsics in toString and console patches

### DIFF
--- a/packages/zone.js/lib/common/to-string.ts
+++ b/packages/zone.js/lib/common/to-string.ts
@@ -13,6 +13,24 @@ export function patchToString(Zone: ZoneType): void {
   // override Function.prototype.toString to make zone.js patched function
   // look like native function
   Zone.__load_patch('toString', (global: any) => {
+    // In hardened environments (Node --frozen-intrinsics, SES lockdown, or
+    // any host that has frozen/sealed Function.prototype or Object.prototype),
+    // overwriting these toString methods will throw. We check both up-front
+    // and bail atomically so we never leave a half-applied patch: applying
+    // only one of the two would make Promise objects stringify inconsistently.
+    //
+    // Trade-off when bailing: patched functions reveal as their wrapper source
+    // via Function.prototype.toString rather than the original native source.
+    // Callers that sniff toString output for "[native code]" detection may
+    // see different results. This is preferred over crashing module load.
+    const functionDescriptor = Object.getOwnPropertyDescriptor(Function.prototype, 'toString');
+    const objectDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, 'toString');
+    const canPatch = (descriptor: PropertyDescriptor | undefined) =>
+      !descriptor || (descriptor.writable !== false && descriptor.configurable !== false);
+    if (!canPatch(functionDescriptor) || !canPatch(objectDescriptor)) {
+      return;
+    }
+
     // patch Func.prototype.toString to let them look like native
     const originalFunctionToString = Function.prototype.toString;
 

--- a/packages/zone.js/lib/node/node.ts
+++ b/packages/zone.js/lib/node/node.ts
@@ -142,6 +142,13 @@ export function patchNode(Zone: ZoneType): void {
   });
 
   Zone.__load_patch('console', (global: any, Zone: ZoneType) => {
+    // Skip entirely under Node --frozen-intrinsics or any host that froze console.
+    // Without instrumentation, console calls run in whatever zone they were called
+    // from rather than being hoisted to Zone.root — acceptable degradation; the
+    // alternative is crashing at load.
+    if (!Object.isExtensible(console)) {
+      return;
+    }
     const consoleMethods = [
       'dir',
       'log',
@@ -154,17 +161,21 @@ export function patchNode(Zone: ZoneType): void {
       'trace',
     ];
     consoleMethods.forEach((m: string) => {
-      const originalMethod = ((console as any)[Zone.__symbol__(m)] = (console as any)[m]);
-      if (originalMethod) {
-        (console as any)[m] = function () {
-          const args = ArraySlice.call(arguments);
-          if (Zone.current === Zone.root) {
-            return originalMethod.apply(this, args);
-          } else {
-            return Zone.root.run(originalMethod, this, args);
-          }
-        };
+      const descriptor = Object.getOwnPropertyDescriptor(console, m);
+      // Only patch if we can both stash the original and overwrite the method.
+      if (!descriptor || descriptor.writable === false || descriptor.configurable === false) {
+        return;
       }
+      const originalMethod = ((console as any)[Zone.__symbol__(m)] = (console as any)[m]);
+      if (!originalMethod) return;
+      (console as any)[m] = function () {
+        const args = ArraySlice.call(arguments);
+        if (Zone.current === Zone.root) {
+          return originalMethod.apply(this, args);
+        } else {
+          return Zone.root.run(originalMethod, this, args);
+        }
+      };
     });
   });
 

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -35,6 +35,7 @@
     "electrontest": "cd test/extra && node electron.js",
     "jest:test": "jest --config ./test/jest/jest.config.js",
     "jest:nodetest": "jest --config ./test/jest/jest.node.config.js",
+    "frozen-intrinsics:test": "node --frozen-intrinsics ./test/node/frozen_intrinsics_load.js",
     "vitest:test": "vitest ./test/vitest/*.spec.js --exclude ./test/vitest/*-globals.spec.js",
     "vitest-globals:test": "vitest ./test/vitest/*-globals.spec.js --globals",
     "promisefinallytest": "mocha ./test/promise/promise.finally.spec.mjs",

--- a/packages/zone.js/test/jest/frozen-intrinsics.spec.js
+++ b/packages/zone.js/test/jest/frozen-intrinsics.spec.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+'use strict';
+
+const {spawnSync} = require('child_process');
+const path = require('path');
+
+describe('zone.js/node under --frozen-intrinsics', () => {
+  it('should load without throwing', () => {
+    const scriptPath = path.resolve(__dirname, '../node/frozen_intrinsics_load.js');
+    const result = spawnSync(process.execPath, ['--frozen-intrinsics', scriptPath], {
+      encoding: 'utf-8',
+    });
+
+    if (result.status !== 0) {
+      throw new Error(
+        `zone.js/node threw under --frozen-intrinsics.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+      );
+    }
+    expect(result.status).toBe(0);
+  });
+});

--- a/packages/zone.js/test/node/frozen_intrinsics_load.js
+++ b/packages/zone.js/test/node/frozen_intrinsics_load.js
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+'use strict';
+
+// This file is run as a subprocess by the frozen-intrinsics jest spec:
+//   node --frozen-intrinsics frozen_intrinsics_load.js
+//
+// A zero exit code means zone.js/node loaded without throwing under frozen
+// intrinsics. Any thrown TypeError (e.g. "Cannot assign to read only property")
+// would produce a non-zero exit and fail the test.
+const path = require('path');
+const bundlePath = path.resolve(
+  __dirname,
+  '../../../../dist/bin/packages/zone.js/npm_package/bundles/zone-node.umd.js',
+);
+require(bundlePath);


### PR DESCRIPTION
Loading zone.js under Node's --frozen-intrinsics (or SES lockdown, or any environment that has frozen the relevant built-ins) crashes at import. Two load_patches are responsible.

The toString patch dies trying to overwrite
Function.prototype.toString:

```
  TypeError: Cannot assign to read only property 'toString' of
  object 'function () { [native code] }'
```

The console patch dies one step earlier, when it tries to stash the original method under a symbol-named property:

```
  TypeError: Cannot add property __zone_symbol__dir, object is
  not extensible
```

Node started freezing the console object a while back (see nodejs/node#46044), so this is expected behavior on the runtime side, not a Node bug — zone.js just isn't checking before it writes.

The fix in both places is to look before leaping. For toString, we inspect the descriptors of Function.prototype.toString and Object.prototype.toString and skip the patch if either one isn't writable or configurable. It has to be all-or-nothing: applying only one of the two would make Promise objects stringify differently depending on which path runs, which is worse than not patching at all.

For console, we first check Object.isExtensible(console), then check each method's descriptor individually. Console methods are independent of each other, so a single locked-down method just gets skipped while the rest are patched normally.

When the patches bail, you lose some behavior:

- Patched functions show their wrapper source through Function.prototype.toString instead of looking like native code. Anything that grep's for "[native code]" to detect natives will see different output.

- console calls from inside a non-root zone stay in the calling zone instead of being hoisted to Zone.root. The output still appears; it's just in a different zone context. Most code won't notice, but zone-aware logging setups might.

Neither is great, but both beat crashing at require().

Worth being clear about scope: this isn't "zone.js now works under --frozen-intrinsics." The whole library is built around mutating intrinsics, which is exactly what the flag forbids, so that's a contradiction we can't resolve. The goal here is just that the library shouldn't crash on import. A couple of other load_patches have similar issues (patchMethod especially) and can be hardened the same way in follow-ups.