### PR TITLE
docs(docs-infra): Social & Theme menu placement

### DIFF
--- a/adev/src/app/core/layout/navigation/navigation.component.html
+++ b/adev/src/app/core/layout/navigation/navigation.component.html
@@ -296,7 +296,7 @@
         <button
           type="button"
           [cdkMenuTriggerFor]="socialMiniMenu"
-          [cdkMenuPosition]="miniMenuPositions"
+          [cdkMenuPosition]="bottomMiniMenuPositions"
           aria-label="Open social media links"
           (cdkMenuClosed)="closeMenu()"
           (cdkMenuOpened)="openMenu('social')"
@@ -318,7 +318,7 @@
                 <!-- Youtube Icon -->
                 <svg
                   width="20"
-                  height="15"
+                  height="20"
                   viewBox="0 0 20 15"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -339,8 +339,8 @@
               >
                 <!-- X Icon -->
                 <svg
-                  width="17"
-                  height="16"
+                  width="20"
+                  height="20"
                   viewBox="0 0 17 16"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -361,8 +361,8 @@
               >
                 <!-- Bluesky Icon -->
                 <svg
-                  width="16"
-                  height="16"
+                  width="20"
+                  height="20"
                   viewBox="0 0 16 16"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -467,7 +467,7 @@
         <button
           type="button"
           [cdkMenuTriggerFor]="themeMiniMenu"
-          [cdkMenuPosition]="miniMenuPositions"
+          [cdkMenuPosition]="bottomMiniMenuPositions"
           [aria-label]="'Change theme. Current theme: ' + theme()"
           aria-controls="theme-mini-menu"
           [aria-expanded]="openedMenu() === 'theme-picker'"

--- a/adev/src/app/core/layout/navigation/navigation.component.ts
+++ b/adev/src/app/core/layout/navigation/navigation.component.ts
@@ -7,7 +7,7 @@
  */
 
 import {CdkMenu, CdkMenuItem, CdkMenuTrigger} from '@angular/cdk/menu';
-import {ConnectionPositionPair} from '@angular/cdk/overlay';
+import {ConnectedPosition, ConnectionPositionPair} from '@angular/cdk/overlay';
 import {DOCUMENT, Location, isPlatformBrowser} from '@angular/common';
 import {Component, PLATFORM_ID, inject, signal} from '@angular/core';
 import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
@@ -63,6 +63,12 @@ export class Navigation {
     new ConnectionPositionPair(
       {originX: 'end', originY: 'top'},
       {overlayX: 'start', overlayY: 'top'},
+    ),
+  ];
+  protected bottomMiniMenuPositions: ConnectedPosition[] = [
+    new ConnectionPositionPair(
+      {originX: 'end', originY: 'bottom'},
+      {overlayX: 'start', overlayY: 'bottom'},
     ),
   ];
 


### PR DESCRIPTION
Bottom align menus with trigger buttons
Align height of social link icons

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
- Social and theme menus try to top-align with their trigger-buttons causing them to touch the edge of the screen
- Social icons vary in size causing menu items to have different sizes

<img width="278" height="473" alt="image" src="https://github.com/user-attachments/assets/81fe2633-ca41-40f3-a8e4-159052ffae86" />

Issue Number: N/A

## What is the new behavior?
- Bottom-align social and theme menus with their trigger-buttons
- Align sizes of social icons

<img width="316" height="581" alt="image" src="https://github.com/user-attachments/assets/03c67646-d68e-47c9-b844-d7be4595ba32" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
