### PR TITLE
refactor(core): move signal debug graph interfaces to primitives/devt…

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/identity-tracker.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/identity-tracker.spec.ts
@@ -14,11 +14,15 @@ describe('IdentityTracker', () => {
   beforeEach(() => {
     (IdentityTracker as any).instance = undefined;
     tracker = IdentityTracker.getInstance();
+    (window as any).ng = {
+      getComponent: () => {},
+    };
   });
 
   afterEach(() => {
     (IdentityTracker as any).instance = undefined;
     document.querySelectorAll('[ng-version]').forEach((el) => el.remove());
+    delete (window as any).ng;
   });
 
   function seedDirective(opts: {dir: object; id: number; isComponent?: boolean}): void {

--- a/packages/core/primitives/devtools/BUILD.bazel
+++ b/packages/core/primitives/devtools/BUILD.bazel
@@ -12,6 +12,9 @@ ts_project(
             "**/*.ts",
         ],
     ),
+    deps = [
+        "//packages/core/primitives/signals",
+    ],
 )
 
 filegroup(

--- a/packages/core/primitives/devtools/index.ts
+++ b/packages/core/primitives/devtools/index.ts
@@ -9,3 +9,8 @@
 export {ProfilerEvent, type Profiler} from './src/profiler_types';
 export {Framework} from './src/framework';
 export type {DevtoolsToolDiscoveryEvent, ToolDefinition, ToolGroup} from './src/tool_definitions';
+export type {
+  DebugSignalGraph,
+  DebugSignalGraphEdge,
+  DebugSignalGraphNode,
+} from './src/debug_signal_graph';

--- a/packages/core/primitives/devtools/src/debug_signal_graph.ts
+++ b/packages/core/primitives/devtools/src/debug_signal_graph.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ReactiveNodeKind} from '@angular/core/primitives/signals';
+
+export interface DebugSignalGraphNode {
+  kind: ReactiveNodeKind;
+  id: string;
+  epoch: number;
+  label?: string;
+  value?: unknown;
+  debuggableFn?: () => unknown;
+}
+
+export interface DebugSignalGraphEdge {
+  /**
+   * Index of a signal node in the `nodes` array that is a consumer of the signal produced by the producer node.
+   */
+  consumer: number;
+
+  /**
+   * Index of a signal node in the `nodes` array that is a producer of the signal consumed by the consumer node.
+   */
+  producer: number;
+}
+
+/**
+ * A debug representation of the signal graph.
+ */
+export interface DebugSignalGraph {
+  nodes: DebugSignalGraphNode[];
+  edges: DebugSignalGraphEdge[];
+}

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -11,6 +11,9 @@
 //
 // no code actually imports these symbols from the @angular/core entry point
 export {
+  type DebugSignalGraph as ɵDebugSignalGraph,
+  type DebugSignalGraphEdge as ɵDebugSignalGraphEdge,
+  type DebugSignalGraphNode as ɵDebugSignalGraphNode,
   Framework as ɵFramework,
   Profiler as ɵProfiler,
   ProfilerEvent as ɵProfilerEvent,
@@ -295,11 +298,6 @@ export {
   ExternalCoreGlobalUtils as ɵExternalCoreGlobalUtils,
   FrameworkAgnosticGlobalUtils as ɵFrameworkAgnosticGlobalUtils,
 } from './render3/util/global_utils';
-export {
-  DebugSignalGraph as ɵDebugSignalGraph,
-  DebugSignalGraphEdge as ɵDebugSignalGraphEdge,
-  DebugSignalGraphNode as ɵDebugSignalGraphNode,
-} from './render3/util/signal_debug';
 export {getTransferState as ɵgetTransferState} from './render3/util/transfer_state_utils';
 export {
   isViewDirty as ɵisViewDirty,

--- a/packages/core/src/debug/ai/signal_graph.ts
+++ b/packages/core/src/debug/ai/signal_graph.ts
@@ -8,8 +8,8 @@
 
 import {NullInjector} from '../../di/null_injector';
 import {getInjector} from '../../render3/util/discovery_utils';
-import {DebugSignalGraph, getSignalGraph} from '../../render3/util/signal_debug';
-import {ToolDefinition} from '../../../primitives/devtools';
+import {getSignalGraph} from '../../render3/util/signal_debug';
+import type {DebugSignalGraph, ToolDefinition} from '../../../primitives/devtools';
 
 // Omit `debuggableFn` and `id` from returned signal graph to AI agent.
 type AiSignalGraph = Omit<DebugSignalGraph, 'nodes'> & {

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -37,7 +37,7 @@ import {
   getInjectorProviders,
   getInjectorResolutionPath,
 } from './injector_discovery_utils';
-import {DebugSignalGraph, getSignalGraph} from './signal_debug';
+import {getSignalGraph} from './signal_debug';
 
 import {
   enableProfiling,
@@ -50,7 +50,7 @@ import {InjectedService, ProviderRecord} from '../debug/injector_profiler';
 
 import {Type} from '../../interface/type';
 import {RElement} from '../interfaces/renderer_dom';
-import {type Profiler} from '../../../primitives/devtools';
+import type {DebugSignalGraph, Profiler} from '../../../primitives/devtools';
 import {ControlFlowBlock} from './control_flow_types';
 
 /**

--- a/packages/core/src/render3/util/signal_debug.ts
+++ b/packages/core/src/render3/util/signal_debug.ts
@@ -14,43 +14,13 @@ import {EffectNode, EffectRefImpl} from '../reactivity/effect';
 import {Injector} from '../../di/injector';
 import {R3Injector} from '../../di/r3_injector';
 import {throwError} from '../../util/assert';
-import {
-  ComputedNode,
-  ReactiveNode,
-  ReactiveNodeKind,
-  SIGNAL,
-  SignalNode,
-} from '../../../primitives/signals';
+import {ComputedNode, ReactiveNode, SIGNAL, SignalNode} from '../../../primitives/signals';
 import {isLView} from '../interfaces/type_checks';
-
-export interface DebugSignalGraphNode {
-  kind: ReactiveNodeKind;
-  id: string;
-  epoch: number;
-  label?: string;
-  value?: unknown;
-  debuggableFn?: () => unknown;
-}
-
-export interface DebugSignalGraphEdge {
-  /**
-   * Index of a signal node in the `nodes` array that is a consumer of the signal produced by the producer node.
-   */
-  consumer: number;
-
-  /**
-   * Index of a signal node in the `nodes` array that is a producer of the signal consumed by the consumer node.
-   */
-  producer: number;
-}
-
-/**
- * A debug representation of the signal graph.
- */
-export interface DebugSignalGraph {
-  nodes: DebugSignalGraphNode[];
-  edges: DebugSignalGraphEdge[];
-}
+import type {
+  DebugSignalGraph,
+  DebugSignalGraphEdge,
+  DebugSignalGraphNode,
+} from '../../../primitives/devtools';
 
 function isComputedNode(node: ReactiveNode): node is ComputedNode<unknown> {
   return node.kind === 'computed';

--- a/packages/core/test/acceptance/signal_debug_spec.ts
+++ b/packages/core/test/acceptance/signal_debug_spec.ts
@@ -25,11 +25,8 @@ import {
   setupFrameworkInjectorProfiler,
 } from '../../src/render3/debug/framework_injector_profiler';
 import {setInjectorProfiler} from '../../src/render3/debug/injector_profiler';
-import {
-  DebugSignalGraphEdge,
-  DebugSignalGraphNode,
-  getSignalGraph,
-} from '../../src/render3/util/signal_debug';
+import type {DebugSignalGraphEdge, DebugSignalGraphNode} from '../../primitives/devtools';
+import {getSignalGraph} from '../../src/render3/util/signal_debug';
 import {fakeAsync, TestBed, tick} from '../../testing';
 
 describe('getSignalGraph', () => {


### PR DESCRIPTION
…ools

Move the DebugSignalGraph, DebugSignalGraphEdge, and DebugSignalGraphNode interfaces from packages/core/src/render3/util/signal_debug.ts into the packages/core/primitives/devtools/src package. This decouples the signal graph debug types from runtime render3 utilities and allows devtools and internal core tooling to import them directly from primitives as type-only exports.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
