### PR TITLE
docs: clarify Signal Forms does not drive native HTML validity

### DIFF
--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -56,6 +56,8 @@ All validation rules run on every change - validation doesn't short-circuit afte
 
 Signal Forms provides validation rules for common validation scenarios. All built-in validation rules accept an options object for custom error messages and conditional logic.
 
+NOTE: Signal Forms validation is independent of the browser's native HTML constraint validation. `FormRoot` sets `novalidate` on the `form` element, and Signal Forms never updates an input's native validity state — the `:valid` and `:invalid` CSS pseudo-classes, the `validity` object, and `validationMessage`. Any native `:invalid` styling you observe, such as on a `type="number"` input constrained by `min()` or `max()`, comes from the browser evaluating the reflected attribute rather than from Signal Forms, so it is not consistent across rules. To reflect validation state in your UI, read the field's `invalid()` and `errors()` signals instead of relying on native CSS pseudo-classes.
+
 ### required()
 
 The `required()` validation rule ensures a field has a value:


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The Signal Forms validation guide doesn't state that validation is independent of the browser's native HTML constraint validation. This surprises users: `min()`/`max()` on a `type="number"` input show native `:invalid` styling, while `minLength()`/`maxLength()` on a text input do not — even though both reflect their attribute. Per maintainer feedback on the issue, interfacing with native HTML validation is not a design goal, and this should be documented.

Issue Number: #69690

## What is the new behavior?

- Adds a `NOTE` to the "Built-in validation rules" section explaining that Signal Forms never drives native validity (`:valid`/`:invalid`, `validity`, `validationMessage`), that any native `:invalid` you see comes from the browser evaluating the reflected attribute and is inconsistent across rules, and that `invalid()`/`errors()` signals are the source of truth.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Fixes #69690
