### PR TITLE
Add conditional control-flow blocks in DevTools

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/tree-strategies/render-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/tree-strategies/render-tree.spec.ts
@@ -238,4 +238,79 @@ describe('render tree extraction', () => {
       }),
     );
   });
+
+  it('should extract conditional control flow blocks', () => {
+    // Represent:
+    //
+    // <app>
+    //   @if {
+    //     <if-child />
+    //   }
+    //   @switch {
+    //     <switch-child />
+    //   }
+    // </app>
+    const appNode = document.createElement('app');
+    const ifHostNode = document.createComment('if');
+    const ifChildNode = document.createElement('if-child');
+    const switchHostNode = document.createComment('switch');
+    const switchChildNode = document.createElement('switch-child');
+
+    appNode.appendChild(ifHostNode);
+    appNode.appendChild(ifChildNode);
+    appNode.appendChild(switchHostNode);
+    appNode.appendChild(switchChildNode);
+
+    componentMap.set(appNode, {});
+    componentMap.set(ifChildNode, {});
+    componentMap.set(switchChildNode, {});
+
+    controlFlowBlocksMap.set(appNode, [
+      {
+        type: ControlFlowBlockType.If,
+        hostNode: ifHostNode,
+        rootNodes: [ifChildNode],
+        branchCount: 2,
+        activeBranchIndex: 0,
+        defaultBranchIndex: 1,
+        conditionExpressions: ['showIf', null],
+      },
+      {
+        type: ControlFlowBlockType.Switch,
+        hostNode: switchHostNode,
+        rootNodes: [switchChildNode],
+        branchCount: 3,
+        activeBranchIndex: 0,
+        defaultBranchIndex: 0,
+        expression: 'selectedCase',
+        caseExpressions: [[], ['one'], ['two']],
+        hasExhaustiveCheck: true,
+      },
+    ]);
+
+    const rtree = treeStrategy.build(appNode);
+    const children = rtree[0].children;
+
+    expect(children.map((c) => c.tagName)).toEqual(['@if', '@switch']);
+    expect(children[0].controlFlowBlock).toEqual(
+      jasmine.objectContaining({
+        type: ControlFlowBlockType.If,
+        branchCount: 2,
+        activeBranchIndex: 0,
+        hasElseBlock: true,
+        conditionExpressions: ['showIf', null],
+      }),
+    );
+    expect(children[1].controlFlowBlock).toEqual(
+      jasmine.objectContaining({
+        type: ControlFlowBlockType.Switch,
+        caseCount: 3,
+        activeCaseIndex: 0,
+        defaultCaseIndex: 0,
+        expression: 'selectedCase',
+        caseExpressions: [[], ['one'], ['two']],
+        hasExhaustiveCheck: true,
+      }),
+    );
+  });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/utils/control-flow.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/utils/control-flow.ts
@@ -16,7 +16,9 @@ import {
   ControlFlowBlockType,
   ForLoopBlock,
   DeferBlock,
+  IfBlock,
   RenderedDeferBlock,
+  SwitchBlock,
 } from '../../../../../protocol';
 import {ComponentTreeNode} from '../../shared/interfaces';
 import {serializeValue} from '../../shared/state-serializer/state-serializer';
@@ -24,6 +26,8 @@ import {serializeValue} from '../../shared/state-serializer/state-serializer';
 const ELEMENT_NAME_MAP: {[key in ControlFlowBlockType]: string} = {
   [ControlFlowBlockType.Defer]: '@defer',
   [ControlFlowBlockType.For]: '@for',
+  [ControlFlowBlockType.If]: '@if',
+  [ControlFlowBlockType.Switch]: '@switch',
 };
 
 export function isControlFlowBlock(node: Node, iterator: ControlFlowBlocksIterator) {
@@ -64,11 +68,49 @@ export function mapToDevtoolsControlFlowModel(
           loadingBlock: block.loadingBlock,
         },
       } satisfies DeferBlock as DeferBlock;
+
+    case ControlFlowBlockTypeInternal.If:
+      return {
+        id: `ifId-${rootId}-${iteratorCurrentIdx}`,
+        type: ControlFlowBlockType.If,
+        branchCount: block.branchCount,
+        activeBranchIndex: block.activeBranchIndex,
+        hasElseBlock: block.defaultBranchIndex !== null,
+        conditionExpressions: normalizeBranchExpressions<string | null>(
+          block.conditionExpressions,
+          block.branchCount,
+          () => null,
+        ),
+      } satisfies IfBlock as IfBlock;
+
+    case ControlFlowBlockTypeInternal.Switch:
+      return {
+        id: `switchId-${rootId}-${iteratorCurrentIdx}`,
+        type: ControlFlowBlockType.Switch,
+        caseCount: block.branchCount,
+        activeCaseIndex: block.activeBranchIndex,
+        defaultCaseIndex: block.defaultBranchIndex,
+        expression: block.expression ?? null,
+        caseExpressions: normalizeBranchExpressions<string[]>(
+          block.caseExpressions,
+          block.branchCount,
+          () => [],
+        ),
+        hasExhaustiveCheck: !!block.hasExhaustiveCheck,
+      } satisfies SwitchBlock as SwitchBlock;
   }
 }
 
+function normalizeBranchExpressions<T>(
+  expressions: ReadonlyArray<T | null | undefined> | undefined,
+  branchCount: number,
+  defaultValue: () => T,
+): T[] {
+  return Array.from({length: branchCount}, (_, index) => expressions?.[index] ?? defaultValue());
+}
+
 /**
- * Creates a synthetic ComponentTreeNode for control flow blocks (@defer, @for).
+ * Creates a synthetic ComponentTreeNode for control flow blocks.
  */
 export function createControlFlowTreeNode(
   controlFlowBlock: ControlFlowBlockInternal,

--- a/devtools/projects/ng-devtools-backend/src/lib/profiling/capture.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/profiling/capture.ts
@@ -32,6 +32,8 @@ let hooks: Partial<Hooks> = {};
 const DIRECTIVE_CONTROL_FLOW: {[key in ControlFlowBlockType]: ElementProfile['type']} = {
   [ControlFlowBlockType.For]: 'for',
   [ControlFlowBlockType.Defer]: 'defer',
+  [ControlFlowBlockType.If]: 'if',
+  [ControlFlowBlockType.Switch]: 'switch',
 };
 
 export const start = (onFrame: (frame: ProfilerFrame) => void): void => {

--- a/devtools/projects/ng-devtools-backend/src/lib/profiling/capture.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/profiling/capture.ts
@@ -34,6 +34,8 @@ let hooks: Partial<Hooks> = {};
 const DIRECTIVE_CONTROL_FLOW: {[key in ControlFlowBlockType]: ElementProfile['type']} = {
   [ControlFlowBlockType.For]: 'for',
   [ControlFlowBlockType.Defer]: 'defer',
+  [ControlFlowBlockType.If]: 'if',
+  [ControlFlowBlockType.Switch]: 'switch',
 };
 
 export const start = (onFrame: (frame: ProfilerFrame) => void): void => {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.html
@@ -51,6 +51,30 @@
         ({{ forLoop.items.length }} {{ forLoop.items.length === 1 ? 'item' : 'items' }})
       </span>
     }
+  } @else if (BlockType.isIfBlock(block)) {
+    @let ifBlock = block;
+
+    @if (ifBlock) {
+      @if (ifBlock.activeBranchIndex === null) {
+        <span class="trait">(non-rendered)</span>
+      } @else if (ifBlock.activeBranchIndex === ifBlock.branchCount - 1 && ifBlock.hasElseBlock) {
+        <span class="trait">(&#64;else)</span>
+      } @else if (ifBlock.activeBranchIndex > 0) {
+        <span class="trait">(&#64;else if)</span>
+      }
+    }
+  } @else if (BlockType.isSwitchBlock(block)) {
+    @let switchBlock = block;
+
+    @if (switchBlock) {
+      @if (switchBlock.activeCaseIndex === null) {
+        <span class="trait">(no match)</span>
+      } @else if (switchBlock.activeCaseIndex === switchBlock.defaultCaseIndex) {
+        <span class="trait">(&#64;default)</span>
+      } @else {
+        <span class="trait">(&#64;case {{ switchBlock.activeCaseIndex + 1 }})</span>
+      }
+    }
   } @else if (!hydration || hydration.status !== 'dehydrated') {
     <!-- Shown/hidden via CSS -->
     <span class="console-reference trait"> == $ng0 </span>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/BUILD.bazel
@@ -19,6 +19,7 @@ ng_project(
     deps = [
         "//:node_modules/@angular/core",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest",
+        "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/defer-view",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/for-loop-view",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane-header",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/BUILD.bazel
@@ -1,0 +1,44 @@
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
+
+package(default_visibility = ["//visibility:public"])
+
+sass_binary(
+    name = "conditional_view_component_styles",
+    src = "conditional-view.component.scss",
+)
+
+ng_project(
+    name = "conditional-view",
+    srcs = [
+        "conditional-view.component.ts",
+    ],
+    angular_assets = [
+        "conditional-view.component.html",
+        ":conditional_view_component_styles",
+        "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/styles:view_tab_styles",
+    ],
+    deps = [
+        "//:node_modules/@angular/core",
+        "//:node_modules/@angular/material",
+        "//devtools/projects/protocol",
+    ],
+)
+
+ts_test_library(
+    name = "conditional_view_test",
+    srcs = ["conditional-view.component.spec.ts"],
+    deps = [
+        ":conditional-view",
+        "//:node_modules/@angular/core",
+        "//:node_modules/@angular/platform-browser",
+        "//devtools/projects/protocol",
+    ],
+)
+
+zoneless_web_test_suite(
+    name = "test",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":conditional_view_test",
+    ],
+)

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,24 +21,5 @@ ng_project(
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/material",
         "//devtools/projects/protocol",
-    ],
-)
-
-ts_test_library(
-    name = "conditional_view_test",
-    srcs = ["conditional-view.component.spec.ts"],
-    deps = [
-        ":conditional-view",
-        "//:node_modules/@angular/core",
-        "//:node_modules/@angular/platform-browser",
-        "//devtools/projects/protocol",
-    ],
-)
-
-zoneless_web_test_suite(
-    name = "test",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":conditional_view_test",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/conditional-view.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/conditional-view.component.html
@@ -1,0 +1,25 @@
+@if (primaryExpression(); as expression) {
+  <mat-toolbar class="section-heading">Expression</mat-toolbar>
+  <div class="details">
+    <span class="pill">{{ expression }}</span>
+  </div>
+}
+
+<mat-toolbar class="section-heading">Rendered block</mat-toolbar>
+<div class="details">
+  @if (renderedBlock(); as block) {
+    <span class="pill flagged">{{ block }}</span>
+  } @else {
+    <em>{{ emptyRenderedBlockLabel() }}</em>
+  }
+</div>
+
+<mat-toolbar class="section-heading">Declared blocks</mat-toolbar>
+<div class="details">
+  @for (block of declaredBlocks(); track $index) {
+    <span class="pill">{{ block }}</span>
+  }
+</div>
+
+<mat-toolbar class="section-heading">State</mat-toolbar>
+<div class="details">{{ state() }}</div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/conditional-view.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/conditional-view.component.scss
@@ -1,0 +1,6 @@
+.details {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/conditional-view.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/conditional-view/conditional-view.component.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, computed, input} from '@angular/core';
+import {MatToolbar} from '@angular/material/toolbar';
+
+import {ControlFlowBlockType, IfBlock, SwitchBlock} from '../../../../../../../protocol';
+
+type ConditionalBlock = IfBlock | SwitchBlock;
+
+@Component({
+  selector: 'ng-conditional-view',
+  templateUrl: './conditional-view.component.html',
+  styleUrls: ['./conditional-view.component.scss', '../styles/view-tab.scss'],
+  imports: [MatToolbar],
+})
+export class ConditionalViewComponent {
+  protected readonly block = input.required<IfBlock | SwitchBlock>();
+
+  protected readonly primaryExpression = computed(() => getPrimaryExpression(this.block()));
+
+  protected readonly renderedBlock = computed(() => {
+    const activeIndex = getActiveBlockIndex(this.block());
+    if (activeIndex === null) {
+      return null;
+    }
+
+    return this.declaredBlocks()[activeIndex] ?? null;
+  });
+
+  protected readonly emptyRenderedBlockLabel = computed(() =>
+    getEmptyRenderedBlockLabel(this.block()),
+  );
+
+  protected readonly declaredBlocks = computed(() => getDeclaredBlocks(this.block()));
+
+  protected readonly state = computed(() => getStateLabel(this.block()));
+}
+
+function getPrimaryExpression(block: ConditionalBlock): string | null {
+  return isIfBlock(block) ? (block.conditionExpressions?.[0] ?? null) : block.expression;
+}
+
+function getActiveBlockIndex(block: ConditionalBlock): number | null {
+  return isIfBlock(block) ? block.activeBranchIndex : block.activeCaseIndex;
+}
+
+function getEmptyRenderedBlockLabel(block: ConditionalBlock): string {
+  return isIfBlock(block) ? 'Nothing rendered' : 'No case matched';
+}
+
+function getDeclaredBlocks(block: ConditionalBlock): string[] {
+  if (isIfBlock(block)) {
+    return getDeclaredIfBlocks(block);
+  }
+
+  return getDeclaredSwitchBlocks(block);
+}
+
+function getDeclaredIfBlocks(block: IfBlock): string[] {
+  return Array.from({length: block.branchCount}, (_, index) => getIfBranchLabel(block, index));
+}
+
+function getIfBranchLabel(block: IfBlock, index: number): string {
+  if (index === 0) {
+    return formatBlockWithExpression('@if', block.conditionExpressions?.[index] ?? null);
+  }
+
+  if (isElseBranch(block, index)) {
+    return '@else';
+  }
+
+  return formatBlockWithExpression('@else if', block.conditionExpressions?.[index] ?? null);
+}
+
+function isElseBranch(block: IfBlock, index: number): boolean {
+  return block.hasElseBlock && index === block.branchCount - 1;
+}
+
+function getDeclaredSwitchBlocks(block: SwitchBlock): string[] {
+  const blocks = Array.from({length: block.caseCount}, (_, index) =>
+    getSwitchCaseLabel(block, index),
+  );
+
+  if (block.hasExhaustiveCheck) {
+    blocks.push('@default never');
+  }
+
+  return blocks;
+}
+
+function getSwitchCaseLabel(block: SwitchBlock, index: number): string {
+  if (index === block.defaultCaseIndex) {
+    return '@default';
+  }
+
+  return formatSwitchCase(block.caseExpressions?.[index] ?? []);
+}
+
+function getStateLabel(block: ConditionalBlock): string {
+  const activeIndex = getActiveBlockIndex(block);
+  const count = getRenderableBlockCount(block);
+  const unit = isIfBlock(block) ? 'branch' : 'case group';
+
+  if (activeIndex === null) {
+    return `${count} declared, none active`;
+  }
+
+  return `Active ${unit} ${activeIndex + 1} of ${count}`;
+}
+
+function getRenderableBlockCount(block: ConditionalBlock): number {
+  if (isIfBlock(block)) {
+    return block.branchCount;
+  }
+
+  return block.caseCount;
+}
+
+function isIfBlock(block: ConditionalBlock): block is IfBlock {
+  return block.type === ControlFlowBlockType.If;
+}
+
+function formatBlockWithExpression(name: string, expression: string | null): string {
+  return expression ? `${name} (${expression})` : name;
+}
+
+function formatSwitchCase(expressions: string[]): string {
+  if (expressions.length === 0) {
+    return '@case (?)';
+  }
+
+  return expressions.map((expression) => `@case (${expression})`).join(', ');
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane.component.html
@@ -32,6 +32,8 @@
       <ng-defer-view [defer]="block" />
     } @else if (BlockType.isForLoopBlock(block)) {
       <ng-for-loop-view [forLoop]="block" />
+    } @else if (BlockType.isConditionalBlock(block)) {
+      <ng-conditional-view [block]="block" />
     }
   </div>
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane.component.ts
@@ -11,6 +11,7 @@ import {DirectivePosition} from '../../../../../../protocol';
 
 import {IndexedNode} from '../directive-forest/index-forest';
 import {PropertyPaneHeaderComponent} from './property-pane-header/property-pane-header.component';
+import {ConditionalViewComponent} from './conditional-view/conditional-view.component';
 import {DeferViewComponent} from './defer-view/defer-view.component';
 import {ForLoopViewComponent} from './for-loop-view/for-loop-view.component';
 import {PropertyViewComponent} from './property-view/property-view.component';
@@ -25,6 +26,7 @@ import {BlockType} from '../../../shared/utils/control-flow';
   imports: [
     PropertyPaneHeaderComponent,
     PropertyViewComponent,
+    ConditionalViewComponent,
     DeferViewComponent,
     ForLoopViewComponent,
   ],

--- a/devtools/projects/ng-devtools/src/lib/shared/utils/control-flow.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/utils/control-flow.ts
@@ -11,6 +11,8 @@ import {
   ControlFlowBlockType,
   DeferBlock,
   ForLoopBlock,
+  IfBlock,
+  SwitchBlock,
 } from '../../../../../protocol';
 
 export const BlockType = {
@@ -20,5 +22,19 @@ export const BlockType = {
 
   isForLoopBlock(node: ControlFlowBlock | null): node is ForLoopBlock {
     return !!node && node.type === ControlFlowBlockType.For;
+  },
+
+  isIfBlock(node: ControlFlowBlock | null): node is IfBlock {
+    return !!node && node.type === ControlFlowBlockType.If;
+  },
+
+  isSwitchBlock(node: ControlFlowBlock | null): node is SwitchBlock {
+    return !!node && node.type === ControlFlowBlockType.Switch;
+  },
+
+  isConditionalBlock(node: ControlFlowBlock | null): node is IfBlock | SwitchBlock {
+    return (
+      !!node && (node.type === ControlFlowBlockType.If || node.type === ControlFlowBlockType.Switch)
+    );
   },
 };

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -77,6 +77,8 @@ export type HydrationStatus =
 export enum ControlFlowBlockType {
   Defer,
   For,
+  If,
+  Switch,
 }
 
 export interface ControlFlowBlock {
@@ -109,6 +111,24 @@ export interface ForLoopBlock extends ControlFlowBlock {
   hasEmptyBlock: boolean;
   items: Descriptor[];
   trackExpression: string;
+}
+
+export interface IfBlock extends ControlFlowBlock {
+  type: ControlFlowBlockType.If;
+  branchCount: number;
+  activeBranchIndex: number | null;
+  hasElseBlock: boolean;
+  conditionExpressions: Array<string | null>;
+}
+
+export interface SwitchBlock extends ControlFlowBlock {
+  type: ControlFlowBlockType.Switch;
+  caseCount: number;
+  activeCaseIndex: number | null;
+  defaultCaseIndex: number | null;
+  expression: string | null;
+  caseExpressions: string[][];
+  hasExhaustiveCheck: boolean;
 }
 
 export type ChangeDetection = 'ng-on-push' | 'ng-eager' | 'acx-on-push' | 'acx-default';
@@ -307,7 +327,7 @@ export interface DirectiveProfile {
 export interface ElementProfile {
   directives: DirectiveProfile[];
   children: ElementProfile[];
-  type: 'element' | 'defer' | 'for';
+  type: 'element' | 'defer' | 'for' | 'if' | 'switch';
 }
 
 export interface ProfilerFrame {

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -78,6 +78,8 @@ export type HydrationStatus =
 export enum ControlFlowBlockType {
   Defer,
   For,
+  If,
+  Switch,
 }
 
 export interface ControlFlowBlock {
@@ -110,6 +112,24 @@ export interface ForLoopBlock extends ControlFlowBlock {
   hasEmptyBlock: boolean;
   items: Descriptor[];
   trackExpression: string;
+}
+
+export interface IfBlock extends ControlFlowBlock {
+  type: ControlFlowBlockType.If;
+  branchCount: number;
+  activeBranchIndex: number | null;
+  hasElseBlock: boolean;
+  conditionExpressions: Array<string | null>;
+}
+
+export interface SwitchBlock extends ControlFlowBlock {
+  type: ControlFlowBlockType.Switch;
+  caseCount: number;
+  activeCaseIndex: number | null;
+  defaultCaseIndex: number | null;
+  expression: string | null;
+  caseExpressions: string[][];
+  hasExhaustiveCheck: boolean;
 }
 
 export type ChangeDetection = 'ng-on-push' | 'ng-eager' | 'acx-on-push' | 'acx-default';
@@ -308,7 +328,7 @@ export interface DirectiveProfile {
 export interface ElementProfile {
   directives: DirectiveProfile[];
   children: ElementProfile[];
-  type: 'element' | 'defer' | 'for';
+  type: 'element' | 'defer' | 'for' | 'if' | 'switch';
 }
 
 export interface ProfilerFrame {

--- a/devtools/src/app/demo-app/todo/home/BUILD.bazel
+++ b/devtools/src/app/demo-app/todo/home/BUILD.bazel
@@ -7,10 +7,17 @@ sass_binary(
     src = "todo.component.scss",
 )
 
+sass_binary(
+    name = "control_flow_cases_styles",
+    src = "control-flow-cases.component.scss",
+)
+
 ng_project(
     name = "home",
     srcs = [
+        "control-flow-cases.component.ts",
         "home.routes.ts",
+        "rendered-text.component.ts",
         "sample.pipe.ts",
         "todo.component.ts",
         "todo.ts",
@@ -20,8 +27,10 @@ ng_project(
         "tooltip.directive.ts",
     ],
     angular_assets = [
+        "control-flow-cases.component.html",
         "todos.component.html",
         "todo.component.html",
+        ":control_flow_cases_styles",
         ":home_styles",
     ],
     deps = [

--- a/devtools/src/app/demo-app/todo/home/control-flow-cases.component.html
+++ b/devtools/src/app/demo-app/todo/home/control-flow-cases.component.html
@@ -1,0 +1,122 @@
+<section class="control-flow-cases" aria-label="Control flow validation cases">
+  <div class="case-grid">
+    <article class="case-card">
+      <h3>&#64;if alias with nested narrowing</h3>
+      @if (selectedProfile; as profile) {
+        @if (profile.role === 'admin' && profile.quota.remaining > 10) {
+          <app-rendered-text [text]="'Admin ' + profile.name + ' has quota.'" />
+        } @else {
+          <app-rendered-text class="muted" text="Profile exists without admin quota." />
+        }
+      } @else {
+        <app-rendered-text class="muted" text="No profile selected." />
+      }
+    </article>
+
+    <article class="case-card">
+      <h3>&#64;if else-if chain with expressions</h3>
+      @if (ifCase === 'ready' && (selectedProfile?.quota?.remaining ?? 0) > 10) {
+        <app-rendered-text text="Ready with quota." />
+      } @else if (ifCase === 'error' || selectedProfile?.role === 'viewer') {
+        <app-rendered-text class="danger" text="Blocked or viewer-only state." />
+      } @else if (ifCase === 'loading' && selectedProfile?.tasks !== 0) {
+        <app-rendered-text text="Loading assigned work." />
+      } @else {
+        <app-rendered-text class="muted" text="Fallback branch." />
+      }
+    </article>
+
+    <article class="case-card">
+      <h3>&#64;switch with grouped cases and default</h3>
+      @switch (filterCase) {
+        @case ('all')
+        @case ('active') {
+          <app-rendered-text text="Shared all/active branch." />
+        }
+        @case ('completed') {
+          <app-rendered-text text="Completed branch." />
+        }
+        @default {
+          <app-rendered-text class="muted" text="Default branch for archived." />
+        }
+      }
+    </article>
+
+    <article class="case-card">
+      <h3>&#64;switch case expressions</h3>
+      @switch (priorityScore + priorityOffset) {
+        @case (criticalPriority) {
+          <app-rendered-text class="danger" text="Critical priority." />
+        }
+        @case (warningPriority) {
+          <app-rendered-text text="Warning priority." />
+        }
+        @default {
+          <app-rendered-text class="muted" text="Unmatched priority expression." />
+        }
+      }
+    </article>
+
+    <article class="case-card">
+      <h3>&#64;switch type narrowing</h3>
+      @let narrowed = narrowedSwitchValue;
+      @switch (narrowed.kind) {
+        @case ('text') {
+          <app-rendered-text [text]="'Text length: ' + narrowed.text.length" />
+        }
+        @case ('count') {
+          <app-rendered-text [text]="'Count doubled: ' + narrowed.count * 2" />
+        }
+        @case ('flag') {
+          <app-rendered-text
+            [text]="'Flag is ' + (narrowed.enabled ? 'enabled' : 'disabled') + '.'"
+          />
+        }
+      }
+    </article>
+
+    <article class="case-card">
+      <h3>Exhaustive &#64;switch default never</h3>
+      @switch (exhaustiveNeverCase) {
+        @case ('loggedOut') {
+          <app-rendered-text class="muted" text="Logged out branch." />
+        }
+        @case ('loading') {
+          <app-rendered-text text="Loading branch." />
+        }
+        @case ('loggedIn') {
+          <app-rendered-text text="Logged in branch." />
+        }
+        @default never;
+      }
+    </article>
+
+    <article class="case-card">
+      <h3>&#64;switch without default and no match</h3>
+      @switch (noDefaultCase) {
+        @case ('draft') {
+          <app-rendered-text text="Draft branch." />
+        }
+        @case ('queued') {
+          <app-rendered-text text="Queued branch." />
+        }
+      }
+      <app-rendered-text class="muted" text="No branch renders for the expired value." />
+    </article>
+
+    <article class="case-card">
+      <h3>&#64;switch default before cases</h3>
+      @switch (defaultFirstCase) {
+        @default {
+          <app-rendered-text class="muted" text="Default appears before the explicit cases." />
+        }
+        @case ('retry') {
+          <app-rendered-text text="Retry branch." />
+        }
+        @case ('success') {
+          <app-rendered-text text="Success branch." />
+        }
+      }
+    </article>
+  </div>
+</section>

--- a/devtools/src/app/demo-app/todo/home/control-flow-cases.component.scss
+++ b/devtools/src/app/demo-app/todo/home/control-flow-cases.component.scss
@@ -1,0 +1,26 @@
+.control-flow-cases {
+  margin: 2rem 0;
+  padding: 1rem;
+  border: 1px solid #d7dce2;
+  border-radius: 8px;
+  background: #f7f9fb;
+}
+
+.case-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 0.75rem;
+}
+
+.case-card {
+  min-height: 8rem;
+  padding: 0.75rem;
+  border: 1px solid #d7dce2;
+  border-radius: 8px;
+  background: #fff;
+
+  h3 {
+    margin: 0 0 0.5rem;
+    font-size: 0.95rem;
+  }
+}

--- a/devtools/src/app/demo-app/todo/home/control-flow-cases.component.ts
+++ b/devtools/src/app/demo-app/todo/home/control-flow-cases.component.ts
@@ -26,9 +26,7 @@ interface Profile {
 }
 
 type NarrowedSwitchValue =
-  | {kind: 'text'; text: string}
-  | {kind: 'count'; count: number}
-  | {kind: 'flag'; enabled: boolean};
+  {kind: 'text'; text: string} | {kind: 'count'; count: number} | {kind: 'flag'; enabled: boolean};
 
 @Component({
   selector: 'app-control-flow-cases',

--- a/devtools/src/app/demo-app/todo/home/control-flow-cases.component.ts
+++ b/devtools/src/app/demo-app/todo/home/control-flow-cases.component.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component} from '@angular/core';
+
+import {RenderedTextComponent} from './rendered-text.component';
+
+type IfCase = 'loading' | 'ready' | 'error';
+type FilterCase = 'all' | 'active' | 'completed' | 'archived';
+type NoDefaultCase = 'draft' | 'queued' | 'expired';
+type DefaultFirstCase = 'retry' | 'success' | 'unknown';
+type ExhaustiveNeverCase = 'loggedOut' | 'loading' | 'loggedIn';
+
+interface Profile {
+  name: string;
+  role: 'admin' | 'editor' | 'viewer';
+  tasks: number;
+  quota: {
+    remaining: number;
+  };
+}
+
+type NarrowedSwitchValue =
+  | {kind: 'text'; text: string}
+  | {kind: 'count'; count: number}
+  | {kind: 'flag'; enabled: boolean};
+
+@Component({
+  selector: 'app-control-flow-cases',
+  imports: [RenderedTextComponent],
+  templateUrl: 'control-flow-cases.component.html',
+  styleUrls: ['./control-flow-cases.component.scss'],
+})
+export class ControlFlowCasesComponent {
+  readonly selectedProfile: Profile | null = {
+    name: 'Ada',
+    role: 'admin',
+    tasks: 3,
+    quota: {remaining: 25},
+  };
+  readonly ifCase: IfCase = 'error';
+  readonly filterCase: FilterCase = 'archived';
+  readonly priorityScore = 10;
+  readonly priorityOffset = 10;
+  readonly criticalPriority = 90;
+  readonly warningPriority = 40;
+  readonly narrowedSwitchValue: NarrowedSwitchValue = {kind: 'count', count: 21};
+  readonly exhaustiveNeverCase: ExhaustiveNeverCase = 'loading';
+  readonly noDefaultCase: NoDefaultCase = 'expired';
+  readonly defaultFirstCase: DefaultFirstCase = 'unknown';
+}

--- a/devtools/src/app/demo-app/todo/home/rendered-text.component.ts
+++ b/devtools/src/app/demo-app/todo/home/rendered-text.component.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, input} from '@angular/core';
+
+@Component({
+  selector: 'app-rendered-text',
+  template: '{{ text() }}',
+  styles: `
+    :host {
+      display: block;
+      margin: 0 0 0.5rem;
+      color: #0f5132;
+    }
+
+    :host(.muted) {
+      color: #4b5563;
+    }
+
+    :host(.danger) {
+      color: #842029;
+    }
+  `,
+})
+export class RenderedTextComponent {
+  readonly text = input.required<string>();
+}

--- a/devtools/src/app/demo-app/todo/home/todos.component.html
+++ b/devtools/src/app/demo-app/todo/home/todos.component.html
@@ -46,4 +46,6 @@
   </foreignObject>
 </svg>
 
+<app-control-flow-cases />
+
 <recursive-component />

--- a/devtools/src/app/demo-app/todo/home/todos.component.ts
+++ b/devtools/src/app/demo-app/todo/home/todos.component.ts
@@ -23,6 +23,7 @@ import {SamplePipe} from './sample.pipe';
 import {TooltipDirective} from './tooltip.directive';
 import {TodoComponent} from './todo.component';
 import {RouterLink} from '@angular/router';
+import {ControlFlowCasesComponent} from './control-flow-cases.component';
 
 const fib = (n: number): number => {
   if (n === 1 || n === 2) {
@@ -75,6 +76,7 @@ export class SvgDemoComponent {}
     TodosFilter,
     RecursiveComponent,
     SvgDemoComponent,
+    ControlFlowCasesComponent,
   ],
 })
 export class TodosComponent implements OnInit, OnDestroy {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_content_fallback.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_content_fallback.js
@@ -67,6 +67,7 @@ $r3$.ɵɵdefineComponent({
       $r3$.ɵɵprojection(3, 1, null, TestComponent_ProjectionFallback_3_Template, 5, 1);
       $r3$.ɵɵdomElementEnd();
       $r3$.ɵɵconditionalCreate(5, TestComponent_Conditional_5_Template, 2, 0);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(5, "if", 1, null, "hasFooter", ["hasFooter"]);
       $r3$.ɵɵdomTemplate(6, TestComponent_ng_content_6_Template, 2, 0, "ng-content", 0);
     }
     if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
@@ -46,6 +46,7 @@ function TestCmpConditional_Conditional_0_Conditional_0_Template(rf, ctx) {
 function TestCmpConditional_Conditional_0_Template(rf, ctx) {
   if (rf & 1) {
     i0.ɵɵconditionalCreate(0, TestCmpConditional_Conditional_0_Conditional_0_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵɵconditionalMetadata(0, "if", 1, null, "innerCondition", ["innerCondition"]);
   }
   if (rf & 2) {
     const ctx_r0 = i0.ɵɵnextContext();
@@ -125,6 +126,7 @@ export class TestCmpConditional {
     template: function TestCmpConditional_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵconditionalCreate(0, TestCmpConditional_Conditional_0_Template, 1, 1);
+        (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵɵconditionalMetadata(0, "if", 1, null, "outerCondition", ["outerCondition"]);
       }
       if (rf & 2) {
         i0.ɵɵconditional(ctx.outerCondition ? 0 : -1);
@@ -133,5 +135,4 @@ export class TestCmpConditional {
     encapsulation: 2
   });
 }
-
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
@@ -46,6 +46,7 @@ function TestCmpConditional_Conditional_0_Conditional_0_Template(rf, ctx) {
 function TestCmpConditional_Conditional_0_Template(rf, ctx) {
   if (rf & 1) {
     i0.ɵɵconditionalCreate(0, TestCmpConditional_Conditional_0_Conditional_0_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵɵconditionalMetadata(0, "if", 1, null, "innerCondition", ["innerCondition"]);
   }
   if (rf & 2) {
     const ctx_r0 = i0.ɵɵnextContext();
@@ -129,6 +130,7 @@ export class TestCmpConditional {
     template: function TestCmpConditional_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵconditionalCreate(0, TestCmpConditional_Conditional_0_Template, 1, 1);
+        (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵɵconditionalMetadata(0, "if", 1, null, "outerCondition", ["outerCondition"]);
       }
       if (rf & 2) {
         i0.ɵɵconditional(ctx.outerCondition ? 0 : -1);
@@ -137,5 +139,4 @@ export class TestCmpConditional {
     encapsulation: 2
   });
 }
-
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_defined_let.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_defined_let.js
@@ -30,6 +30,7 @@ $r3$.ɵɵdefineComponent({
       $r3$.ɵɵdeclareLet(0);
       $r3$.ɵɵtext(1);
       $r3$.ɵɵconditionalCreate(2, TestComp_Conditional_2_Template, 2, 1);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 1, null, "true", ["true"]);
     }
     if (rf & 2) {
       const $fn_r6$ = $r3$.ɵɵstoreLet($r3$.ɵɵarrowFunction(2, $arrowFn0$, ctx));

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_dollar_event.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_dollar_event.js
@@ -28,6 +28,7 @@ $r3$.ɵɵdefineComponent({
     if (rf & 1) {
       $r3$.ɵɵdeclareLet(0);
       $r3$.ɵɵconditionalCreate(1, TestComp_Conditional_1_Template, 2, 1, "button");
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "true", ["true"]);
     }
     if (rf & 2) {
       $r3$.ɵɵstoreLet(1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_let_nested.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_let_nested.js
@@ -24,6 +24,7 @@ function TestComp_Conditional_1_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵdeclareLet(0);
     $r3$.ɵɵconditionalCreate(1, TestComp_Conditional_1_Conditional_1_Template, 2, 3);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "true", ["true"]);
   }
   if (rf & 2) {
     $r3$.ɵɵstoreLet(2);
@@ -40,6 +41,7 @@ $r3$.ɵɵdefineComponent({
     if (rf & 1) {
       $r3$.ɵɵdeclareLet(0);
       $r3$.ɵɵconditionalCreate(1, TestComp_Conditional_1_Template, 2, 2);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "true", ["true"]);
     }
     if (rf & 2) {
       $r3$.ɵɵstoreLet(1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_nested_listeners.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_nested_listeners.js
@@ -22,6 +22,7 @@ function TestComp_Conditional_1_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵdomElement(0, "input", null, 0);
     $r3$.ɵɵconditionalCreate(2, TestComp_Conditional_1_Conditional_2_Template, 2, 1, "button");
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 1, null, "true", ["true"]);
   }
   if (rf & 2) {
     $r3$.ɵɵadvance(2);
@@ -38,6 +39,7 @@ $r3$.ɵɵdefineComponent({
     if (rf & 1) {
       $r3$.ɵɵdeclareLet(0);
       $r3$.ɵɵconditionalCreate(1, TestComp_Conditional_1_Template, 3, 1);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "true", ["true"]);
     }
     if (rf & 2) {
       $r3$.ɵɵstoreLet(1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_returning_arrow_function_nested_context.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_returning_arrow_function_nested_context.js
@@ -20,6 +20,7 @@ function TestComp_Conditional_1_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵdeclareLet(0);
     $r3$.ɵɵconditionalCreate(1, TestComp_Conditional_1_Conditional_1_Template, 1, 2);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "true", ["true"]);
   }
   if (rf & 2) {
     $r3$.ɵɵstoreLet(2);
@@ -36,6 +37,7 @@ $r3$.ɵɵdefineComponent({
     if (rf & 1) {
       $r3$.ɵɵdeclareLet(0);
       $r3$.ɵɵconditionalCreate(1, TestComp_Conditional_1_Template, 2, 2);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "true", ["true"]);
     }
     if (rf & 2) {
       $r3$.ɵɵstoreLet(1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_safe_access_nested_views.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_safe_access_nested_views.js
@@ -16,6 +16,7 @@ function TestComp_Conditional_0_Conditional_0_Conditional_0_Template(rf, ctx) {
 function TestComp_Conditional_0_Conditional_0_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵconditionalCreate(0, TestComp_Conditional_0_Conditional_0_Conditional_0_Template, 1, 2);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "true", ["true"]);
   }
   if (rf & 2) {
     $r3$.ɵɵconditional(true ? 0 : -1);
@@ -25,6 +26,7 @@ function TestComp_Conditional_0_Conditional_0_Template(rf, ctx) {
 function TestComp_Conditional_0_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵconditionalCreate(0, TestComp_Conditional_0_Conditional_0_Template, 1, 1);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "true", ["true"]);
   }
   if (rf & 2) {
     $r3$.ɵɵconditional(true ? 0 : -1);
@@ -40,6 +42,7 @@ $r3$.ɵɵdefineComponent({
   template: function TestComp_Template(rf, ctx) {
     if (rf & 1) {
       $r3$.ɵɵconditionalCreate(0, TestComp_Conditional_0_Template, 1, 1);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "true", ["true"]);
     }
     if (rf & 2) {
       $r3$.ɵɵconditional(true ? 0 : -1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_safe_access_nested_views_use_null.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_arrow_functions/arrow_function_safe_access_nested_views_use_null.js
@@ -32,6 +32,7 @@ function TestComp_Conditional_0_Conditional_0_Conditional_0_Template(rf, ctx) {
 function TestComp_Conditional_0_Conditional_0_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵconditionalCreate(0, TestComp_Conditional_0_Conditional_0_Conditional_0_Template, 1, 2);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "true", ["true"]);
   }
   if (rf & 2) {
     $r3$.ɵɵconditional(true ? 0 : -1);
@@ -41,6 +42,7 @@ function TestComp_Conditional_0_Conditional_0_Template(rf, ctx) {
 function TestComp_Conditional_0_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵconditionalCreate(0, TestComp_Conditional_0_Conditional_0_Template, 1, 1);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "true", ["true"]);
   }
   if (rf & 2) {
     $r3$.ɵɵconditional(true ? 0 : -1);
@@ -56,6 +58,7 @@ $r3$.ɵɵdefineComponent({
   template: function TestComp_Template(rf, ctx) {
     if (rf & 1) {
       $r3$.ɵɵconditionalCreate(0, TestComp_Conditional_0_Template, 1, 1);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "true", ["true"]);
     }
     if (rf & 2) {
       $r3$.ɵɵconditional(true ? 0 : -1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if_template.js
@@ -27,6 +27,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 0)(3, MyApp_Conditional_3_Template, 1, 0)(4, MyApp_Conditional_4_Template, 1, 0)(5, MyApp_Conditional_5_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 4, 3, "value() === 1", ["value() === 1", "otherValue() === 2", "message", null]);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_template.js
@@ -15,6 +15,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 0)(3, MyApp_Conditional_3_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 2, 1, "value()", ["value()", null]);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_template.js
@@ -9,6 +9,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 1, null, "value()", ["value()"]);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch_template.js
@@ -27,6 +27,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Case_2_Template, 1, 0)(3, MyApp_Case_3_Template, 1, 0)(4, MyApp_Case_4_Template, 1, 0)(5, MyApp_Case_5_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "switch", 4, 3, "value()", [["0"], ["1"], ["2"], []]);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_multiple_with_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_multiple_with_alias_template.js
@@ -52,6 +52,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵdomElementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 1)(3, MyApp_Conditional_3_Template, 1, 1)(4, MyApp_Conditional_4_Template, 1, 1)(5, MyApp_Conditional_5_Template, 1, 1)(6, MyApp_Conditional_6_Template, 1, 1);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 5, null, "one", ["one", "two", "three", "four", "five"]);
     $r3$.ɵɵdomElementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_nested_with_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_nested_with_alias_template.js
@@ -28,6 +28,7 @@ function MyApp_Conditional_1_Conditional_2_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0);
     $r3$.ɵɵconditionalCreate(1, MyApp_Conditional_1_Conditional_2_Conditional_1_Template, 1, 0)(2, MyApp_Conditional_1_Conditional_2_Conditional_2_Template, 1, 4);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 2, null, "foo", ["foo", "value()"]);
   }
   if (rf & 2) {
     let $tmp_5_0$;
@@ -42,6 +43,7 @@ function MyApp_Conditional_1_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0);
     $r3$.ɵɵconditionalCreate(1, MyApp_Conditional_1_Conditional_1_Template, 1, 0)(2, MyApp_Conditional_1_Conditional_2_Template, 3, 4);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 2, null, "foo", ["foo", "value()"]);
   }
   if (rf & 2) {
     let $tmp_3_0$;
@@ -57,6 +59,7 @@ function MyApp_Conditional_1_Template(rf, ctx) {
 function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵconditionalCreate(0, MyApp_Conditional_0_Template, 1, 0)(1, MyApp_Conditional_1_Template, 3, 3);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 2, null, "foo", ["foo", "value()"]);
   }
   if (rf & 2) {
     let $tmp_0_0$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_alias_template.js
@@ -22,6 +22,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵdomElementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 1)(3, MyApp_Conditional_3_Template, 1, 2);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 2, null, "one", ["one", "value()"]);
     $r3$.ɵɵdomElementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_same_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_same_alias_template.js
@@ -22,6 +22,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵdomElementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 1)(3, MyApp_Conditional_3_Template, 1, 1);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 2, null, "one", ["one", "two"]);
     $r3$.ɵɵdomElementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners_template.js
@@ -25,6 +25,7 @@ function MyApp_Conditional_0_Conditional_1_Conditional_1_Template(rf, ctx) {
 	  });
 	  $r3$.ɵɵelementEnd();
 	  $r3$.ɵɵconditionalCreate(1, MyApp_Conditional_0_Conditional_1_Conditional_1_Template, 1, 0, "button");
+	  (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "value()", ["value()"]);
 	}
 	if (rf & 2) {
 	  let $MyApp_Conditional_0_Conditional_1_contFlowTmp$;
@@ -45,6 +46,7 @@ function MyApp_Conditional_0_Conditional_1_Conditional_1_Template(rf, ctx) {
 	  });
 	  $r3$.ɵɵelementEnd();
 	  $r3$.ɵɵconditionalCreate(1, MyApp_Conditional_0_Conditional_1_Template, 2, 1);
+	  (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "value()", ["value()"]);
 	}
 	if (rf & 2) {
 	  let $MyApp_Conditional_0_contFlowTmp$;
@@ -57,6 +59,7 @@ function MyApp_Conditional_0_Conditional_1_Conditional_1_Template(rf, ctx) {
   function MyApp_Template(rf, ctx) {
 	if (rf & 1) {
 	  $r3$.ɵɵconditionalCreate(0, MyApp_Conditional_0_Template, 2, 1);
+	  (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "value()", ["value()"]);
 	}
 	if (rf & 2) {
 	  let $MyApp_contFlowTmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_template.js
@@ -14,6 +14,7 @@ function MyApp_Conditional_0_Conditional_1_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0);
     $r3$.ɵɵconditionalCreate(1, MyApp_Conditional_0_Conditional_1_Conditional_1_Template, 1, 4);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "value()", ["value()"]);
   }
   if (rf & 2) {
     // NOTE: TODO: These ellipses were added because of a different variable order between
@@ -33,6 +34,7 @@ function MyApp_Conditional_0_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0);
     $r3$.ɵɵconditionalCreate(1, MyApp_Conditional_0_Conditional_1_Template, 2, 4);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "value()", ["value()"]);
   }
   if (rf & 2) {
     …
@@ -47,6 +49,7 @@ function MyApp_Conditional_0_Template(rf, ctx) {
 function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵconditionalCreate(0, MyApp_Conditional_0_Template, 2, 3);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "value()", ["value()"]);
   }
   if (rf & 2) {
     let $MyApp_contFlowTmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias_template.js
@@ -13,6 +13,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 2);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 1, null, "value()", ["value()"]);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe_template.js
@@ -24,6 +24,7 @@ function $MyApp_Conditional_3_Template$(rf, ctx) {
 	  $r3$.ɵɵpipe(3, "test");
 	  $r3$.ɵɵpipe(4, "test");
 	  $r3$.ɵɵconditionalBranchCreate(5, MyApp_Conditional_5_Template, 1, 0)(6, MyApp_Conditional_6_Template, 1, 0);
+	  (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 3, 2, "(val | test) === 1", ["(val | test) === 1", "(val | test) === 2", null]);
 	  $r3$.ɵɵdomElementEnd();
 	}
 	if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if_template.js
@@ -37,6 +37,7 @@ function MyApp_Conditional_4_Conditional_3_Template(rf, ctx) {
 function MyApp_Conditional_4_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵconditionalCreate(0, MyApp_Conditional_4_Conditional_0_Template, 1, 0)(1, MyApp_Conditional_4_Conditional_1_Template, 1, 0)(2, MyApp_Conditional_4_Conditional_2_Template, 1, 0)(3, MyApp_Conditional_4_Conditional_3_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 4, 3, "innerVal === 0", ["innerVal === 0", "innerVal === 1", "innerVal === 2", null]);
   }
   if (rf & 2) {
     const $ctx_r2$ = $r3$.ɵɵnextContext();
@@ -55,6 +56,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 0)(3, MyApp_Conditional_3_Template, 1, 0)(4, MyApp_Conditional_4_Template, 4, 1)(5, MyApp_Conditional_5_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 4, 3, "val === 0", ["val === 0", "val === 1", "val === 2", null]);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch_template.js
@@ -25,6 +25,7 @@ function MyApp_Case_3_Case_2_Template(rf, ctx) {
 function MyApp_Case_3_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵconditionalCreate(0, MyApp_Case_3_Case_0_Template, 1, 0)(1, MyApp_Case_3_Case_1_Template, 1, 0)(2, MyApp_Case_3_Case_2_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "switch", 3, null, "nestedValue()", [["0"], ["1"], ["2"]]);
   }
   if (rf & 2) {
     …
@@ -45,6 +46,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Case_2_Template, 1, 0)(3, MyApp_Case_3_Template, 3, 1)(4, MyApp_Case_4_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "switch", 3, null, "value()", [["0"], ["1"], ["2"]]);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_multiple_cases_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_multiple_cases_template.js
@@ -23,6 +23,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Case_2_Template, 0, 0)(3, MyApp_Case_3_Template, 1, 0)(4, MyApp_Case_4_Template, 1, 0)(5, MyApp_Case_5_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "switch", 4, 3, "value()", [["-1"], ["0", "1"], ["2"], []]);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe_template.js
@@ -7,6 +7,7 @@ function MyApp_Template(rf, ctx) {
 	  $r3$.ɵɵpipe(4, "test");
 	  $r3$.ɵɵpipe(5, "test");
 	  $r3$.ɵɵconditionalBranchCreate(6, MyApp_Case_6_Template, 1, 0)(7, MyApp_Case_7_Template, 1, 0);
+	  (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "switch", 3, 2, "value() | test", [["0 | test"], ["1 | test"], []]);
 	  $r3$.ɵɵdomElementEnd();
 	}
 	if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default_template.js
@@ -21,6 +21,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵconditionalCreate(2, MyApp_Case_2_Template, 1, 0)(3, MyApp_Case_3_Template, 1, 0)(4, MyApp_Case_4_Template, 1, 0);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "switch", 3, null, "value()", [["0"], ["1"], ["2"]]);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/blocks/conditional_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/blocks/conditional_template.js
@@ -85,7 +85,9 @@ export class MyApp {
       $r3$.ɵɵelementStart(0, "div");
       $r3$.ɵɵi18nStart(1, 0);
       $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 2, 0)(3, MyApp_Conditional_3_Template, 2, 0)(4, MyApp_Conditional_4_Template, 2, 0);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "if", 3, 2, "count === 0", ["count === 0", "count === 1", null]);
       $r3$.ɵɵconditionalCreate(5, MyApp_Conditional_5_Template, 2, 0);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(5, "if", 1, null, "count === 7", ["count === 7"]);
       $r3$.ɵɵi18nEnd();
       $r3$.ɵɵelementEnd();
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/blocks/switch_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/blocks/switch_template.js
@@ -73,6 +73,7 @@ export class MyApp {
       $r3$.ɵɵelementStart(0, "div");
       $r3$.ɵɵi18nStart(1, 0);
       $r3$.ɵɵconditionalCreate(2, MyApp_Case_2_Template, 2, 0)(3, MyApp_Case_3_Template, 2, 0)(4, MyApp_Case_4_Template, 2, 0);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(2, "switch", 3, 2, "count", [["0"], ["1"], []]);
       $r3$.ɵɵi18nEnd();
       $r3$.ɵɵelementEnd();
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/let_in_child_view_listener_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/let_in_child_view_listener_template.js
@@ -32,6 +32,7 @@ function MyApp_ng_template_1_Conditional_1_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵdeclareLet(0);
     $r3$.ɵɵconditionalCreate(1, MyApp_ng_template_1_Conditional_1_Case_1_Template, 2, 1, "button");
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "switch", 1, null, "1", [["1"]]);
   }
   if (rf & 2) {
     let $tmp_5_0$;
@@ -49,6 +50,7 @@ function MyApp_ng_template_1_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵdeclareLet(0);
     $r3$.ɵɵconditionalCreate(1, MyApp_ng_template_1_Conditional_1_Template, 2, 2);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(1, "if", 1, null, "true", ["true"]);
   }
   if (rf & 2) {
     $r3$.ɵɵnextContext();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/let_in_child_view_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/let_in_child_view_template.js
@@ -15,6 +15,7 @@ function MyApp_Conditional_0_Conditional_0_Template(rf, ctx) {
 function MyApp_Conditional_0_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵconditionalCreate(0, MyApp_Conditional_0_Conditional_0_Template, 1, 1);
+    (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "true", ["true"]);
     $r3$.ɵɵdeclareLet(1);
   }
   if (rf & 2) {
@@ -35,6 +36,7 @@ $r3$.ɵɵdefineComponent({
   template: function MyApp_Template(rf, ctx) {
     if (rf & 1) {
       $r3$.ɵɵconditionalCreate(0, MyApp_Conditional_0_Template, 2, 2);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "true", ["true"]);
       $r3$.ɵɵdeclareLet(1);
     }
     if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/let_optimization_child_view_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/let_optimization_child_view_template.js
@@ -21,6 +21,7 @@ $r3$.ɵɵdefineComponent({
       $r3$.ɵɵdeclareLet(1);
       $r3$.ɵɵtext(2);
       $r3$.ɵɵconditionalCreate(3, MyApp_Conditional_3_Template, 1, 1);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(3, "if", 1, null, "true", ["true"]);
     }
     if (rf & 2) {
       $r3$.ɵɵtextInterpolate1(" ", ctx.value, " ");

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/shadowed_let_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/shadowed_let_template.js
@@ -17,6 +17,7 @@ $r3$.ɵɵdefineComponent({
   template: function MyApp_Template(rf, ctx) {
     if (rf & 1) {
       $r3$.ɵɵconditionalCreate(0, MyApp_Conditional_0_Template, 1, 1);
+      (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵɵconditionalMetadata(0, "if", 1, null, "true", ["true"]);
     }
     if (rf & 2) {
       "parent";

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -201,6 +201,10 @@ export class Identifiers {
     name: 'ɵɵconditionalBranchCreate',
     moduleName: CORE,
   };
+  static conditionalMetadata: o.ExternalReference = {
+    name: 'ɵɵconditionalMetadata',
+    moduleName: CORE,
+  };
   static conditional: o.ExternalReference = {name: 'ɵɵconditional', moduleName: CORE};
   static repeater: o.ExternalReference = {name: 'ɵɵrepeater', moduleName: CORE};
   static repeaterCreate: o.ExternalReference = {name: 'ɵɵrepeaterCreate', moduleName: CORE};

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -201,6 +201,10 @@ export class Identifiers {
     name: 'ɵɵconditionalBranchCreate',
     moduleName: CORE,
   };
+  static conditionalMetadata: o.ExternalReference = {
+    name: 'ɵɵconditionalMetadata',
+    moduleName: CORE,
+  };
   static conditional: o.ExternalReference = {name: 'ɵɵconditional', moduleName: CORE};
   static boundaryCreate: o.ExternalReference = {name: 'ɵɵboundaryCreate', moduleName: CORE};
   static boundaryUpdate: o.ExternalReference = {name: 'ɵɵboundaryUpdate', moduleName: CORE};

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -59,7 +59,7 @@ export function devOnlyGuardedExpression(expr: o.Expression): o.Expression {
 }
 
 function guardedExpression(guard: string, expr: o.Expression): o.Expression {
-  const guardExpr = new o.ExternalExpr({name: guard, moduleName: null});
+  const guardExpr = o.variable(guard);
   const guardNotDefined = new o.BinaryOperatorExpr(
     o.BinaryOperator.Identical,
     new o.TypeofExpr(guardExpr),

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -146,7 +146,7 @@ export function devOnlyGuardedExpression(expr: o.Expression): o.Expression {
 }
 
 function guardedExpression(guard: string, expr: o.Expression): o.Expression {
-  const guardExpr = new o.ExternalExpr({name: guard, moduleName: null});
+  const guardExpr = o.variable(guard);
   const guardNotDefined = new o.BinaryOperatorExpr(
     o.BinaryOperator.Identical,
     new o.TypeofExpr(guardExpr),

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -298,6 +298,11 @@ export enum OpKind {
   SourceLocation,
 
   /**
+   * Creation op that attaches debug metadata to a conditional control flow block.
+   */
+  ConditionalMetadata,
+
+  /**
    * An operation to bind animation css classes to an element.
    */
   Animation,

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -313,6 +313,11 @@ export enum OpKind {
   SourceLocation,
 
   /**
+   * Creation op that attaches debug metadata to a conditional control flow block.
+   */
+  ConditionalMetadata,
+
+  /**
    * An operation to bind animation css classes to an element.
    */
   Animation,

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1341,6 +1341,7 @@ export function transformExpressionsInOp(
     case OpKind.IcuPlaceholder:
     case OpKind.DeclareLet:
     case OpKind.SourceLocation:
+    case OpKind.ConditionalMetadata:
     case OpKind.ConditionalCreate:
     case OpKind.ConditionalBranchCreate:
     case OpKind.Control:

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1384,6 +1384,7 @@ export function transformExpressionsInOp(
     case OpKind.IcuPlaceholder:
     case OpKind.DeclareLet:
     case OpKind.SourceLocation:
+    case OpKind.ConditionalMetadata:
     case OpKind.ConditionalCreate:
     case OpKind.ConditionalBranchCreate:
     case OpKind.Control:

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -77,6 +77,7 @@ export type CreateOp =
   | I18nContextOp
   | I18nAttributesOp
   | DeclareLetOp
+  | ConditionalMetadataOp
   | AnimationListenerOp
   | AnimationStringOp
   | AnimationOp
@@ -527,6 +528,45 @@ export function createConditionalBranchCreateOp(
     startSourceSpan,
     wholeSourceSpan,
     ...TRAIT_CONSUMES_SLOT,
+    ...NEW_OP,
+  };
+}
+
+/**
+ * Debug metadata for a conditional control flow block.
+ */
+export interface ConditionalMetadataOp extends Op<CreateOp> {
+  kind: OpKind.ConditionalMetadata;
+  targetSlot: SlotHandle;
+  conditionalKind: 'if' | 'switch';
+  branchCount: number;
+  defaultBranchIndex: number | null;
+  expression: string | null;
+  branchExpressions: Array<string | null | string[]>;
+  hasExhaustiveCheck: boolean;
+  sourceSpan: ParseSourceSpan;
+}
+
+export function createConditionalMetadataOp(
+  targetSlot: SlotHandle,
+  conditionalKind: 'if' | 'switch',
+  branchCount: number,
+  defaultBranchIndex: number | null,
+  expression: string | null,
+  branchExpressions: Array<string | null | string[]>,
+  sourceSpan: ParseSourceSpan,
+  hasExhaustiveCheck = false,
+): ConditionalMetadataOp {
+  return {
+    kind: OpKind.ConditionalMetadata,
+    targetSlot,
+    conditionalKind,
+    branchCount,
+    defaultBranchIndex,
+    expression,
+    branchExpressions,
+    hasExhaustiveCheck,
+    sourceSpan,
     ...NEW_OP,
   };
 }

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -78,6 +78,7 @@ export type CreateOp =
   | I18nContextOp
   | I18nAttributesOp
   | DeclareLetOp
+  | ConditionalMetadataOp
   | AnimationListenerOp
   | AnimationStringOp
   | AnimationOp
@@ -656,6 +657,45 @@ export function createBoundaryErrorCreateOp(
     boundaryXref,
     contextVariables,
     ...TRAIT_CONSUMES_SLOT,
+    ...NEW_OP,
+  };
+}
+
+/**
+ * Debug metadata for a conditional control flow block.
+ */
+export interface ConditionalMetadataOp extends Op<CreateOp> {
+  kind: OpKind.ConditionalMetadata;
+  targetSlot: SlotHandle;
+  conditionalKind: 'if' | 'switch';
+  branchCount: number;
+  defaultBranchIndex: number | null;
+  expression: string | null;
+  branchExpressions: Array<string | null | string[]>;
+  hasExhaustiveCheck: boolean;
+  sourceSpan: ParseSourceSpan;
+}
+
+export function createConditionalMetadataOp(
+  targetSlot: SlotHandle,
+  conditionalKind: 'if' | 'switch',
+  branchCount: number,
+  defaultBranchIndex: number | null,
+  expression: string | null,
+  branchExpressions: Array<string | null | string[]>,
+  sourceSpan: ParseSourceSpan,
+  hasExhaustiveCheck = false,
+): ConditionalMetadataOp {
+  return {
+    kind: OpKind.ConditionalMetadata,
+    targetSlot,
+    conditionalKind,
+    branchCount,
+    defaultBranchIndex,
+    expression,
+    branchExpressions,
+    hasExhaustiveCheck,
+    sourceSpan,
     ...NEW_OP,
   };
 }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -621,6 +621,9 @@ function ingestBoundText(
  */
 function ingestIfBlock(unit: ViewCompilationUnit, ifBlock: t.IfBlock): void {
   let firstXref: ir.XrefId | null = null;
+  let firstConditionalCreateOp: ir.ConditionalCreateOp | ir.ConditionalBranchCreateOp | null = null;
+  let defaultBranchIndex: number | null = null;
+  const branchExpressions: Array<string | null> = [];
   let conditions: Array<ir.ConditionalCaseExpr> = [];
   for (let i = 0; i < ifBlock.branches.length; i++) {
     const ifCase = ifBlock.branches[i];
@@ -655,9 +658,14 @@ function ingestIfBlock(unit: ViewCompilationUnit, ifBlock: t.IfBlock): void {
 
     if (firstXref === null) {
       firstXref = cView.xref;
+      firstConditionalCreateOp = conditionalCreateOp;
     }
 
     const caseExpr = ifCase.expression ? convertAst(ifCase.expression, unit.job, null) : null;
+    if (caseExpr === null) {
+      defaultBranchIndex = i;
+    }
+    branchExpressions.push(getExpressionSource(ifCase.expression));
     const conditionalCaseExpr = new ir.ConditionalCaseExpr(
       caseExpr,
       conditionalCreateOp.xref,
@@ -667,6 +675,17 @@ function ingestIfBlock(unit: ViewCompilationUnit, ifBlock: t.IfBlock): void {
     conditions.push(conditionalCaseExpr);
     ingestNodes(cView, ifCase.children);
   }
+  unit.create.push(
+    ir.createConditionalMetadataOp(
+      firstConditionalCreateOp!.handle,
+      'if',
+      ifBlock.branches.length,
+      defaultBranchIndex,
+      branchExpressions[0] ?? null,
+      branchExpressions,
+      ifBlock.sourceSpan,
+    ),
+  );
   unit.update.push(ir.createConditionalOp(firstXref!, null, conditions, ifBlock.sourceSpan));
 }
 
@@ -680,6 +699,9 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
   }
 
   let firstXref: ir.XrefId | null = null;
+  let firstConditionalCreateOp: ir.ConditionalCreateOp | ir.ConditionalBranchCreateOp | null = null;
+  let defaultBranchIndex: number | null = null;
+  const caseExpressions: string[][] = [];
   let conditions: Array<ir.ConditionalCaseExpr> = [];
   for (let i = 0; i < switchBlock.groups.length; i++) {
     const switchCaseGroup = switchBlock.groups[i];
@@ -711,12 +733,16 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
 
     if (firstXref === null) {
       firstXref = cView.xref;
+      firstConditionalCreateOp = conditionalCreateOp;
     }
 
     for (const switchCase of switchCaseGroup.cases) {
       const caseExpr = switchCase.expression
         ? convertAst(switchCase.expression, unit.job, switchBlock.startSourceSpan)
         : null;
+      if (caseExpr === null) {
+        defaultBranchIndex = i;
+      }
       const conditionalCaseExpr = new ir.ConditionalCaseExpr(
         caseExpr,
         conditionalCreateOp.xref,
@@ -724,8 +750,26 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
       );
       conditions.push(conditionalCaseExpr);
     }
+    caseExpressions.push(
+      switchCaseGroup.cases.flatMap((switchCase) => {
+        const expression = getExpressionSource(switchCase.expression);
+        return expression === null ? [] : [expression];
+      }),
+    );
     ingestNodes(cView, switchCaseGroup.children);
   }
+  unit.create.push(
+    ir.createConditionalMetadataOp(
+      firstConditionalCreateOp!.handle,
+      'switch',
+      switchBlock.groups.length,
+      defaultBranchIndex,
+      getExpressionSource(switchBlock.expression),
+      caseExpressions,
+      switchBlock.sourceSpan,
+      switchBlock.exhaustiveCheck !== null,
+    ),
+  );
   unit.update.push(
     ir.createConditionalOp(
       firstXref!,
@@ -734,6 +778,10 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
       switchBlock.sourceSpan,
     ),
   );
+}
+
+function getExpressionSource(expression: e.AST | null): string | null {
+  return expression instanceof e.ASTWithSource ? expression.source : null;
 }
 
 function ingestDeferView(

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -623,6 +623,9 @@ function ingestBoundText(
  */
 function ingestIfBlock(unit: ViewCompilationUnit, ifBlock: t.IfBlock): void {
   let firstXref: ir.XrefId | null = null;
+  let firstConditionalCreateOp: ir.ConditionalCreateOp | ir.ConditionalBranchCreateOp | null = null;
+  let defaultBranchIndex: number | null = null;
+  const branchExpressions: Array<string | null> = [];
   let conditions: Array<ir.ConditionalCaseExpr> = [];
   for (let i = 0; i < ifBlock.branches.length; i++) {
     const ifCase = ifBlock.branches[i];
@@ -657,9 +660,14 @@ function ingestIfBlock(unit: ViewCompilationUnit, ifBlock: t.IfBlock): void {
 
     if (firstXref === null) {
       firstXref = cView.xref;
+      firstConditionalCreateOp = conditionalCreateOp;
     }
 
     const caseExpr = ifCase.expression ? convertAst(ifCase.expression, unit.job, null) : null;
+    if (caseExpr === null) {
+      defaultBranchIndex = i;
+    }
+    branchExpressions.push(getExpressionSource(ifCase.expression));
     const conditionalCaseExpr = new ir.ConditionalCaseExpr(
       caseExpr,
       conditionalCreateOp.xref,
@@ -669,6 +677,17 @@ function ingestIfBlock(unit: ViewCompilationUnit, ifBlock: t.IfBlock): void {
     conditions.push(conditionalCaseExpr);
     ingestNodes(cView, ifCase.children);
   }
+  unit.create.push(
+    ir.createConditionalMetadataOp(
+      firstConditionalCreateOp!.handle,
+      'if',
+      ifBlock.branches.length,
+      defaultBranchIndex,
+      branchExpressions[0] ?? null,
+      branchExpressions,
+      ifBlock.sourceSpan,
+    ),
+  );
   unit.update.push(ir.createConditionalOp(firstXref!, null, conditions, ifBlock.sourceSpan));
 }
 
@@ -780,6 +799,9 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
   }
 
   let firstXref: ir.XrefId | null = null;
+  let firstConditionalCreateOp: ir.ConditionalCreateOp | ir.ConditionalBranchCreateOp | null = null;
+  let defaultBranchIndex: number | null = null;
+  const caseExpressions: string[][] = [];
   let conditions: Array<ir.ConditionalCaseExpr> = [];
   for (let i = 0; i < switchBlock.groups.length; i++) {
     const switchCaseGroup = switchBlock.groups[i];
@@ -811,12 +833,16 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
 
     if (firstXref === null) {
       firstXref = cView.xref;
+      firstConditionalCreateOp = conditionalCreateOp;
     }
 
     for (const switchCase of switchCaseGroup.cases) {
       const caseExpr = switchCase.expression
         ? convertAst(switchCase.expression, unit.job, switchBlock.startSourceSpan)
         : null;
+      if (caseExpr === null) {
+        defaultBranchIndex = i;
+      }
       const conditionalCaseExpr = new ir.ConditionalCaseExpr(
         caseExpr,
         conditionalCreateOp.xref,
@@ -824,8 +850,26 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
       );
       conditions.push(conditionalCaseExpr);
     }
+    caseExpressions.push(
+      switchCaseGroup.cases.flatMap((switchCase) => {
+        const expression = getExpressionSource(switchCase.expression);
+        return expression === null ? [] : [expression];
+      }),
+    );
     ingestNodes(cView, switchCaseGroup.children);
   }
+  unit.create.push(
+    ir.createConditionalMetadataOp(
+      firstConditionalCreateOp!.handle,
+      'switch',
+      switchBlock.groups.length,
+      defaultBranchIndex,
+      getExpressionSource(switchBlock.expression),
+      caseExpressions,
+      switchBlock.sourceSpan,
+      switchBlock.exhaustiveCheck !== null,
+    ),
+  );
   unit.update.push(
     ir.createConditionalOp(
       firstXref!,
@@ -834,6 +878,10 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
       switchBlock.sourceSpan,
     ),
   );
+}
+
+function getExpressionSource(expression: e.AST | null): string | null {
+  return expression instanceof e.ASTWithSource ? expression.source : null;
 }
 
 function ingestDeferView(

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -9,6 +9,7 @@
 import * as o from '../../../output/output_ast';
 import {ParseSourceSpan} from '../../../parse_util';
 import {Identifiers} from '../../../render3/r3_identifiers';
+import {devOnlyGuardedExpression} from '../../../render3/util';
 import * as ir from '../ir';
 
 // This file contains helpers for generating calls to Ivy instructions. In particular, each
@@ -509,6 +510,38 @@ export function conditionalBranchCreate(
     args.pop();
   }
   return call(Identifiers.conditionalBranchCreate, args, sourceSpan);
+}
+
+export function conditionalMetadata(
+  slot: number,
+  kind: 'if' | 'switch',
+  branchCount: number,
+  defaultBranchIndex: number | null,
+  expression: string | null,
+  branchExpressions: Array<string | null | string[]>,
+  sourceSpan: ParseSourceSpan,
+  hasExhaustiveCheck = false,
+): ir.CreateOp {
+  const args = [
+    o.literal(slot),
+    o.literal(kind),
+    o.literal(branchCount),
+    o.literal(defaultBranchIndex),
+    o.literal(expression),
+    o.literalArr(
+      branchExpressions.map((branchExpression) =>
+        Array.isArray(branchExpression)
+          ? o.literalArr(branchExpression.map((expression) => o.literal(expression)))
+          : o.literal(branchExpression),
+      ),
+    ),
+  ];
+  if (hasExhaustiveCheck) {
+    args.push(o.literal(hasExhaustiveCheck));
+  }
+
+  const expr = o.importExpr(Identifiers.conditionalMetadata).callFn(args, sourceSpan);
+  return ir.createStatementOp(new o.ExpressionStatement(devOnlyGuardedExpression(expr)));
 }
 
 export function repeaterCreate(

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -9,6 +9,7 @@
 import * as o from '../../../output/output_ast';
 import {ParseSourceSpan} from '../../../parse_util';
 import {Identifiers} from '../../../render3/r3_identifiers';
+import {devOnlyGuardedExpression} from '../../../render3/util';
 import * as ir from '../ir';
 
 // This file contains helpers for generating calls to Ivy instructions. In particular, each
@@ -528,6 +529,39 @@ export function boundary(
   const args = [slot, processedExpr, primarySlot];
   return call(Identifiers.boundaryUpdate, args, sourceSpan);
 }
+
+export function conditionalMetadata(
+  slot: number,
+  kind: 'if' | 'switch',
+  branchCount: number,
+  defaultBranchIndex: number | null,
+  expression: string | null,
+  branchExpressions: Array<string | null | string[]>,
+  sourceSpan: ParseSourceSpan,
+  hasExhaustiveCheck = false,
+): ir.CreateOp {
+  const args = [
+    o.literal(slot),
+    o.literal(kind),
+    o.literal(branchCount),
+    o.literal(defaultBranchIndex),
+    o.literal(expression),
+    o.literalArr(
+      branchExpressions.map((branchExpression) =>
+        Array.isArray(branchExpression)
+          ? o.literalArr(branchExpression.map((expression) => o.literal(expression)))
+          : o.literal(branchExpression),
+      ),
+    ),
+  ];
+  if (hasExhaustiveCheck) {
+    args.push(o.literal(hasExhaustiveCheck));
+  }
+
+  const expr = o.importExpr(Identifiers.conditionalMetadata).callFn(args, sourceSpan);
+  return ir.createStatementOp(new o.ExpressionStatement(devOnlyGuardedExpression(expr)));
+}
+
 export function repeaterCreate(
   slot: number,
   viewFnName: string,

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -625,6 +625,24 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
 
         ir.OpList.replace(op, ng.attachSourceLocation(op.templatePath, locationsLiteral));
         break;
+      case ir.OpKind.ConditionalMetadata:
+        if (op.targetSlot.slot === null) {
+          throw new Error('No slot was assigned for conditional metadata');
+        }
+        ir.OpList.replace(
+          op,
+          ng.conditionalMetadata(
+            op.targetSlot.slot,
+            op.conditionalKind,
+            op.branchCount,
+            op.defaultBranchIndex,
+            op.expression,
+            op.branchExpressions,
+            op.sourceSpan,
+            op.hasExhaustiveCheck,
+          ),
+        );
+        break;
       case ir.OpKind.ControlCreate:
         ir.OpList.replace(op, ng.controlCreate(op.sourceSpan));
         break;

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -656,6 +656,24 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
 
         ir.OpList.replace(op, ng.attachSourceLocation(op.templatePath, locationsLiteral));
         break;
+      case ir.OpKind.ConditionalMetadata:
+        if (op.targetSlot.slot === null) {
+          throw new Error('No slot was assigned for conditional metadata');
+        }
+        ir.OpList.replace(
+          op,
+          ng.conditionalMetadata(
+            op.targetSlot.slot,
+            op.conditionalKind,
+            op.branchCount,
+            op.defaultBranchIndex,
+            op.expression,
+            op.branchExpressions,
+            op.sourceSpan,
+            op.hasExhaustiveCheck,
+          ),
+        );
+        break;
       case ir.OpKind.ControlCreate:
         ir.OpList.replace(op, ng.controlCreate(op.sourceSpan));
         break;

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -102,6 +102,7 @@ export {
   ɵɵconditional,
   ɵɵconditionalBranchCreate,
   ɵɵconditionalCreate,
+  ɵɵconditionalMetadata,
   ɵɵcontentQuery,
   ɵɵcontentQuerySignal,
   ɵɵcontrol,
@@ -293,6 +294,8 @@ export {
   ControlFlowBlockType as ɵControlFlowBlockType,
   DeferBlockData as ɵDeferBlockData,
   ForLoopBlockData as ɵForLoopBlockData,
+  IfBlockData as ɵIfBlockData,
+  SwitchBlockData as ɵSwitchBlockData,
 } from './render3/util/control_flow_types';
 export {
   ExternalCoreGlobalUtils as ɵExternalCoreGlobalUtils,

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -104,6 +104,7 @@ export {
   ɵɵconditional,
   ɵɵconditionalBranchCreate,
   ɵɵconditionalCreate,
+  ɵɵconditionalMetadata,
   ɵɵcontentQuery,
   ɵɵcontentQuerySignal,
   ɵɵcontrol,
@@ -296,6 +297,8 @@ export {
   ControlFlowBlockType as ɵControlFlowBlockType,
   DeferBlockData as ɵDeferBlockData,
   ForLoopBlockData as ɵForLoopBlockData,
+  IfBlockData as ɵIfBlockData,
+  SwitchBlockData as ɵSwitchBlockData,
 } from './render3/util/control_flow_types';
 export {
   ExternalCoreGlobalUtils as ɵExternalCoreGlobalUtils,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -120,6 +120,7 @@ export {
   ɵɵconditional,
   ɵɵconditionalCreate,
   ɵɵconditionalBranchCreate,
+  ɵɵconditionalMetadata,
   ɵɵdefer,
   ɵɵdeferWhen,
   ɵɵdeferOnIdle,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -123,6 +123,7 @@ export {
   ɵɵboundaryCreate,
   ɵɵboundaryUpdate,
   ɵɵgetBoundary,
+  ɵɵconditionalMetadata,
   ɵɵdefer,
   ɵɵdeferWhen,
   ɵɵdeferOnIdle,

--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -38,6 +38,11 @@ import {LiveCollection, reconcile} from '../list_reconciliation';
 import {destroyLView} from '../node_manipulation';
 import {getLView, getSelectedIndex, getTView, nextBindingIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
+import {
+  ConditionalBlockKind,
+  ConditionalBranchExpression,
+  setConditionalBlockMetadata,
+} from '../util/control_flow_metadata';
 import {getConstant, getTNode} from '../util/view_utils';
 import {createAndRenderEmbeddedLView, shouldAddViewToDom} from '../view_manipulation';
 
@@ -148,6 +153,38 @@ export function ɵɵconditionalBranchCreate(
     localRefExtractor,
   );
   return ɵɵconditionalBranchCreate;
+}
+
+/**
+ * Attaches debug metadata to a conditional control flow block (`@if` or `@switch`).
+ *
+ * @param index The index of the first branch container in the data array.
+ * @param kind The control flow block kind.
+ * @param branchCount The number of branch containers in this block.
+ * @param defaultBranchIndex The `@else` or `@default` branch index, if one exists.
+ * @param expression The primary expression evaluated by the block.
+ * @param branchExpressions The expressions evaluated by each branch.
+ * @param hasExhaustiveCheck Whether the switch block has an exhaustive type check.
+ * @codeGenApi
+ */
+export function ɵɵconditionalMetadata(
+  index: number,
+  kind: ConditionalBlockKind,
+  branchCount: number,
+  defaultBranchIndex: number | null = null,
+  expression: string | null = null,
+  branchExpressions: ConditionalBranchExpression[] = [],
+  hasExhaustiveCheck = false,
+): void {
+  const tNode = getExistingTNode(getTView(), HEADER_OFFSET + index);
+  setConditionalBlockMetadata(tNode, {
+    kind,
+    branchCount,
+    defaultBranchIndex,
+    expression,
+    branchExpressions,
+    hasExhaustiveCheck,
+  });
 }
 
 /**

--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -38,6 +38,11 @@ import {LiveCollection, reconcile} from '../list_reconciliation';
 import {destroyLView} from '../node_manipulation';
 import {getLView, getSelectedIndex, getTView, nextBindingIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
+import {
+  ConditionalBlockKind,
+  ConditionalBranchExpression,
+  setConditionalBlockMetadata,
+} from '../util/control_flow_metadata';
 import {getConstant, getTNode} from '../util/view_utils';
 import {createAndRenderEmbeddedLView, shouldAddViewToDom} from '../view_manipulation';
 
@@ -173,6 +178,38 @@ export function createControlFlowBranch(
     localRefsIndex,
     localRefExtractor,
   );
+}
+
+/**
+ * Attaches debug metadata to a conditional control flow block (`@if` or `@switch`).
+ *
+ * @param index The index of the first branch container in the data array.
+ * @param kind The control flow block kind.
+ * @param branchCount The number of branch containers in this block.
+ * @param defaultBranchIndex The `@else` or `@default` branch index, if one exists.
+ * @param expression The primary expression evaluated by the block.
+ * @param branchExpressions The expressions evaluated by each branch.
+ * @param hasExhaustiveCheck Whether the switch block has an exhaustive type check.
+ * @codeGenApi
+ */
+export function ɵɵconditionalMetadata(
+  index: number,
+  kind: ConditionalBlockKind,
+  branchCount: number,
+  defaultBranchIndex: number | null = null,
+  expression: string | null = null,
+  branchExpressions: ConditionalBranchExpression[] = [],
+  hasExhaustiveCheck = false,
+): void {
+  const tNode = getExistingTNode(getTView(), HEADER_OFFSET + index);
+  setConditionalBlockMetadata(tNode, {
+    kind,
+    branchCount,
+    defaultBranchIndex,
+    expression,
+    branchExpressions,
+    hasExhaustiveCheck,
+  });
 }
 
 /**

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -114,6 +114,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵconditional': r3.ɵɵconditional,
   'ɵɵconditionalCreate': r3.ɵɵconditionalCreate,
   'ɵɵconditionalBranchCreate': r3.ɵɵconditionalBranchCreate,
+  'ɵɵconditionalMetadata': r3.ɵɵconditionalMetadata,
   'ɵɵdefer': r3.ɵɵdefer,
   'ɵɵdeferWhen': r3.ɵɵdeferWhen,
   'ɵɵdeferOnIdle': r3.ɵɵdeferOnIdle,

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -117,6 +117,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵboundaryCreate': r3.ɵɵboundaryCreate,
   'ɵɵboundaryUpdate': r3.ɵɵboundaryUpdate,
   'ɵɵgetBoundary': r3.ɵɵgetBoundary,
+  'ɵɵconditionalMetadata': r3.ɵɵconditionalMetadata,
   'ɵɵdefer': r3.ɵɵdefer,
   'ɵɵdeferWhen': r3.ɵɵdeferWhen,
   'ɵɵdeferOnIdle': r3.ɵɵdeferOnIdle,

--- a/packages/core/src/render3/util/control_flow.ts
+++ b/packages/core/src/render3/util/control_flow.ts
@@ -30,7 +30,7 @@ import {assertLView} from '../assert';
 import {collectNativeNodes} from '../collect_native_nodes';
 import {getLContext} from '../context_discovery';
 import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from '../interfaces/container';
-import {HOST, INJECTOR, LView, TVIEW, HEADER_OFFSET} from '../interfaces/view';
+import {HOST, INJECTOR, LView, TVIEW, HEADER_OFFSET, TView} from '../interfaces/view';
 import {getNativeByTNode} from './view_utils';
 import {isLContainer, isLView} from '../interfaces/type_checks';
 
@@ -41,9 +41,12 @@ import {
   ControlFlowBlockType,
   DeferBlockData,
   ForLoopBlockData,
+  IfBlockData,
   RepeaterMetadataShape,
+  SwitchBlockData,
 } from './control_flow_types';
-import {TNode} from '../interfaces/node';
+import {TNode, TNodeFlags} from '../interfaces/node';
+import {getConditionalBlockMetadata} from './control_flow_metadata';
 
 /**
  * Gets all of the control flow blocks that are present inside the specified DOM node.
@@ -185,18 +188,10 @@ const forLoopFinder: ControlFlowBlockViewFinder = ({
 
   const containerIndex = slotIdx + 1;
   const lContainer = lView[containerIndex];
-  const rootNodes: Node[] = [];
+  let rootNodes: Node[] = [];
 
   if (isLContainer(lContainer)) {
-    // Collect root nodes from each view in the container
-    for (let viewIdx = CONTAINER_HEADER_OFFSET; viewIdx < lContainer.length; viewIdx++) {
-      const viewAtIdx = lContainer[viewIdx];
-      if (isLView(viewAtIdx)) {
-        const viewTView = viewAtIdx[TVIEW];
-        const viewNodes = collectNativeNodes(viewTView, viewAtIdx, viewTView.firstChild, []);
-        rootNodes.push(...viewNodes);
-      }
-    }
+    rootNodes = collectLContainerRootNodes(lContainer);
   }
 
   return {
@@ -209,8 +204,80 @@ const forLoopFinder: ControlFlowBlockViewFinder = ({
   } satisfies ForLoopBlockData;
 };
 
+/**
+ * Finds and returns all `@if` and `@switch` blocks in a LView.
+ *
+ * @param config Finder configuration object.
+ * @returns
+ */
+const conditionalBlockFinder: ControlFlowBlockViewFinder = ({
+  node,
+  lView,
+  tView,
+  slotIdx,
+}: ControlFlowBlockViewFinderConfig) => {
+  const slot = lView[slotIdx];
+  if (!isLContainer(slot)) {
+    return null;
+  }
+
+  const tNode = tView.data[slotIdx] as TNode;
+  const metadata = getConditionalBlockMetadata(tNode);
+  if (!metadata) {
+    return null;
+  }
+
+  const hostNode = slot[HOST] as Node;
+  if (!node.contains(hostNode)) {
+    return null;
+  }
+
+  const branchSlotIdxs = findConditionalBranchSlotIdxs(lView, tView, slotIdx, metadata.branchCount);
+  if (branchSlotIdxs.length !== metadata.branchCount) {
+    return null;
+  }
+
+  const activeBranchIndex = findActiveConditionalBranchIndex(lView, branchSlotIdxs);
+  const rootNodes =
+    activeBranchIndex === null
+      ? []
+      : collectLContainerRootNodes(lView[branchSlotIdxs[activeBranchIndex]] as LContainer);
+
+  const base = {
+    branchCount: metadata.branchCount,
+    activeBranchIndex,
+    defaultBranchIndex: metadata.defaultBranchIndex,
+    rootNodes,
+    hostNode,
+  };
+
+  if (metadata.kind === 'if') {
+    return {
+      type: ControlFlowBlockType.If,
+      ...base,
+      conditionExpressions: metadata.branchExpressions.map((expression) =>
+        typeof expression === 'string' ? expression : null,
+      ),
+    } satisfies IfBlockData;
+  }
+
+  return {
+    type: ControlFlowBlockType.Switch,
+    ...base,
+    expression: metadata.expression,
+    caseExpressions: metadata.branchExpressions.map((expression) =>
+      Array.isArray(expression) ? expression : expression === null ? [] : [expression],
+    ),
+    hasExhaustiveCheck: metadata.hasExhaustiveCheck,
+  } satisfies SwitchBlockData;
+};
+
 // Represents all supported control flow block finders.
-const CONTROL_FLOW_BLOCK_FINDERS: ControlFlowBlockViewFinder[] = [deferBlockFinder, forLoopFinder];
+const CONTROL_FLOW_BLOCK_FINDERS: ControlFlowBlockViewFinder[] = [
+  deferBlockFinder,
+  forLoopFinder,
+  conditionalBlockFinder,
+];
 
 /**
  * Finds all the control flow blocks inside a specific node and view.
@@ -318,6 +385,61 @@ function getRendererLView(lContainer: LContainer): LView | null {
   const lView = lContainer[CONTAINER_HEADER_OFFSET];
   ngDevMode && assertLView(lView);
   return lView;
+}
+
+function collectLContainerRootNodes(lContainer: LContainer): Node[] {
+  const rootNodes: Node[] = [];
+
+  for (let viewIdx = CONTAINER_HEADER_OFFSET; viewIdx < lContainer.length; viewIdx++) {
+    const viewAtIdx = lContainer[viewIdx];
+    if (isLView(viewAtIdx)) {
+      const viewTView = viewAtIdx[TVIEW];
+      const viewNodes = collectNativeNodes(viewTView, viewAtIdx, viewTView.firstChild, []);
+      rootNodes.push(...viewNodes);
+    }
+  }
+
+  return rootNodes;
+}
+
+function findConditionalBranchSlotIdxs(
+  lView: LView,
+  tView: TView,
+  firstBranchSlotIdx: number,
+  branchCount: number,
+): number[] {
+  const branchSlotIdxs: number[] = [];
+
+  for (
+    let i = firstBranchSlotIdx;
+    i < tView.bindingStartIndex && branchSlotIdxs.length < branchCount;
+    i++
+  ) {
+    const lContainer = lView[i];
+    if (!isLContainer(lContainer)) {
+      continue;
+    }
+
+    const tNode = tView.data[i] as TNode;
+    const isConditionalBranch =
+      (tNode.flags & (TNodeFlags.isControlFlowStart | TNodeFlags.isInControlFlow)) !== 0;
+    if (isConditionalBranch) {
+      branchSlotIdxs.push(i);
+    }
+  }
+
+  return branchSlotIdxs;
+}
+
+function findActiveConditionalBranchIndex(lView: LView, branchSlotIdxs: number[]): number | null {
+  for (let i = 0; i < branchSlotIdxs.length; i++) {
+    const lContainer = lView[branchSlotIdxs[i]];
+    if (isLContainer(lContainer) && lContainer.length > CONTAINER_HEADER_OFFSET) {
+      return i;
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/packages/core/src/render3/util/control_flow_metadata.ts
+++ b/packages/core/src/render3/util/control_flow_metadata.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TNode} from '../interfaces/node';
+
+export type ConditionalBlockKind = 'if' | 'switch';
+
+export type ConditionalBranchExpression = string | null | string[];
+
+export interface ConditionalBlockMetadata {
+  kind: ConditionalBlockKind;
+  branchCount: number;
+  defaultBranchIndex: number | null;
+  expression: string | null;
+  branchExpressions: ConditionalBranchExpression[];
+  hasExhaustiveCheck: boolean;
+}
+
+const conditionalBlockMetadata = new WeakMap<TNode, ConditionalBlockMetadata>();
+
+export function setConditionalBlockMetadata(
+  tNode: TNode,
+  metadata: ConditionalBlockMetadata,
+): void {
+  conditionalBlockMetadata.set(tNode, metadata);
+}
+
+export function getConditionalBlockMetadata(tNode: TNode): ConditionalBlockMetadata | undefined {
+  return conditionalBlockMetadata.get(tNode);
+}

--- a/packages/core/src/render3/util/control_flow_types.ts
+++ b/packages/core/src/render3/util/control_flow_types.ts
@@ -13,6 +13,8 @@ import {LiveCollection} from '../list_reconciliation';
 export enum ControlFlowBlockType {
   Defer,
   For,
+  If,
+  Switch,
 }
 
 export interface ControlFlowBlockDataBase {
@@ -75,10 +77,50 @@ export interface ForLoopBlockData extends ControlFlowBlockDataBase {
   trackExpression: string;
 }
 
+/** Retrieved information about an `@if` block. */
+export interface IfBlockData extends ControlFlowBlockDataBase {
+  type: ControlFlowBlockType.If;
+
+  /** Number of branches connected to this block, including `@else if` and `@else`. */
+  branchCount: number;
+
+  /** Index of the currently rendered branch, or null if no branch is rendered. */
+  activeBranchIndex: number | null;
+
+  /** Index of the connected `@else` branch, or null if the block does not have one. */
+  defaultBranchIndex: number | null;
+
+  /** Expression text for each conditional branch, or null for `@else`. */
+  conditionExpressions: Array<string | null>;
+}
+
+/** Retrieved information about an `@switch` block. */
+export interface SwitchBlockData extends ControlFlowBlockDataBase {
+  type: ControlFlowBlockType.Switch;
+
+  /** Number of case groups connected to this block, including `@default`. */
+  branchCount: number;
+
+  /** Index of the currently rendered case group, or null if no case matched. */
+  activeBranchIndex: number | null;
+
+  /** Index of the connected `@default` case group, or null if the block does not have one. */
+  defaultBranchIndex: number | null;
+
+  /** Expression text evaluated by the `@switch` block. */
+  expression: string | null;
+
+  /** Expression text for each case group. `@default` groups are represented by an empty array. */
+  caseExpressions: string[][];
+
+  /** Whether the switch block declares an exhaustive type check via `@default never`. */
+  hasExhaustiveCheck: boolean;
+}
+
 /**
  * A control flow block information object.
  */
-export type ControlFlowBlock = DeferBlockData | ForLoopBlockData;
+export type ControlFlowBlock = DeferBlockData | ForLoopBlockData | IfBlockData | SwitchBlockData;
 
 /**
  * A configuration object passed to a `ControlFlowBlockViewFinder` function.

--- a/packages/core/test/acceptance/control_flow_utils_spec.ts
+++ b/packages/core/test/acceptance/control_flow_utils_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component} from '../../src/core';
+import {Component, Pipe, PipeTransform, signal} from '../../src/core';
 import {DeferBlockBehavior, DeferBlockState, TestBed} from '../../testing';
 
 import {getControlFlowBlocks} from '../../src/render3/util/control_flow';
@@ -13,6 +13,8 @@ import {
   ControlFlowBlockType,
   DeferBlockData,
   ForLoopBlockData,
+  IfBlockData,
+  SwitchBlockData,
 } from '../../src/render3/util/control_flow_types';
 
 describe('getControlFlowBlocks', () => {
@@ -52,7 +54,9 @@ describe('getControlFlowBlocks', () => {
 describe('getControlFlowBlocks > @defer blocks', () => {
   // Use to narrow down type to `DeferBlockData` for `@defer`-specific tests.
   function getDeferBlocks(node: Node): DeferBlockData[] {
-    return getControlFlowBlocks(node) as DeferBlockData[];
+    return getControlFlowBlocks(node).filter(
+      (block): block is DeferBlockData => block.type === ControlFlowBlockType.Defer,
+    );
   }
 
   beforeEach(() => {
@@ -391,6 +395,276 @@ describe('getControlFlowBlocks > @defer blocks', () => {
       }
     });
   }
+});
+
+describe('getControlFlowBlocks > conditional blocks', () => {
+  @Pipe({name: 'identity'})
+  class IdentityPipe implements PipeTransform {
+    transform(value: unknown): unknown {
+      return value;
+    }
+  }
+
+  function getIfBlocks(node: Node): IfBlockData[] {
+    return getControlFlowBlocks(node).filter(
+      (block): block is IfBlockData => block.type === ControlFlowBlockType.If,
+    );
+  }
+
+  function getSwitchBlocks(node: Node): SwitchBlockData[] {
+    return getControlFlowBlocks(node).filter(
+      (block): block is SwitchBlockData => block.type === ControlFlowBlockType.Switch,
+    );
+  }
+
+  it('should get an @if block and its active @else branch', async () => {
+    @Component({
+      template: `
+        <section>
+          @if (condition()) {
+            <p>Truthy</p>
+          } @else {
+            <span>Falsy</span>
+          }
+        </section>
+      `,
+    })
+    class App {
+      condition = signal(false);
+    }
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    let [ifBlock] = getIfBlocks(fixture.nativeElement);
+    expect(ifBlock).toEqual(
+      jasmine.objectContaining({
+        type: ControlFlowBlockType.If,
+        branchCount: 2,
+        activeBranchIndex: 1,
+        defaultBranchIndex: 1,
+        conditionExpressions: ['condition()', null],
+      } satisfies Partial<IfBlockData>),
+    );
+    expect(ifBlock.rootNodes.map((node) => node.nodeName.toLowerCase())).toEqual(['span']);
+
+    fixture.componentInstance.condition.set(true);
+    await fixture.whenStable();
+
+    [ifBlock] = getIfBlocks(fixture.nativeElement);
+    expect(ifBlock.activeBranchIndex).toBe(0);
+    expect(ifBlock.rootNodes.map((node) => node.nodeName.toLowerCase())).toEqual(['p']);
+  });
+
+  it('should get a non-rendered @if block without an @else branch', async () => {
+    @Component({
+      template: `
+        <section>
+          @if (condition()) {
+            <p>Truthy</p>
+          }
+        </section>
+      `,
+    })
+    class App {
+      condition = signal(false);
+    }
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    const [ifBlock] = getIfBlocks(fixture.nativeElement);
+    expect(ifBlock).toEqual(
+      jasmine.objectContaining({
+        type: ControlFlowBlockType.If,
+        branchCount: 1,
+        activeBranchIndex: null,
+        defaultBranchIndex: null,
+        conditionExpressions: ['condition()'],
+      } satisfies Partial<IfBlockData>),
+    );
+    expect(ifBlock.rootNodes).toEqual([]);
+    expect(ifBlock.hostNode).toBeTruthy();
+  });
+
+  it('should get an @switch block and its active case', async () => {
+    @Component({
+      template: `
+        <section>
+          @switch (value()) {
+            @case (1) {
+              <p>One</p>
+            }
+            @case (2) {
+              <span>Two</span>
+            }
+            @default {
+              <strong>Default</strong>
+            }
+          }
+        </section>
+      `,
+    })
+    class App {
+      value = signal(2);
+    }
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    let [switchBlock] = getSwitchBlocks(fixture.nativeElement);
+    expect(switchBlock).toEqual(
+      jasmine.objectContaining({
+        type: ControlFlowBlockType.Switch,
+        branchCount: 3,
+        activeBranchIndex: 1,
+        defaultBranchIndex: 2,
+        expression: 'value()',
+        caseExpressions: [['1'], ['2'], []],
+      } satisfies Partial<SwitchBlockData>),
+    );
+    expect(switchBlock.rootNodes.map((node) => node.nodeName.toLowerCase())).toEqual(['span']);
+
+    fixture.componentInstance.value.set(3);
+    await fixture.whenStable();
+
+    [switchBlock] = getSwitchBlocks(fixture.nativeElement);
+    expect(switchBlock.activeBranchIndex).toBe(2);
+    expect(switchBlock.rootNodes.map((node) => node.nodeName.toLowerCase())).toEqual(['strong']);
+  });
+
+  it('should get a non-rendered @switch block without a default case', async () => {
+    @Component({
+      template: `
+        <section>
+          @switch (value()) {
+            @case (1) {
+              <p>One</p>
+            }
+          }
+        </section>
+      `,
+    })
+    class App {
+      value = signal(2);
+    }
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    const [switchBlock] = getSwitchBlocks(fixture.nativeElement);
+    expect(switchBlock).toEqual(
+      jasmine.objectContaining({
+        type: ControlFlowBlockType.Switch,
+        branchCount: 1,
+        activeBranchIndex: null,
+        defaultBranchIndex: null,
+        expression: 'value()',
+        caseExpressions: [['1']],
+      } satisfies Partial<SwitchBlockData>),
+    );
+    expect(switchBlock.rootNodes).toEqual([]);
+    expect(switchBlock.hostNode).toBeTruthy();
+  });
+
+  it('should expose exhaustive @switch checks', async () => {
+    @Component({
+      template: `
+        <section>
+          @switch (value) {
+            @case (0) {
+              <p>Zero</p>
+            }
+            @case (1) {
+              <span>One</span>
+            }
+            @default never;
+          }
+        </section>
+      `,
+    })
+    class App {
+      value: 0 | 1 = 1;
+    }
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    const [switchBlock] = getSwitchBlocks(fixture.nativeElement);
+    expect(switchBlock).toEqual(
+      jasmine.objectContaining({
+        type: ControlFlowBlockType.Switch,
+        branchCount: 2,
+        activeBranchIndex: 1,
+        defaultBranchIndex: null,
+        expression: 'value',
+        caseExpressions: [['0'], ['1']],
+        hasExhaustiveCheck: true,
+      } satisfies Partial<SwitchBlockData>),
+    );
+    expect(switchBlock.rootNodes.map((node) => node.nodeName.toLowerCase())).toEqual(['span']);
+  });
+
+  it('should handle conditional branch containers separated by pipe slots', async () => {
+    @Component({
+      imports: [IdentityPipe],
+      template: `
+        <section>
+          @if ((value() | identity) === 1) {
+            <p>One</p>
+          } @else if ((value() | identity) === 2) {
+            <span>Two</span>
+          } @else {
+            <strong>Default</strong>
+          }
+
+          @switch (value() | identity) {
+            @case (1 | identity) {
+              <em>One</em>
+            }
+            @case (2 | identity) {
+              <b>Two</b>
+            }
+            @default {
+              <i>Default</i>
+            }
+          }
+        </section>
+      `,
+    })
+    class App {
+      value = signal(2);
+    }
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    let [ifBlock] = getIfBlocks(fixture.nativeElement);
+    let [switchBlock] = getSwitchBlocks(fixture.nativeElement);
+
+    expect(ifBlock.activeBranchIndex).toBe(1);
+    expect(ifBlock.conditionExpressions).toEqual([
+      '(value() | identity) === 1',
+      '(value() | identity) === 2',
+      null,
+    ]);
+    expect(ifBlock.rootNodes.map((node) => node.nodeName.toLowerCase())).toEqual(['span']);
+    expect(switchBlock.activeBranchIndex).toBe(1);
+    expect(switchBlock.expression).toBe('value() | identity');
+    expect(switchBlock.caseExpressions).toEqual([['1 | identity'], ['2 | identity'], []]);
+    expect(switchBlock.rootNodes.map((node) => node.nodeName.toLowerCase())).toEqual(['b']);
+
+    fixture.componentInstance.value.set(3);
+    await fixture.whenStable();
+
+    [ifBlock] = getIfBlocks(fixture.nativeElement);
+    [switchBlock] = getSwitchBlocks(fixture.nativeElement);
+
+    expect(ifBlock.activeBranchIndex).toBe(2);
+    expect(ifBlock.rootNodes.map((node) => node.nodeName.toLowerCase())).toEqual(['strong']);
+    expect(switchBlock.activeBranchIndex).toBe(2);
+    expect(switchBlock.rootNodes.map((node) => node.nodeName.toLowerCase())).toEqual(['i']);
+  });
 });
 
 describe('getControlFlowBlocks > @for blocks', () => {


### PR DESCRIPTION
### refactor(compiler): collect metadata for conditional blocks

Carry conditional block metadata through template lowering and emit the debug instruction that records it in generated views.

This keeps the original expressions for if and switch branches so runtime inspection can report the declared control-flow structure.


### feat(core): expose metadata for conditional blocks

Record development-mode metadata for conditional control-flow blocks so debugging APIs can describe `@if` and `@switch` views.

This gives DevTools the context it needs to show which branch is active and where each condition came from, while keeping the data limited to development-time inspection.

### feat(devtools): show conditional control-flow blocks

Surface conditional control-flow blocks in Angular DevTools alongside the existing `@defer` and `@for` blocks.

The directive tree now labels active branches and cases, and the property pane shows the declared blocks, rendered state, and source expressions from the runtime metadata.


---

This would align with what was commented at https://github.com/angular/angular/issues/65849#issuecomment-3613137691


https://github.com/user-attachments/assets/294a2b10-e029-40ce-a6c9-d4eddf6bc0cf


