### PR TITLE
docs: correct import path for AdminPage in routing guide

### DIFF
--- a/adev/src/content/guide/routing/define-routes.md
+++ b/adev/src/content/guide/routing/define-routes.md
@@ -28,7 +28,7 @@ A collection of routes looks like this:
 ```ts
 import {Routes} from '@angular/router';
 import {HomePage} from './home-page';
-import {AdminPage} from './about-page';
+import {AdminPage} from './admin-page';
 
 export const routes: Routes = [
   {


### PR DESCRIPTION
Fix: #69670