### PR TITLE
fix(docs-infra): keep copy link icon out of the search index

### DIFF
--- a/adev/shared-docs/components/copy-link-anchor/copy-link-anchor.component.ts
+++ b/adev/shared-docs/components/copy-link-anchor/copy-link-anchor.component.ts
@@ -15,7 +15,7 @@ export const CONFIRMATION_DISPLAY_TIME_MS = 1000;
 
 @Component({
   selector: 'docs-copy-link-button',
-  template: `<docs-icon>{{ showCopySuccess() ? 'check' : 'link' }}</docs-icon>`,
+  template: `<docs-icon></docs-icon>`,
   styles: `
     :host {
       cursor: pointer;
@@ -30,6 +30,13 @@ export const CONFIRMATION_DISPLAY_TIME_MS = 1000;
     }
     :host(.docs-copy-link-success) {
       color: var(--bright-blue);
+    }
+    docs-icon::before {
+      content: '\\e250'; /* codepoint for "link" */
+      font-family: 'Material Symbols Outlined';
+    }
+    :host(.docs-copy-link-success) docs-icon::before {
+      content: '\\e668'; /* codepoint for "check" */
     }
   `,
   hostDirectives: [

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
@@ -238,6 +238,16 @@ describe('DocViewer', () => {
     expect(copyButton).toBeTruthy();
   });
 
+  it('should not leak any icon text content (so it stays out of the search index)', () => {
+    const fixture = TestBed.createComponent(CopyLinkButton);
+    fixture.componentRef.setInput('href', '#test-section');
+    fixture.componentRef.setInput('label', 'Test Section');
+    fixture.componentRef.setInput('matTooltip', 'Copy link to Test Section');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent.trim()).toBe('');
+  });
+
   it('should copy link to clipboard when copy button is clicked', async () => {
     const clipboard = TestBed.inject(Clipboard);
     const clipboardSpy = spyOn(clipboard, 'copy').and.returnValue(true);


### PR DESCRIPTION
The copy link button rendered its icon as a Material Symbols ligature text node, and since the button is appended inside each heading's `.docs-anchor`, that text leaked into the heading and the Algolia crawler indexed values like `Descriptionlink`. The glyph is now rendered via a `::before` pseudo-element using the icon codepoint, so no `link`/`check` text exists in the DOM and headings index correctly again.

Fixes #69587

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

The copy link button renders its icon as a Material Symbols ligature text node (`link`/`check`), and since the button sits inside each heading's `.docs-anchor`, that text becomes part of the heading and the Algolia crawler indexes values like `Descriptionlink`. This surfaces a stray "link" in docs search results.

## What is the new behavior?

The glyph is now rendered via a `::before` pseudo-element using the icon codepoint, so no `link`/`check` text exists in the DOM and headings index correctly again. Button position, hover, tooltip, and success state are unchanged. Fixes #69587 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No