### PR TITLE
fix(localize): use Object.hasOwn for placeholder lookup in translate

### DIFF
--- a/packages/localize/src/utils/src/translations.ts
+++ b/packages/localize/src/utils/src/translations.ts
@@ -68,7 +68,7 @@ export function translate(
   return [
     translation.messageParts,
     translation.placeholderNames.map((placeholder) => {
-      if (message.substitutions.hasOwnProperty(placeholder)) {
+      if (Object.hasOwn(message.substitutions, placeholder)) {
         return message.substitutions[placeholder];
       } else {
         throw new Error(

--- a/packages/localize/src/utils/test/translations_spec.ts
+++ b/packages/localize/src/utils/test/translations_spec.ts
@@ -137,6 +137,17 @@ describe('utils', () => {
       );
     });
 
+    it('should substitute a placeholder whose name shadows an Object.prototype member', () => {
+      // A placeholder legitimately named `hasOwnProperty` puts that key on the
+      // substitutions object, so calling it as a method would throw a TypeError.
+      expect(
+        doTranslate(
+          {'abc{$hasOwnProperty}def': 'abc{$hasOwnProperty}def'},
+          parts`abc${1 + 2}:hasOwnProperty:def`,
+        ),
+      ).toEqual(parts`abc${3}def`);
+    });
+
     it('(with identity translations) should render template literals as-is', () => {
       const translations = {
         'abc': 'abc',


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`translate()` calls `message.substitutions.hasOwnProperty(placeholder)` to decide whether a translation placeholder has a matching substitution. A message whose placeholder is legitimately named `hasOwnProperty` stores that key on the plain `substitutions` object built by `parseMessage`, which shadows the method, so the lookup calls the substitution value instead of the method and throws `TypeError: message.substitutions.hasOwnProperty is not a function`.

## What is the new behavior?

The lookup uses `Object.hasOwn(message.substitutions, placeholder)`, which resolves through `Object` and is unaffected by a shadowed key or a null-prototype object, so the placeholder resolves normally. This is the same swap made recently for `I18nSelectPipe`. Added a regression test that throws before the change and passes after.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information