### PR TITLE
docs(signal-forms): rename output touch to touchedChange

### DIFF
--- a/adev/src/content/guide/forms/signals/custom-controls.md
+++ b/adev/src/content/guide/forms/signals/custom-controls.md
@@ -268,7 +268,7 @@ import {
           [readonly]="readonly()"
           [class.invalid]="invalid()"
           [attr.aria-invalid]="invalid()"
-          (blur)="touch.emit()"
+          (blur)="touchedChange.emit(true)"
         />
 
         @if (invalid()) {
@@ -296,7 +296,7 @@ export class StatefulInput implements FormValueControl<string> {
 
   // Writable interaction state - control updates these
   touched = input<boolean>(false);
-  touch = output<void>();
+  touchedChange = output<boolean>();
 
   // Read-only state - form system manages these
   disabled = input<boolean>(false);
@@ -344,7 +344,7 @@ Most state properties use `input()` (read-only from the form). Use `model()` for
 
 ### Working with `debounce('blur')`
 
-The [`debounce('blur')`](api/forms/signals/debounce) rule delays updates from the UI to the form model until the field is blurred, instead of applying them on every keystroke. Built-in controls report a blur to the form automatically. A custom control only participates if it emits its `touch` output in response to the native [`blur` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event):
+The [`debounce('blur')`](api/forms/signals/debounce) rule delays updates from the UI to the form model until the field is blurred, instead of applying them on every keystroke. Built-in controls report a blur to the form automatically. A custom control only participates if it emits its `touchedChange` output in response to the native [`blur` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event):
 
 ```angular-ts
 import {Component, model, output} from '@angular/core';
@@ -357,17 +357,17 @@ import {FormValueControl} from '@angular/forms/signals';
       type="text"
       [value]="value()"
       (input)="value.set($event.target.value)"
-      (blur)="touch.emit()"
+      (blur)="touchedChange.emit(true)"
     />
   `,
 })
 export class CustomInput implements FormValueControl<string> {
   value = model('');
-  touch = output<void>();
+  touchedChange = output<boolean>();
 }
 ```
 
-With the `touch` output in place, `debounce('blur')` behaves the same for your control as it does for built-in inputs:
+With the `touchedChange` output in place, `debounce('blur')` behaves the same for your control as it does for built-in inputs:
 
 ```angular-ts
 import {Component, signal} from '@angular/core';
@@ -388,7 +388,7 @@ export class App {
 }
 ```
 
-IMPORTANT: Emit `touch` on `blur` (when focus leaves the control), not on `focus`. Without the `touch` output the field never registers as blurred, so `debounce('blur')` has no effect on your control.
+IMPORTANT: Emit `touchedChange` on `blur` (when focus leaves the control), not on `focus`. Without the `touchedChange` output the field never registers as blurred, so `debounce('blur')` has no effect on your control.
 
 ## Value transformation
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The signal forms [Custom Controls](https://angular.dev/guide/forms/signals/custom-controls) shows an example using `touch` as output to handle the `blur` event of the input. The form field is not reacting on the `touch` output, because `FormUiControl` exposes `touched` as model and it should be named `touchedChange`.

## What is the new behavior?

Updating the Custom Controls section to use `touchedChange` instead of `touch`.  `FormUiControl` exposes `touched` as a model. 

```ts
import {Component, model, output} from '@angular/core';
import {FormValueControl} from '@angular/forms/signals';
@Component({
  selector: 'app-custom-input',
  template: `
    <input
      type="text"
      [value]="value()"
      (input)="value.set($event.target.value)"
      (blur)="touched.set(true)"
    />
  `,
})
export class CustomInput implements FormValueControl<string> {
  value = model('');
  touched = model<boolean>(false);
}
```

It can also be split up into an input and output - model `touched` registers `touchedChange` as the output name.

```ts
import {Component, model, output} from '@angular/core';
import {FormValueControl} from '@angular/forms/signals';
@Component({
  selector: 'app-custom-input',
  template: `
    <input
      type="text"
      [value]="value()"
      (input)="value.set($event.target.value)"
      (blur)="touchedChange.emit(true)"
    />
  `,
})
export class CustomInput implements FormValueControl<string> {
  value = model('');
  // split touched model into input and output
  touched = input<boolean>(false);
  touchedChange = output<boolean>();
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
