### PR TITLE
docs: fix service decorator example

### DIFF
--- a/adev/src/content/guide/di/creating-and-using-services.md
+++ b/adev/src/content/guide/di/creating-and-using-services.md
@@ -12,14 +12,14 @@ ng generate service CUSTOM_NAME
 
 This command creates a dedicated `CUSTOM_NAME.ts` file in your `src` directory.
 
-You can also manually create a service by adding the `@Service()` decorator to a TypeScript class. This tells Angular that you can use the class as an injectable dependency.
+You can also manually create a service by adding the `@Injectable()` decorator to a TypeScript class with `providedIn: 'root'`. This tells Angular that you can use the class as an injectable dependency.
 
 The following example defines a service that allows users to add and retrieve data:
 
 ```ts {header: "src/app/basic-data-store.ts"}
-import {Service} from '@angular/core';
+import {Injectable} from '@angular/core';
 
-@Service()
+@Injectable({providedIn: 'root'})
 export class BasicDataStore {
   private data: string[] = [];
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines.
- [ ] Tests for the changes have been added (not applicable).
- [x] Docs have been added / updated.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

Issue Number: #69563

The first `BasicDataStore` example already uses `@Service()`, but the later “Using the @Service decorator” section says the example can be rewritten with `@Service()`.

## What is the new behavior?

The first `BasicDataStore` example now uses `@Injectable({providedIn: 'root'})`, so the later `@Service()` section correctly shows the rewrite.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Fixes #69563.