### PR TITLE
docs: improve discoverability of resource({ stream })

### DIFF
--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -57,6 +57,25 @@ The `ResourceLoaderParams` object contains three properties: `params`, `previous
 
 If the `params` computation returns `undefined`, the loader function does not run and the resource status becomes `'idle'`.
 
+### Streaming resources
+
+Use `loader` when a resource performs a single asynchronous operation, such as fetching data from an HTTP endpoint.
+
+Use `stream` when your data source can emit multiple values over time. Unlike `loader`, which resolves once for each request, `stream` returns a signal whose value can continue to update as new data becomes available.
+
+Streaming resources are useful for continuously updating data sources such as WebSockets, Server-Sent Events (SSE), or Firestore `onSnapshot` listeners.
+
+```typescript
+const userUpdates = signal({value: 'Alice'});
+
+const userResource = resource({
+  stream: () => userUpdates,
+});
+
+// Later, when new data arrives:
+userUpdates.set({value: 'Bob'});
+```
+
 ### Aborting requests
 
 A resource aborts an outstanding loading operation if the `params` computation changes while the resource is loading.

--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -59,11 +59,11 @@ If the `params` computation returns `undefined`, the loader function does not ru
 
 ### Streaming resources
 
-Use `loader` when a resource performs a single asynchronous operation, such as fetching data from an HTTP endpoint.
+Some asynchronous data sources produce multiple values over time instead of returning a single result. Examples include WebSockets, Server-Sent Events (SSE), and Firestore `onSnapshot` listeners.
 
-Use `stream` when your data source can emit multiple values over time. Unlike `loader`, which resolves once for each request, `stream` returns a signal whose value can continue to update as new data becomes available.
+Use `stream` for these continuously updating data sources. Unlike `loader`, which resolves once for each request, `stream` returns a signal whose value can continue to update as new data becomes available.
 
-Streaming resources are useful for continuously updating data sources such as WebSockets, Server-Sent Events (SSE), or Firestore `onSnapshot` listeners.
+Use `loader` for one-time asynchronous operations, such as fetching data from an HTTP endpoint.
 
 ```typescript
 const userUpdates = signal({value: 'Alice'});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (not applicable - documentation only)
* [x] Docs have been added / updated

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The Signals Resource guide documents `resource({ loader })`, but does not mention `resource({ stream })`, making the streaming API difficult to discover outside of the API reference.

Fixes #69500.

## What is the new behavior?

This PR adds a new **Streaming resources** section to the Signals Resource guide that:

* Explains when to use `stream` instead of `loader`.
* Describes the difference between one-time asynchronous loading and continuously updating resources.
* Includes a simple example demonstrating `resource({ stream })`.
* Mentions common streaming use cases such as WebSockets, Server-Sent Events (SSE), and Firestore `onSnapshot` listeners.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This is a documentation-only change intended to improve discoverability of the `resource({ stream })` API without changing existing behavior.
