### PR TITLE
docs: improve Signal Forms complete example

### DIFF
--- a/adev/src/content/examples/signal-forms/src/login-simple/app/app.html
+++ b/adev/src/content/examples/signal-forms/src/login-simple/app/app.html
@@ -1,4 +1,4 @@
-<form>
+<form (submit)="onSubmit($event)">
   <label>
     Email:
     <input type="email" [formField]="loginForm.email" />
@@ -11,4 +11,6 @@
 
   <p>Hello {{ loginForm.email().value() }}!</p>
   <p>Password length: {{ loginForm.password().value().length }}</p>
+
+  <button type="submit">Log In</button>
 </form>

--- a/adev/src/content/examples/signal-forms/src/login-simple/app/app.ts
+++ b/adev/src/content/examples/signal-forms/src/login-simple/app/app.ts
@@ -19,4 +19,14 @@ export class App {
   });
 
   loginForm = form(this.loginModel);
+
+  onSubmit(event: Event) {
+    event.preventDefault();
+
+    // Perform login logic here
+    const credentials = this.loginModel();
+    console.log('Logging in with:', credentials);
+
+    // e.g., await this.authService.login(credentials);
+  }
 }

--- a/adev/src/content/introduction/essentials/signal-forms.md
+++ b/adev/src/content/introduction/essentials/signal-forms.md
@@ -83,7 +83,7 @@ As a result, both the field value and the model signal are updated automatically
 console.log(loginModel().email); // 'alice@wonderland.com'
 ```
 
-Here's a complete example:
+### Complete example
 
 <docs-code-multifile preview path="adev/src/content/examples/signal-forms/src/login-simple/app/app.ts">
   <docs-code header="app.ts" path="adev/src/content/examples/signal-forms/src/login-simple/app/app.ts"/>
@@ -237,7 +237,7 @@ email(schemaPath.email, {message: 'Please enter a valid email address'});
 
 Each form field exposes its validation state through signals. For example, you can check `field().valid()` to see if validation passes, `field().touched()` to see if the user has interacted with it, and `field().errors()` to get the list of validation errors.
 
-Here's a complete example:
+### Complete example
 
 <docs-code-multifile preview path="adev/src/content/examples/signal-forms/src/login-validation/app/app.ts">
   <docs-code header="app.ts" path="adev/src/content/examples/signal-forms/src/login-validation/app/app.ts"/>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (not applicable)
- [x] Docs have been added / updated

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The "Complete example" on the Signal Forms documentation page is presented under the **"Update field values with `set()`"** section even though the example does not demonstrate `value.set()`. Additionally, the example does not show how to submit the form, requiring readers to refer to the later validation example to learn form submission.

Fixes #69546.

## What is the new behavior?

- Moves the "Complete example" into its own subsection so it is no longer associated with the `set()` section.
- Adds form submission to the basic Signal Forms example by including:
  - a submit handler,
  - a submit button, and
  - a form submit event binding.
- Uses a matching **"Complete example"** subsection under **"Validation and state"** for consistency.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change is documentation-only and updates the accompanying example to better demonstrate the complete Signal Forms workflow.