### PR TITLE
fix(core): prevent orphaned requestIdleCallback handle from re-entrant scheduling

### DIFF
--- a/packages/core/src/defer/idle_scheduler.ts
+++ b/packages/core/src/defer/idle_scheduler.ts
@@ -102,8 +102,10 @@ export class IdleScheduler implements OnDestroy {
 
     const key = getIdleRequestKey(options);
     const callback = (deadline?: IdleDeadline) => {
-      this.cancelBucket(bucket);
-
+      // Do not cancelBucket() here. The browser has already fired this handle so
+      // cancelling it is moot, and leaving idleId set prevents re-entrant add()
+      // calls during the drain from scheduling a redundant requestOnIdle that
+      // would be orphaned once the queue empties at the end of this invocation.
       for (const cb of bucket.queue) {
         cb();
         // _tick here is an optimized change detection check and is safe to call here.
@@ -117,6 +119,10 @@ export class IdleScheduler implements OnDestroy {
           break;
         }
       }
+
+      // The handle has been consumed; clear idleId so scheduleBucket() below can
+      // register a fresh one for any callbacks that remain after a deadline break.
+      bucket.idleId = null;
 
       if (bucket.queue.size > 0) {
         this.scheduleBucket(bucket, options);

--- a/packages/core/src/defer/idle_scheduler.ts
+++ b/packages/core/src/defer/idle_scheduler.ts
@@ -102,8 +102,7 @@ export class IdleScheduler implements OnDestroy {
 
     const key = getIdleRequestKey(options);
     const callback = (deadline?: IdleDeadline) => {
-      this.cancelBucket(bucket);
-
+      // Keep idleId set during the drain to prevent re-entrant add() from scheduling redundant callbacks.
       for (const cb of bucket.queue) {
         cb();
         // _tick here is an optimized change detection check and is safe to call here.
@@ -117,6 +116,8 @@ export class IdleScheduler implements OnDestroy {
           break;
         }
       }
+
+      bucket.idleId = null;
 
       if (bucket.queue.size > 0) {
         this.scheduleBucket(bucket, options);

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -5486,4 +5486,173 @@ describe('IdleScheduler', () => {
     capturedCbs[0]({didTimeout: false, timeRemaining: () => 10});
     expect(cb1).toHaveBeenCalledTimes(1);
   });
+
+  it('should not register a spurious requestOnIdle when a callback re-entrantly adds to the same bucket', () => {
+    // Regression: cancelBucket() at the top of the drain set idleId to null, so a
+    // re-entrant scheduler.add() during the drain called scheduleBucket() and registered
+    // a second requestOnIdle handle. That handle was then orphaned (never cancelled)
+    // because the bucket was removed from this.buckets once the queue emptied in the
+    // same drain iteration.
+    let capturedCb: ((deadline: any) => void) | null = null;
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCb = cb;
+      return 100 + ricCount;
+    });
+
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      // Re-entrantly schedule B into the same bucket (no options → key '').
+      scheduler.add(cbB);
+    });
+
+    scheduler.add(cbA);
+    expect(ricCount).toBe(1);
+
+    capturedCb!({didTimeout: false, timeRemaining: () => 9999});
+
+    // A and B both ran (JS Set iterator visits B because it was appended after the cursor).
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+
+    // Exactly one requestOnIdle was issued. No spurious second registration means no
+    // orphaned handle that would survive ngOnDestroy and fire against a destroyed scheduler.
+    expect(ricCount).toBe(1);
+  });
+
+  it('should defer a re-entrantly-added same-bucket callback to the next idle period when the deadline expires', () => {
+    let capturedCbs: Array<(deadline: any) => void> = [];
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCbs.push(cb);
+      return 100 + ricCount;
+    });
+
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      scheduler.add(cbB); // re-entrant add — same bucket (no options)
+    });
+
+    scheduler.add(cbA);
+    capturedCbs[0]({didTimeout: false, timeRemaining: () => 0}); // deadline expires after A
+
+    // A ran; deadline expired before B was visited.
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(0);
+
+    // A second idle was registered for B by the post-drain scheduleBucket call.
+    expect(ricCount).toBe(2);
+    capturedCbs[1]({didTimeout: false, timeRemaining: () => 10});
+    expect(cbB).toHaveBeenCalledTimes(1);
+  });
+
+  it('should isolate a re-entrantly-added callback in a different bucket from the current drain', () => {
+    let capturedCbs: Array<(deadline: any) => void> = [];
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCbs.push(cb);
+      return 100 + ricCount;
+    });
+
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      scheduler.add(cbB, {timeout: 500}); // different bucket key
+    });
+
+    scheduler.add(cbA);
+    capturedCbs[0]({didTimeout: false, timeRemaining: () => 10});
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(0); // B is in its own bucket, not yet visited
+    expect(ricCount).toBe(2); // one registration per bucket — both legitimate
+
+    capturedCbs[1]({didTimeout: false, timeRemaining: () => 10});
+    expect(cbB).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip a same-bucket sibling that is removed during a drain', () => {
+    let capturedCb: ((deadline: any) => void) | null = null;
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCb = cb;
+      return 100 + ricCount;
+    });
+
+    const cbC = jasmine.createSpy('cbC');
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      scheduler.remove(cbC); // remove C before the iterator reaches it
+    });
+
+    scheduler.add(cbA);
+    scheduler.add(cbB);
+    scheduler.add(cbC);
+
+    capturedCb!({didTimeout: false, timeRemaining: () => 10});
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+    expect(cbC).toHaveBeenCalledTimes(0); // deleted from the Set before the iterator reached it
+    expect(ricCount).toBe(1); // remove() did not trigger spurious scheduling
+  });
+
+  it('should skip the immediately-next callback when it is removed during a drain', () => {
+    let capturedCb: ((deadline: any) => void) | null = null;
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCb = cb;
+      return 100 + ricCount;
+    });
+
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      scheduler.remove(cbB);
+    });
+
+    scheduler.add(cbA);
+    scheduler.add(cbB);
+
+    capturedCb!({didTimeout: false, timeRemaining: () => 10});
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(0); // skipped
+    expect(ricCount).toBe(1);
+  });
+
+  it('should ignore re-entrant remove() calls for callbacks already processed in the current drain', () => {
+    let capturedCb: ((deadline: any) => void) | null = null;
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCb = cb;
+      return 100 + ricCount;
+    });
+
+    const cbA = jasmine.createSpy('cbA');
+    const cbB = jasmine.createSpy('cbB').and.callFake(() => {
+      // A has already been fully processed: the drain deleted it from callbackBucket.
+      // remove(A) finds no entry → returns early with no side-effects.
+      scheduler.remove(cbA);
+    });
+
+    scheduler.add(cbA);
+    scheduler.add(cbB);
+
+    expect(() => capturedCb!({didTimeout: false, timeRemaining: () => 10})).not.toThrow();
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+    expect(ricCount).toBe(1); // no extra scheduling from the no-op remove()
+  });
 });

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -5502,4 +5502,158 @@ describe('IdleScheduler', () => {
     capturedCbs[0]({didTimeout: false, timeRemaining: () => 10});
     expect(cb1).toHaveBeenCalledTimes(1);
   });
+
+  it('should not register a spurious requestOnIdle when a callback re-entrantly adds to the same bucket', () => {
+    let capturedCb: ((deadline: any) => void) | null = null;
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCb = cb;
+      return 100 + ricCount;
+    });
+
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      scheduler.add(cbB);
+    });
+
+    scheduler.add(cbA);
+    expect(ricCount).toBe(1);
+
+    capturedCb!({didTimeout: false, timeRemaining: () => 9999});
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+    expect(ricCount).toBe(1);
+  });
+
+  it('should defer a re-entrantly-added same-bucket callback to the next idle period when the deadline expires', () => {
+    let capturedCbs: Array<(deadline: any) => void> = [];
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCbs.push(cb);
+      return 100 + ricCount;
+    });
+
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      scheduler.add(cbB);
+    });
+
+    scheduler.add(cbA);
+    capturedCbs[0]({didTimeout: false, timeRemaining: () => 0});
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(0);
+    expect(ricCount).toBe(2);
+    capturedCbs[1]({didTimeout: false, timeRemaining: () => 10});
+    expect(cbB).toHaveBeenCalledTimes(1);
+  });
+
+  it('should isolate a re-entrantly-added callback in a different bucket from the current drain', () => {
+    let capturedCbs: Array<(deadline: any) => void> = [];
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCbs.push(cb);
+      return 100 + ricCount;
+    });
+
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      scheduler.add(cbB, {timeout: 500});
+    });
+
+    scheduler.add(cbA);
+    capturedCbs[0]({didTimeout: false, timeRemaining: () => 10});
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(0);
+    expect(ricCount).toBe(2);
+
+    capturedCbs[1]({didTimeout: false, timeRemaining: () => 10});
+    expect(cbB).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip a same-bucket sibling that is removed during a drain', () => {
+    let capturedCb: ((deadline: any) => void) | null = null;
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCb = cb;
+      return 100 + ricCount;
+    });
+
+    const cbC = jasmine.createSpy('cbC');
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      scheduler.remove(cbC);
+    });
+
+    scheduler.add(cbA);
+    scheduler.add(cbB);
+    scheduler.add(cbC);
+
+    capturedCb!({didTimeout: false, timeRemaining: () => 10});
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+    expect(cbC).toHaveBeenCalledTimes(0);
+    expect(ricCount).toBe(1);
+  });
+
+  it('should skip the immediately-next callback when it is removed during a drain', () => {
+    let capturedCb: ((deadline: any) => void) | null = null;
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCb = cb;
+      return 100 + ricCount;
+    });
+
+    const cbB = jasmine.createSpy('cbB');
+    const cbA = jasmine.createSpy('cbA').and.callFake(() => {
+      scheduler.remove(cbB);
+    });
+
+    scheduler.add(cbA);
+    scheduler.add(cbB);
+
+    capturedCb!({didTimeout: false, timeRemaining: () => 10});
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(0);
+    expect(ricCount).toBe(1);
+  });
+
+  it('should ignore re-entrant remove() calls for callbacks already processed in the current drain', () => {
+    let capturedCb: ((deadline: any) => void) | null = null;
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any) => {
+      ricCount++;
+      capturedCb = cb;
+      return 100 + ricCount;
+    });
+
+    const cbA = jasmine.createSpy('cbA');
+    const cbB = jasmine.createSpy('cbB').and.callFake(() => {
+      scheduler.remove(cbA);
+    });
+
+    scheduler.add(cbA);
+    scheduler.add(cbB);
+
+    expect(() => capturedCb!({didTimeout: false, timeRemaining: () => 10})).not.toThrow();
+
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+    expect(ricCount).toBe(1);
+  });
 });


### PR DESCRIPTION
Defer blocks that ask to run during browser idle time with the same
options get grouped into one batch ("bucket") and processed together
the next time the browser is idle. While that batch runs, if one
callback (or the change-detection check right after it) asks to
schedule more idle work for that same batch, Angular used to register
a second idle-callback handle instead of reusing the one already in
flight.

That second handle became orphaned. By the time the batch finished
running, its queue was empty, so Angular threw away the bookkeeping
for it — including the only reference that could have cancelled the
handle. If the app was destroyed before the browser got around to
calling it, it fired anyway, against a scheduler that no longer
existed.

The root cause was a marker (idleId) that IdleScheduler uses to know
"I already have a browser callback pending for this batch, don't
request another one." That marker was being cleared to null right at
the start of processing a batch, before any of its callbacks had
actually run. So a callback that re-entrantly asked to schedule more
work mid-batch saw "nothing pending" and requested a redundant handle.

The fix: leave the marker set for the entire batch instead of clearing
it up front. Only clear it once every callback in the batch has run —
at that point, if there's leftover work, it's safe to request a fresh
handle for it.

Added a test for the basic re-entrant scenario, plus five more for
edge cases: a re-entrant add() into a different batch, and re-entrant
remove() of a sibling callback that hasn't run yet versus one that
already has.