### PR TITLE
fix(docs-infra): restyle prefer/avoid code block headers

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -297,7 +297,7 @@ $code-font-size: 0.875rem;
 
   .docs-code:has(.docs-code-header) {
     button[docs-copy-source-code] {
-      top: 0.45rem;
+      top: 0.26rem;
     }
 
     .docs-code-header {
@@ -325,6 +325,9 @@ $code-font-size: 0.875rem;
 
   .docs-code-header {
     display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    height: 2.9rem;
     padding: 0.75rem;
 
     background: var(--subtle-purple);
@@ -333,25 +336,37 @@ $code-font-size: 0.875rem;
 
     .docs-code-avoid &,
     .docs-code-prefer & {
-      background: color-mix(in srgb, var(--style-color) 17%, var(--page-background));
-      color: color-mix(in srgb, var(--style-color) 60%, var(--primary-contrast));
+      background: color-mix(in srgb, var(--style-color) 15%, var(--octonary-contrast));
+      box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--style-color) 35%, transparent);
       h3 {
         color: color-mix(in srgb, var(--style-color) 60%, var(--primary-contrast));
+        font-weight: 700;
       }
     }
 
     .docs-code-header-style {
-      display: flex;
+      display: inline-flex;
       align-items: center;
-      font-size: 0.8rem;
+      gap: 0.4rem;
+      padding: 0.25rem 0.6rem;
+      border-radius: 6px;
+      background: color-mix(in srgb, var(--style-color) 20%, transparent);
+      font-size: 0.72rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      color: color-mix(in srgb, var(--style-color) 55%, var(--primary-contrast));
+
+      &:not(:last-child) {
+        margin-inline-end: 0.7rem;
+      }
 
       &::before {
+        color: var(--style-color);
         font-family: var(--icons);
-        margin-right: 0.5rem;
-      }
-      &:not(:last-child)::after {
-        content: '-';
-        margin: 0 0.5rem;
+        font-size: 0.9rem;
+        letter-spacing: normal;
+        text-transform: none;
       }
     }
 
@@ -366,7 +381,7 @@ $code-font-size: 0.875rem;
     .docs-code-header-style {
       .docs-code-avoid & {
         &::before {
-          content: 'dangerous';
+          content: 'close';
         }
       }
     }


### PR DESCRIPTION
This reworks the styling of the "Prefer" / "Avoid" `docs-code` block
headers so the two block types are easier to tell apart, and gives every
header variant the same height so the copy button stays centered.

Supersedes #69638, folding in its centering fix for the copy button offset
that #69030 introduced.

closes #69644 

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

<img width="829" height="345" alt="image" src="https://github.com/user-attachments/assets/7466a774-15cd-44bb-84ab-e9c86518605c" />

<img width="845" height="831" alt="image" src="https://github.com/user-attachments/assets/f1645697-c371-4f23-9017-877870b21a1b" />


## What is the new behavior?

<img width="824" height="324" alt="image" src="https://github.com/user-attachments/assets/c9e4b51f-189a-45d5-9302-5c247f8c9620" />

<img width="838" height="828" alt="image" src="https://github.com/user-attachments/assets/70c47433-f928-4417-923a-f4cd72836056" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No