### PR TITLE
fix(router): fix malformed jsdoc comment for RouterLinkWithHref export

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -587,8 +587,6 @@ export class RouterLink implements OnChanges, OnDestroy {
  * An alias for the `RouterLink` directive.
  * Deprecated since v15, use `RouterLink` directive instead.
  *
-export { RouterLink as RouterLinkWithHref };
-nstead.
  * @publicApi
  */
 export {RouterLink as RouterLinkWithHref};


### PR DESCRIPTION
The export statement was incorrectly placed inside the JSDoc comment block, and there was a stray text fragment "nstead." from the deprecation message. This moves the export statement outside the comment and removes the stray text.