### PR TITLE
fix(docs-infra): center copy button in code block header

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -297,7 +297,7 @@ $code-font-size: 0.875rem;
 
   .docs-code:has(.docs-code-header) {
     button[docs-copy-source-code] {
-      top: 0.45rem;
+      top: 0.26rem;
     }
 
     .docs-code-header {
@@ -325,6 +325,9 @@ $code-font-size: 0.875rem;
 
   .docs-code-header {
     display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    min-height: 2.9rem;
     padding: 0.75rem;
 
     background: var(--subtle-purple);


### PR DESCRIPTION
The copy button in code block headers was misaligned, and the offset
differed between header variants because the headers were not the same
height. The filename (`h3`) header and the shorter prefer/avoid style
header rendered at different heights, so a single `top` value could not
center the button in both.

Give every `.docs-code-header` a shared `min-height` (with `box-sizing:
border-box` so the padding is not double-counted) and vertically center
its contents, so all header variants render at the same height. The copy
button's `top` is then a single value that centers it against every
header.

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

<img width="805" height="123" alt="image" src="https://github.com/user-attachments/assets/3ffdda16-a1ea-42e1-8637-e1f93b4285ef" />

## What is the new behavior?

<img width="808" height="164" alt="image" src="https://github.com/user-attachments/assets/a709e9a7-0b9e-4671-901e-16984ac75cd4" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No