### PR TITLE
refactor(core): enable foreign components to render content lazily

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/foreign_component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/foreign_component.ts
@@ -347,9 +347,9 @@ class ForeignComponentFeatureAnalyzer extends TmplAstRecursiveVisitor {
       );
     }
 
-    // Explicitly defining a `@content(children)` block is unnecessary because child nodes are
-    // implicitly passed to the `children` property.
-    if (block.name === CHILDREN) {
+    // Explicitly defining a `@content(children)` block without parameters is unnecessary because
+    // child nodes are implicitly passed to the `children` property.
+    if (block.name === CHILDREN && block.variables.length === 0) {
       this.diagnostics.push(
         makeTemplateDiagnostic(
           '' as TypeCheckId,
@@ -357,7 +357,7 @@ class ForeignComponentFeatureAnalyzer extends TmplAstRecursiveVisitor {
           block.sourceSpan,
           ts.DiagnosticCategory.Error,
           ngErrorCode(ErrorCode.FOREIGN_COMPONENT_CONTENT_UNNECESSARY_FOR_CHILDREN),
-          `Defining a @content (${CHILDREN}) block is unnecessary. ` +
+          `Defining a @content (${CHILDREN}) block with no parameters is unnecessary. ` +
             'Pass children as direct nested content of the foreign component instead.',
         ),
       );

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
@@ -68,7 +68,7 @@ export class TestCmpChildren {
     template: function TestCmpChildren_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵdomTemplate(0, TestCmpChildren_Icon_0_Template, 2, 0)(1, TestCmpChildren_Description_1_Template, 2, 0)(2, TestCmpChildren_Children_2_Template, 2, 0);
-        i0.ɵɵforeignComponent(3, 0, { label: ctx.title, icon: i0.ɵɵforeignContent(0), description: i0.ɵɵforeignContent(1), children: i0.ɵɵforeignContent(2) });
+        i0.ɵɵforeignComponent(3, 0, { label: ctx.title, icon: i0.ɵɵforeignContent(0, 0), description: i0.ɵɵforeignContent(1, 0), children: i0.ɵɵforeignContent(2, 0) });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
@@ -68,7 +68,7 @@ export class TestCmpChildren {
     template: function TestCmpChildren_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵtemplate(0, TestCmpChildren_Icon_0_Template, 2, 0)(1, TestCmpChildren_Description_1_Template, 2, 0)(2, TestCmpChildren_Children_2_Template, 2, 0);
-        i0.ɵɵforeignComponent(3, 0, { label: ctx.title, icon: i0.ɵɵforeignContent(0), description: i0.ɵɵforeignContent(1), children: i0.ɵɵforeignContent(2) });
+        i0.ɵɵforeignComponent(3, 0, { label: ctx.title, icon: i0.ɵɵforeignContent(0, 0), description: i0.ɵɵforeignContent(1, 0), children: i0.ɵɵforeignContent(2, 0) });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -2425,9 +2425,27 @@ runInEachFileSystem(() => {
           ngErrorCode(ErrorCode.FOREIGN_COMPONENT_CONTENT_UNNECESSARY_FOR_CHILDREN),
         );
         expect(diags[0].messageText).toEqual(
-          'Defining a @content (children) block is unnecessary. ' +
+          'Defining a @content (children) block with no parameters is unnecessary. ' +
             'Pass children as direct nested content of the foreign component instead.',
         );
+      });
+
+      it('should allow @content (children, let ...) with parameters', () => {
+        env.write(
+          'test.ts',
+          `
+          ${foreignSetupCode}
+
+          @Component({
+            selector: 'test',
+            template: '<FancyButton> @content (children; let arg) {} </FancyButton>',
+            foreignImports: [frameworkImport(FancyButton)],
+          })
+          export class TestCmp {}
+        `,
+        );
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
       });
 
       it('should detect duplicate @content blocks under the same foreign component', () => {

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -62,6 +62,16 @@ export function foreignComponent(
   return call(Identifiers.foreignComponent, args, sourceSpan);
 }
 
+export function foreignContent(
+  slot: number,
+  foreignComponentIndex: number,
+  parameterized: boolean,
+): o.Expression {
+  return o
+    .importExpr(parameterized ? Identifiers.foreignContentFn : Identifiers.foreignContent)
+    .callFn([o.literal(slot), o.literal(foreignComponentIndex)]);
+}
+
 function elementOrContainerBase(
   instruction: o.ExternalReference,
   slot: number,

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -803,13 +803,12 @@ function reifyIrExpression(unit: CompilationUnit, expr: o.Expression): o.Express
       if (!(unit instanceof ViewCompilationUnit)) {
         throw new Error(`AssertionError: must be compiling a component`);
       }
-      const isFn = unit.job.views.get(expr.childrenViewXref)!.contextVariables.size > 0;
-      const slot = o.literal(expr.childrenViewHandle.slot!);
-      return isFn
-        ? o
-            .importExpr(Identifiers.foreignContentFn)
-            .callFn([slot, o.literal(expr.foreignComponentConstIndex)])
-        : o.importExpr(Identifiers.foreignContent).callFn([slot]);
+      const parameterized = unit.job.views.get(expr.childrenViewXref)!.contextVariables.size > 0;
+      return ng.foreignContent(
+        expr.childrenViewHandle.slot!,
+        expr.foreignComponentConstIndex,
+        parameterized,
+      );
     case ir.ExpressionKind.LexicalRead:
       throw new Error(`AssertionError: unresolved LexicalRead of ${expr.name}`);
     case ir.ExpressionKind.TwoWayBindingSet:

--- a/packages/core/src/interface/foreign_component.ts
+++ b/packages/core/src/interface/foreign_component.ts
@@ -12,6 +12,9 @@ export const RENDER: unique symbol = Symbol('RENDER');
 /** Symbol used to store and retrieve the disposal registration function for a foreign component. */
 export const ON_DESTROY: unique symbol = Symbol('ON_DESTROY');
 
+/** Symbol used to store and retrieve the content adapter function for a foreign component. */
+export const CONTENT_ADAPTER: unique symbol = Symbol('CONTENT_ADAPTER');
+
 /**
  * A function used to render a foreign component in an Angular template.
  *
@@ -34,6 +37,12 @@ export type ForeignRenderFn<TProps> = (props: TProps) => [Node[], VoidFunction?]
 export type ForeignOnDestroyFn = (destroy: VoidFunction) => void;
 
 /**
+ * A function that adapts an Angular content producer callback into a compatible representation for
+ * the foreign component.
+ */
+export type ForeignContentAdapterFn = (producer: () => Node[]) => any;
+
+/**
  * Represents a component from another framework that Angular can import and render.
  *
  * @template TProps The properties of the foreign component.
@@ -41,4 +50,5 @@ export type ForeignOnDestroyFn = (destroy: VoidFunction) => void;
 export interface ForeignComponent<TProps> {
   readonly [RENDER]: ForeignRenderFn<TProps>;
   readonly [ON_DESTROY]: ForeignOnDestroyFn;
+  readonly [CONTENT_ADAPTER]: ForeignContentAdapterFn;
 }

--- a/packages/core/src/render3/foreign_import.ts
+++ b/packages/core/src/render3/foreign_import.ts
@@ -10,8 +10,10 @@ import {
   ForeignComponent,
   ForeignRenderFn,
   ForeignOnDestroyFn,
+  ForeignContentAdapterFn,
   RENDER,
   ON_DESTROY,
+  CONTENT_ADAPTER,
 } from '../interface/foreign_component';
 
 /**
@@ -20,13 +22,17 @@ import {
  * @template TProps The properties of the foreign component.
  * @param render A function that renders a foreign component.
  * @param onDestroy A function for foreign content to register a destroy callback.
+ * @param contentAdapter A function that adapts Angular content to a representation expected by the
+ * foreign component.
  */
 export function foreignImport<TProps>(
   render: ForeignRenderFn<TProps>,
   onDestroy: ForeignOnDestroyFn,
+  contentAdapter: ForeignContentAdapterFn,
 ): ForeignComponent<TProps> {
   return {
     [RENDER]: render,
     [ON_DESTROY]: onDestroy,
+    [CONTENT_ADAPTER]: contentAdapter,
   };
 }

--- a/packages/core/src/render3/instructions/foreign_component.ts
+++ b/packages/core/src/render3/instructions/foreign_component.ts
@@ -6,13 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ForeignComponent, RENDER, ON_DESTROY} from '../../interface/foreign_component';
+import {
+  ForeignComponent,
+  RENDER,
+  ON_DESTROY,
+  CONTENT_ADAPTER,
+} from '../../interface/foreign_component';
 import {attachPatchData} from '../context_discovery';
 import {nativeInsertBefore} from '../dom_node_manipulation';
 import {createForeignView} from '../foreign_view';
 import {TContainerNode, TNodeType} from '../interfaces/node';
-import {HEADER_OFFSET, RENDERER, TVIEW, FLAGS, LViewFlags} from '../interfaces/view';
-import {appendChild, destroyLView} from '../node_manipulation';
+import {HEADER_OFFSET, RENDERER, TVIEW, FLAGS} from '../interfaces/view';
+import {appendChild} from '../node_manipulation';
 import {getLView, getTView, setCurrentTNode, setCurrentTNodeAsNotParent} from '../state';
 import {getOrCreateTNode} from '../tnode_manipulation';
 import {addToEndOfViewTree} from '../view/construction';
@@ -27,7 +32,7 @@ import {assertLContainer} from '../assert';
 import {CONTAINER_HEADER_OFFSET, LContainer, LContainerFlags} from '../interfaces/container';
 import {getConstant} from '../util/view_utils';
 import {isDestroyed} from '../interfaces/type_checks';
-import {assertNotEqual, assertNotSame} from '../../util/assert';
+import {assertNotSame} from '../../util/assert';
 
 /**
  * Creation phase instruction to render a foreign component.
@@ -96,42 +101,10 @@ export function ɵɵforeignComponent(
  * and extract its root DOM nodes.
  *
  * @param index The index of the container in the data array.
- * @codeGenApi
- */
-export function ɵɵforeignContent(index: number): any[] {
-  const lView = getLView();
-  const adjustedIndex = index + HEADER_OFFSET;
-
-  // The template is already declared at adjustedIndex, so lContainer must exist.
-  const lContainer = lView[adjustedIndex] as LContainer;
-  ngDevMode && assertLContainer(lContainer);
-  lContainer[FLAGS] |= LContainerFlags.LogicalOnly;
-
-  const tView = getTView();
-  const tNode = tView.data[adjustedIndex] as TContainerNode;
-
-  // Instantiate and render the embedded view inside the container, but do not add its elements to
-  // the DOM at the container anchor since the nodes will be projected into a foreign view.
-  const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, null);
-  addLViewToLContainer(lContainer, embeddedLView, 0, /* addToDOM */ false);
-
-  // Extract and return the root nodes of the created view
-  const embeddedTView = embeddedLView[TVIEW];
-  return collectNativeNodes(embeddedTView, embeddedLView, embeddedTView.firstChild, []);
-}
-
-/**
- * Creation phase instruction to return a function for rendering foreign content dynamically
- * with arguments.
- *
- * @param index The index of the container in the data array.
  * @param foreignComponentConstIndex The index of the matched foreign component in the constant pool.
  * @codeGenApi
  */
-export function ɵɵforeignContentFn(
-  index: number,
-  foreignComponentConstIndex: number,
-): (...args: any[]) => any[] {
+export function ɵɵforeignContent(index: number, foreignComponentConstIndex: number): any {
   const lView = getLView();
   const adjustedIndex = index + HEADER_OFFSET;
 
@@ -146,13 +119,11 @@ export function ɵɵforeignContentFn(
     tView.consts,
     foreignComponentConstIndex,
   )!;
+  const adapter = foreignComponent[CONTENT_ADAPTER];
   const onDestroy = foreignComponent[ON_DESTROY];
 
-  return (...args: any[]) => {
-    // When the function is called, instantiate and render a new embedded view inside the container.
-    // The arguments are passed directly as the context of the view.
-    const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, args);
-
+  const producer = () => {
+    const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, null);
     addLViewToLContainer(
       lContainer,
       embeddedLView,
@@ -168,8 +139,66 @@ export function ɵɵforeignContentFn(
       }
     });
 
-    // Extract and return the root nodes of the created view
     const embeddedTView = embeddedLView[TVIEW];
     return collectNativeNodes(embeddedTView, embeddedLView, embeddedTView.firstChild, []);
+  };
+
+  return adapter(producer);
+}
+
+/**
+ * Creation phase instruction to return a function for rendering foreign content dynamically
+ * with arguments.
+ *
+ * @param index The index of the container in the data array.
+ * @param foreignComponentConstIndex The index of the matched foreign component in the constant pool.
+ * @codeGenApi
+ */
+export function ɵɵforeignContentFn(
+  index: number,
+  foreignComponentConstIndex: number,
+): (...args: any[]) => any {
+  const lView = getLView();
+  const adjustedIndex = index + HEADER_OFFSET;
+
+  // The template is already declared at adjustedIndex, so lContainer must exist.
+  const lContainer = lView[adjustedIndex] as LContainer;
+  ngDevMode && assertLContainer(lContainer);
+  lContainer[FLAGS] |= LContainerFlags.LogicalOnly;
+
+  const tView = getTView();
+  const tNode = tView.data[adjustedIndex] as TContainerNode;
+  const foreignComponent = getConstant<ForeignComponent<any>>(
+    tView.consts,
+    foreignComponentConstIndex,
+  )!;
+  const adapter = foreignComponent[CONTENT_ADAPTER];
+  const onDestroy = foreignComponent[ON_DESTROY];
+
+  return (...args: any[]) => {
+    const producer = () => {
+      const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, args);
+
+      addLViewToLContainer(
+        lContainer,
+        embeddedLView,
+        lContainer.length - CONTAINER_HEADER_OFFSET,
+        /* addToDOM */ false,
+      );
+
+      onDestroy(() => {
+        if (!isDestroyed(embeddedLView)) {
+          const embeddedLViewIndex = lContainer.indexOf(embeddedLView, CONTAINER_HEADER_OFFSET);
+          ngDevMode &&
+            assertNotSame(embeddedLViewIndex, -1, 'Embedded view not found in container');
+          removeLViewFromLContainer(lContainer, embeddedLViewIndex - CONTAINER_HEADER_OFFSET);
+        }
+      });
+
+      const embeddedTView = embeddedLView[TVIEW];
+      return collectNativeNodes(embeddedTView, embeddedLView, embeddedTView.firstChild, []);
+    };
+
+    return adapter(producer);
   };
 }

--- a/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
+++ b/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
@@ -6,7 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, ElementRef, computed, effect, signal, viewChildren} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  computed,
+  effect,
+  signal,
+  untracked,
+  viewChildren,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {ForeignComponent} from '../../../src/interface/foreign_component';
 import {foreignImport} from '../../../src/render3/foreign_import';
@@ -15,6 +23,7 @@ function frameworkImport<TProps>(component: (props: TProps) => Node[]): ForeignC
   return foreignImport(
     (props) => [component(props)],
     () => {},
+    (producer) => producer(),
   );
 }
 
@@ -692,45 +701,87 @@ describe('foreign components', () => {
   });
 
   describe('lifecycle', () => {
-    it('should destroy projected content when its foreign container is destroyed', async () => {
-      // Track the destroy callback registered by the projected content.
-      let destroy: VoidFunction | undefined;
-      function frameworkOnDestroy(callback: VoidFunction) {
-        destroy = callback;
+    // A minimal foreign context system for tracking cleanup.
+    class Context {
+      private static current: Context | undefined;
+
+      // Ensures there is currently an active context and returns it.
+      static get active(): Context {
+        if (!Context.current) {
+          throw new Error('There is no active context');
+        }
+        return Context.current;
       }
 
-      function frameworkImport<TProps>(
-        component: (props: TProps) => Node[],
-      ): ForeignComponent<TProps> {
-        return foreignImport((props) => [component(props)], frameworkOnDestroy);
+      private destroyFn: VoidFunction | undefined;
+
+      // Executes action with this context.
+      run<T>(action: () => T): T {
+        const prev = Context.current;
+        Context.current = this;
+        try {
+          return action();
+        } finally {
+          Context.current = prev;
+        }
       }
 
-      // A foreign component that acts like a conditional container (e.g. @if).
-      function Conditional(props: {when: () => boolean; then: () => Node[]}) {
+      // Destroys this context.
+      destroy() {
+        this.destroyFn?.();
+        this.destroyFn = undefined;
+      }
+
+      // Registers a callback to be invoked when this context is destroyed.
+      onDestroy(callback: VoidFunction) {
+        if (this.destroyFn) {
+          throw new Error('There is already a destroy callback registered');
+        }
+        this.destroyFn = callback;
+      }
+    }
+
+    function frameworkImport<TProps>(
+      component: (props: TProps) => Node[],
+    ): ForeignComponent<TProps> {
+      return foreignImport(
+        (props) => [component(props)],
+        (callback) => Context.active.onDestroy(callback),
+        // Do *not* render nodes eagerly. Return the node producer function directly.
+        (producer) => producer,
+      );
+    }
+
+    it('should integrate lifecycle of static content', async () => {
+      function StaticIf(props: {cond: () => boolean; children: () => Node[]}) {
+        const container = document.createElement('div');
+        const context = new Context();
+
         effect((onCleanup) => {
-          // On cleanup (when `when()` changes or the component is destroyed), call the destroy
-          // callback registered by Angular for the projected content.
-          onCleanup(() => destroy?.());
+          onCleanup(() => context.destroy());
 
-          if (props.when()) {
-            // Render the conditional content, instantiating any Angular views contained within.
-            // Internally this will call `frameworkOnDestroy` to register a callback to destroy the
-            // views when this effect's cleanup is run.
-            props.then();
+          if (props.cond()) {
+            context.run(() => {
+              const nodes = untracked(() => props.children());
+              for (const node of nodes) {
+                container.appendChild(node);
+              }
+            });
           }
         });
 
-        // We don't care about returning any nodes since we're just testing the content lifecycle.
-        return [];
+        return [container];
       }
 
-      const ngOnDestroySpy = jasmine.createSpy();
+      const ngOnInitSpy = jasmine.createSpy('ngOnInit');
+      const ngOnDestroySpy = jasmine.createSpy('ngOnDestroy');
 
-      @Component({
-        selector: 'disposable',
-        template: ``,
-      })
-      class Disposable {
+      @Component({selector: 'child', template: '<div>child</div>'})
+      class Child {
+        ngOnInit() {
+          ngOnInitSpy();
+        }
+
         ngOnDestroy() {
           ngOnDestroySpy();
         }
@@ -738,46 +789,135 @@ describe('foreign components', () => {
 
       @Component({
         template: `
-          <Conditional [when]="visible">
-            @content (then; let _) {
-              <disposable />
-            }
-          </Conditional>
+          <StaticIf [cond]="visible">
+            <child />
+          </StaticIf>
         `,
-        imports: [Disposable],
+        imports: [Child],
         // @ts-ignore
-        foreignImports: [frameworkImport(Conditional)],
+        foreignImports: [frameworkImport(StaticIf)],
       })
-      class TestDisposal {
-        readonly visible = signal(true);
+      class App {
+        readonly visible = signal(false);
       }
 
-      const fixture = TestBed.createComponent(TestDisposal);
+      const fixture = TestBed.createComponent(App);
       await fixture.whenStable();
 
-      // Initially, visible is true, so the <disposable> component is created and NOT destroyed.
+      // Initially, visible is false, so <child> is not rendered.
+      expect(ngOnInitSpy).not.toHaveBeenCalled();
       expect(ngOnDestroySpy).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.textContent).toBe('');
 
-      // Toggle visible to false: this triggers the Conditional component's effect cleanup,
-      // which calls the destroy callback registered during props.then() invocation.
-      fixture.componentInstance.visible.set(false);
-      await fixture.whenStable();
-
-      // The projected Angular content <disposable> should be destroyed.
-      expect(ngOnDestroySpy).toHaveBeenCalledTimes(1);
-
-      // Toggle visible back to true: a new instance of <disposable> is created.
+      // Toggle visible to true: this renders <child>.
       fixture.componentInstance.visible.set(true);
       await fixture.whenStable();
 
-      // Since the new instance is not yet destroyed, the destroy spy count remains at 1.
-      expect(ngOnDestroySpy).toHaveBeenCalledTimes(1);
+      expect(ngOnInitSpy).toHaveBeenCalledTimes(1);
+      expect(ngOnDestroySpy).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.textContent).toBe('child');
 
-      // Toggle visible to false again: the new instance is destroyed.
+      // Toggle visible back to false: this destroys the previously rendered <child>.
       fixture.componentInstance.visible.set(false);
       await fixture.whenStable();
 
-      expect(ngOnDestroySpy).toHaveBeenCalledTimes(2);
+      expect(ngOnInitSpy).toHaveBeenCalledTimes(1);
+      expect(ngOnDestroySpy).toHaveBeenCalledTimes(1);
+      expect(fixture.nativeElement.textContent).toBe('');
+
+      // Toggle visible to true again: this renders a new <child>.
+      fixture.componentInstance.visible.set(true);
+      await fixture.whenStable();
+
+      expect(ngOnInitSpy).toHaveBeenCalledTimes(2);
+      expect(ngOnDestroySpy).toHaveBeenCalledTimes(1);
+      expect(fixture.nativeElement.textContent).toBe('child');
+    });
+
+    it('should integrate lifecycle of dynamic content', async () => {
+      function DynamicIf(props: {cond: () => boolean; children: (value: boolean) => () => Node[]}) {
+        const container = document.createElement('div');
+        const context = new Context();
+
+        effect((onCleanup) => {
+          onCleanup(() => context.destroy());
+
+          const result = props.cond();
+          if (result) {
+            context.run(() => {
+              const children = untracked(() => props.children(result));
+              const nodes = children();
+              for (const node of nodes) {
+                container.appendChild(node);
+              }
+            });
+          }
+        });
+
+        return [container];
+      }
+
+      const ngOnInitSpy = jasmine.createSpy('ngOnInit');
+      const ngOnDestroySpy = jasmine.createSpy('ngOnDestroy');
+
+      @Component({selector: 'child', template: '<ng-content />'})
+      class Child {
+        ngOnInit() {
+          ngOnInitSpy();
+        }
+
+        ngOnDestroy() {
+          ngOnDestroySpy();
+        }
+      }
+
+      @Component({
+        template: `
+          <DynamicIf [cond]="visible">
+            @content(children; let result) {
+              <child>{{ result }}</child>
+            }
+          </DynamicIf>
+        `,
+        imports: [Child],
+        // @ts-ignore
+        foreignImports: [frameworkImport(DynamicIf)],
+      })
+      class App {
+        readonly visible = signal(false);
+      }
+
+      const fixture = TestBed.createComponent(App);
+      await fixture.whenStable();
+
+      // Initially, visible is false, so <child> is not rendered.
+      expect(ngOnInitSpy).not.toHaveBeenCalled();
+      expect(ngOnDestroySpy).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.textContent).toBe('');
+
+      // Toggle visible to true: this renders <child>.
+      fixture.componentInstance.visible.set(true);
+      await fixture.whenStable();
+
+      expect(ngOnInitSpy).toHaveBeenCalledTimes(1);
+      expect(ngOnDestroySpy).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.textContent).toBe('true');
+
+      // Toggle visible back to false: this destroys the previously rendered <child>.
+      fixture.componentInstance.visible.set(false);
+      await fixture.whenStable();
+
+      expect(ngOnInitSpy).toHaveBeenCalledTimes(1);
+      expect(ngOnDestroySpy).toHaveBeenCalledTimes(1);
+      expect(fixture.nativeElement.textContent).toBe('');
+
+      // Toggle visible to true again: this renders a new <child>.
+      fixture.componentInstance.visible.set(true);
+      await fixture.whenStable();
+
+      expect(ngOnInitSpy).toHaveBeenCalledTimes(2);
+      expect(ngOnDestroySpy).toHaveBeenCalledTimes(1);
+      expect(fixture.nativeElement.textContent).toBe('true');
     });
   });
 });

--- a/packages/core/test/render3/foreign_component_spec.ts
+++ b/packages/core/test/render3/foreign_component_spec.ts
@@ -37,7 +37,8 @@ describe('ɵɵforeignComponent', () => {
         el.textContent = 'Foreign Content';
         return [[el]];
       },
-      () => {},
+      noopOnDestroy,
+      eagerContentAdapter,
     );
 
     const fixture = new ViewFixture({
@@ -53,14 +54,8 @@ describe('ɵɵforeignComponent', () => {
   });
 
   it('should pass props to a foreign component', () => {
-    let passedProps: any = null;
-    const foreignComp = foreignImport<{name: string}>(
-      (props) => {
-        passedProps = props;
-        return [[]];
-      },
-      () => {},
-    );
+    const render = jasmine.createSpy('render').and.returnValue([[]]);
+    const foreignComp = foreignImport<{name: string}>(render, noopOnDestroy, eagerContentAdapter);
 
     new ViewFixture({
       decls: 1,
@@ -71,21 +66,17 @@ describe('ɵɵforeignComponent', () => {
       },
     });
 
-    expect(passedProps).toEqual({name: 'Angular'});
+    expect(render).toHaveBeenCalledOnceWith({name: 'Angular'});
   });
 
   it('should call the dispose function when the containing view is destroyed', () => {
-    let disposeCalled = false;
+    const dispose = jasmine.createSpy();
     const foreignComp = foreignImport(
       () => {
-        return [
-          [],
-          () => {
-            disposeCalled = true;
-          },
-        ];
+        return [[], dispose];
       },
-      () => {},
+      noopOnDestroy,
+      eagerContentAdapter,
     );
 
     const fixture = new ViewFixture({
@@ -97,11 +88,11 @@ describe('ɵɵforeignComponent', () => {
       },
     });
 
-    expect(disposeCalled).toBeFalse();
+    expect(dispose).toHaveBeenCalledTimes(0);
 
     destroyLView(fixture.tView, fixture.lView);
 
-    expect(disposeCalled).toBeTrue();
+    expect(dispose).toHaveBeenCalledTimes(1);
   });
 
   it('should render foreign view between sibling elements', () => {
@@ -111,7 +102,8 @@ describe('ɵɵforeignComponent', () => {
         el.textContent = 'Foreign Content';
         return [[el]];
       },
-      () => {},
+      noopOnDestroy,
+      eagerContentAdapter,
     );
 
     const fixture = new ViewFixture({
@@ -143,7 +135,8 @@ describe('ɵɵforeignComponent', () => {
         el.textContent = 'Foreign Content';
         return [[el]];
       },
-      () => {},
+      noopOnDestroy,
+      eagerContentAdapter,
     );
 
     const fixture = new ViewFixture({
@@ -179,7 +172,8 @@ describe('ɵɵforeignComponent', () => {
         el.textContent = value;
         return [[el]];
       },
-      () => {},
+      noopOnDestroy,
+      eagerContentAdapter,
     );
 
     class ProviderDirective {
@@ -211,7 +205,8 @@ describe('ɵɵforeignComponent', () => {
       () => {
         return [[document.createTextNode('foreign content')]];
       },
-      () => {},
+      noopOnDestroy,
+      eagerContentAdapter,
     );
 
     const createFn = () => {
@@ -273,7 +268,8 @@ describe('ɵɵforeignComponent', () => {
 
         return [[div]];
       },
-      () => {},
+      noopOnDestroy,
+      eagerContentAdapter,
     );
 
     const iconTemplate = (rf: number, ctx: any) => {
@@ -309,9 +305,9 @@ describe('ɵɵforeignComponent', () => {
         ɵɵdomTemplate(1, descriptionTemplate, 2, 0);
         ɵɵdomTemplate(2, childrenTemplate, 2, 0);
         ɵɵforeignComponent(3, 0, {
-          icon: ɵɵforeignContent(0),
-          description: ɵɵforeignContent(1),
-          children: ɵɵforeignContent(2),
+          icon: ɵɵforeignContent(0, 0),
+          description: ɵɵforeignContent(1, 0),
+          children: ɵɵforeignContent(2, 0),
         });
       },
     });
@@ -346,7 +342,8 @@ describe('ɵɵforeignComponent', () => {
 
         return [[div]];
       },
-      () => {},
+      noopOnDestroy,
+      eagerContentAdapter,
     );
 
     const itemTemplate = (rf: number, ctx: any) => {
@@ -382,6 +379,12 @@ describe('ɵɵforeignComponent', () => {
     );
   });
 });
+
+function noopOnDestroy() {}
+
+function eagerContentAdapter(producer: () => Node[]): Node[] {
+  return producer();
+}
 
 function renderSecondInstance(fixture: ViewFixture): HTMLElement {
   const hostLView = fixture.lView[PARENT] as LView;


### PR DESCRIPTION
Transition parameterless `@content` projection in foreign components from eager DOM creation to lazy evaluation. Previously, projecting content into a foreign component eagerly instantiated the embedded view and created DOM nodes, causing unnecessary resource consumption if the content was hidden or unmounted.

With this change, runtime content instructions (`ɵɵforeignContent` and `ɵɵforeignContentFn`) pass lazy producer callbacks directly through the foreign component's configured `contentAdapter`. View creation and teardown registration occur lazily when the external framework evaluates the adapted producer.

`foreignImport` now requires a third argument, `contentAdapter`, specifying how Angular content producer callbacks are adapted for the target external framework.