### PR TITLE
fix(docs-infra): prevent tab labels from being clipped

### DIFF
--- a/adev/shared-docs/styles/_resets.scss
+++ b/adev/shared-docs/styles/_resets.scss
@@ -310,16 +310,15 @@
 
       .mdc-tab {
         padding-inline: 15px !important;
+        border-block-end: 2px solid transparent;
       }
 
       .mdc-tab__text-label {
         transition: none;
+        line-height: 1.5;
       }
 
       .mdc-tab--active {
-        border: 0;
-        border-block-end-width: 2px;
-        border-style: solid;
         border-image: var(--purple-to-blue-horizontal-gradient) 1;
 
         .mdc-tab__text-label {


### PR DESCRIPTION
The active docs tab applied a 2px bottom border that inactive tabs lacked, which shrank the active label's content box and clipped its descenders. It also set `line-height: 1.5` only on the active label, so switching tabs nudged the text. Reserve the border as transparent on every tab and recolor it on the active one, and share the label `line-height`, so the letters are no longer cut and the label stays put when switching.

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

https://github.com/user-attachments/assets/1cf2b52c-6e84-46e2-8463-aea2d89b3468

## What is the new behavior?

https://github.com/user-attachments/assets/20c8dc14-4697-4529-9c75-3a0791843957

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No