### PR TITLE
refactor(forms): improve type safety of RadioControlRegistry._accessors

### DIFF
--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -53,7 +53,7 @@ function throwNameError() {
  */
 @Service()
 export class RadioControlRegistry {
-  private _accessors: any[] = [];
+  private _accessors: [NgControl, RadioControlValueAccessor][] = [];
 
   /**
    * @description


### PR DESCRIPTION
Replace `any[]` with `[NgControl, RadioControlValueAccessor][]` for the private `_accessors` field in `RadioControlRegistry`. This aligns the field type with how it is used in `add()`, `remove()`, `select()`, and `_isSameGroup()`, which already typed its parameter as `[NgControl, RadioControlValueAccessor]`.
