### PR TITLE
fix(compiler): use regular optional chaining expression for safe function calls in TCBs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
@@ -370,4 +370,35 @@ runInEachFileSystem(() => {
       expect(diags[0].code).toBe(ngErrorCode(ErrorCode.OPTIONAL_CHAIN_NOT_NULLABLE));
     });
   });
+
+  it('should not produce a warning on function calls with consecutive optional chaining', () => {
+    const fileName = absoluteFrom('/main.ts');
+    const {program, templateTypeChecker} = setup([
+      {
+        fileName,
+        templates: {
+          'TestCmp': `{{ func()?.xx?.() }}`,
+        },
+        source: `
+               export class TestCmp {
+                func(): {xx?: () => void} | undefined {
+                  return undefined;
+                }
+              }
+             `,
+      },
+    ]);
+    const sf = getSourceFileOrError(program, fileName);
+    const component = getClass(sf, 'TestCmp');
+    const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+      templateTypeChecker,
+      program.getTypeChecker(),
+      [optionalChainNotNullableFactory],
+      {strictNullChecks: true} /* options */,
+    );
+    const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+    expect(diags.length).toBe(0);
+  });
+
+  it('should not produce a warning on function calls with consecutive optional chaining with legacy behavior', () => {});
 });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -85,7 +85,7 @@ describe('type check blocks diagnostics', () => {
     it('should annotate safe calls', () => {
       const TEMPLATE = `{{ method?.(a, b) }}`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '((0 as any ? (((this).method /*3,9*/) /*3,9*/)!(((this).a /*12,13*/) /*12,13*/, ((this).b /*15,16*/) /*15,16*/) : undefined) /*3,17*/)',
+        '(((((this).method /*3,9*/) /*3,9*/)?.(((this).a /*12,13*/) /*12,13*/, ((this).b /*15,16*/) /*15,16*/)) /*3,17*/)',
       );
     });
 
@@ -146,7 +146,7 @@ describe('type check blocks diagnostics', () => {
     it('should annotate safe method calls', () => {
       const TEMPLATE = `{{ a?.method(b) }}`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '((0 as any ? (((this).a /*3,4*/) /*3,4*/)?.method /*6,12*/ /*3,12*/!(((this).b /*13,14*/) /*13,14*/) : undefined) /*3,15*/)',
+        '(((((this).a /*3,4*/) /*3,4*/)?.method /*6,12*/ /*3,12*/?.(((this).b /*13,14*/) /*13,14*/)) /*3,15*/)',
       );
     });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -19,10 +19,10 @@ import {
   ReferenceEmitResult,
   ReferenceEmitter,
 } from '../../imports';
-import {OptimizeFor} from '../api';
-import {ALL_ENABLED_CONFIG, diagnose, setup, tcb, TestDeclaration, TestDirective} from '../testing';
 import {InliningMode} from '../../program_driver';
+import {OptimizeFor} from '../api';
 import {TypeCheckShimGenerator} from '../src/shim';
+import {ALL_ENABLED_CONFIG, diagnose, setup, tcb, TestDeclaration, TestDirective} from '../testing';
 
 describe('type check blocks', () => {
   beforeEach(() => initMockFileSystem('Native'));
@@ -1480,10 +1480,10 @@ describe('type check blocks', () => {
 
       it('should use undefined for safe navigation operations when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('(0 as any ? (((this).a))?.method!() : undefined)');
+        expect(block).toContain('(((this).a))?.method?.())');
         expect(block).toContain('((((this).a))?.b)');
         expect(block).toContain('((((this).a))?.[0])');
-        expect(block).toContain('(0 as any ? (((((this).a)).optionalMethod))!() : undefined)');
+        expect(block).toContain('(((((this).a)).optionalMethod))?.())');
       });
 
       it('should use undefined for safe navigation operations when using the $safeNavigationMigration magic function', () => {
@@ -1491,10 +1491,10 @@ describe('type check blocks', () => {
         // See https://github.com/angular/angular/issues/37622
         const TEMPLATE = `{{$safeNavigationMigration(a?.b)}} {{$safeNavigationMigration(a?.method())}} {{$safeNavigationMigration(a?.[0])}} {{$safeNavigationMigration(a.optionalMethod?.())}}`;
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('(0 as any ? (((this).a))?.method!() : undefined)');
+        expect(block).toContain('((((this).a))?.method?.())');
         expect(block).toContain('((((this).a))?.b)');
         expect(block).toContain('((((this).a))?.[0])');
-        expect(block).toContain('(0 as any ? (((((this).a)).optionalMethod))!() : undefined)');
+        expect(block).toContain('((((((this).a)).optionalMethod))?.())');
       });
 
       it("should use an 'any' type for safe navigation operations when disabled", () => {
@@ -1515,11 +1515,9 @@ describe('type check blocks', () => {
       it('should check the presence of a property/method on the receiver when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain('(((((this).a)).method())?.b)');
-        expect(block).toContain('(0 as any ? ((this).a())?.method!() : undefined)');
+        expect(block).toContain('(((this).a())?.method?.())');
         expect(block).toContain('(((((this).a)).method())?.[0])');
-        expect(block).toContain(
-          '(0 as any ? (((((this).a)).method())?.otherMethod)!() : undefined)',
-        );
+        expect(block).toContain('((((((this).a)).method())?.otherMethod)?.())');
       });
 
       it('should not check the presence of a property/method on the receiver when disabled', () => {
@@ -3177,7 +3175,7 @@ describe('type check blocks', () => {
         '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
       );
       expect(block).toContain(
-        '_t1.max[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((0 as any ? (((((this).f)()).max))!() : undefined));',
+        '_t1.max[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = (((((((this).f)()).max))?.()));',
       );
       expect(block).toContain('var _t2 = null! as i0.FormField;');
       expect(block).toContain('_t2.field = (((this).f));');

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -7,29 +7,29 @@
  */
 
 import {
+  AST,
   ASTWithSource,
   Binary,
   BindingPipe,
   Conditional,
   Interpolation,
+  LiteralArray,
+  LiteralMap,
+  MatchSource,
+  ParseTemplateOptions,
   PropertyRead,
+  SafePropertyRead,
   TmplAstBoundAttribute,
   TmplAstBoundText,
+  TmplAstComponent,
   TmplAstElement,
   TmplAstForLoopBlock,
+  TmplAstIfBlock,
+  TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstReference,
   TmplAstTemplate,
-  AST,
-  LiteralArray,
-  LiteralMap,
-  TmplAstIfBlock,
-  TmplAstLetDeclaration,
   TypeCheckingConfig,
-  ParseTemplateOptions,
-  TmplAstComponent,
-  MatchSource,
-  SafePropertyRead,
 } from '@angular/compiler';
 import ts from 'typescript';
 
@@ -55,17 +55,16 @@ import {
   TemplateTypeChecker,
   VariableSymbol,
 } from '../api';
+import {findNodeInFile} from '../src/tcb_util';
 import {
+  setup as baseTestSetup,
+  createNgCompilerForFile,
   getClass,
   ngForDeclaration,
   ngForTypeCheckTarget,
-  setup as baseTestSetup,
-  TypeCheckingTarget,
-  createNgCompilerForFile,
   TestDirective,
+  TypeCheckingTarget,
 } from '../testing';
-import {TsCreateProgramDriver} from '../../program_driver';
-import {findNodeInFile} from '../src/tcb_util';
 
 runInEachFileSystem(() => {
   describe('TemplateTypeChecker.getSymbolOfNode', () => {
@@ -814,8 +813,6 @@ runInEachFileSystem(() => {
           const safeMethodCall = nodes[2].inputs[0].value as ASTWithSource;
           const methodCallSymbol = templateTypeChecker.getSymbolOfNode(safeMethodCall, cmp)!;
           assertExpressionSymbol(methodCallSymbol);
-          // Note that the symbol returned is for the return value of the safe method call.
-          expect(templateTypeChecker.getTsSymbolOfSymbol(methodCallSymbol)).toBeNull();
           expect(
             program
               .getTypeChecker()

--- a/packages/compiler/src/typecheck/expression.ts
+++ b/packages/compiler/src/typecheck/expression.ts
@@ -401,7 +401,7 @@ class TcbExprTranslator implements AstVisitor {
     const args = argNodes.map((node) => node.print()).join(', ');
 
     if (this.config.strictSafeNavigationTypes) {
-      return new TcbExpr(`(0 as any ? ${expr}!(${args}) : undefined)`);
+      return new TcbExpr(`(${expr}?.(${args}))`);
     }
 
     if (VeSafeLhsInferenceBugDetector.veWillInferAnyFor(ast)) {

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -541,7 +541,7 @@ describe('quick info', () => {
         const appFile = project.openFile('app.ts');
         appFile.moveCursorToText('something?.va¦lue()');
         const info = appFile.getQuickInfoAtPosition()!;
-        expect(toText(info.displayParts)).toEqual('(property) value: Signal<number>');
+        expect(toText(info.displayParts)).toEqual('(property) value: () => number');
         expect(toText(info.documentation)).toEqual('Documentation for value.');
       });
 


### PR DESCRIPTION
Should not report non-nullable optional chaning on function calls.

fixes #69609
