### PR TITLE
refactor(devtools): stop component inspector on esc press

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -60,6 +60,9 @@ type Tab = 'Components' | 'Profiler' | 'Router Tree' | 'Injector Tree' | 'Transf
     ButtonComponent,
   ],
   providers: [TabUpdate],
+  host: {
+    '(document:keydown.Escape)': 'stopInspecting()',
+  },
 })
 export class DevToolsTabsComponent {
   public readonly frameManager = inject(FrameManager);
@@ -163,6 +166,12 @@ export class DevToolsTabsComponent {
   toggleInspector(): void {
     this.toggleInspectorState();
     this.emitInspectorEvent();
+  }
+
+  stopInspecting(): void {
+    if (this.inspectorRunning()) {
+      this.toggleInspector();
+    }
   }
 
   emitInspectorEvent(): void {


### PR DESCRIPTION
Stop the component inspector when Escape is pressed similarly to Chrome DevTools.