### PR TITLE
docs: remove fixed font-size from table headers in docs

### DIFF
--- a/adev/shared-docs/styles/docs/_table.scss
+++ b/adev/shared-docs/styles/docs/_table.scss
@@ -18,7 +18,6 @@
       padding-block: 0.4rem;
       padding-inline-end: 1.5rem;
       border-block: 1px solid var(--senary-contrast);
-      font-size: 0.75rem;
       font-weight: 600;
 
       code {


### PR DESCRIPTION
Removes the fixed font size from table headers to ensure they scale properly and do not appear smaller than the table content.