### PR TITLE
docs: show ng-add schema files in schematics-for-libraries guide

### DIFF
--- a/adev/src/content/tools/cli/schematics-for-libraries.md
+++ b/adev/src/content/tools/cli/schematics-for-libraries.md
@@ -36,10 +36,17 @@ A schematic for the `ng add` command can enhance the initial installation proces
 The following steps define this type of schematic.
 
 1. Go to the `<lib-root>/schematics/ng-add` folder.
-1. Create the main file, `index.ts`.
-1. Open `index.ts` and add the source code for your schematic factory function.
+1. Create a `schema.json` file to define the options that the schematic accepts.
 
-<docs-code header="projects/my-lib/schematics/ng-add/index.ts (ng-add Rule Factory)" path="adev/src/content/examples/schematics-for-libraries/projects/my-lib/schematics/ng-add/index.ts"/>
+   <docs-code header="projects/my-lib/schematics/ng-add/schema.json (ng-add Schema)" path="adev/src/content/examples/schematics-for-libraries/projects/my-lib/schematics/ng-add/schema.json"/>
+
+1. Create a `schema.ts` file to define an interface for the options defined in the `schema.json` file.
+
+   <docs-code header="projects/my-lib/schematics/ng-add/schema.ts (ng-add Schema Interface)" path="adev/src/content/examples/schematics-for-libraries/projects/my-lib/schematics/ng-add/schema.ts"/>
+
+1. Create the main file, `index.ts`, and add the source code for your schematic factory function.
+
+   <docs-code header="projects/my-lib/schematics/ng-add/index.ts (ng-add Rule Factory)" path="adev/src/content/examples/schematics-for-libraries/projects/my-lib/schematics/ng-add/index.ts"/>
 
 The Angular CLI will install the latest version of the library automatically, and this example is taking it a step further by adding the `MyLibModule` to the root of the application. The `addRootImport` function accepts a callback that needs to return a code block. You can write any code inside of the string tagged with the `code` function and any external symbol have to be wrapped with the `external` function to ensure that the appropriate import statements are generated.
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

In the "Schematics for libraries" guide, the `ng add` walkthrough references two files it never shows: the collection (`collection.1.json`) points to `ng-add/schema.json`, and `ng-add/index.ts` imports its `Schema` interface from `ng-add/schema.ts`. A reader following the walkthrough hits both references with no definition.

Issue Number: #57005

## What is the new behavior?

- The "Providing installation support" section now shows `ng-add/schema.json` and `ng-add/schema.ts`, mirroring the "Providing generation support" section that already shows the equivalent files for `my-service`.
- Both files already exist in the guide's example project; this only surfaces them with `<docs-code>` blocks. No prose rewrite and no example-code changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Fixes #57005
