### PR TITLE
test(router): Update tests to use `currentNavigation()`

### DIFF
--- a/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
+++ b/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
@@ -187,8 +187,8 @@ export function duplicateInFlightNavigationsIntegrationSuite(browserAPI: 'histor
           }
           router.events.subscribe((e) => {
             if (e instanceof GuardsCheckEnd) {
-              expect(router.getCurrentNavigation()?.extractedUrl.toString()).toEqual('/two');
-              expect(router.getCurrentNavigation()?.extras).toBeDefined();
+              expect(router.currentNavigation()?.extractedUrl.toString()).toEqual('/two');
+              expect(router.currentNavigation()?.extras).toBeDefined();
             }
           });
         }

--- a/packages/router/test/integration/eager_url_update_strategy.spec.ts
+++ b/packages/router/test/integration/eager_url_update_strategy.spec.ts
@@ -176,7 +176,7 @@ export function eagerUrlUpdateStrategyIntegrationSuite() {
       let navigation: Navigation = null!;
       router.events.subscribe((e) => {
         if (e instanceof NavigationStart) {
-          navigation = router.getCurrentNavigation()!;
+          navigation = router.currentNavigation()!;
         }
       });
 

--- a/packages/router/test/integration/guards.spec.ts
+++ b/packages/router/test/integration/guards.spec.ts
@@ -113,7 +113,7 @@ export function guardsIntegrationSuite() {
           fixture.destroy();
 
           // Wait until the event task is dispatched.
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await timeout(10);
           window.removeEventListener('unhandledrejection', onUnhandledrejection);
 
           expect(onUnhandledrejection).not.toHaveBeenCalled();

--- a/packages/router/test/integration/integration.spec.ts
+++ b/packages/router/test/integration/integration.spec.ts
@@ -795,7 +795,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       expect(router.lastSuccessfulNavigation()).toBe(null);
 
       router.navigateByUrl('/user/init');
-      const navigation = router.getCurrentNavigation();
+      const navigation = router.currentNavigation();
       expect(router.lastSuccessfulNavigation()).toBe(null);
       await advance(fixture);
 

--- a/packages/router/test/integration/navigation.spec.ts
+++ b/packages/router/test/integration/navigation.spec.ts
@@ -153,7 +153,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
           component: SimpleCmp,
           canActivate: [
             () => {
-              observedInfo = inject(Router).getCurrentNavigation()?.extras?.info;
+              observedInfo = inject(Router).currentNavigation()?.extras?.info;
               return true;
             },
           ],
@@ -173,7 +173,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
           component: SimpleCmp,
           canActivate: [
             () => {
-              observedInfo = inject(Router).getCurrentNavigation()?.extras?.info;
+              observedInfo = inject(Router).currentNavigation()?.extras?.info;
               return true;
             },
           ],
@@ -210,7 +210,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
           component: SimpleCmp,
           canActivate: [
             () => {
-              observedInfo = inject(Router).getCurrentNavigation()?.extras?.info;
+              observedInfo = inject(Router).currentNavigation()?.extras?.info;
               return true;
             },
           ],
@@ -274,7 +274,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
       let navigation: Navigation = null!;
       router.events.subscribe((e) => {
         if (e instanceof NavigationStart) {
-          navigation = router.getCurrentNavigation()!;
+          navigation = router.currentNavigation()!;
         }
       });
 
@@ -300,7 +300,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
       let navigation: Navigation = null!;
       router.events.subscribe((e) => {
         if (e instanceof NavigationStart) {
-          navigation = <Navigation>router.getCurrentNavigation()!;
+          navigation = <Navigation>router.currentNavigation()!;
         }
       });
 
@@ -381,7 +381,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
       let navigation: Navigation = null!;
       router.events.subscribe((e) => {
         if (e instanceof NavigationStart) {
-          navigation = <Navigation>router.getCurrentNavigation()!;
+          navigation = <Navigation>router.currentNavigation()!;
         }
       });
 
@@ -883,7 +883,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
       router.events.subscribe(replay);
 
       const navigationPromise = router.navigateByUrl('a');
-      router.getCurrentNavigation()!.abort();
+      router.currentNavigation()!.abort();
 
       expect(router.getCurrentNavigation()).toBe(null);
       expect(router.currentNavigation()).toBe(null);
@@ -895,7 +895,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
       @Component({template: ''})
       class Aborting {
         constructor() {
-          inject(Router).getCurrentNavigation()!.abort();
+          inject(Router).currentNavigation()!.abort();
         }
       }
       const router = setup([{path: '**', component: Aborting}]);
@@ -903,7 +903,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
       router.events.subscribe({next: (e) => void events.push(e)});
 
       const navigationPromise = (await RouterTestingHarness.create()).navigateByUrl('/abc');
-      const navigation = router.getCurrentNavigation()!;
+      const navigation = router.currentNavigation()!;
       await navigationPromise;
 
       expect(events.at(-1)).toBeInstanceOf(NavigationEnd);
@@ -926,7 +926,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
       router.events.subscribe({next: (e) => void events.push(e)});
 
       const navigationPromise = router.navigateByUrl('/abc')!;
-      const navigation = router.getCurrentNavigation()!;
+      const navigation = router.currentNavigation()!;
       await navigationPromise;
 
       expect(events.at(-1)).toBeInstanceOf(NavigationCancel);
@@ -947,7 +947,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
           component: class {},
           canActivate: [
             () => {
-              inject(Router).getCurrentNavigation()!.abort();
+              inject(Router).currentNavigation()!.abort();
               return false;
             },
           ],
@@ -969,7 +969,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
           component: class {},
           canMatch: [
             () => {
-              inject(Router).getCurrentNavigation()!.abort();
+              inject(Router).currentNavigation()!.abort();
               return false;
             },
           ],
@@ -1001,7 +1001,7 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
       router.events.subscribe({next: (e) => void events.push(e)});
 
       const navigationPromise = router.navigateByUrl('/initial')!;
-      const navigation = router.getCurrentNavigation()!;
+      const navigation = router.currentNavigation()!;
       // wait for NavigationStart from the redirecting navigation
       await firstValueFrom(router.events.pipe(filter((e) => e instanceof NavigationStart)));
       // abort the original navigation
@@ -1041,8 +1041,8 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
 
       const navigationPromise = router.navigateByUrl('/abc123');
       // wait one macrotask to ensure we're in the canMatch guard
-      await new Promise((resolve) => setTimeout(resolve));
-      router.getCurrentNavigation()?.abort();
+      await timeout();
+      router.currentNavigation()?.abort();
 
       expect(events.at(-1)).toBeInstanceOf(NavigationCancel);
       await expectAsync(navigationPromise).toBeResolvedTo(false);

--- a/packages/router/test/with_platform_navigation.spec.ts
+++ b/packages/router/test/with_platform_navigation.spec.ts
@@ -103,7 +103,7 @@ describe('withPlatformNavigation feature', () => {
 
       location.go('/c');
       expect(changed).toBeFalse();
-      await new Promise((resolve) => setTimeout(resolve, 1));
+      await timeout(1);
       expect(changed).toBeTrue();
     });
   });


### PR DESCRIPTION
Updates router integration tests to use the `currentNavigation()` method instead of deprecated `getCurrentNavigation`.

Also replaces direct `setTimeout` calls with the `timeout()` utility function.

