### PR TITLE
fix(forms): restore early NgControl valueAccessor initialization

### DIFF
--- a/packages/forms/src/directives/ng_control.ts
+++ b/packages/forms/src/directives/ng_control.ts
@@ -9,14 +9,14 @@
 import {
   ChangeDetectorRef,
   DestroyRef,
+  Provider,
+  Signal,
   computed,
   effect,
-  type Injector,
-  type Renderer2,
-  Signal,
   inject,
   type ɵControlDirectiveHost as ControlDirectiveHost,
-  Provider,
+  type Injector,
+  type Renderer2,
 } from '@angular/core';
 import {Subscription} from 'rxjs';
 
@@ -28,8 +28,8 @@ import {ControlContainer} from './control_container';
 import {ControlValueAccessor} from './control_value_accessor';
 import {isNativeFormElement, setNativeDomProperty, type NativeFormControl} from './native';
 import {ReactiveValidationError} from './reactive_validation_error';
+import {ɵFORM_CONTROL_INTEGRATION as FORM_CONTROL_INTEGRATION, selectValueAccessor} from './shared';
 import {RequiredValidator, ValidationErrors, ValidatorFn} from './validators';
-import {selectValueAccessor, ɵFORM_CONTROL_INTEGRATION as FORM_CONTROL_INTEGRATION} from './shared';
 
 type ParseError = {readonly kind: string};
 
@@ -166,6 +166,15 @@ export abstract class NgControl extends AbstractControlDirective {
     this.injector = injector;
     this.renderer = renderer;
     this.rawValueAccessors = rawValueAccessors;
+    // Keep valueAccessor available during directive construction on the same element.
+    if (rawValueAccessors?.length) {
+      // try {
+      this.valueAccessor = this.selectedValueAccessor;
+      // } catch {
+      // Ignore errors from multiple CVAs or missing inputs during construction.
+      // Real validation and error reporting is deferred to ngOnChanges / ngControlCreate.
+      // }
+    }
     this.injector?.get(DestroyRef)?.onDestroy(() => {
       this.removeParseErrorsValidator(this.control);
       this.subscription?.unsubscribe();

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -50,6 +50,7 @@ import {
   NG_ASYNC_VALIDATORS,
   NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
+  NgControl,
   ReactiveFormsModule,
   Validator,
   Validators,
@@ -220,6 +221,15 @@ describe('reactive forms integration tests', () => {
 
       expect(form.value).toEqual({'login': 'updatedValue'});
     });
+
+    it('should expose the selected value accessor during sibling directive construction', () => {
+      TestBed.configureTestingModule({imports: [FormGroupWithConstructorNgControlDirective]});
+      const fixture = TestBed.createComponent(FormGroupWithConstructorNgControlDirective);
+      fixture.componentInstance.form = new FormGroup({login: new FormControl('loginValue')});
+
+      expect(() => fixture.detectChanges()).not.toThrow();
+    });
+
   });
 
   describe('re-bound form groups', () => {
@@ -6371,6 +6381,18 @@ class UniqLoginValidator implements AsyncValidator {
   }
 }
 
+@Directive({
+  selector: '[constructor-ng-control-check]',
+  standalone: true,
+})
+class ConstructorNgControlCheck {
+  constructor(controlDir: NgControl) {
+    if (!controlDir.valueAccessor) {
+      throw new Error('Missing value accessor during directive construction.');
+    }
+  }
+}
+
 @Component({
   selector: 'form-control-comp',
   template: `<input type="text" [formControl]="control" />`,
@@ -6393,6 +6415,53 @@ class FormGroupComp {
   control!: FormControl;
   form!: FormGroup;
   event!: Event;
+}
+
+@Component({
+  selector: 'form-group-with-constructor-ng-control-directive',
+  template: ` <form [formGroup]="form">
+    <input type="text" formControlName="login" constructor-ng-control-check />
+  </form>`,
+  imports: [ReactiveFormsModule, ConstructorNgControlCheck],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class FormGroupWithConstructorNgControlDirective {
+  form!: FormGroup;
+}
+
+@Directive({
+  selector: '[myCustomCva]',
+  standalone: true,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MyCustomCva),
+      multi: true,
+    },
+  ],
+})
+class MyCustomCva implements ControlValueAccessor {
+  writeValue() {}
+  registerOnChange() {}
+  registerOnTouched() {}
+}
+
+@Directive({
+  selector: '[myCustomCva2]',
+  standalone: true,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MyCustomCva2),
+      multi: true,
+    },
+  ],
+})
+class MyCustomCva2 implements ControlValueAccessor {
+  writeValue() {}
+  registerOnChange() {}
+  registerOnTouched() {}
 }
 
 @Component({

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -33,6 +33,7 @@ import {
   NG_ASYNC_VALIDATORS,
   NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
+  NgControl,
   NgForm,
   NgModel,
   Validator,
@@ -81,6 +82,14 @@ describe('template-driven forms integration tests', () => {
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       expect(form.value).toEqual({name: 'Nancy'});
       expect(form.valid).toBe(false);
+    });
+
+    it('should throw an error with the correct control path if multiple value accessors are present', async () => {
+      TestBed.configureTestingModule({imports: [NgModelMultipleCvaTestComp]});
+      const fixture = TestBed.createComponent(NgModelMultipleCvaTestComp);
+
+      // It successfully delays throwing to ngOnChanges, allowing the name to be fully populated.
+      expect(() => fixture.detectChanges()).toThrowError(/name: 'login'/);
     });
 
     it('should report properties which are written outside of template bindings', async () => {
@@ -3123,4 +3132,49 @@ class NgModelNoMinMaxValidator {
 })
 class NativeDialogForm {
   @ViewChild('form') form!: ElementRef<HTMLFormElement>;
+}
+
+@Directive({
+  selector: '[myCustomCvaNgModel]',
+  standalone: true,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MyCustomCvaNgModel),
+      multi: true,
+    },
+  ],
+})
+class MyCustomCvaNgModel implements ControlValueAccessor {
+  writeValue() {}
+  registerOnChange() {}
+  registerOnTouched() {}
+}
+
+@Directive({
+  selector: '[myCustomCva2NgModel]',
+  standalone: true,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MyCustomCva2NgModel),
+      multi: true,
+    },
+  ],
+})
+class MyCustomCva2NgModel implements ControlValueAccessor {
+  writeValue() {}
+  registerOnChange() {}
+  registerOnTouched() {}
+}
+
+@Component({
+  selector: 'ng-model-multiple-cva-test-comp',
+  template:
+    '<input type="text" [(ngModel)]="val" name="login" myCustomCvaNgModel myCustomCva2NgModel>',
+  standalone: true,
+  imports: [FormsModule, MyCustomCvaNgModel, MyCustomCva2NgModel],
+})
+class NgModelMultipleCvaTestComp {
+  val = 'test';
 }


### PR DESCRIPTION
Ensure NgControl selects and assigns its valueAccessor during construction when CVAs are present, so sibling directives can safely read valueAccessor in their constructor. Adds a reactive forms regression test covering constructor-time NgControl access with formControlName.

fixes #69421
