### PR TITLE
fix(localize): build runtime translations map with a null prototype

### DIFF
--- a/packages/localize/src/translate.ts
+++ b/packages/localize/src/translate.ts
@@ -67,7 +67,11 @@ export function loadTranslations(translations: Record<MessageId, TargetMessage>)
     $localize.translate = translate;
   }
   if (!$localize.TRANSLATIONS) {
-    $localize.TRANSLATIONS = {};
+    // Keyed by message ID, which is taken verbatim from the `translations` map (e.g. parsed from a
+    // translation file), so it can be `__proto__`. Indexing a plain object with that key assigns
+    // through the inherited `__proto__` setter, reparenting the map instead of storing the entry
+    // (and throwing under `--disable-proto=throw`). A null-prototype map makes it an ordinary key.
+    $localize.TRANSLATIONS = Object.create(null);
   }
   Object.keys(translations).forEach((key) => {
     $localize.TRANSLATIONS[key] = parseTranslation(translations[key]);
@@ -86,7 +90,7 @@ export function loadTranslations(translations: Record<MessageId, TargetMessage>)
  */
 export function clearTranslations() {
   $localize.translate = undefined;
-  $localize.TRANSLATIONS = {};
+  $localize.TRANSLATIONS = Object.create(null);
 }
 
 /**

--- a/packages/localize/test/translate_spec.ts
+++ b/packages/localize/test/translate_spec.ts
@@ -103,6 +103,27 @@ describe('$localize tag with translations', () => {
       );
     });
   });
+
+  describe('with a `__proto__` message id', () => {
+    afterEach(() => {
+      clearTranslations();
+    });
+
+    it('should treat `__proto__` as an ordinary translation key', () => {
+      loadTranslations({
+        ['__proto__' as MessageId]: 'pwned' as TargetMessage,
+        [computeMsgId('abc', '')]: 'abc' as TargetMessage,
+      });
+
+      const store = ($localize as unknown as {TRANSLATIONS: Record<string, unknown>}).TRANSLATIONS;
+      // The malicious id must be stored as an own key rather than assigned through the inherited
+      // `__proto__` setter, which would reparent the map (and drop the entry).
+      expect(Object.getPrototypeOf(store)).toBe(null);
+      expect(Object.prototype.hasOwnProperty.call(store, '__proto__')).toBe(true);
+      // A translation loaded alongside it still resolves.
+      expect($localize`abc`).toEqual('abc');
+    });
+  });
 });
 
 function computeIds(


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: N/A

`loadTranslations` builds the shared global `$localize.TRANSLATIONS` as a plain `{}` and then indexes it with message ids taken verbatim from the `translations` map, which is commonly parsed from a translation file. A translation whose id is `__proto__` therefore assigns a `ParsedTranslation` through the inherited `__proto__` setter, which reparents the map instead of storing the entry: the `__proto__` translation is silently dropped, a later lookup for an id such as `text` resolves to the injected value through the prototype, and under `node --disable-proto=throw` the assignment throws.

## What is the new behavior?

The translations store is created with `Object.create(null)` in both `loadTranslations` and `clearTranslations`, so a `__proto__` message id is treated as an ordinary key. This mirrors the null-prototype hardening already used for outlet maps in the router url parser. Added a regression test that loads a `__proto__` id alongside a normal one and checks the map is not reparented and the normal translation still resolves.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
