### PR TITLE
fix(router): pass correct component to canDeactivate for named outlets in componentless parent routes

### DIFF
--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -101,7 +101,7 @@ function getChildRouteGuards(
 
   // Process any children left from the current route (not active for the future route)
   Object.entries(prevChildren).forEach(([k, v]: [string, TreeNode<ActivatedRouteSnapshot>]) =>
-    deactivateRouteAndItsChildren(v, contexts!.getContext(k), checks),
+    deactivateRouteAndItsChildren(v, contexts!.getContext(k), contexts, checks),
   );
 
   return checks;
@@ -156,7 +156,7 @@ function getRouteGuards(
     }
   } else {
     if (curr) {
-      deactivateRouteAndItsChildren(currNode, context, checks);
+      deactivateRouteAndItsChildren(currNode, context, parentContexts, checks);
     }
 
     checks.canActivateChecks.push(new CanActivate(futurePath));
@@ -208,6 +208,7 @@ function shouldRunGuardsAndResolvers(
 function deactivateRouteAndItsChildren(
   route: TreeNode<ActivatedRouteSnapshot>,
   context: OutletContext | null,
+  parentContexts: ChildrenOutletContexts | null,
   checks: Checks,
 ): void {
   const children = nodeChildrenAsMap(route);
@@ -215,11 +216,24 @@ function deactivateRouteAndItsChildren(
 
   Object.entries(children).forEach(([childName, node]) => {
     if (!r.component) {
-      deactivateRouteAndItsChildren(node, context, checks);
+      // For componentless routes, children share the parent's outlet contexts. Look up each
+      // child by its outlet name in parentContexts rather than passing the same context
+      // (which was derived from the componentless route's own outlet and may be null or wrong).
+      deactivateRouteAndItsChildren(
+        node,
+        parentContexts ? parentContexts.getContext(childName) : null,
+        parentContexts,
+        checks,
+      );
     } else if (context) {
-      deactivateRouteAndItsChildren(node, context.children.getContext(childName), checks);
+      deactivateRouteAndItsChildren(
+        node,
+        context.children.getContext(childName),
+        context.children,
+        checks,
+      );
     } else {
-      deactivateRouteAndItsChildren(node, null, checks);
+      deactivateRouteAndItsChildren(node, null, null, checks);
     }
   });
 

--- a/packages/router/test/integration/guards.spec.ts
+++ b/packages/router/test/integration/guards.spec.ts
@@ -44,6 +44,7 @@ import {
   RunGuardsAndResolvers,
   Data,
   RouterModule,
+  RouterOutlet,
   NavigationCancellationCode,
   RouteConfigLoadStart,
   RouteConfigLoadEnd,
@@ -1185,6 +1186,65 @@ export function guardsIntegrationSuite() {
         await advance(fixture);
 
         expect(log[0].component).toBeInstanceOf(AdminComponent);
+      });
+
+      it('should pass correct component to canDeactivate when using named outlets in componentless parent routes', async () => {
+        @Component({
+          selector: 'outer',
+          template: '<router-outlet name="inner"></router-outlet>',
+          standalone: true,
+          imports: [RouterOutlet],
+        })
+        class OuterCmp {}
+
+        @Component({selector: 'inner1', template: '', standalone: true})
+        class Inner1Cmp {}
+
+        @Component({selector: 'inner2', template: '', standalone: true})
+        class Inner2Cmp {}
+
+        const router: Router = TestBed.inject(Router);
+        const fixture = await createRoot(router, RootCmp);
+
+        router.resetConfig([
+          {
+            path: '',
+            component: OuterCmp,
+            children: [
+              {
+                path: 'one',
+                children: [
+                  {
+                    path: '',
+                    outlet: 'inner',
+                    component: Inner1Cmp,
+                    canDeactivate: [recordingDeactivate],
+                  },
+                ],
+              },
+              {
+                path: 'two',
+                children: [
+                  {
+                    path: '',
+                    outlet: 'inner',
+                    component: Inner2Cmp,
+                    canDeactivate: [recordingDeactivate],
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+
+        router.navigateByUrl('/one');
+        await advance(fixture);
+
+        router.navigateByUrl('/two');
+        await advance(fixture);
+
+        expect(log.length).toBe(1);
+        expect(log[0].component).toBeInstanceOf(Inner1Cmp);
       });
 
       it('should not create a route state if navigation is canceled', async () => {


### PR DESCRIPTION
When a componentless parent route has children rendered into a named outlet (e.g. `outlet: 'inner'`), the `canDeactivate` guard received `null` as the component argument instead of the actual component instance.

The bug was in `deactivateRouteAndItsChildren`: for componentless routes, each child was passed the same `context` inherited from the parent lookup, which was `null` when the parent component only registered a named outlet. The children's actual outlet contexts were never consulted.

The fix adds a `parentContexts: ChildrenOutletContexts | null` parameter so that for componentless routes, each child is looked up by its own outlet name in `parentContexts` (e.g. `parentContexts.getContext('inner')`). For component routes, `context.children` is passed as the new `parentContexts` on recursion, ensuring correct context resolution across component boundaries.

This re-addresses #34614. A previous fix (#36302) was reverted because it passed `parentContexts` unchanged through component boundaries; this fix updates `parentContexts` to `context.children` when descending into a component route, preventing the wrong contexts from propagating into deeper componentless levels.

Fixes #34614