### PR TITLE
ci: setup Node.js in adev-preview-deploy workflow using .nvmrc

### DIFF
--- a/.github/workflows/adev-preview-deploy.yml
+++ b/.github/workflows/adev-preview-deploy.yml
@@ -33,7 +33,10 @@ jobs:
         with:
           token: '${{secrets.GITHUB_TOKEN}}'
           persist-credentials: false
-
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          package-manager-cache: false
       - name: Configure Firebase deploy target
         working-directory: ./
         run: |


### PR DESCRIPTION
Ensures that the correct Node.js version is used.