### PR TITLE
docs: fix broken ordered list in NG0912 error page

### DIFF
--- a/adev/src/content/reference/errors/NG0912.md
+++ b/adev/src/content/reference/errors/NG0912.md
@@ -35,21 +35,21 @@ The problem can be resolved using one of the solutions below:
 
 1. Change the selector of one of the two components. For example by using a pseudo-selector with no effect like `:not()` and a different tag name.
 
-```typescript
-@Component({
-  selector: 'my-component:not(p)',
-  template: 'empty-template',
-})
-class SomeMocked {}
-```
+   ```typescript
+   @Component({
+     selector: 'my-component:not(p)',
+     template: 'empty-template',
+   })
+   class SomeMocked {}
+   ```
 
 1. Add an extra host attribute to one of the components.
 
-```typescript
-@Component({
-  selector: 'my-component',
-  template: 'complex-template',
-  host: {'some-binding': 'some-value'},
-})
-class Some {}
-```
+   ```typescript
+   @Component({
+     selector: 'my-component',
+     template: 'complex-template',
+     host: {'some-binding': 'some-value'},
+   })
+   class Some {}
+   ```


### PR DESCRIPTION
Fenced code blocks between list items in NG0912.md were not indented, causing Marked.js to treat them as top-level block elements that interrupt the list. This resulted in two separate **ol** elements being rendered instead of one. Indent the code blocks by 4 spaces so they are treated as continuation content of their list items, and change the second `1.` to `2.` for correctness.

## What is the current behavior?
<img width="1644" height="1374" alt="image" src="https://github.com/user-attachments/assets/0d357ec0-4438-403f-9531-5202940c9909" />

## What is the new behavior?
<img width="1636" height="1432" alt="image" src="https://github.com/user-attachments/assets/4e853e3d-d759-4e34-a95a-a7ccfd0f9fe8" />
