### PR TITLE
feat(forms): support imperative disable and enable in SignalFormControl

### DIFF
--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -309,10 +309,14 @@ const value = userControl.sourceValue();
 
 ### Disabling/Enabling control
 
-Imperative APIs for changing the enabled/disabled state (like `enable()`, `disable()`) are intentionally not supported
-in `SignalFormControl`. This is because the state of the control should be derived from the signal state and rules.
+`SignalFormControl` supports the imperative `disable()` and `enable()` methods for interoperability
+with Reactive Forms APIs, such as calling `disable()` on a parent `FormGroup`. Internally, the
+imperatively set disabled status is applied through a `disabled` rule.
 
-Attempting to call disable/enable would throw an error.
+Note that `enable()` only clears the imperatively set disabled status. If a `disabled` rule from
+the control's schema is currently active, the control remains disabled.
+
+While the imperative APIs work, prefer deriving the disabled state from the signal state and rules:
 
 ```typescript {avoid}
 import {signal, effect} from '@angular/core';
@@ -323,7 +327,7 @@ export class UserProfile {
   readonly isLoading = signal(false);
 
   constructor() {
-    // This will throw an error
+    // Avoid imperatively toggling the disabled state from an effect
     effect(() => {
       if (this.isLoading()) {
         this.emailControl.disable();

--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -69,14 +69,14 @@ export class SignalFormControl<T> extends AbstractControl {
     get dirty(): boolean;
     set dirty(_: boolean);
     // (undocumented)
-    disable(_opts?: {
+    disable(opts?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
     // (undocumented)
     get disabled(): boolean;
     // (undocumented)
-    enable(_opts?: {
+    enable(opts?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;

--- a/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
+++ b/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
@@ -30,8 +30,9 @@ import {
   ValueChangeEvent,
 } from '@angular/forms';
 
-import {FormOptions} from '../../../src/api/structure';
-import {FieldState, FieldTree, SchemaFn} from '../../../src/api/types';
+import {disabled} from '../../../src/api/rules';
+import {apply, FormOptions} from '../../../src/api/structure';
+import {FieldState, FieldTree, SchemaFn, SchemaPath} from '../../../src/api/types';
 import {signalErrorsToValidationErrors} from '../../../src/compat/validation_errors';
 import {RuntimeErrorCode} from '../../../src/errors';
 import {FieldNode} from '../../../src/field/node';
@@ -89,7 +90,9 @@ export class SignalFormControl<T> extends AbstractControl {
 
   private readonly fieldState: FieldState<T>;
   private readonly initialValue: T;
+  private readonly imperativelyDisabled = signal(false);
   private pendingParentNotifications = 0;
+  private lastEmittedStatus: FormControlStatus | null = null;
   private readonly onChangeCallbacks: Array<(value?: any, emitModelEvent?: boolean) => void> = [];
   private readonly onDisabledChangeCallbacks: Array<(isDisabled: boolean) => void> = [];
   override readonly valueChanges = new EventEmitter<T>();
@@ -103,9 +106,16 @@ export class SignalFormControl<T> extends AbstractControl {
     this.initialValue = value;
     const injector = opts?.injector ?? inject(Injector);
 
-    const rawTree = schema
-      ? compatForm(this.sourceValue, schema, {injector})
-      : compatForm(this.sourceValue, {injector});
+    const wrappedSchema: SchemaFn<T> = (p) => {
+      // `SchemaPathTree<T>` cannot resolve rule support for a generic `T`. The root model is
+      // never an `AbstractControl`, so rules are always supported on the root path.
+      const rootPath = p as SchemaPath<T>;
+      if (schema) {
+        apply(rootPath, schema);
+      }
+      disabled(rootPath, {when: () => this.imperativelyDisabled()});
+    };
+    const rawTree = compatForm(this.sourceValue, wrappedSchema, {injector});
 
     this.fieldTree = wrapFieldTreeForSyncUpdates(rawTree, () =>
       this.parent?.updateValueAndValidity({sourceControl: this} as any),
@@ -132,9 +142,13 @@ export class SignalFormControl<T> extends AbstractControl {
       () => {
         const status = this.status;
         untracked(() => {
+          if (status === this.lastEmittedStatus) {
+            return;
+          }
+          this.lastEmittedStatus = status;
           this.statusChanges.emit(status);
+          this.emitControlEvent(new StatusChangeEvent(status, this));
         });
-        this.emitControlEvent(new StatusChangeEvent(status, this));
       },
       {injector},
     );
@@ -156,16 +170,18 @@ export class SignalFormControl<T> extends AbstractControl {
     effect(
       () => {
         const isTouched = this.fieldState.touched();
-        this.emitControlEvent(new TouchedChangeEvent(isTouched, this));
-        const parent = this.parent;
-        if (!parent) {
-          return;
-        }
-        if (!isTouched) {
-          parent.markAsUntouched();
-        } else {
-          parent.markAsTouched();
-        }
+        untracked(() => {
+          this.emitControlEvent(new TouchedChangeEvent(isTouched, this));
+          const parent = this.parent;
+          if (!parent) {
+            return;
+          }
+          if (!isTouched) {
+            (parent as any)._updateTouched({}, this);
+          } else {
+            parent.markAsTouched();
+          }
+        });
       },
       {injector},
     );
@@ -174,16 +190,18 @@ export class SignalFormControl<T> extends AbstractControl {
     effect(
       () => {
         const isDirty = this.fieldState.dirty();
-        this.emitControlEvent(new PristineChangeEvent(!isDirty, this));
-        const parent = this.parent;
-        if (!parent) {
-          return;
-        }
-        if (isDirty) {
-          parent.markAsDirty();
-        } else {
-          parent.markAsPristine();
-        }
+        untracked(() => {
+          this.emitControlEvent(new PristineChangeEvent(!isDirty, this));
+          const parent = this.parent;
+          if (!parent) {
+            return;
+          }
+          if (isDirty) {
+            parent.markAsDirty();
+          } else {
+            (parent as any)._updatePristine({}, this);
+          }
+        });
       },
       {injector},
     );
@@ -255,8 +273,9 @@ export class SignalFormControl<T> extends AbstractControl {
   }
 
   override reset(value?: T | FormControlState<T>, options?: ValueUpdateOptions): void {
-    if (isFormControlState(value)) {
-      throw unsupportedDisableEnableError();
+    if (isFormControlState<T>(value)) {
+      this.setDisabledState(value.disabled, options?.emitEvent);
+      value = value.value;
     }
 
     const resetValue = value ?? this.initialValue;
@@ -431,12 +450,27 @@ export class SignalFormControl<T> extends AbstractControl {
     return false;
   }
 
-  override disable(_opts?: {onlySelf?: boolean; emitEvent?: boolean}): void {
-    throw unsupportedDisableEnableError();
+  override disable(opts?: {onlySelf?: boolean; emitEvent?: boolean}): void {
+    this.setDisabledState(true, opts?.emitEvent);
+    this.propagateToParent(opts, (parent) =>
+      this.updateParentValueAndValidity(parent, opts?.emitEvent),
+    );
   }
 
-  override enable(_opts?: {onlySelf?: boolean; emitEvent?: boolean}): void {
-    throw unsupportedDisableEnableError();
+  override enable(opts?: {onlySelf?: boolean; emitEvent?: boolean}): void {
+    this.setDisabledState(false, opts?.emitEvent);
+    this.propagateToParent(opts, (parent) =>
+      this.updateParentValueAndValidity(parent, opts?.emitEvent),
+    );
+  }
+
+  private setDisabledState(isDisabled: boolean, emitEvent: boolean | undefined): void {
+    this.imperativelyDisabled.set(isDisabled);
+    if (emitEvent === false) {
+      this.lastEmittedStatus = untracked(() => this.status);
+    } else {
+      this.lastEmittedStatus = null;
+    }
   }
 
   override setValidators(_validators: any): void {
@@ -549,7 +583,7 @@ function wrapFieldTreeForSyncUpdates<T>(tree: FieldTree<T>, onUpdate: () => void
   return wrapTree(tree) as FieldTree<T>;
 }
 
-function isFormControlState(formState: unknown): formState is FormControlState<unknown> {
+function isFormControlState<T>(formState: unknown): formState is FormControlState<T> {
   return (
     typeof formState === 'object' &&
     formState !== null &&
@@ -561,13 +595,6 @@ function isFormControlState(formState: unknown): formState is FormControlState<u
 
 function unsupportedFeatureError(message: string | null): Error {
   return new RuntimeError(RuntimeErrorCode.UNSUPPORTED_FEATURE, message ?? false);
-}
-
-function unsupportedDisableEnableError(): Error {
-  return unsupportedFeatureError(
-    ngDevMode &&
-      'Imperatively changing enabled/disabled status in form control is not supported in signal forms. Instead use a "disabled" rule to derive the disabled status from a signal.',
-  );
 }
 
 function unsupportedValidatorsError(): Error {

--- a/packages/forms/signals/test/node/compat/signal_form_control.spec.ts
+++ b/packages/forms/signals/test/node/compat/signal_form_control.spec.ts
@@ -491,15 +491,27 @@ describe('SignalFormControl', () => {
       expect(form.dirty).toBe(false);
     });
 
-    it('should throw when boxed value is passed to reset', () => {
+    it('should set the value and disable the control when a boxed value is passed to reset', () => {
       const form = createSignalFormControl(10);
-      expect(() => form.reset({value: 20, disabled: true})).toThrowError(
-        /Imperatively changing enabled\/disabled status in form control is not supported/,
-      );
 
-      expect(() => form.reset({value: 20, disabled: false})).toThrowError(
-        /Imperatively changing enabled\/disabled status in form control is not supported/,
-      );
+      form.reset({value: 20, disabled: true});
+
+      expect(form.value).toBe(20);
+      expect(form.disabled).toBe(true);
+      expect(form.status).toBe('DISABLED');
+    });
+
+    it('should set the value and re-enable the control when a boxed value is passed to reset', () => {
+      const form = createSignalFormControl(10);
+
+      form.disable();
+      expect(form.disabled).toBe(true);
+
+      form.reset({value: 20, disabled: false});
+
+      expect(form.value).toBe(20);
+      expect(form.disabled).toBe(false);
+      expect(form.status).toBe('VALID');
     });
 
     it('should NOT unbox value in reset if it has extra keys', () => {
@@ -539,21 +551,143 @@ describe('SignalFormControl', () => {
     });
   });
 
+  describe('disable and enable', () => {
+    it('should disable and re-enable the control', () => {
+      const form = createSignalFormControl(10);
+
+      expect(form.disabled).toBe(false);
+      expect(form.enabled).toBe(true);
+
+      form.disable();
+
+      expect(form.disabled).toBe(true);
+      expect(form.enabled).toBe(false);
+      expect(form.status).toBe('DISABLED');
+
+      form.enable();
+
+      expect(form.disabled).toBe(false);
+      expect(form.enabled).toBe(true);
+      expect(form.status).toBe('VALID');
+    });
+
+    it('should call registered onDisabledChange callbacks on disable() and enable()', () => {
+      const form = createSignalFormControl(10);
+      const callback = jasmine.createSpy('onDisabledChange');
+
+      form.registerOnDisabledChange(callback);
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.tick();
+
+      expect(callback).toHaveBeenCalledWith(false);
+      callback.calls.reset();
+
+      form.disable();
+      appRef.tick();
+
+      expect(callback).toHaveBeenCalledWith(true);
+      callback.calls.reset();
+
+      form.enable();
+      appRef.tick();
+
+      expect(callback).toHaveBeenCalledWith(false);
+    });
+
+    it('should NOT re-enable the control when a disabled rule from the schema is active', () => {
+      const form = createSignalFormControl(20, (p) => {
+        disabled(p, {when: ({value}) => value() > 15});
+      });
+
+      expect(form.disabled).toBe(true);
+
+      form.enable();
+
+      expect(form.disabled).toBe(true);
+      expect(form.status).toBe('DISABLED');
+    });
+
+    it('should restore previously-set dirty and touched state after disable() then enable()', () => {
+      const form = createSignalFormControl(10);
+      const appRef = TestBed.inject(ApplicationRef);
+
+      form.markAsDirty();
+      form.markAsTouched();
+      appRef.tick();
+
+      expect(form.dirty).toBe(true);
+      expect(form.touched).toBe(true);
+
+      form.disable();
+      appRef.tick();
+
+      expect(form.dirty).toBe(false);
+      expect(form.touched).toBe(false);
+
+      form.enable();
+      appRef.tick();
+
+      expect(form.dirty).toBe(true);
+      expect(form.touched).toBe(true);
+    });
+
+    it('should still emit a later status change after a same-tick disable/enable that nets to no change', () => {
+      const form = createSignalFormControl<number | undefined>(10, (p) => {
+        required(p);
+      });
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.tick();
+
+      const statuses: FormControlStatus[] = [];
+      form.statusChanges.subscribe((status: FormControlStatus) => statuses.push(status));
+
+      form.disable({emitEvent: false});
+      form.enable();
+      appRef.tick();
+
+      statuses.length = 0;
+
+      form.setValue(undefined);
+      appRef.tick();
+
+      expect(statuses).toEqual(['INVALID']);
+    });
+
+    it('should NOT emit statusChanges when a boxed reset disables with emitEvent false', () => {
+      const form = createSignalFormControl(10);
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.tick();
+
+      const statuses: FormControlStatus[] = [];
+      form.statusChanges.subscribe((status: FormControlStatus) => statuses.push(status));
+
+      form.reset({value: 20, disabled: true}, {emitEvent: false});
+      appRef.tick();
+
+      expect(statuses).toEqual([]);
+      expect(form.disabled).toBe(true);
+      expect(form.value).toBe(20);
+    });
+
+    it('should emit exactly one status per disable() and enable() transition', () => {
+      const form = createSignalFormControl(10);
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.tick();
+
+      const statuses: FormControlStatus[] = [];
+      form.statusChanges.subscribe((status: FormControlStatus) => statuses.push(status));
+
+      form.disable();
+      appRef.tick();
+      expect(statuses).toEqual(['DISABLED']);
+
+      form.enable();
+      appRef.tick();
+      expect(statuses).toEqual(['DISABLED', 'VALID']);
+    });
+  });
+
   describe('unsupported methods', () => {
-    it('should throw error when calling disable()', () => {
-      const form = createSignalFormControl(10);
-      expect(() => form.disable()).toThrowError(
-        /Imperatively changing enabled\/disabled status in form control is not supported/,
-      );
-    });
-
-    it('should throw error when calling enable()', () => {
-      const form = createSignalFormControl(10);
-      expect(() => form.enable()).toThrowError(
-        /Imperatively changing enabled\/disabled status in form control is not supported/,
-      );
-    });
-
     it('should throw error when calling setValidators()', () => {
       const form = createSignalFormControl(10);
       expect(() => form.setValidators(null)).toThrowError(

--- a/packages/forms/signals/test/node/compat/signal_form_control_in_form_group.spec.ts
+++ b/packages/forms/signals/test/node/compat/signal_form_control_in_form_group.spec.ts
@@ -6,9 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injector} from '@angular/core';
+import {ApplicationRef, Injector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {FormArray, FormControlStatus, FormGroup} from '@angular/forms';
+import {
+  AbstractControl,
+  ControlEvent,
+  FormArray,
+  FormControl,
+  FormControlStatus,
+  FormGroup,
+} from '@angular/forms';
 import {SignalFormControl} from '../../../compat/src/signal_form_control/signal_form_control';
 import {required} from '../../../public_api';
 import {SchemaFn} from '../../../src/api/types';
@@ -254,6 +261,253 @@ describe('SignalFormControl in FormGroup', () => {
 
     expect(value()).toBe(20);
     expect(form.value).toBe(20);
+  });
+
+  describe('disable and enable', () => {
+    it('should disable the group and the child when parent disable() is called', () => {
+      const child = createSignalFormControl(10);
+      const group = new FormGroup({
+        n: child,
+      });
+
+      expect(() => group.disable()).not.toThrow();
+
+      expect(group.disabled).toBe(true);
+      expect(group.status).toBe('DISABLED');
+      expect(child.disabled).toBe(true);
+      expect(child.status).toBe('DISABLED');
+    });
+
+    it('should re-enable the group and the child when parent enable() is called', () => {
+      const child = createSignalFormControl(10);
+      const group = new FormGroup({
+        n: child,
+      });
+
+      group.disable();
+      expect(child.disabled).toBe(true);
+
+      group.enable();
+
+      expect(group.disabled).toBe(false);
+      expect(group.status).toBe('VALID');
+      expect(child.disabled).toBe(false);
+      expect(child.status).toBe('VALID');
+      expect(group.value).toEqual({n: 10});
+    });
+
+    it('should exclude a disabled child from the group value but include it in getRawValue', () => {
+      const child = createSignalFormControl(10);
+      const group = new FormGroup({
+        n: child,
+        other: new FormControl(1),
+      });
+
+      child.disable();
+
+      expect(group.value).toEqual({other: 1});
+      expect(group.getRawValue()).toEqual({n: 10, other: 1});
+    });
+
+    it('should update parent status and value when the child is disabled directly', () => {
+      const child = createSignalFormControl(10);
+      const group = new FormGroup({
+        n: child,
+        other: new FormControl(1),
+      });
+
+      child.disable();
+
+      expect(group.status).toBe('VALID');
+      expect(group.value).toEqual({other: 1});
+
+      child.enable();
+
+      expect(group.status).toBe('VALID');
+      expect(group.value).toEqual({n: 10, other: 1});
+    });
+
+    it('should behave consistently for FormControl and SignalFormControl children', () => {
+      const signalChild = createSignalFormControl(10);
+      const plainChild = new FormControl(1);
+      const group = new FormGroup({
+        signal: signalChild,
+        plain: plainChild,
+      });
+
+      group.disable();
+
+      expect(signalChild.disabled).toBe(true);
+      expect(plainChild.disabled).toBe(true);
+      expect(group.status).toBe('DISABLED');
+      expect(group.value).toEqual({signal: 10, plain: 1});
+
+      group.enable();
+
+      expect(signalChild.disabled).toBe(false);
+      expect(plainChild.disabled).toBe(false);
+      expect(group.status).toBe('VALID');
+      expect(group.value).toEqual({signal: 10, plain: 1});
+    });
+
+    it('should preserve a dirty sibling and restore own dirty state when a dirty child is disabled', () => {
+      const child = createSignalFormControl(10);
+      const sibling = new FormControl(1);
+      const group = new FormGroup({
+        n: child,
+        other: sibling,
+      });
+      const appRef = TestBed.inject(ApplicationRef);
+
+      child.markAsDirty();
+      sibling.markAsDirty();
+      appRef.tick();
+
+      expect(child.dirty).toBe(true);
+      expect(sibling.dirty).toBe(true);
+      expect(group.dirty).toBe(true);
+
+      child.disable();
+      appRef.tick();
+
+      expect(sibling.dirty).toBe(true);
+      expect(group.dirty).toBe(true);
+
+      child.enable();
+      appRef.tick();
+
+      expect(child.dirty).toBe(true);
+    });
+
+    it('should preserve a touched sibling and restore own touched state when a touched child is disabled', () => {
+      const child = createSignalFormControl(10);
+      const sibling = new FormControl(1);
+      const group = new FormGroup({
+        n: child,
+        other: sibling,
+      });
+      const appRef = TestBed.inject(ApplicationRef);
+
+      child.markAsTouched();
+      sibling.markAsTouched();
+      appRef.tick();
+
+      expect(child.touched).toBe(true);
+      expect(sibling.touched).toBe(true);
+      expect(group.touched).toBe(true);
+
+      child.disable();
+      appRef.tick();
+
+      expect(sibling.touched).toBe(true);
+      expect(group.touched).toBe(true);
+
+      child.enable();
+      appRef.tick();
+
+      expect(child.touched).toBe(true);
+    });
+
+    it('should not update the parent when child.disable({onlySelf: true}) is called', () => {
+      const child = createSignalFormControl(10);
+      const group = new FormGroup({
+        n: child,
+        other: new FormControl(1),
+      });
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.tick();
+
+      const parentValues: unknown[] = [];
+      const parentStatuses: FormControlStatus[] = [];
+      group.valueChanges.subscribe((v) => parentValues.push(v));
+      group.statusChanges.subscribe((s) => parentStatuses.push(s));
+
+      child.disable({onlySelf: true});
+      appRef.tick();
+
+      expect(child.disabled).toBe(true);
+      expect(group.value).toEqual({n: 10, other: 1});
+      expect(parentValues).toEqual([]);
+      expect(parentStatuses).toEqual([]);
+    });
+
+    it('should not emit status or value changes when child.disable({emitEvent: false}) is called', () => {
+      const child = createSignalFormControl(10);
+      const group = new FormGroup({
+        n: child,
+        other: new FormControl(1),
+      });
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.tick();
+
+      const childStatuses: FormControlStatus[] = [];
+      const parentStatuses: FormControlStatus[] = [];
+      const parentValues: unknown[] = [];
+      child.statusChanges.subscribe((s) => childStatuses.push(s));
+      group.statusChanges.subscribe((s) => parentStatuses.push(s));
+      group.valueChanges.subscribe((v) => parentValues.push(v));
+
+      child.disable({emitEvent: false});
+      appRef.tick();
+
+      expect(child.disabled).toBe(true);
+      expect(childStatuses).toEqual([]);
+      expect(parentStatuses).toEqual([]);
+      expect(parentValues).toEqual([]);
+    });
+
+    it('should support disable/enable and value exclusion when nested in a FormArray', () => {
+      const child = createSignalFormControl(10);
+      const array = new FormArray<AbstractControl>([child, new FormControl(1)]);
+
+      expect(() => array.disable()).not.toThrow();
+      expect(array.status).toBe('DISABLED');
+      expect(child.disabled).toBe(true);
+
+      array.enable();
+      expect(array.status).toBe('VALID');
+      expect(child.disabled).toBe(false);
+
+      child.disable();
+      expect(array.value).toEqual([1]);
+      expect(array.getRawValue()).toEqual([10, 1]);
+    });
+
+    it('should not re-emit on a sibling SignalFormControl when another child changes dirty/touched', () => {
+      const changed = createSignalFormControl(10);
+      const sibling = createSignalFormControl(20);
+      const group = new FormGroup({
+        changed,
+        sibling,
+      });
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.tick();
+
+      const siblingEvents: ControlEvent[] = [];
+      const siblingStatuses: FormControlStatus[] = [];
+      sibling.events.subscribe((e) => siblingEvents.push(e));
+      sibling.statusChanges.subscribe((s) => siblingStatuses.push(s));
+
+      changed.markAsDirty();
+      changed.markAsTouched();
+      appRef.tick();
+
+      expect(siblingEvents).toEqual([]);
+      expect(siblingStatuses).toEqual([]);
+      expect(group.dirty).toBe(true);
+      expect(group.touched).toBe(true);
+
+      changed.disable();
+      appRef.tick();
+
+      expect(sibling.dirty).toBe(false);
+      expect(sibling.touched).toBe(false);
+      expect(sibling.disabled).toBe(false);
+      expect(group.dirty).toBe(false);
+      expect(group.touched).toBe(false);
+      expect(group.value).toEqual({sibling: 20});
+      expect(group.getRawValue()).toEqual({changed: 10, sibling: 20});
+    });
   });
 
   describe('integration with parent', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`SignalFormControl.disable()` and `enable()` throw. Because `FormGroup.disable()` calls `disable()` on every child, a group or array containing a `SignalFormControl` cannot be disabled at all. `reset({value, disabled})` also throws.

Issue Number: #68882

## What is the new behavior?

- `disable()` / `enable()` work, both directly and from a parent `FormGroup` / `FormArray`.
- The imperative status is applied through a root-level `disabled` rule on the control's internal schema, so status, `enabled`, parent value exclusion, and `onDisabledChange` callbacks derive from the existing signal forms machinery.
- `enable()` only clears the imperatively set status; a control disabled by a schema `disabled` rule stays disabled.
- Boxed `reset({value, disabled})` is supported instead of throwing.
- Disabling a dirty/touched control recalculates parent pristine/touched state without resetting siblings, matching reactive forms.
- `emitEvent: false` is honored for the control's own status emissions.
- Migration guide updated.

Not done in this PR: extending `AbstractControl<T>` for a typed `value` (also requested in #68882). That changes the typed public API surface and is left as a follow-up.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Fixes #68882
