### PR TITLE
fix(vscode-extension): Support inlay hint in inline templates

### DIFF
--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -290,13 +290,9 @@ export class AngularLanguageClient implements vscode.Disposable {
             return null;
           }
 
-          // For TypeScript files, only request Angular inlay hints when the
-          // visible range intersects supported decorator fields (e.g. inline
-          // template/style metadata). This matches the guarding strategy used
-          // by other Angular LSP features and avoids work on unsupported TS regions.
-          if (!isNotTypescriptOrSupportedDecoratorRange(document, range)) {
-            return null;
-          }
+          // For TypeScript files, we always request Angular inlay hints.
+          // The server is responsible for filtering hints that do not intersect
+          // with the requested span and unsupported TS regions.
 
           return next(document, range, token);
         },

--- a/vscode-ng-language-service/integration/e2e/helper.ts
+++ b/vscode-ng-language-service/integration/e2e/helper.ts
@@ -1,13 +1,20 @@
 import {setTimeout} from 'node:timers/promises';
 import * as vscode from 'vscode';
 
-import {APP_COMPONENT, FOO_TEMPLATE} from '../test_constants';
+import {
+  APP_COMPONENT,
+  FOO_TEMPLATE,
+  INLAY_HINTS_COMPONENT,
+  INLAY_HINTS_EXTERNAL_TEMPLATE,
+} from '../test_constants';
 
 export const COMPLETION_COMMAND = 'vscode.executeCompletionItemProvider';
 export const HOVER_COMMAND = 'vscode.executeHoverProvider';
 export const DEFINITION_COMMAND = 'vscode.executeDefinitionProvider';
 export const APP_COMPONENT_URI = vscode.Uri.file(APP_COMPONENT);
 export const FOO_TEMPLATE_URI = vscode.Uri.file(FOO_TEMPLATE);
+export const INLAY_HINTS_COMPONENT_URI = vscode.Uri.file(INLAY_HINTS_COMPONENT);
+export const INLAY_HINTS_EXTERNAL_TEMPLATE_URI = vscode.Uri.file(INLAY_HINTS_EXTERNAL_TEMPLATE);
 
 export async function activate(uri: vscode.Uri): Promise<void> {
   await vscode.window.showTextDocument(uri);

--- a/vscode-ng-language-service/integration/e2e/inlay_hints_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/inlay_hints_spec.ts
@@ -1,0 +1,93 @@
+import * as vscode from 'vscode';
+import {activate, INLAY_HINTS_COMPONENT_URI, INLAY_HINTS_EXTERNAL_TEMPLATE_URI} from './helper';
+
+const INLAY_HINT_COMMAND = 'vscode.executeInlayHintProvider';
+
+describe('Angular LS inlay hints', () => {
+  let previousForLoopVariableTypes: boolean | undefined;
+  let previousEditorInlayHintsEnabled: string | boolean | undefined;
+
+  beforeAll(async () => {
+    const angularConfig = vscode.workspace.getConfiguration('angular');
+    previousForLoopVariableTypes = angularConfig.get<boolean>(
+      'inlayHints.variableTypes.forLoopVariableTypes',
+    );
+    await angularConfig.update(
+      'inlayHints.variableTypes.forLoopVariableTypes',
+      true,
+      vscode.ConfigurationTarget.Workspace,
+    );
+
+    const editorConfig = vscode.workspace.getConfiguration('editor');
+    previousEditorInlayHintsEnabled = editorConfig.get<string | boolean>('inlayHints.enabled');
+    await editorConfig.update('inlayHints.enabled', 'on', vscode.ConfigurationTarget.Workspace);
+  });
+
+  afterAll(async () => {
+    const angularConfig = vscode.workspace.getConfiguration('angular');
+    await angularConfig.update(
+      'inlayHints.variableTypes.forLoopVariableTypes',
+      previousForLoopVariableTypes,
+      vscode.ConfigurationTarget.Workspace,
+    );
+
+    const editorConfig = vscode.workspace.getConfiguration('editor');
+    await editorConfig.update(
+      'inlayHints.enabled',
+      previousEditorInlayHintsEnabled,
+      vscode.ConfigurationTarget.Workspace,
+    );
+  });
+
+  it('should return an Angular-specific inlay hint for inline template', async () => {
+    await activate(INLAY_HINTS_COMPONENT_URI);
+
+    const inlineDocument = await vscode.workspace.openTextDocument(INLAY_HINTS_COMPONENT_URI);
+    const inlineRange = new vscode.Range(
+      new vscode.Position(0, 0),
+      inlineDocument.lineAt(inlineDocument.lineCount - 1).range.end,
+    );
+    const hints = await vscode.commands.executeCommand<vscode.InlayHint[]>(
+      INLAY_HINT_COMMAND,
+      INLAY_HINTS_COMPONENT_URI,
+      inlineRange,
+    );
+
+    expect(hints).toBeDefined();
+    expect(hints!.length).toBeGreaterThan(0);
+
+    const hasNumberHint = hints!.some((hint) => {
+      const label =
+        typeof hint.label === 'string' ? hint.label : hint.label.map((l) => l.value).join('');
+      return label.includes(': number');
+    });
+    expect(hasNumberHint).toBeTrue();
+  });
+
+  it('should return an Angular-specific inlay hint for external template', async () => {
+    await activate(INLAY_HINTS_EXTERNAL_TEMPLATE_URI);
+
+    const externalDocument = await vscode.workspace.openTextDocument(
+      INLAY_HINTS_EXTERNAL_TEMPLATE_URI,
+    );
+    const externalRange = new vscode.Range(
+      new vscode.Position(0, 0),
+      externalDocument.lineAt(externalDocument.lineCount - 1).range.end,
+    );
+    const hints = await vscode.commands.executeCommand<vscode.InlayHint[]>(
+      INLAY_HINT_COMMAND,
+      INLAY_HINTS_EXTERNAL_TEMPLATE_URI,
+      externalRange,
+    );
+
+    expect(hints).toBeDefined();
+    expect(hints!.length).toBeGreaterThan(0);
+
+    const hasNumberHint = hints!.some((hint) => {
+      const label =
+        typeof hint.label === 'string' ? hint.label : hint.label.map((l) => l.value).join('');
+      return label.includes(': number');
+    });
+    expect(hasNumberHint).toBeTrue();
+  });
+});

--- a/vscode-ng-language-service/integration/project/app/inlay_hints.component.ts
+++ b/vscode-ng-language-service/integration/project/app/inlay_hints.component.ts
@@ -1,0 +1,9 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'inlay-hints',
+  template: `@for (item of [1, 2, 3]; track item) {
+    {{ item }}
+  }`,
+})
+export class InlayHintsComponent {}

--- a/vscode-ng-language-service/integration/project/app/inlay_hints_external.component.html
+++ b/vscode-ng-language-service/integration/project/app/inlay_hints_external.component.html
@@ -1,0 +1,3 @@
+@for (item of [1, 2, 3]; track item) {
+  {{ item }}
+}

--- a/vscode-ng-language-service/integration/project/app/inlay_hints_external.component.ts
+++ b/vscode-ng-language-service/integration/project/app/inlay_hints_external.component.ts
@@ -1,0 +1,7 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'inlay-hints-external',
+  templateUrl: './inlay_hints_external.component.html',
+})
+export class InlayHintsExternalComponent {}

--- a/vscode-ng-language-service/integration/test_constants.ts
+++ b/vscode-ng-language-service/integration/test_constants.ts
@@ -30,4 +30,12 @@ export const FOO_TEMPLATE = join(PROJECT_PATH, 'app', 'foo.component.html');
 export const FOO_TEMPLATE_URI = pathToFileURL(FOO_TEMPLATE).href;
 export const FOO_COMPONENT = join(PROJECT_PATH, 'app', 'foo.component.ts');
 export const FOO_COMPONENT_URI = pathToFileURL(FOO_COMPONENT).href;
+export const INLAY_HINTS_COMPONENT = join(PROJECT_PATH, 'app', 'inlay_hints.component.ts');
+export const INLAY_HINTS_COMPONENT_URI = pathToFileURL(INLAY_HINTS_COMPONENT).href;
+export const INLAY_HINTS_EXTERNAL_TEMPLATE = join(
+  PROJECT_PATH,
+  'app',
+  'inlay_hints_external.component.html',
+);
+export const INLAY_HINTS_EXTERNAL_TEMPLATE_URI = pathToFileURL(INLAY_HINTS_EXTERNAL_TEMPLATE).href;
 export const TSCONFIG = join(PROJECT_PATH, 'tsconfig.json');


### PR DESCRIPTION
We were explicitly not supporting them with an early return.

fixes #69649
