### PR TITLE
fix(docs-infra): lock background scroll while the search dialog is open

### DIFF
--- a/adev/shared-docs/styles/_resets.scss
+++ b/adev/shared-docs/styles/_resets.scss
@@ -48,6 +48,11 @@
     overflow-y: auto;
     overflow-x: hidden;
     scrollbar-gutter: stable;
+
+    // Lock background scrolling while the search dialog is open as a modal.
+    &:has(docs-search-dialog dialog[open]) {
+      overflow: hidden;
+    }
   }
 
   html,


### PR DESCRIPTION
The search dialog (Cmd/Ctrl+K) opens as a native modal via `showModal()`, but the page behind it stayed scrollable, so scrolling drifted the underlying content beneath the blurred backdrop.

`body` already reserves a stable scrollbar gutter, so setting `overflow: hidden` while the dialog is open blocks background scrolling with no layout shift. The rule keys off the dialog's `[open]` state, so it restores automatically on every close path (Escape, click-outside, navigation) with no script involved.

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

https://github.com/user-attachments/assets/8b028b60-4569-4b35-959d-69eb2dffb2b7

## What is the new behavior?

https://github.com/user-attachments/assets/3c08c1af-3499-4737-bbf0-b5cc6ec2a610

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No