### PR TITLE
fix(compiler): parsing of an empty template literal interpolation

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -1646,9 +1646,8 @@ class _ParseAST {
         const expression = this.parsePipe();
         if (expression instanceof EmptyExpr) {
           this.error('Template literal interpolation cannot be empty');
-        } else {
-          expressions.push(expression);
         }
+        expressions.push(expression);
         this.rbracesExpected--;
       } else {
         this.advance();

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -529,6 +529,9 @@ describe('parser', () => {
       });
 
       it('should report error if interpolation is empty', () => {
+        // Even though an empty interpolation should result in an error,
+        // we should retain the expression.
+        checkBinding('`hello ${}`');
         expectBindingError('`hello ${}`', 'Template literal interpolation cannot be empty');
       });
 

--- a/packages/language-service/test/diagnostic_spec.ts
+++ b/packages/language-service/test/diagnostic_spec.ts
@@ -194,6 +194,30 @@ describe('getSemanticDiagnostics', () => {
     );
   });
 
+  it('should report a parse error for an empty template literal interpolation', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '<p>{{ \`Hello, $\{\}!\` }}</p>',
+      })
+      export class AppComponent {}
+    `,
+    };
+
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    const diags = project.getDiagnosticsForFile('app.ts');
+
+    expect(
+      diags.some((diag) =>
+        ts
+          .flattenDiagnosticMessageText(diag.messageText, '')
+          .includes('Parser Error: Template literal interpolation cannot be empty'),
+      ),
+    ).toBe(true);
+  });
+
   it('reports html parse errors along with typecheck errors as diagnostics', () => {
     const files = {
       'app.ts': `


### PR DESCRIPTION
A minor fix. 

Even if we have an `EmptyExpr`, add that expression to the expressions array when a literal is parsed. The lack of the expression results in a discrepancy in the sizes of the `elements` and the `expressions` arrays of a `TemplateLiteral`, that leads to an error when we visit that same literal due to the missing expression.

Fixes #69699

Additionally, I've added a test to the language service, just in case, that ensures the scenario is handled gracefully.