### PR TITLE
docs(docs-infra): show the schema function in the validation example

### DIFF
--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -21,8 +21,8 @@ The schema function receives a `SchemaPathTree` object that lets you define your
 <docs-code
   header="app.ts"
   path="adev/src/content/examples/signal-forms/src/login-validation-complete/app/app.ts"
-  visibleLines="[21,22,23,24,25,26,27]"
-  highlight="[23,24,26]"
+  visibleLines="[29,30,31,32,33,34]"
+  highlight="[30,31,33]"
 />
 
 The schema function runs once during form initialization. Validation rules bind to fields using the schema path parameter (such as `schemaPath.email`, `schemaPath.password`), and validation runs automatically whenever field values change.


### PR DESCRIPTION
The "schema function" example on the Validation guide page pointed its visibleLines and highlight ranges at the wrong source lines. The collapsed view showed the component's imports and model signal instead of the schema function, and the highlight marked unrelated lines, so readers had to expand the example to find the code the section is about.

The example file was edited at some point and these line numbers were not updated to follow it. Point visibleLines at the form() schema call (lines 29-34) and highlight the three validator calls (lines 30, 31, 33) so the relevant code is visible by default.

Fixes #69547 

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other

## What is the current behavior?

On the Validation guide page, the "The schema function" section embeds the
`login-validation-complete` example with `visibleLines="[21,22,23,24,25,26,27]"`
and `highlight="[23,24,26]"`. Those ranges no longer match the source file:
the collapsed view shows the component's `imports` and `loginModel` signal,
and the highlight marks `export class App`, the model declaration, and an
empty-string property. The actual schema function (the `form(...)` call) is
hidden until the reader clicks "Expand example".

<img width="822" height="541" alt="image" src="https://github.com/user-attachments/assets/cac904ea-a780-4176-a38b-5fa91225f419" />

Issue Number: #69547

## What is the new behavior?

`visibleLines` and `highlight` point at the schema function: lines 29-34 are
shown in the collapsed view and the three validator calls (lines 30, 31, 33)
are highlighted, so the relevant code is visible by default.

<img width="859" height="517" alt="image" src="https://github.com/user-attachments/assets/122f8fdf-0576-4b2c-a7aa-ed5c164e41c2" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No