### PR TITLE
fix(docs-infra): cap code block height to prevent unbounded vertical …

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -182,6 +182,7 @@ $code-font-size: 0.875rem;
       flex-direction: column;
       font-size: $code-font-size;
       counter-reset: line;
+      max-height: 100vh;
     }
 
     &.compact {


### PR DESCRIPTION
Add max-height: 100vh to .shiki code in _code.scss so that
tall code blocks scroll vertically instead of extending the full
length of their content.

Closes #69571
