### PR TITLE
fix(docs-infra): strip newlines from class signature in API gen

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
@@ -507,7 +507,7 @@ function appendPrefixAndSuffix(entry: DocEntry, codeTocData: CodeTableOfContents
     const implementsStr =
       entry.implements.length > 0 ? ` implements ${entry.implements.join(' ,')}` : '';
 
-    const signature = `${entry.name}${generics}${extendsStr}${implementsStr}`;
+    const signature = `${entry.name}${generics}${extendsStr}${implementsStr}`.replaceAll('\n', '');
     if (isClassEntry(entry)) {
       const abstractPrefix = entry.isAbstract ? 'abstract ' : '';
       appendFirstAndLastLines(codeTocData, `${abstractPrefix}class ${signature} {`, `\n}`);


### PR DESCRIPTION
Prevents multiline generics or implements clauses from breaking the rendered class signature in the API reference docs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: #58053

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
