### PR TITLE
fix(core): reject dynamic script host elements

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -183,6 +183,15 @@ function createHostElement(componentDef: ComponentDef<unknown>, renderer: Render
   return createElementNode(renderer, tagName, namespace);
 }
 
+function assertNotScriptHostElement(tagName: string | null | undefined): void {
+  if (tagName?.toLowerCase() === 'script') {
+    throw new RuntimeError(
+      RuntimeErrorCode.UNSAFE_VALUE_IN_SCRIPT,
+      ngDevMode && `"<script>" tag is not allowed as a component host element.`,
+    );
+  }
+}
+
 /**
  * Infers the tag name that should be used for a component based on its definition.
  * @param componentDef Definition for which to resolve the tag name.
@@ -303,6 +312,7 @@ export class ComponentFactory<T> {
     const hostElement = rootSelectorOrNode
       ? locateHostElement(hostRenderer, rootSelectorOrNode, cmpDef.encapsulation, rootViewInjector)
       : createHostElement(cmpDef, hostRenderer);
+    assertNotScriptHostElement(hostElement?.tagName);
 
     const sharedStylesHost = rootViewInjector.get(SHARED_STYLES_HOST, null);
     const styleHost = getStyleHost(

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -15,7 +15,6 @@ import {ViewEncapsulation} from '../../metadata/view';
 import {validateAgainstEventProperties} from '../../sanitization/sanitization';
 
 import {ProfilerEvent} from '../../../primitives/devtools';
-import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../../ng_reflect';
 import {assertIndexInRange, assertNotSame} from '../../util/assert';
 import {escapeCommentText} from '../../util/dom';
@@ -181,12 +180,6 @@ export function locateHostElement(
     encapsulation === ViewEncapsulation.ShadowDom ||
     encapsulation === ViewEncapsulation.ExperimentalIsolatedShadowDom;
   const rootElement = renderer.selectRootElement(elementOrSelector, preserveContent);
-  if (rootElement.tagName.toLowerCase() === 'script') {
-    throw new RuntimeError(
-      RuntimeErrorCode.UNSAFE_VALUE_IN_SCRIPT,
-      ngDevMode && `"<script>" tag is not allowed as a component host element.`,
-    );
-  }
   applyRootElementTransform(rootElement as HTMLElement);
   return rootElement;
 }

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -873,6 +873,19 @@ describe('innerHTML processing', () => {
 });
 
 describe('Component host element validation', () => {
+  it('should throw an error when dynamically creating a component with a script selector', () => {
+    @Component({
+      selector: 'script',
+      template: '',
+    })
+    class ScriptHost {}
+
+    const environmentInjector = TestBed.inject(EnvironmentInjector);
+    expect(() => {
+      createComponent(ScriptHost, {environmentInjector});
+    }).toThrowError(/"<script>" tag is not allowed as a component host element/);
+  });
+
   it('should throw an error when dynamically mounting a component onto a script tag', () => {
     @Component({
       selector: 'my-sink',

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -338,6 +338,7 @@
       "areAnimationSupported",
       "arrRemove",
       "assertNotDestroyed",
+      "assertNotScriptHostElement",
       "assertTypeDefined",
       "attachPatchData",
       "balancePreviousStylesIntoKeyframes",

--- a/packages/core/test/bundling/create_component/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/create_component/bundle.golden_symbols.json
@@ -263,6 +263,7 @@
       "areAnimationSupported",
       "arrRemove",
       "assertNotDestroyed",
+      "assertNotScriptHostElement",
       "assertTypeDefined",
       "attachPatchData",
       "baseElement",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -309,6 +309,7 @@
       "areAnimationSupported",
       "arrRemove",
       "assertNotDestroyed",
+      "assertNotScriptHostElement",
       "assertTypeDefined",
       "attachPatchData",
       "bind",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -389,6 +389,7 @@
       "assertAllValuesPresent",
       "assertControlPresent",
       "assertNotDestroyed",
+      "assertNotScriptHostElement",
       "assertPlatform",
       "assertTypeDefined",
       "attachPatchData",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -390,6 +390,7 @@
       "assertAllValuesPresent",
       "assertControlPresent",
       "assertNotDestroyed",
+      "assertNotScriptHostElement",
       "assertPlatform",
       "assertTypeDefined",
       "attachPatchData",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -375,6 +375,7 @@
       "areAnimationSupported",
       "arrRemove",
       "assertNotDestroyed",
+      "assertNotScriptHostElement",
       "assertTypeDefined",
       "attachPatchData",
       "baseElement",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -423,6 +423,7 @@
       "arrRemove",
       "arrayEquals",
       "assertNotDestroyed",
+      "assertNotScriptHostElement",
       "assertTypeDefined",
       "attachPatchData",
       "baseElement",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -244,6 +244,7 @@
       "areAnimationSupported",
       "arrRemove",
       "assertNotDestroyed",
+      "assertNotScriptHostElement",
       "assertTypeDefined",
       "attachPatchData",
       "baseElement",


### PR DESCRIPTION
The previous fix for  https://github.com/angular/angular/security/advisories/GHSA-692r-grfm-v8x7  was incomplete because it rejected script tags only when locating an explicit host element. Dynamic component instantiation can also infer the host element from the component selector.

Move the script-host rejection to the point where ComponentFactory has resolved the host element for either path, so createComponent rejects script hosts consistently.
 