### PR TITLE
fix(compiler-cli): include toSignal in debugName transform

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/implicit_signal_debug_name_transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/implicit_signal_debug_name_transform.ts
@@ -231,6 +231,7 @@ const signalFunctions: ReadonlyMap<string, PackageName> = new Map([
   ['contentChild', 'core'],
   ['contentChildren', 'core'],
   ['effect', 'core'],
+  ['toSignal', 'core'],
   ['resource', 'core'],
   ['httpResource', 'common'],
 ]);

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -30,6 +30,7 @@ jasmine_test(
     timeout = "long",
     data = [
         ":ngtsc_lib",
+        "//:node_modules/rxjs",
         "//:node_modules/yargs",
         "//packages/compiler-cli/src/ngtsc/testing/fake_common:npm_package",
         "//packages/core:npm_package",

--- a/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
@@ -14,6 +14,7 @@ import {NgtscTestEnvironment} from './env';
 
 const testFiles = loadStandardTestFiles({
   fakeCommon: true,
+  rxjs: true,
 });
 
 const minifiedDevBuildOptions = {
@@ -2981,6 +2982,344 @@ runInEachFileSystem(() => {
           const contentWoNewLines = cleanNewLines(builtContent);
           expect(contentWoNewLines).toContain(
             'testHttpResource = httpResource( () => "/api", { debugName: "testHttpResource" } )',
+          );
+        });
+      });
+    });
+
+    describe('toSignal', () => {
+      it('should not insert debug info into toSignal function if not imported from angular core', () => {
+        env.write(
+          'test.ts',
+          `
+            import {Component} from '@angular/core';
+            import {of} from 'rxjs';
+            declare function toSignal(source: any): any;
+
+            @Component({
+                template: ''
+            }) class MyComponent {
+                testSignal = toSignal(of(0));
+            }
+          `,
+        );
+        env.driveMain();
+
+        const jsContents = env.getContents('test.js');
+        expect(jsContents).not.toContain('debugName');
+      });
+
+      it('should insert debug info into toSignal function if imported from angular core', () => {
+        env.write(
+          'test.ts',
+          `
+            import {Component} from '@angular/core';
+            import {toSignal} from '@angular/core/rxjs-interop';
+            import {of} from 'rxjs';
+
+            @Component({
+                template: ''
+            }) class MyComponent {
+                testSignal = toSignal(of(0));
+            }
+          `,
+        );
+        env.driveMain();
+
+        const jsContents = env.getContents('test.js');
+        expect(cleanNewLines(jsContents)).toContain(
+          `toSignal(of(0), /* @ts-ignore */ ...(ngDevMode ? [{ debugName: "testSignal" }] : /* istanbul ignore next */ []))`,
+        );
+      });
+
+      describe('Property Declaration Case', () => {
+        it('should tree-shake away debug info if in prod mode', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0));
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
+          expect(builtContent).not.toContain('debugName');
+          expect(cleanNewLines(builtContent)).toContain('toSignal( of(0) )');
+        });
+
+        it('should not tree-shake away debug info if in dev mode', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0));
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedDevBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(
+            `toSignal( of(0), { debugName: "testSignal" } )`,
+          );
+        });
+
+        it('should insert debug info into toSignal function that already has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0), { initialValue: 0 });
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          expect(cleanNewLines(jsContents)).toContain(
+            `toSignal(of(0), { ...(ngDevMode ? { debugName: "testSignal" } : /* istanbul ignore next */ {}), initialValue: 0 })`,
+          );
+        });
+
+        it('should tree-shake away debug info if in prod mode for toSignal function that has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0), { initialValue: 0 });
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(`toSignal(of(0), { initialValue: 0 })`);
+          expect(builtContent).not.toContain('ngDevMode');
+          expect(builtContent).not.toContain('debugName');
+        });
+
+        it('should not tree-shake away debug info if in dev mode and has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal = toSignal(of(0), { initialValue: 0 });
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedDevBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(
+            `toSignal(of(0), { debugName: "testSignal", initialValue: 0 })`,
+          );
+        });
+      });
+
+      describe('Property Assignment Case', () => {
+        it('should insert debug info into toSignal function', () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number|undefined>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0));
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          expect(cleanNewLines(jsContents)).toContain(
+            `toSignal(of(0), /* @ts-ignore */ ...(ngDevMode ? [{ debugName: "testSignal" }] : /* istanbul ignore next */ [])`,
+          );
+        });
+
+        it('should tree-shake away debug info if in prod mode', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number|undefined>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0));
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
+          expect(builtContent).not.toContain('debugName');
+          expect(cleanNewLines(builtContent)).toContain('toSignal( of(0) )');
+        });
+
+        it('should not tree-shake away debug info if in dev mode', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number|undefined>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0));
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedDevBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(
+            `toSignal( of(0), { debugName: "testSignal" } )`,
+          );
+        });
+
+        it('should insert debug info into toSignal function that already has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0), { initialValue: 0 });
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          expect(cleanNewLines(jsContents)).toContain(
+            `toSignal(of(0), { ...(ngDevMode ? { debugName: "testSignal" } : /* istanbul ignore next */ {}), initialValue: 0 })`,
+          );
+        });
+
+        it('should tree-shake away debug info if in prod mode for toSignal function that has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0), { initialValue: 0 });
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(`toSignal(of(0), { initialValue: 0 })`);
+          expect(builtContent).not.toContain('ngDevMode');
+          expect(builtContent).not.toContain('debugName');
+        });
+
+        it('should not tree-shake away debug info if in dev mode and has custom options', async () => {
+          env.write(
+            'test.ts',
+            `
+              import {Component, Signal} from '@angular/core';
+              import {toSignal} from '@angular/core/rxjs-interop';
+              import {of} from 'rxjs';
+
+              @Component({
+                  template: ''
+              }) class MyComponent
+              {
+                  testSignal: Signal<number>;
+                  constructor() {
+                      this.testSignal = toSignal(of(0), { initialValue: 0 });
+                  }
+              }
+            `,
+          );
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          const builtContent = (await esbuild.transform(jsContents, minifiedDevBuildOptions)).code;
+          expect(cleanNewLines(builtContent)).toContain(
+            `toSignal(of(0), { debugName: "testSignal", initialValue: 0 })`,
           );
         });
       });


### PR DESCRIPTION
the toSignal function received a debugName option in 0812ac3, but was not covered by the signalMetadataTransform which sets the debugName in dev mode automatically.


Trying to re-land #69461