### PR TITLE
docs: fix incorrect @defer trigger names and a duplicate word in guides

### DIFF
--- a/adev/src/content/guide/routing/customizing-route-behavior.md
+++ b/adev/src/content/guide/routing/customizing-route-behavior.md
@@ -37,7 +37,7 @@ This is useful when you want repeated clicks on a list filter, left-nav item, or
 provideRouter(routes, withRouterConfig({onSameUrlNavigation: 'reload'}));
 ```
 
-You can also control this behavior on individual navigations rather than globally. This allows you to keep the keep the default of `'ignore'` while selectively enabling reload behavior for specific use cases:
+You can also control this behavior on individual navigations rather than globally. This allows you to keep the default of `'ignore'` while selectively enabling reload behavior for specific use cases:
 
 ```ts
 router.navigate(['/some-path'], {onSameUrlNavigation: 'reload'});

--- a/adev/src/content/guide/templates/defer.md
+++ b/adev/src/content/guide/templates/defer.md
@@ -237,7 +237,7 @@ By default, the placeholder acts as the interaction element. Placeholders used t
 }
 ```
 
-Alternatively, you can specify a [template reference variable](/guide/templates/variables) in the same template as the `@defer` block as the element that is watched for interactions. This variable is passed in as a parameter on the viewport trigger.
+Alternatively, you can specify a [template reference variable](/guide/templates/variables) in the same template as the `@defer` block as the element that is watched for interactions. This variable is passed in as a parameter on the interaction trigger.
 
 ```angular-html
 <div #greeting>Hello!</div>
@@ -260,7 +260,7 @@ By default, the placeholder acts as the interaction element. Placeholders used t
 }
 ```
 
-Alternatively, you can specify a [template reference variable](/guide/templates/variables) in the same template as the `@defer` block as the element that is watched to enter the viewport. This variable is passed in as a parameter on the viewport trigger.
+Alternatively, you can specify a [template reference variable](/guide/templates/variables) in the same template as the `@defer` block as the element that is hovered over. This variable is passed in as a parameter on the hover trigger.
 
 ```angular-html
 <div #greeting>Hello!</div>


### PR DESCRIPTION
## PR Type

Documentation.

## What is the current behavior?

The `@defer` template guide (`adev/src/content/guide/templates/defer.md`) reuses the `viewport` section's prose in the `interaction` and `hover` sections without adapting it, so it names the wrong trigger:

- **`#### interaction`**: "This variable is passed in as a parameter on the **viewport** trigger." — should be the **interaction** trigger.
- **`#### hover`**: "the element that is **watched to enter the viewport** ... on the **viewport** trigger." — the `hover` trigger fires on hover, so this should read "**hovered over** ... on the **hover** trigger."

Separately, the routing guide (`adev/src/content/guide/routing/customizing-route-behavior.md`) has a duplicate word: "This allows you to **keep the keep the** default of `'ignore'`".

## What is the new behavior?

- `interaction` section now references the `interaction` trigger.
- `hover` section now describes the element being hovered over and references the `hover` trigger.
- The duplicate "keep the" is removed.

The `viewport` section itself (the original, correct text) is unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Documentation-only changes; no code or public API is affected.