### PR TITLE
refactor(forms): extract shared promiseWithResolvers test helper to p…

### DIFF
--- a/packages/forms/signals/test/node/api/debounce.spec.ts
+++ b/packages/forms/signals/test/node/api/debounce.spec.ts
@@ -9,6 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {applyWhenValue, debounce, form} from '@angular/forms/signals';
+import {promiseWithResolvers} from '@angular/private/testing';
 
 describe('debounce', () => {
   describe('by duration', () => {
@@ -518,26 +519,4 @@ function timeout(durationInMilliseconds: number): Promise<void> {
 /** Returns a promise that will never resolve. */
 function forever(): Promise<never> {
   return new Promise(() => {});
-}
-
-/**
- * Replace with `Promise.withResolvers()` once it's available.
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
- */
-// TODO: share this with submit.spec.ts
-function promiseWithResolvers<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
 }

--- a/packages/forms/signals/test/node/compat/compat.spec.ts
+++ b/packages/forms/signals/test/node/compat/compat.spec.ts
@@ -24,22 +24,7 @@ import {
   validate,
   validateTree,
 } from '../../../public_api';
-
-function promiseWithResolvers<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
-}
+import {promiseWithResolvers} from '@angular/private/testing';
 
 describe('Forms compat', () => {
   it('should not error on a valid value', () => {

--- a/packages/forms/signals/test/node/compat/signal_form_control.spec.ts
+++ b/packages/forms/signals/test/node/compat/signal_form_control.spec.ts
@@ -19,25 +19,12 @@ import {ControlEvent, FormControlStatus, FormGroup, FormResetEvent} from '@angul
 import {disabled, required, validateAsync, ValidationError} from '@angular/forms/signals';
 import {SchemaFn} from '../../../src/api/types';
 import {SignalFormControl} from '../../../compat';
+import {promiseWithResolvers} from '@angular/private/testing';
 
 function createSignalFormControl<T>(initialValue: T, schema?: SchemaFn<T>) {
   const injector = TestBed.inject(Injector);
 
   return new SignalFormControl(initialValue, schema, {injector});
-}
-
-function promiseWithResolvers<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return {promise, resolve, reject};
 }
 
 describe('SignalFormControl', () => {

--- a/packages/forms/signals/test/node/submit.spec.ts
+++ b/packages/forms/signals/test/node/submit.spec.ts
@@ -19,6 +19,7 @@ import {
   validateAsync,
   ValidationError,
 } from '../../public_api';
+import {promiseWithResolvers} from '@angular/private/testing';
 
 describe('submit', () => {
   let injector: Injector;
@@ -142,7 +143,7 @@ describe('submit', () => {
     it('should resolve pending validation after successful submit', async () => {
       const appRef = TestBed.inject(ApplicationRef);
       const data = signal('foo');
-      const {promise, resolve} = promiseWithResolvers();
+      const {promise, resolve} = promiseWithResolvers<boolean>();
       const f = form(
         data,
         (p) => {
@@ -642,24 +643,3 @@ describe('submit', () => {
     expect(submitSpy).toHaveBeenCalledWith({name: 'Alice'}, {name: 'Alice'}, 'Alice');
   });
 });
-
-/**
- * Replace with `Promise.withResolvers()` once it's available.
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
- */
-function promiseWithResolvers<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
-}

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -69,6 +69,7 @@ import {
 } from '../../public_api';
 import {InputValidityMonitor} from '../../src/directive/input_validity_monitor';
 import {TestInputValidityMonitor} from './test_input_validity_monitor';
+import {promiseWithResolvers} from '@angular/private/testing';
 
 function configureTestValidityMonitor() {
   TestBed.configureTestingModule({
@@ -6489,26 +6490,4 @@ function act<T>(fn: () => T): T {
   } finally {
     TestBed.tick();
   }
-}
-
-/**
- * Replace with `Promise.withResolvers()` once it's available.
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
- */
-// TODO: share this with submit.spec.ts
-function promiseWithResolvers<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
 }

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -56,6 +56,7 @@ import {
   WithOptionalFieldTree,
   transformedValue,
 } from '@angular/forms/signals';
+import {promiseWithResolvers} from '@angular/private/testing';
 
 describe('ControlValueAccessor', () => {
   beforeEach(() => {
@@ -1456,26 +1457,4 @@ async function actAsync<T>(fn: () => T): Promise<T> {
   } finally {
     await TestBed.inject(ApplicationRef).whenStable();
   }
-}
-
-/**
- * Replace with `Promise.withResolvers()` once it's available.
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
- */
-// TODO: share this with submit.spec.ts
-function promiseWithResolvers<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
 }

--- a/packages/private/testing/src/utils.ts
+++ b/packages/private/testing/src/utils.ts
@@ -298,3 +298,25 @@ export async function waitFor<T>(
     await new Promise((resolve) => void realSetTimeout(resolve, interval));
   }
 }
+
+/**
+ * Replace with `Promise.withResolvers()` once it's available.
+ * NET September 2026
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
+ */
+export function promiseWithResolvers<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: any) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {promise, resolve, reject};
+}


### PR DESCRIPTION
Move the duplicated `promiseWithResolvers` utility function from  submit.spec.ts, debounce.spec.ts, form_field.spec.ts, interop.spec.ts, compat.spec.ts, and signal_form_control.spec.ts into `packages/private/testing/src/utils.ts` and replace all local definitions with an import from `@angular/private/testing`.

Fix call sites that resolve with a non-void value to use an explicit  type parameter (e.g. `promiseWithResolvers<boolean>()`) to match the  shared function's `T = void` default.