### PR TITLE
fix(docs-infra): don't auto-link code symbols used as link text

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/test/link/link.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/link/link.md
@@ -2,3 +2,4 @@
 [same page](#test)
 [same site](../other/page)
 [npm packages](https://docs.npmjs.com/getting-started/what-is-npm 'What is npm?')
+[`CommonModule`](../other/page)

--- a/adev/shared-docs/pipeline/shared/marked/test/link/link.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/link/link.spec.mts
@@ -38,6 +38,10 @@ describe('markdown to html', () => {
     );
   });
 
+  it('should not auto-link a code symbol used as link text', () => {
+    expect(parsedMarkdown).toContain('<a href="../other/page"><code>CommonModule</code></a>');
+  });
+
   it('should throw if on absolute links to adev', async () => {
     try {
       parsedMarkdown = await parseMarkdown(

--- a/adev/shared-docs/pipeline/shared/marked/transformations/link.mts
+++ b/adev/shared-docs/pipeline/shared/marked/transformations/link.mts
@@ -35,5 +35,12 @@ export function linkRender(this: AdevDocsRenderer, {href, title, tokens}: Tokens
   }
 
   const titleAttribute = title ? ` title="${title}"` : '';
-  return `<a href="${href}"${titleAttribute}${anchorTarget(href)}>${this.parser.parseInline(tokens)}</a>`;
+  // Disable auto-linking while rendering the link's content so that a code symbol used as the
+  // link text (e.g. [`httpResource`](/guide/http/http-resource)) isn't turned into a nested
+  // anchor pointing at the API reference, which would override the explicit link.
+  const previousDisableAutoLinking = this.context.disableAutoLinking;
+  this.context.disableAutoLinking = true;
+  const content = this.parser.parseInline(tokens);
+  this.context.disableAutoLinking = previousDisableAutoLinking;
+  return `<a href="${href}"${titleAttribute}${anchorTarget(href)}>${content}</a>`;
 }


### PR DESCRIPTION
When an inline code symbol is used as the text of an explicit markdown link (e.g. [`httpResource`](/guide/http/http-resource)), the codespan renderer recognized it as an API symbol and wrapped it in a second anchor pointing at the API reference. This produced nested <a> tags, so the explicit link was effectively replaced by the API symbol link.

Disable auto-linking while rendering a link's inner tokens so the explicit href is preserved, matching the pattern already used by the heading and docs-card renderers.

Fixes #69549

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #69549 

When a code symbol is used as the text of an explicit markdown link
(e.g. ``[`httpResource`](/guide/http/http-resource)``), the codespan
renderer recognizes it as an API symbol and wraps it in a second anchor
to the API reference. The resulting nested `<a>` tags mean the explicit
link is replaced by the API symbol link.

## What is the new behavior?

Auto-linking is disabled while rendering a link's inner tokens, so a
code symbol used as link text keeps the explicit href and renders as a
single anchor (no nested API link). Standalone code-symbol auto-linking
is unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
