### PR TITLE
docs: fix import of `AdminPage` in Angular routing documentation #69670

### DIFF
--- a/adev/src/content/guide/routing/define-routes.md
+++ b/adev/src/content/guide/routing/define-routes.md
@@ -28,7 +28,7 @@ A collection of routes looks like this:
 ```ts
 import {Routes} from '@angular/router';
 import {HomePage} from './home-page';
-import {AdminPage} from './about-page';
+import {AdminPage} from './admin-page';
 
 export const routes: Routes = [
   {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
There is a discrepancy in the example given in the 'Define Routes' documentation, where `AdminPage` component is imported from `./about-page`, while the route path and component name both refer to `"admin"`.

Issue Number: #69670

## What is the new behavior?
`AdminPage` component is imported from `./admin-page`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
