### PR TITLE
feat(router): allow throwing RedirectCommand to trigger redirects

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -597,7 +597,7 @@ export function provideRouter(routes: Routes, ...features: RouterFeatures[]): En
 export type QueryParamsHandling = 'merge' | 'preserve' | 'replace' | '';
 
 // @public
-export class RedirectCommand {
+export class RedirectCommand extends Error {
     constructor(redirectTo: UrlTree, navigationBehaviorOptions?: NavigationBehaviorOptions | undefined);
     // (undocumented)
     readonly navigationBehaviorOptions?: NavigationBehaviorOptions | undefined;

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -117,11 +117,14 @@ export type GuardResult = boolean | UrlTree | RedirectCommand;
  *
  * @publicApi
  */
-export class RedirectCommand {
+export class RedirectCommand extends Error {
   constructor(
     readonly redirectTo: UrlTree,
     readonly navigationBehaviorOptions?: NavigationBehaviorOptions,
-  ) {}
+  ) {
+    super();
+    Object.setPrototypeOf(this, RedirectCommand.prototype);
+  }
 }
 
 /**

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -884,6 +884,10 @@ export class NavigationTransitions {
               return EMPTY;
             }
 
+            if (e instanceof RedirectCommand) {
+              e = redirectingNavigationError(this.urlSerializer, e);
+            }
+
             /* This error type is issued during Redirect, and is handled as a
              * cancellation rather than an error. */
             if (isNavigationCancelingError(e)) {

--- a/packages/router/test/integration/guards.spec.ts
+++ b/packages/router/test/integration/guards.spec.ts
@@ -2488,5 +2488,61 @@ export function guardsIntegrationSuite() {
       await router.navigateByUrl('/a?q=2');
       expect(resolveCount).toBe(2);
     });
+
+    describe('throwing redirect', () => {
+      it('should redirect when a guard throws a RedirectCommand', async () => {
+        const router = TestBed.inject(Router);
+        const location = TestBed.inject(Location);
+        const fixture = await createRoot(router, RootCmp);
+
+        router.resetConfig([
+          {
+            path: 'a',
+            canActivate: [
+              () => {
+                throw new RedirectCommand(router.parseUrl('/b'));
+              },
+            ],
+            component: BlankCmp,
+          },
+          {
+            path: 'b',
+            component: BlankCmp,
+          },
+        ]);
+
+        router.navigateByUrl('/a');
+        await advance(fixture);
+
+        expect(location.path()).toEqual('/b');
+      });
+
+      it('should redirect when a resolver throws a RedirectCommand', async () => {
+        const router = TestBed.inject(Router);
+        const location = TestBed.inject(Location);
+        const fixture = await createRoot(router, RootCmp);
+
+        router.resetConfig([
+          {
+            path: 'a',
+            resolve: {
+              data: () => {
+                throw new RedirectCommand(router.parseUrl('/b'));
+              },
+            },
+            component: BlankCmp,
+          },
+          {
+            path: 'b',
+            component: BlankCmp,
+          },
+        ]);
+
+        router.navigateByUrl('/a');
+        await advance(fixture);
+
+        expect(location.path()).toEqual('/b');
+      });
+    });
   });
 }


### PR DESCRIPTION
This allows developers to throw a `RedirectCommand` directly from guards and resolvers to trigger a redirect.

The primary benefit is that we no longer need to pollute the return type of functions that redirect. For example, a deeply nested helper function or a resolver can now simply throw a `RedirectCommand` to short-circuit and redirect, instead of having to return the `UrlTree` or `RedirectCommand` all the way up the call stack.

This aligns with prior art in other modern framework routers (such as Next.js, Remix, and SvelteKit), which commonly use thrown exceptions or special redirect responses to abort execution and trigger immediate redirection.
