### PR TITLE
refactor(core): remove unused utility functions

### DIFF
--- a/packages/core/src/util/iterable.ts
+++ b/packages/core/src/util/iterable.ts
@@ -6,10 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export function isIterable(obj: any): obj is Iterable<any> {
-  return obj !== null && typeof obj === 'object' && obj[Symbol.iterator] !== undefined;
-}
-
 export function isListLikeIterable(obj: any): boolean {
   if (!isJsObject(obj)) return false;
   return (

--- a/packages/core/src/util/security/trusted_types.ts
+++ b/packages/core/src/util/security/trusted_types.ts
@@ -20,7 +20,6 @@ import {global} from '../global';
 
 import {
   TrustedHTML,
-  TrustedScript,
   TrustedScriptURL,
   TrustedTypePolicy,
   TrustedTypePolicyFactory,
@@ -71,17 +70,6 @@ export function trustedHTMLFromString(html: string): TrustedHTML | string {
 }
 
 /**
- * Unsafely promote a string to a TrustedScript, falling back to strings when
- * Trusted Types are not available.
- * @security In particular, it must be assured that the provided string will
- * never cause an XSS vulnerability if used in a context that will be
- * interpreted and executed as a script by a browser, e.g. when calling eval.
- */
-export function trustedScriptFromString(script: string): TrustedScript | string {
-  return getPolicy()?.createScript(script) || script;
-}
-
-/**
  * Unsafely promote a string to a TrustedScriptURL, falling back to strings
  * when Trusted Types are not available.
  * @security This is a security-sensitive function; any use of this function
@@ -92,57 +80,4 @@ export function trustedScriptFromString(script: string): TrustedScript | string 
  */
 export function trustedScriptURLFromString(url: string): TrustedScriptURL | string {
   return getPolicy()?.createScriptURL(url) || url;
-}
-
-/**
- * Unsafely call the Function constructor with the given string arguments. It
- * is only available in development mode, and should be stripped out of
- * production code.
- * @security This is a security-sensitive function; any use of this function
- * must go through security review. In particular, it must be assured that it
- * is only called from development code, as use in production code can lead to
- * XSS vulnerabilities.
- */
-export function newTrustedFunctionForDev(...args: string[]): Function {
-  if (typeof ngDevMode === 'undefined') {
-    throw new Error('newTrustedFunctionForDev should never be called in production');
-  }
-  if (!global.trustedTypes) {
-    // In environments that don't support Trusted Types, fall back to the most
-    // straightforward implementation:
-    return new Function(...args);
-  }
-
-  // Chrome currently does not support passing TrustedScript to the Function
-  // constructor. The following implements the workaround proposed on the page
-  // below, where the Chromium bug is also referenced:
-  // https://github.com/w3c/webappsec-trusted-types/wiki/Trusted-Types-for-function-constructor
-  const fnArgs = args.slice(0, -1).join(',');
-  const fnBody = args[args.length - 1];
-  const body = `(function anonymous(${fnArgs}
-) { ${fnBody}
-})`;
-
-  // Using eval directly confuses the compiler and prevents this module from
-  // being stripped out of JS binaries even if not used. The global['eval']
-  // indirection fixes that.
-  const fn = global['eval'](trustedScriptFromString(body)) as Function;
-  if (fn.bind === undefined) {
-    // Workaround for a browser bug that only exists in Chrome 83, where passing
-    // a TrustedScript to eval just returns the TrustedScript back without
-    // evaluating it. In that case, fall back to the most straightforward
-    // implementation:
-    return new Function(...args);
-  }
-
-  // To completely mimic the behavior of calling "new Function", two more
-  // things need to happen:
-  // 1. Stringifying the resulting function should return its source code
-  fn.toString = () => body;
-  // 2. When calling the resulting function, `this` should refer to `global`
-  return fn.bind(global);
-
-  // When Trusted Types support in Function constructors is widely available,
-  // the implementation of this function can be simplified to:
-  // return new Function(...args.map(a => trustedScriptFromString(a)));
 }


### PR DESCRIPTION
Remove `isIterable` from `util/iterable.ts` and
`newTrustedFunctionForDev` from `util/security/trusted_types.ts` as they are no longer referenced anywhere in the codebase.