### PR TITLE
docs(forms): correct signal field access in form model example

### DIFF
--- a/adev/src/content/guide/forms/signals/designing-your-form-model.md
+++ b/adev/src/content/guide/forms/signals/designing-your-form-model.md
@@ -380,7 +380,7 @@ class MyForm {
 
   handleSubmit() {
     submit(this.myForm, async () => {
-      await this.myDataService.update(formModelToDomainModel(this.myForm.value()));
+      await this.myDataService.update(formModelToDomainModel(this.myForm().value()));
     });
   };
 }
@@ -402,7 +402,7 @@ class MyForm {
     effect(() => {
       // When the form model changes to a valid value, update the domain model.
       if (this.myForm().valid()) {
-        this.domainModel.set(formModelToDomainModel(this.myForm.value()));
+        this.domainModel.set(formModelToDomainModel(this.myForm().value()));
       }
     });
   };


### PR DESCRIPTION
## PR Checklist

* [x] The commit message follows our guidelines.
* [ ] Tests for the changes have been added (not applicable).
* [x] Docs have been added / updated.

## PR Type

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no API changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other

## What is the current behavior?

Issue Number: #69498

The code example in the "Form model to domain model" section accesses the form signal as `this.myForm.value()`, which does not invoke the signal before reading its value.

## What is the new behavior?

The example now correctly invokes the signal before accessing its value:

```ts
this.myForm().value()
```

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

Fixes #69498.
