### PR TITLE
fix(compiler): permissive whitespace parsing in default never blocks

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -160,6 +160,8 @@ const INTERPOLATION = {start: '{{', end: '}}'} as const;
 
 const DEFAULT_NEVER_PATTERN = /^default[^\S\r\n]+never/;
 
+const ELSE_IF_PATTERN = /^else[^\S\r\n]+if/;
+
 // See https://www.w3.org/TR/html51/syntax.html#writing-html-documents
 class _Tokenizer {
   private _cursor: CharacterCursor;
@@ -298,7 +300,9 @@ class _Tokenizer {
     let result = this._cursor.getChars(nameCursor).trim();
 
     // Normalize whitespaces.
-    if (DEFAULT_NEVER_PATTERN.test(result)) {
+    if (ELSE_IF_PATTERN.test(result)) {
+      result = 'else if';
+    } else if (DEFAULT_NEVER_PATTERN.test(result)) {
       result = 'default never';
     }
 

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -158,6 +158,8 @@ const SUPPORTED_BLOCKS = [
 
 const INTERPOLATION = {start: '{{', end: '}}'} as const;
 
+const DEFAULT_NEVER_PATTERN = /^default[^\S\r\n]+never/;
+
 // See https://www.w3.org/TR/html51/syntax.html#writing-html-documents
 class _Tokenizer {
   private _cursor: CharacterCursor;
@@ -292,7 +294,15 @@ class _Tokenizer {
       }
       return true;
     });
-    return this._cursor.getChars(nameCursor).trim();
+
+    let result = this._cursor.getChars(nameCursor).trim();
+
+    // Normalize whitespaces.
+    if (DEFAULT_NEVER_PATTERN.test(result)) {
+      result = 'default never';
+    }
+
+    return result;
   }
 
   private _consumeBlockStart(start: CharacterCursor) {

--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -23,9 +23,6 @@ const FOR_LOOP_TRACK_PATTERN = /^track\s+([\S\s]*)/;
 /** Pattern for the `as` expression in a conditional block. */
 const CONDITIONAL_ALIAS_PATTERN = /^(as\s+)(.*)/;
 
-/** Pattern used to identify an `else if` block. */
-const ELSE_IF_PATTERN = /^else[^\S\r\n]+if/;
-
 /**
  * Pattern to group a string into leading whitespace, non whitespace, and trailing whitespace.
  * Useful for getting the variable name span when a span can contain leading and trailing space.
@@ -55,7 +52,7 @@ export function isConnectedForLoopBlock(name: string): boolean {
  * a specific name cam be connected to an `if` block.
  */
 export function isConnectedIfLoopBlock(name: string): boolean {
-  return name === 'else' || ELSE_IF_PATTERN.test(name);
+  return name === 'else' || name === 'else if';
 }
 
 /** Creates an `if` loop block from an HTML AST node. */
@@ -85,7 +82,7 @@ export function createIfBlock(
   }
 
   for (const block of connectedBlocks) {
-    if (ELSE_IF_PATTERN.test(block.name)) {
+    if (block.name === 'else if') {
       const params = parseConditionalBlockParameters(block, errors, bindingParser);
 
       if (params !== null) {
@@ -588,7 +585,7 @@ function validateIfConnectedBlocks(connectedBlocks: html.Block[]): ParseError[] 
         errors.push(new ParseError(block.startSourceSpan, '@else block cannot have parameters'));
       }
       hasElse = true;
-    } else if (!ELSE_IF_PATTERN.test(block.name)) {
+    } else if (block.name !== 'else if') {
       errors.push(
         new ParseError(block.startSourceSpan, `Unrecognized conditional block @${block.name}`),
       );
@@ -721,7 +718,7 @@ function parseConditionalBlockParameters(
           `Unrecognized conditional parameter "${param.expression}"`,
         ),
       );
-    } else if (block.name !== 'if' && !ELSE_IF_PATTERN.test(block.name)) {
+    } else if (block.name !== 'if' && block.name !== 'else if') {
       errors.push(
         new ParseError(
           param.sourceSpan,

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -3394,6 +3394,13 @@ describe('HtmlLexer', () => {
         [TokenType.BLOCK_CLOSE],
         [TokenType.EOF],
       ]);
+
+      expect(tokenizeAndHumanizeParts('@default                  never;')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'default never'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
     });
 
     it('should parse @default never(expr);', () => {

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -3464,6 +3464,16 @@ describe('HtmlLexer', () => {
       ]);
     });
 
+    it('should normalize @else if block name with spaces', () => {
+      expect(tokenizeAndHumanizeParts('@else            if {hello}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'else if'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
     it('should parse a block with an arbitrary amount of spaces around the parentheses', () => {
       const expected = [
         [TokenType.BLOCK_OPEN_START, 'for'],

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1748,10 +1748,16 @@ describe('R3 template transform', () => {
 
     it('should parse a switch block with a default never case', () => {
       expectFromHtml(`
-          @switch (cond.kind) {
-            @default never;
-          }
-        `).toEqual([['SwitchBlock', 'cond.kind'], ['SwitchExhaustiveCheck']]);
+        @switch (cond.kind) {
+          @default never;
+        }
+      `).toEqual([['SwitchBlock', 'cond.kind'], ['SwitchExhaustiveCheck']]);
+
+      expectFromHtml(`
+        @switch (cond.kind) {
+          @default                              never;
+        }
+      `).toEqual([['SwitchBlock', 'cond.kind'], ['SwitchExhaustiveCheck']]);
     });
 
     // This is a special case for `switch` blocks, because `preserveWhitespaces` will cause


### PR DESCRIPTION
Makes the parser more permissive towards whitespaces between words in the `default never` block.

Also moves the block name normalization into the lexer so we don't need to do it in multiple places downstream.