### PR TITLE
docs: fix layout shift when refreshing the stagger example

### DIFF
--- a/adev/src/content/examples/animations/src/app/native-css/stagger.css
+++ b/adev/src/content/examples/animations/src/app/native-css/stagger.css
@@ -1,3 +1,7 @@
+.items-container {
+  min-height: 4.5rem;
+}
+
 .items {
   list-style: none;
   padding: 0;

--- a/adev/src/content/examples/animations/src/app/native-css/stagger.html
+++ b/adev/src/content/examples/animations/src/app/native-css/stagger.html
@@ -1,10 +1,12 @@
 <!-- #docplaster -->
 <h1>Stagger Example</h1>
 <button type="button" class="toggle-btn" (click)="refresh()">Refresh</button>
-@if (show()) {
-  <ul class="items">
-    @for (item of items; track item) {
-      <li class="item" style="--index: {{ item }}">{{ item }}</li>
-    }
-  </ul>
-}
+<div class="items-container">
+  @if (show()) {
+    <ul class="items">
+      @for (item of items; track $index) {
+        <li class="item" style="--index: {{ $index }}">{{ item }}</li>
+      }
+    </ul>
+  }
+</div>


### PR DESCRIPTION
Clicking "Refresh" toggles the list out of and back into the DOM, but the `<ul>` lived inside the `@if`, so removing it collapsed the layout and caused a vertical jump. Wrap the list in a fixed-height `.items-container` to reserve the space while it re-mounts. Also key the stagger delay off `$index` so the first item animates immediately instead of being delayed a step.

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other

## What is the current behavior?

In the native-css "Stagger" animations example, clicking **Refresh** makes the whole box shrink and snap back, with the list jumping up and then down. This happens because the `<ul>` sits inside the `@if`, so replaying the animation removes it from the layout and collapses the container to zero height. The first item is also delayed one full step before it animates in, because the stagger delay is keyed off the item value instead of its position.

https://github.com/user-attachments/assets/b1017b43-0885-419e-8afc-23758d684d8a

## What is the new behavior?

The list is wrapped in a fixed-height `.items-container` (matching the wrapper convention used by the neighboring insert/remove/open-close examples), so the space is held while the list re-mounts and there is no layout jump. The stagger delay is keyed off `$index`, so the first item animates immediately and the cascade no longer depends on the item values.

https://github.com/user-attachments/assets/a98152c9-f504-4219-bb81-1f42c4ce9a2b

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
