### PR TITLE
docs: use descriptive link text for the AI overview page link

### DIFF
--- a/adev/src/content/ai/develop-with-ai.md
+++ b/adev/src/content/ai/develop-with-ai.md
@@ -42,7 +42,7 @@ The Angular CLI includes an experimental [Model Context Protocol (MCP) server](h
 - <a href="/llms.txt" target="_blank">llms.txt</a> - an index file providing links to key files and resources.
 - <a href="/assets/context/llms-full.txt" target="_blank">llms-full.txt</a> - a more robust compiled set of resources describing how Angular works and how to build Angular applications.
 
-Be sure [to check out the overview page](/ai) for more information on how to integrate AI into your Angular applications.
+Be sure to check out the [overview page](/ai) for more information on how to integrate AI into your Angular applications.
 
 ## Web Codegen Scorer
 


### PR DESCRIPTION
The link on the "develop with AI" page wrapped the verb phrase "to check out the overview page" in the link text, burying the destination in a call-to-action. Per the adev writing guide's descriptive-link-text rule, link only the noun that names the destination.

Change the link text to "overview page" so it clearly indicates where the link goes.

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other

## What is the current behavior?

On the "develop with AI" page, the link to the AI overview page uses the link text "to check out the overview page". The link text swallows the verb phrase instead of naming the destination, which reads like a "click here" style call-to-action and contradicts the adev writing guide's guidance to use descriptive link text.

## What is the new behavior?

The link text is now just "overview page", so the anchor clearly indicates where the link leads. The surrounding sentence ("Be sure to check out the ...") is unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No