### PR TITLE
fix(compiler): remove unused import breaking CI in 22.0.x

### DIFF
--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -25,7 +25,6 @@ import {BindingParser} from '../template_parser/binding_parser';
 import {PreparsedElementType, preparseElement} from '../template_parser/template_preparser';
 
 import * as t from './r3_ast';
-import {createContentBlock} from './r3_content_blocks';
 import {
   createForLoop,
   createIfBlock,


### PR DESCRIPTION
The import of `createContentBlock` from `./r3_content_blocks` was erroneously included in a cherry-pick but the file does not exist in this branch. This PR removes the unused import to fix the build.