### PR TITLE
docs: correct docs about the chain behavior.

### DIFF
--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -47,8 +47,8 @@ export class ResourceParamsStatus extends Error {
 export interface ResourceParamsContext {
   /**
    * Chains the current params off of the value of another resource, returning the value
-   * of the other resource if it is available, or propagating the status to the current resource by
-   * throwing the appropriate status code if the value is not available.
+   * of the other resource only when its status is `resolved` or `local`, or propagating status to
+   * the current resource by throwing the appropriate status code when the value is not available.
    */
   readonly chain: <T>(resource: Resource<T>) => T;
 }

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -638,9 +638,9 @@ class ResourceWrappedError extends Error {
 }
 
 /**
- * Chains the value of another resource into the params of the current resource, returning the value
- * of the other resource if it is available, or propagating the status to the current resource if it
- * is not.
+ * Chains the current params off of the value of another resource, returning the value
+ * of the other resource only when its status is `resolved` or `local`, or propagating status to
+ * the current resource by throwing the appropriate status code when the value is not available.
  */
 export function chain<T>(resource: Resource<T>): T {
   switch (resource.status()) {


### PR DESCRIPTION
Even if the chained resource has a value, it might throw an error.

fixes #69330
