### PR TITLE
docs: add angular-library skill for creating, building and publishing…

### DIFF
--- a/skills/dev-skills/README.md
+++ b/skills/dev-skills/README.md
@@ -5,6 +5,7 @@ The Angular skills are designed to help coding agents create applications aligne
 ## Available Skills
 
 - **`angular-developer`**: Generates Angular code and provides architectural guidance. Useful for creating components, services, or obtaining best practices on reactivity (signals, linkedSignal, resource), forms, dependency injection, routing, SSR, accessibility (ARIA), animations, styling, testing, or CLI tooling.
+- **`angular-library`**: Guides the creation, build, and publishing of Angular libraries. Covers ng-packagr, secondary entry points, public API surface, library testing, schematics (`ng add`, `ng generate`), and publishing to npm.
 - **`angular-new-app`**: Creates a new Angular app using the Angular CLI. Provides important guidelines for effectively setting up and structuring a modern Angular application.
 
 ## Using Agent Skills

--- a/skills/dev-skills/angular-library/SKILL.md
+++ b/skills/dev-skills/angular-library/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: angular-library
+description: Guide for creating, building, and publishing Angular libraries. Trigger when working with ng-packagr, secondary entry points, public API surface, library testing, schematics, or publishing to npm.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Library Guidelines
+
+1. Always analyze the Angular version of the workspace before providing guidance, as library APIs and tooling may differ between versions.
+
+2. Angular libraries are built with **ng-packagr** via the Angular CLI. Follow the Angular Package Format (APF) to ensure compatibility with downstream consumers.
+
+3. After generating or modifying library code, run `ng build <library-name>` to confirm there are no build errors before proceeding.
+
+4. Libraries must never import from the consuming application — they must be self-contained.
+
+## Creating a New Library
+
+When creating a new Angular library inside a workspace, consult the following reference:
+
+- **Creating a Library**: Generating the library, workspace structure, and `ng-package.json`. Read [creating-library.md](references/creating-library.md)
+
+## Public API Surface
+
+Managing what consumers can import from your library is critical. Consult:
+
+- **Public API**: Exporting symbols via `public-api.ts` and controlling the library's API surface. Read [public-api.md](references/public-api.md)
+
+## Secondary Entry Points
+
+When a library is large enough to benefit from tree-shakable sub-packages (e.g. `@my-lib/testing`), consult:
+
+- **Secondary Entry Points**: Defining multiple entry points and their constraints. Read [secondary-entrypoints.md](references/secondary-entrypoints.md)
+
+## Build and Packaging
+
+For configuration of the build pipeline and output format:
+
+- **ng-packagr**: Understanding `ng-package.json`, compilation output (ESM), and peer dependencies. Read [ng-packagr.md](references/ng-packagr.md)
+
+## Testing
+
+Libraries require a slightly different testing strategy than applications:
+
+- **Library Testing**: Unit testing library code and validating integration inside a consumer app. Read [library-testing.md](references/library-testing.md)
+
+## Publishing to npm
+
+When preparing a library for distribution:
+
+- **Publishing to npm**: Versioning, `peerDependencies`, `npm publish`, and automation. Read [publishing-npm.md](references/publishing-npm.md)
+
+## Schematics
+
+To provide `ng add` or `ng generate` commands for library consumers:
+
+- **Schematics**: Adding Angular schematics to a library for code generation and automated setup. Read [schematics.md](references/schematics.md)
+
+If you need deeper documentation, refer to the [official Angular Libraries guide](https://angular.dev/tools/libraries).

--- a/skills/dev-skills/angular-library/references/creating-library.md
+++ b/skills/dev-skills/angular-library/references/creating-library.md
@@ -1,0 +1,164 @@
+# Creating an Angular Library
+
+## Overview
+
+An Angular library is a reusable Angular project that can be shared across multiple Angular applications or published to npm.
+
+Libraries are created inside an Angular **workspace** (a project created with `ng new`).
+
+---
+
+## Generating a Library
+
+Use the Angular CLI to generate a library. It is common to create a dedicated workspace without an initial application:
+
+```bash
+ng new my-workspace --no-create-application
+cd my-workspace
+ng generate library my-lib
+```
+
+Or with a scope:
+
+```bash
+ng generate library @my-org/my-lib
+```
+
+This creates the following structure in the workspace:
+
+```
+my-workspace/
+├── projects/
+│   └── my-lib/
+│       ├── src/
+│       │   ├── lib/
+│       │   │   ├── my-lib.component.ts
+│       │   │   ├── my-lib.service.ts
+│       │   │   └── my-lib.component.spec.ts
+│       │   └── public-api.ts       ← controls what consumers can import
+│       ├── ng-package.json         ← ng-packagr configuration
+│       ├── package.json
+│       └── tsconfig.lib.json
+├── angular.json
+└── tsconfig.json
+```
+
+---
+
+## Building the Library
+
+Build the library before using it locally or publishing:
+
+```bash
+ng build my-lib
+```
+
+The output is placed in `dist/my-lib/` by default.
+
+> **Path Mapping Warning:** An application that depends on a library should only use TypeScript path mappings that point to the _built library_ in the `dist/` folder. Path mappings should **not** point to the library source `.ts` files, because the build systems are different (`esbuild` for applications vs `ng-packagr` for libraries).
+
+---
+
+## Using the Library in the Same Workspace
+
+After building, Angular automatically configures path mappings in `tsconfig.json` so the consuming app can import from the library by name:
+
+```ts
+import {MyLibComponent} from 'my-lib';
+```
+
+For **development without rebuilding on every change**, use the `--watch` flag:
+
+```bash
+ng build my-lib --watch
+```
+
+---
+
+## Key Files Explained
+
+### `ng-package.json`
+
+Configures the ng-packagr build:
+
+```json
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}
+```
+
+### `public-api.ts`
+
+The single entry point defining the library's public surface. See [public-api.md](public-api.md).
+
+### `package.json`
+
+Defines the library's name, version, and `peerDependencies`. See [publishing-npm.md](publishing-npm.md).
+
+---
+
+## Scaffolding Inside the Library
+
+After generating the library, use the CLI to add components, services, and other artifacts scoped to it:
+
+```bash
+ng generate component my-component --project=my-lib
+ng generate service my-service --project=my-lib
+ng generate directive my-directive --project=my-lib
+ng generate pipe my-pipe --project=my-lib
+```
+
+> **Note:** By default in modern Angular versions, `ng generate component` creates **standalone** components. This is the recommended pattern for libraries as well, avoiding the need for internal `NgModule`s.
+
+---
+
+> Libraries cannot use browser-specific APIs directly in their module code if you intend to support SSR consumers. Use `isPlatformBrowser` or inject `PLATFORM_ID` where needed.
+
+---
+
+## Refactoring Applications into Libraries
+
+When moving application code into a library to make it reusable:
+
+- **Stateless Components:** Components and pipes should be stateless. Avoid relying on external application-specific state.
+- **Tree-Shakable Providers:** Services should use `providedIn: 'root'` instead of being declared in `NgModule` providers so they can be tree-shaken by consumers.
+- **Lightweight Tokens:** For optional services, use the lightweight injection token pattern to ensure the library doesn't drag in unnecessary dependencies.
+
+---
+
+## Linking Libraries for Local Development
+
+To test a standalone library with an external application during local development (without publishing to npm or using a monorepo), use `npm link` or `pnpm link`.
+
+You must configure the **consuming application's** `angular.json` to properly handle the symlinks:
+
+```json
+{
+  "projects": {
+    "your-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "preserveSymlinks": true
+          }
+        },
+        "serve": {
+          "builder": "@angular/build:dev-server",
+          "options": {
+            "prebundle": {
+              "exclude": ["my-lib"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- `preserveSymlinks: true` prevents multiple copies of dependencies.
+- `prebundle.exclude` ensures Vite does not cache the linked library, allowing it to be rebuilt when changes occur.

--- a/skills/dev-skills/angular-library/references/library-testing.md
+++ b/skills/dev-skills/angular-library/references/library-testing.md
@@ -1,0 +1,174 @@
+# Library Testing
+
+## Overview
+
+Testing an Angular library involves two levels:
+
+1. **Unit tests** — testing the library's components, services, and utilities in isolation.
+2. **Integration tests** — verifying that the compiled library works correctly when consumed by a real Angular application.
+
+---
+
+## Unit Testing
+
+Library unit tests work the same as application tests. They live alongside the source files:
+
+```
+projects/my-lib/src/lib/
+├── my-lib.component.ts
+├── my-lib.component.spec.ts   ← unit test
+├── my-lib.service.ts
+└── my-lib.service.spec.ts     ← unit test
+```
+
+Run library tests with:
+
+```bash
+ng test my-lib
+```
+
+---
+
+## Writing Unit Tests
+
+Use `TestBed` to configure a minimal testing module for the library:
+
+```ts
+import {TestBed} from '@angular/core/testing';
+import {MyLibComponent} from './my-lib.component';
+
+describe('MyLibComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MyLibComponent],
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(MyLibComponent);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});
+```
+
+---
+
+## Async-First Pattern
+
+Follow the zoneless async-first pattern for all library tests:
+
+```ts
+it('should update when input changes', async () => {
+  const fixture = TestBed.createComponent(MyLibComponent);
+  const component = fixture.componentInstance;
+
+  // Act
+  component.label.set('New Label');
+
+  // Wait
+  await fixture.whenStable();
+
+  // Assert
+  const el = fixture.nativeElement.querySelector('.label');
+  expect(el.textContent).toBe('New Label');
+});
+```
+
+- Do **not** call `fixture.detectChanges()` manually.
+- Always use `await fixture.whenStable()` after state changes.
+
+---
+
+## Testing Services with `inject()`
+
+For services that use `inject()` instead of constructor injection:
+
+```ts
+import {TestBed} from '@angular/core/testing';
+import {MyLibService} from './my-lib.service';
+
+describe('MyLibService', () => {
+  let service: MyLibService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MyLibService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});
+```
+
+---
+
+## Integration Testing with a Consumer App
+
+To verify the compiled library works end-to-end:
+
+1. **Build the library** in watch mode:
+
+```bash
+ng build my-lib --watch
+```
+
+2. **Import from the library name** in the consuming app (the path mapping in `tsconfig.json` handles resolution):
+
+```ts
+import {MyLibComponent} from 'my-lib';
+```
+
+3. **Run the consuming app's tests** to catch integration issues:
+
+```bash
+ng test my-app
+```
+
+---
+
+## Providing a `testing` Entry Point
+
+For complex libraries, expose test utilities via a dedicated secondary entry point:
+
+```ts
+// my-lib/testing/src/public-api.ts
+export * from './my-lib-harness';
+```
+
+```ts
+// In consumer test files
+import {MyLibHarness} from 'my-lib/testing';
+```
+
+See [secondary-entrypoints.md](secondary-entrypoints.md) for setup details.
+
+---
+
+## Component Harnesses
+
+For UI component libraries, provide a **Component Harness** so consumers can interact with your components in tests without coupling to the DOM structure:
+
+```ts
+import {ComponentHarness} from '@angular/cdk/testing';
+
+export class MyButtonHarness extends ComponentHarness {
+  static hostSelector = 'my-button';
+
+  async click(): Promise<void> {
+    const host = await this.host();
+    await host.click();
+  }
+
+  async getText(): Promise<string> {
+    const host = await this.host();
+    return host.text();
+  }
+}
+```
+
+Export the harness from the `testing` secondary entry point.
+
+---
+
+> Do not test the contents of the `dist/` folder directly. Test the source. The build pipeline is validated separately by `ng build`.

--- a/skills/dev-skills/angular-library/references/ng-packagr.md
+++ b/skills/dev-skills/angular-library/references/ng-packagr.md
@@ -1,0 +1,129 @@
+# ng-packagr and the Angular Package Format
+
+## Overview
+
+**ng-packagr** is the build tool used by the Angular CLI to compile Angular libraries into the **Angular Package Format (APF)**, which is the standard format for distributing Angular libraries on npm.
+
+---
+
+## `ng-package.json`
+
+The `ng-package.json` file at the root of your library configures the ng-packagr build:
+
+```json
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  },
+  "assets": ["./styles/**/*.scss", "./themes/**/*.css"]
+}
+```
+
+### Key Options
+
+| Option           | Description                                                          |
+| ---------------- | -------------------------------------------------------------------- |
+| `lib.entryFile`  | Path to the public API file (required)                               |
+| `assets`         | Files to copy to the dist folder (e.g. styles, themes)               |
+| `deleteDestPath` | Whether to clean the output directory before build (default: `true`) |
+| `dest`           | Custom output directory (defaults to `dist/<library-name>`)          |
+
+---
+
+## Angular Package Format (APF)
+
+ng-packagr produces an output conforming to the APF. The key outputs are:
+
+| File / Folder  | Purpose                                      |
+| -------------- | -------------------------------------------- |
+| `esm2022/`     | ES Modules (tree-shakable, used by bundlers) |
+| `fesm2022/`    | Flattened ESM (single file, fewer imports)   |
+| `*.d.ts`       | TypeScript type declarations                 |
+| `*.d.ts.map`   | Declaration source maps                      |
+| `package.json` | npm package descriptor with `exports` field  |
+
+Modern bundlers (Webpack, esbuild, Rollup) resolve the `exports` field in `package.json` to pick the right format automatically.
+
+---
+
+## `peerDependencies`
+
+Libraries should **not** bundle Angular itself. Instead, declare Angular as a peer dependency in the library's `package.json`:
+
+```json
+{
+  "name": "my-lib",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@angular/core": ">=19.0.0",
+    "@angular/common": ">=19.0.0"
+  },
+  "dependencies": {}
+}
+```
+
+### Rules for `peerDependencies`
+
+- Declare all `@angular/*` packages your library imports as `peerDependencies`.
+- Use `>=` version ranges to stay compatible with future Angular versions.
+- Only add to `dependencies` packages that are not expected to be installed by the consumer (rare for Angular libs).
+- Never put `@angular/core` or `rxjs` in `dependencies`.
+
+---
+
+## Enabling CSS / SCSS Compilation
+
+For libraries that ship styles, ng-packagr can compile SCSS to CSS. Reference them in component metadata:
+
+```ts
+@Component({
+  selector: 'my-button',
+  templateUrl: './my-button.component.html',
+  styleUrl: './my-button.component.scss',
+})
+export class MyButtonComponent {}
+```
+
+To ship **global styles or themes** (not scoped to a component), list them in `ng-package.json` under `assets`.
+
+### Exposing Assets via Package Exports
+
+When including additional assets like Sass mixins or pre-compiled CSS, you must manually add these to the conditional `"exports"` in the primary `package.json` of your library.
+
+`ng-packagr` merges these handwritten `"exports"` with the auto-generated ones, allowing you to configure custom export subpaths:
+
+```json
+"exports": {
+  ".": {
+    "sass": "./_index.scss",
+  },
+  "./theming": {
+    "sass": "./_theming.scss"
+  },
+  "./prebuilt-themes/indigo-pink.css": {
+    "style": "./prebuilt-themes/indigo-pink.css"
+  }
+}
+```
+
+---
+
+## Preserving Comments for API Documentation
+
+ng-packagr strips most comments by default. To preserve JSDoc comments for API documentation tools (e.g., Compodoc, TypeDoc), they must be attached directly above exported symbols and follow the JSDoc format:
+
+```ts
+/**
+ * A button component with Angular Aria support.
+ *
+ * @example
+ * <my-button variant="primary">Click me</my-button>
+ */
+@Component({...})
+export class MyButtonComponent {}
+```
+
+---
+
+> Do not manually edit the files inside `dist/`. They are generated artifacts and will be overwritten on every build.

--- a/skills/dev-skills/angular-library/references/public-api.md
+++ b/skills/dev-skills/angular-library/references/public-api.md
@@ -1,0 +1,74 @@
+# Public API Surface
+
+## What is the Public API?
+
+The **public API** of a library is the set of symbols (components, directives, services, pipes, functions, types, etc.) that consumers can import.
+
+It is defined by the `public-api.ts` file referenced as the `entryFile` in `ng-package.json`.
+
+---
+
+## The `public-api.ts` File
+
+Everything exported from `public-api.ts` becomes part of the library's public contract:
+
+```ts
+// src/public-api.ts
+
+export * from './lib/my-lib.component';
+export * from './lib/my-lib.service';
+export * from './lib/my-lib.pipe';
+export * from './lib/tokens';
+export type {MyLibConfig} from './lib/config';
+```
+
+Consumers then import directly from the library name:
+
+```ts
+import {MyLibComponent, MyLibService} from 'my-lib';
+```
+
+---
+
+## What to Export
+
+| Symbol type                   | Export? | Notes                                   |
+| ----------------------------- | ------- | --------------------------------------- |
+| Components, Directives, Pipes | ✅ Yes  | Core building blocks                    |
+| Public Services               | ✅ Yes  | If consumers need to inject them        |
+| `InjectionToken`s             | ✅ Yes  | If consumers need to provide values     |
+| TypeScript interfaces / types | ✅ Yes  | For consumer type safety                |
+| Internal utilities            | ❌ No   | Keep as implementation details          |
+| Internal helper services      | ❌ No   | Only export if consumers need DI access |
+
+---
+
+## Controlling Type-Only Exports
+
+Use `export type` for types and interfaces that are only needed for type checking. This prevents them from being included in the runtime bundle:
+
+```ts
+export type {MyConfig} from './lib/config';
+export type {MyEventData} from './lib/events';
+```
+
+---
+
+## Breaking Changes and API Stability
+
+- **Every export is a public commitment.** Removing or renaming an export is a breaking change.
+- Use semantic versioning (semver) to communicate changes to consumers.
+- Mark unstable APIs with a comment or a separate `experimental` entry point:
+
+```ts
+// Only export stable APIs from public-api.ts
+export * from './lib/stable-feature';
+```
+
+---
+
+## Barrel File Discipline
+
+Avoid re-exporting everything from barrel files without intent. Only export what consumers genuinely need.
+
+> **Tip:** Periodically audit `public-api.ts` to remove symbols that were accidentally exposed or are no longer needed. Each removal after release is a breaking change, so it is better to be conservative upfront.

--- a/skills/dev-skills/angular-library/references/publishing-npm.md
+++ b/skills/dev-skills/angular-library/references/publishing-npm.md
@@ -1,0 +1,144 @@
+# Publishing to npm
+
+## Overview
+
+Publishing an Angular library to npm makes it available for any Angular project to install and use.
+
+---
+
+## Pre-publish Checklist
+
+Before publishing, ensure:
+
+- [ ] The library builds without errors: `ng build my-lib`
+- [ ] All unit tests pass: `ng test my-lib`
+- [ ] `peerDependencies` are correctly defined in `package.json`
+- [ ] The version number follows [semantic versioning](https://semver.org/)
+- [ ] `README.md` is present in the library's `dist/` or source folder
+
+---
+
+## Versioning with Semantic Versioning (semver)
+
+| Change type                      | Version bump | Example           |
+| -------------------------------- | ------------ | ----------------- |
+| Bug fix, no breaking changes     | Patch        | `1.0.0` → `1.0.1` |
+| New feature, backward compatible | Minor        | `1.0.0` → `1.1.0` |
+| Breaking change                  | Major        | `1.0.0` → `2.0.0` |
+
+Update the version in the library's `package.json`:
+
+```json
+{
+  "name": "@my-org/my-lib",
+  "version": "1.1.0"
+}
+```
+
+Or use `npm version` from the `dist/` folder:
+
+```bash
+cd dist/my-lib
+npm version patch
+```
+
+---
+
+## `package.json` Configuration
+
+A well-configured library `package.json`:
+
+```json
+{
+  "name": "@my-org/my-lib",
+  "version": "1.0.0",
+  "description": "An Angular component library",
+  "keywords": ["angular", "components"],
+  "license": "MIT",
+  "author": "Your Name",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/my-org/my-lib.git"
+  },
+  "peerDependencies": {
+    "@angular/core": ">=19.0.0",
+    "@angular/common": ">=19.0.0"
+  },
+  "dependencies": {}
+}
+```
+
+---
+
+## Publishing the Built Package
+
+Always publish from the `dist/` directory, not the source:
+
+```bash
+cd dist/my-lib
+npm publish
+```
+
+For scoped packages under an npm organization, publish with public access:
+
+```bash
+npm publish --access public
+```
+
+---
+
+## Automating with a Script
+
+Add a publish script in the workspace root `package.json`:
+
+```json
+{
+  "scripts": {
+    "publish:my-lib": "ng build my-lib && cd dist/my-lib && npm publish --access public"
+  }
+}
+```
+
+---
+
+## Using `.npmignore` or `ng-package.json` Assets
+
+Files in the library source that should **not** appear in the published package (e.g., spec files, internal scripts) are automatically excluded by ng-packagr.
+
+To include extra files (e.g., a `README.md` or `CHANGELOG.md`), add them to the `assets` array in `ng-package.json`:
+
+```json
+{
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  },
+  "assets": ["README.md", "CHANGELOG.md"]
+}
+```
+
+---
+
+## Prerelease Versions
+
+For alpha, beta, or release candidate versions:
+
+```bash
+npm version 2.0.0-beta.1
+npm publish --tag beta
+```
+
+Consumers install a specific tag with:
+
+```bash
+npm install @my-org/my-lib@beta
+```
+
+---
+
+## `ng add` Support
+
+To support `ng add my-lib`, add an `ng-add` schematic to the library. See [schematics.md](schematics.md).
+
+---
+
+> Never publish from the `projects/my-lib/` source folder. Always build first and publish from `dist/my-lib/`.

--- a/skills/dev-skills/angular-library/references/schematics.md
+++ b/skills/dev-skills/angular-library/references/schematics.md
@@ -1,0 +1,199 @@
+# Angular Schematics for Libraries
+
+## Overview
+
+**Schematics** allow your Angular library to provide CLI-integrated automation to consumers, such as:
+
+- `ng add @my-org/my-lib` — automatic installation and setup
+- `ng generate @my-org/my-lib:component` — code generation
+
+Schematics are TypeScript programs that read and transform the file system using a virtual tree.
+
+---
+
+## Setting Up Schematics in a Library
+
+### 1. Install the Schematics CLI
+
+```bash
+npm install --save-dev @angular-devkit/schematics-cli
+```
+
+### 2. Create the Schematics Folder
+
+Inside the library project, create a `schematics/` directory:
+
+```
+projects/my-lib/
+├── src/
+├── schematics/
+│   ├── ng-add/
+│   │   ├── index.ts         ← schematic factory
+│   │   └── schema.json      ← JSON schema for options
+│   └── collection.json      ← schematics registry
+└── ng-package.json
+```
+
+### 3. Define `collection.json`
+
+```json
+{
+  "$schema": "../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Add MyLib to an Angular project.",
+      "factory": "./ng-add/index",
+      "schema": "./ng-add/schema.json"
+    }
+  }
+}
+```
+
+### 4. Register the Collection in `package.json`
+
+```json
+{
+  "name": "@my-org/my-lib",
+  "schematics": "./schematics/collection.json"
+}
+```
+
+---
+
+## Writing an `ng-add` Schematic
+
+The `ng-add` schematic runs automatically when a consumer executes `ng add @my-org/my-lib`.
+
+```ts
+// schematics/ng-add/index.ts
+import {Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
+import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
+
+export function ngAdd(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    // Schedule npm install
+    context.addTask(new NodePackageInstallTask());
+
+    // Optionally modify files (e.g., add provideMyLib() to app.config.ts)
+    // const configPath = '/src/app/app.config.ts';
+    // const content = tree.read(configPath)?.toString('utf-8') ?? '';
+    // tree.overwrite(configPath, modifiedContent);
+
+    context.logger.log('info', '✅ MyLib has been added to your project.');
+    return tree;
+  };
+}
+```
+
+---
+
+## Writing a `ng-generate` Schematic
+
+```ts
+// schematics/my-component/index.ts
+import {Rule, apply, mergeWith, template, url, move} from '@angular-devkit/schematics';
+import {strings} from '@angular-devkit/core';
+import {Schema} from './schema';
+
+export function myComponent(options: Schema): Rule {
+  const templateSource = apply(url('./files'), [
+    template({
+      ...strings,
+      ...options,
+    }),
+    move(options.path ?? ''),
+  ]);
+
+  return mergeWith(templateSource);
+}
+```
+
+Template files live in a `files/` subdirectory and can use `<%= name %>` interpolation.
+
+---
+
+## Writing an `ng update` Schematic
+
+An `ng update` schematic provides migrations for consumers when they upgrade your library to a new major version.
+
+1. **Define a `migration.json`** file in your schematics folder (similar to `collection.json` but specifically for updates):
+
+```json
+{
+  "$schema": "../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "my-lib-migration-v2": {
+      "version": "2",
+      "description": "Migrates MyLib to version 2.",
+      "factory": "./update-v2/index"
+    }
+  }
+}
+```
+
+2. **Register it in `package.json`**:
+
+```json
+{
+  "name": "@my-org/my-lib",
+  "ng-update": {
+    "migrations": "./schematics/migration.json"
+  }
+}
+```
+
+3. **Write the migration logic** in `./schematics/update-v2/index.ts` to transform old APIs to new APIs using the `Tree`.
+
+---
+
+## Building Schematics
+
+Schematics must be compiled to JavaScript before they are usable. Add a build step:
+
+```json
+// tsconfig.schematics.json
+{
+  "compilerOptions": {
+    "baseUrl": "tsconfig.json",
+    "declaration": true,
+    "module": "commonjs",
+    "outDir": "../../dist/my-lib/schematics",
+    "skipLibCheck": true,
+    "target": "ES2022"
+  },
+  "include": ["projects/my-lib/schematics/**/*.ts"]
+}
+```
+
+Build command:
+
+```bash
+tsc -p tsconfig.schematics.json
+```
+
+Add this step to the library publish pipeline.
+
+---
+
+## Testing Schematics
+
+Use `SchematicTestRunner` from `@angular-devkit/schematics/testing`:
+
+```ts
+import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+
+const collectionPath = path.join(__dirname, '../collection.json');
+
+describe('ng-add', () => {
+  it('should run without errors', async () => {
+    const runner = new SchematicTestRunner('my-lib', collectionPath);
+    const tree = await runner.runSchematic('ng-add', {}, Tree.empty());
+    expect(tree).toBeTruthy();
+  });
+});
+```
+
+---
+
+> Always test schematics in a real Angular workspace before publishing. The virtual tree in unit tests may not catch all real-world issues.

--- a/skills/dev-skills/angular-library/references/secondary-entrypoints.md
+++ b/skills/dev-skills/angular-library/references/secondary-entrypoints.md
@@ -1,0 +1,108 @@
+# Secondary Entry Points
+
+## What Are Secondary Entry Points?
+
+A **secondary entry point** is an additional import path within the same library package that can be imported independently from the primary entry point.
+
+For example, `@angular/common` provides:
+
+- `@angular/common` — primary entry point
+- `@angular/common/http` — secondary entry point
+
+This allows consumers to import only what they need, enabling better tree-shaking.
+
+---
+
+## When to Use Secondary Entry Points
+
+Use secondary entry points when:
+
+- The library has **distinct feature areas** that are rarely used together (e.g., a `testing` utilities module).
+- You want to avoid loading heavy dependencies when consumers only need a subset of the library.
+- You provide **testing utilities** that should not be included in production bundles.
+
+A common pattern is `@my-lib/testing`:
+
+```ts
+import {MyLibHarness} from '@my-lib/testing';
+```
+
+---
+
+## Creating a Secondary Entry Point
+
+Create a subdirectory inside the library's `src/` folder with its own `ng-package.json` and `public-api.ts`:
+
+```
+projects/my-lib/
+├── src/
+│   ├── lib/                     ← primary entry point source
+│   └── public-api.ts            ← primary public API
+├── testing/                     ← secondary entry point
+│   ├── src/
+│   │   ├── my-lib-harness.ts
+│   │   └── public-api.ts
+│   └── ng-package.json
+└── ng-package.json
+```
+
+### `testing/ng-package.json`
+
+```json
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}
+```
+
+### `testing/src/public-api.ts`
+
+```ts
+export * from './my-lib-harness';
+```
+
+---
+
+## Dependency Rules Between Entry Points
+
+Secondary entry points **can depend on the primary entry point**, but not the other way around.
+
+```ts
+// ✅ Allowed: testing entry point imports from primary
+import {MyLibComponent} from 'my-lib';
+
+// ❌ Forbidden: primary entry point imports from secondary
+import {MyLibHarness} from 'my-lib/testing';
+```
+
+ng-packagr enforces this rule at build time.
+
+---
+
+## Building
+
+ng-packagr automatically discovers and builds all secondary entry points when you run:
+
+```bash
+ng build my-lib
+```
+
+The output in `dist/my-lib/` will contain:
+
+```
+dist/my-lib/
+├── index.d.ts          ← primary entry point typings
+├── testing/
+│   └── index.d.ts      ← secondary entry point typings
+├── esm2022/
+│   ├── my-lib.mjs
+│   └── testing/
+│       └── my-lib-testing.mjs
+└── package.json
+```
+
+---
+
+> Keep secondary entry points minimal and purpose-specific. Too many entry points increase maintenance overhead.


### PR DESCRIPTION
… Angular libraries

Adds a new 'angular-library' agent skill that guides developers through the full lifecycle of an Angular library:

- Creating a library with the Angular CLI (ng generate library)
- Defining and managing the public API surface (public-api.ts)
- Setting up secondary entry points (e.g. @my-lib/testing)
- Configuring ng-packagr and the Angular Package Format (APF)
- Writing unit and integration tests, including component harnesses
- Publishing to npm with correct semver and peerDependencies
- Adding Angular schematics (ng add / ng generate) to a library

Updates skills/dev-skills/README.md to list the new skill.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
