### PR TITLE
fix(docs-infra): improve code selection contrast in dark mode

### DIFF
--- a/adev/shared-docs/styles/_typography.scss
+++ b/adev/shared-docs/styles/_typography.scss
@@ -39,6 +39,10 @@
     // Added fallback color due to browser idiosyncrasies with color-mix and ::selection
     background: color-mix(in srgb, var(--selection-background) 10%, var(--octonary-contrast));
     color: color-mix(in srgb, var(--selection-color) 40%, var(--primary-contrast));
+
+    .docs-dark-mode & {
+      background: color-mix(in srgb, var(--selection-background) 30%, var(--octonary-contrast));
+    }
   }
 
   h1,


### PR DESCRIPTION
The ::selection background mixes only 10% of the accent color into --octonary-contrast. In dark mode --octonary-contrast resolves to gray-900 (#151417), which is the same color code blocks use as their background, so selected code renders ~90% code-background and is almost invisible.

Add a .docs-dark-mode ::selection override that raises the tint to 30% so highlighted text stays legible over the near-black surface. Light mode is unchanged, as its selection already contrasts the white page.

Fixes #69507

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #69507

In dark mode, selecting code on angular.dev produces a highlight that is
almost indistinguishable from the background. The `::selection` background
is `color-mix(... var(--selection-background) 10%, var(--octonary-contrast))`,
and in dark mode `--octonary-contrast` is gray-900 (`#151417`), the same
color used for code block backgrounds, so the selection blends into the code.

<img width="851" height="684" alt="image" src="https://github.com/user-attachments/assets/5e41d705-5a0c-4cdd-aba2-afa5b9632c71" />

## What is the new behavior?

Adds a `.docs-dark-mode ::selection` rule that increases the accent tint
from 10% to 30%, keeping selected text clearly visible over the near-black
surface. Light mode is left untouched.

<img width="881" height="715" alt="image" src="https://github.com/user-attachments/assets/ecc2a112-92a8-4cfa-b79e-ddf5b1c78395" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
