### PR TITLE
fix(common): support Infinity/-Infinity strings in DecimalPipe, PercentPipe, CurrencyPipe

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -323,8 +323,16 @@ function isValue(value: number | string | null | undefined): value is number | s
  */
 function strToNumber(value: number | string): number {
   // Convert strings to numbers
-  if (typeof value === 'string' && !isNaN(Number(value) - parseFloat(value))) {
-    return Number(value);
+  if (typeof value === 'string') {
+    const num = Number(value);
+    const parsed = parseFloat(value);
+    // `Number()` and `parseFloat()` normally agree on a string's numeric value, which is what
+    // the `isNaN` check below verifies. The exception is `Infinity`/`-Infinity`: both parsers
+    // resolve to the same infinite value, but `Infinity - Infinity` is `NaN`, so that case has
+    // to be handled separately from the subtraction check.
+    if (!isNaN(num - parsed) || (num === parsed && !isFinite(num))) {
+      return num;
+    }
   }
   if (typeof value !== 'number') {
     throw new RuntimeError(

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -49,6 +49,13 @@ describe('Number pipes', () => {
         expect(pipe.transform('1.1234')).toEqual('1.123');
       });
 
+      it('should support "Infinity" and "-Infinity" strings, same as the numeric values', () => {
+        expect(pipe.transform('Infinity')).toEqual(pipe.transform(Infinity));
+        expect(pipe.transform('-Infinity')).toEqual(pipe.transform(-Infinity));
+        // Also covers any string both `Number()` and `parseFloat()` resolve to Infinity.
+        expect(pipe.transform('1e500')).toEqual(pipe.transform(Infinity));
+      });
+
       it('should return null for NaN', () => {
         expect(pipe.transform(Number.NaN)).toEqual(null);
       });
@@ -109,6 +116,11 @@ describe('Number pipes', () => {
         expect(pipe.transform(1.234)).toEqual('123%');
         expect(pipe.transform(1.236)).toEqual('124%');
         expect(pipe.transform(12.3456, '0.0-10')).toEqual('1,234.56%');
+      });
+
+      it('should support "Infinity" and "-Infinity" strings, same as the numeric values', () => {
+        expect(pipe.transform('Infinity')).toEqual(pipe.transform(Infinity));
+        expect(pipe.transform('-Infinity')).toEqual(pipe.transform(-Infinity));
       });
 
       it('should return null for NaN', () => {
@@ -198,6 +210,11 @@ describe('Number pipes', () => {
         expect(pipe.transform(5.1234, 'unexisting_ISO_code', 'Custom name')).toEqual(
           'Custom name5.12',
         );
+      });
+
+      it('should support "Infinity" and "-Infinity" strings, same as the numeric values', () => {
+        expect(pipe.transform('Infinity')).toEqual(pipe.transform(Infinity));
+        expect(pipe.transform('-Infinity')).toEqual(pipe.transform(-Infinity));
       });
 
       it('should return null for NaN', () => {


### PR DESCRIPTION
`{{ Infinity | number }}` renders `∞` just fine, but `{{ "Infinity" | number }}` throws `NG02100: InvalidPipeArgument`. Same for `"-Infinity"` and anything like `"1e500"` that both `Number()` and `parseFloat()` resolve to an infinite value. The string validation in `strToNumber` checks `Number(value) - parseFloat(value)` for NaN, which works for ordinary numeric strings but breaks here since `Infinity - Infinity` is itself `NaN`.

Added a small carve-out for the case where both parsers agree the value is infinite, without touching the general validation logic - things like `"0x10"` or `"123abc"` keep behaving exactly as before.

Somewhat related to #47809, which the team closed in favor of matching native JS behavior for a different decimal-precision edge case - this change actually goes the other way and makes the pipe agree with what `Number("Infinity")` already does in plain JS.