### PR TITLE
fix(devtools): bump settings z-index due to overlapping elements

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/settings/settings.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/settings/settings.component.scss
@@ -14,6 +14,7 @@
   box-sizing: border-box;
   border: 1px solid var(--quinary-contrast);
   overflow: hidden;
+  z-index: 999999;
 
   .wrapper {
     overflow-y: auto;


### PR DESCRIPTION
Fixes the bug where the Transfer State table header is overlapping the settings window.

**Bug:**
<img width="831" height="529" alt="Screenshot 2026-07-09 at 18 00 05" src="https://github.com/user-attachments/assets/e221a815-94c5-4750-8abb-8a4671c3203b" />
