### PR TITLE
docs: fix code snippet formatting and highlight lines

### DIFF
--- a/adev/src/content/guide/components/outputs.md
+++ b/adev/src/content/guide/components/outputs.md
@@ -4,7 +4,7 @@ TIP: This guide assumes you've already read the [Essentials Guide](essentials). 
 
 Angular components can define custom events by assigning a property to the `output` function:
 
-```ts {highlight:[3]}
+```ts {highlight:[5]}
 @Component({
   /*...*/
 })

--- a/adev/src/content/guide/elements.md
+++ b/adev/src/content/guide/elements.md
@@ -39,7 +39,7 @@ The `createCustomElement()` function converts a component into a class that can 
 After you register your configured class with the browser's custom-element registry, use the new element just like a built-in HTML element in content that you add directly into the DOM:
 
 ```html
-<my-popup message="Use Angular!"></my-popup>
+<my-popup message="Use Angular!" />
 ```
 
 When your custom element is placed on a page, the browser creates an instance of the registered class and adds it to the DOM.


### PR DESCRIPTION
Correct a mismatched line highlight in the documentation examples and convert tags to the preferred self-closing format for consistency.

## What is the current behavior?
<img width="1624" height="616" alt="image" src="https://github.com/user-attachments/assets/8ea3f2f2-389a-43c5-8f17-d5bbde7ffbe4" />
