### PR TITLE
docs: clarify runtime component comparison in elements guide

### DIFF
--- a/adev/src/content/guide/elements.md
+++ b/adev/src/content/guide/elements.md
@@ -78,10 +78,10 @@ For more information, see Web Component documentation for [Creating custom event
 
 ## Example: A Popup Service
 
-Previously, when you wanted to add a component to an application at runtime, you had to define a _dynamic component_, and then you would have to load it, attach it to an element in the DOM, and wire up all of the dependencies, change detection, and event handling.
+To add a component to an application at runtime, you can [render it programmatically](guide/components/programmatic-rendering) with the `createComponent` API.
+With this approach, you are responsible for the surrounding infrastructure: attaching the component's host view to the `ApplicationRef` so that change detection runs, setting its inputs, subscribing to its outputs, and detaching and cleaning up the view when the component is removed.
 
-Using an Angular custom element makes the process simpler and more transparent, by providing all the infrastructure and framework automatically —all you have to do is define the kind of event handling you want.
-\(You do still have to exclude the component from compilation, if you are not going to use it in your application.\)
+Using an Angular custom element makes the process simpler and more transparent, by providing all of this infrastructure automatically — all you have to do is define the kind of event handling you want.
 
 The following Popup Service example application defines a component that you can either load dynamically or convert to a custom element.
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The "Example: A Popup Service" section in the Angular Elements guide compares custom elements against a vague "previously you had to define a dynamic component" workflow, referencing manual steps that no guide describes. It also says you "have to exclude the component from compilation", which no longer applies to standalone components.

Issue Number: #55148

## What is the new behavior?

- The comparison now describes today's programmatic rendering approach with `createComponent` — which is what the accompanying `popup.service.ts` example actually uses — and links to the programmatic rendering guide.
- The outdated note about excluding the component from compilation is removed.

Not done: the example code files are unchanged; they already use the current `createComponent` API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Fixes #55148
