### PR TITLE
fix(core): ensure PendingTasks.run() removes task when error handler throws synchronously

### DIFF
--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -78,8 +78,11 @@ export class PendingTasks {
     try {
       fn().catch(this.errorHandler).finally(removeTask);
     } catch (err) {
-      this.errorHandler(err);
-      removeTask();
+      try {
+        this.errorHandler(err);
+      } finally {
+        removeTask();
+      }
     }
   }
 

--- a/packages/core/test/acceptance/pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/pending_tasks_spec.ts
@@ -134,6 +134,61 @@ describe('public PendingTasks', () => {
     expect(spy).toHaveBeenCalled();
     expect(spy.calls.mostRecent().args[0].message).toContain('Sync error');
   });
+
+  it('should clean up pending task even if error handler throws during sync error', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ErrorHandler,
+          useValue: {
+            handleError() {
+              throw new Error('error handler threw');
+            },
+          },
+        },
+      ],
+      rethrowApplicationErrors: false,
+    });
+
+    const pendingTasksInternal = TestBed.inject(PendingTasksInternal);
+    const pendingTasks = TestBed.inject(PendingTasks);
+    const removeSpy = spyOn(pendingTasksInternal, 'remove').and.callThrough();
+
+    expect(() => {
+      pendingTasks.run(() => {
+        throw new Error('sync error');
+      });
+    }).toThrowError('error handler threw');
+
+    expect(removeSpy).toHaveBeenCalled();
+  });
+
+  it('should clean up pending task when async rejection and error handler throws', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ErrorHandler,
+          useValue: {
+            handleError() {
+              throw new Error('error handler threw');
+            },
+          },
+        },
+      ],
+      rethrowApplicationErrors: false,
+    });
+
+    const appRef = TestBed.inject(ApplicationRef);
+    const pendingTasksInternal = TestBed.inject(PendingTasksInternal);
+    const pendingTasks = TestBed.inject(PendingTasks);
+
+    pendingTasks.run(() => Promise.reject(new Error('async rejection')));
+    // whenStable() resolves as soon as all pending tasks are removed (PendingTasksInternal
+    // BehaviorSubject), independent of NgZone stability.
+    await appRef.whenStable();
+
+    expect(pendingTasksInternal.hasPendingTasks).toBeFalse();
+  });
 });
 
 function applicationRefIsStable(applicationRef: ApplicationRef) {


### PR DESCRIPTION
When `run(fn)` catches a synchronous throw from fn and the configured `errorHandler` also throws, `removeTask()` is never reached — leaving the pending task permanently registered. This blocks `whenStable()` from resolving and stalls SSR serialization.

The async path (`fn().catch(handler).finally(removeTask)`) was already correct. The fix wraps the `errorHandler` call in `try/finally` on the sync catch path so `removeTask()` is guaranteed to run regardless of what the error handler does.