### PR TITLE
feat(migrations): add migration to remove unclaimed bindings on ng-template

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -154,6 +154,10 @@ bundle_entrypoints = [
         "safe-optional-chaining",
         "packages/core/schematics/migrations/safe-optional-chaining/index.js",
     ],
+    [
+        "ng-template-unclaimed-bindings",
+        "packages/core/schematics/migrations/ng-template-unclaimed-bindings/index.js",
+    ],
 ]
 
 rollup.rollup(
@@ -170,6 +174,7 @@ rollup.rollup(
         "//packages/core/schematics/migrations/http-xhr-backend",
         "//packages/core/schematics/migrations/incremental-hydration",
         "//packages/core/schematics/migrations/model-output",
+        "//packages/core/schematics/migrations/ng-template-unclaimed-bindings",
         "//packages/core/schematics/migrations/safe-optional-chaining",
         "//packages/core/schematics/migrations/strict-safe-navigation-narrow",
         "//packages/core/schematics/migrations/strict-templates-default",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -1,5 +1,10 @@
 {
   "schematics": {
+    "ng-template-unclaimed-bindings": {
+      "version": "22.1.0",
+      "description": "Removes property bindings on '<ng-template>' elements that are not matched by any directive. Such bindings had no effect at runtime and are now reported as compile-time errors (NG8002).",
+      "factory": "./bundles/ng-template-unclaimed-bindings.cjs#migrate"
+    },
     "change-detection-eager": {
       "version": "22.0.0",
       "description": "Adds `ChangeDetectionStrategy.Eager` to all components.",
@@ -39,6 +44,11 @@
       "version": "22.0.0",
       "description": "Wraps optional chaining expressions in $safeNavigationMigration().",
       "factory": "./bundles/safe-optional-chaining.cjs#migrate"
+    },
+    "ng-template-unclaimed-bindings": {
+      "version": "22.1.0",
+      "description": "Removes property bindings on <ng-template> elements that are not claimed by any directive, which are now reported as compile errors.",
+      "factory": "./bundles/ng-template-unclaimed-bindings.cjs#migrate"
     }
   }
 }

--- a/packages/core/schematics/migrations/ng-template-unclaimed-bindings/BUILD.bazel
+++ b/packages/core/schematics/migrations/ng-template-unclaimed-bindings/BUILD.bazel
@@ -1,0 +1,41 @@
+load("//tools:defaults.bzl", "jasmine_test", "ts_project")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_project(
+    name = "ng-template-unclaimed-bindings",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["*.spec.ts"],
+    ),
+    deps = [
+        "//:node_modules/@angular-devkit/schematics",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+        "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+    ],
+)
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        ":ng-template-unclaimed-bindings",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli",
+        "//packages/core/schematics/utils/tsurge",
+    ],
+)
+
+jasmine_test(
+    name = "test",
+    data = [":test_lib"],
+)

--- a/packages/core/schematics/migrations/ng-template-unclaimed-bindings/index.ts
+++ b/packages/core/schematics/migrations/ng-template-unclaimed-bindings/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+import {NgTemplateUnclaimedBindingsMigration} from './migration';
+
+export function migrate(): Rule {
+  return async (tree) => {
+    await runMigrationInDevkit({
+      tree,
+      getMigration: () => new NgTemplateUnclaimedBindingsMigration(),
+    });
+  };
+}

--- a/packages/core/schematics/migrations/ng-template-unclaimed-bindings/migration.ts
+++ b/packages/core/schematics/migrations/ng-template-unclaimed-bindings/migration.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {OptimizeFor} from '@angular/compiler-cli';
+import ts from 'typescript';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  projectFile,
+  Replacement,
+  Serializable,
+  TextUpdate,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+
+export interface CompilationUnitData {
+  replacements: Replacement[];
+}
+
+/**
+ * Error code of the "Can't bind to 'x' since it isn't a known property of 'y'" diagnostic
+ * produced by the template type checker (`ngErrorCode(ErrorCode.SCHEMA_INVALID_ATTRIBUTE)`,
+ * reported as `NG8002`).
+ */
+const UNKNOWN_PROPERTY_DIAGNOSTIC_CODE = -998002;
+
+export class NgTemplateUnclaimedBindingsMigration extends TsurgeFunnelMigration<
+  CompilationUnitData,
+  CompilationUnitData
+> {
+  override async analyze(info: ProgramInfo): Promise<Serializable<CompilationUnitData>> {
+    const replacements: Replacement[] = [];
+
+    if (info.ngCompiler === null) {
+      return confirmAsSerializable({replacements});
+    }
+
+    const seen = new Set<string>();
+
+    for (const sourceFile of info.sourceFiles) {
+      const diagnostics = info.ngCompiler.getDiagnosticsForFile(
+        sourceFile,
+        OptimizeFor.WholeProgram,
+      );
+
+      for (const diag of diagnostics) {
+        if (
+          diag.code !== UNKNOWN_PROPERTY_DIAGNOSTIC_CODE ||
+          diag.file === undefined ||
+          diag.start === undefined ||
+          diag.length === undefined
+        ) {
+          continue;
+        }
+
+        const message = ts.flattenDiagnosticMessageText(diag.messageText, '\n');
+        if (!message.includes(`known property of 'ng-template'`)) {
+          continue;
+        }
+
+        const text = diag.file.text;
+        const end = diag.start + diag.length;
+
+        // Only remove actual property/two-way bindings (`[foo]="..."`, `[(foo)]="..."`).
+        if (text[diag.start] !== '[') {
+          continue;
+        }
+
+        // Include the whitespace between the binding and whatever precedes it.
+        let start = diag.start;
+        while (start > 0 && /\s/.test(text[start - 1])) {
+          start--;
+        }
+
+        // The same diagnostic can be reported through multiple source files, e.g. for
+        // external templates shared by more than one component.
+        const key = `${diag.file.fileName}@${start}:${end}`;
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+
+        replacements.push(
+          new Replacement(
+            projectFile(diag.file, info),
+            new TextUpdate({position: start, end, toInsert: ''}),
+          ),
+        );
+      }
+    }
+
+    return confirmAsSerializable({replacements});
+  }
+
+  override async combine(
+    unitA: CompilationUnitData,
+    unitB: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    const seen = new Set<string>();
+    const replacements: Replacement[] = [];
+
+    for (const replacement of [...unitA.replacements, ...unitB.replacements]) {
+      const {position, end, toInsert} = replacement.update.data;
+      const key = `${replacement.projectFile.rootRelativePath}@${position}:${end}:${toInsert}`;
+
+      if (!seen.has(key)) {
+        seen.add(key);
+        replacements.push(replacement);
+      }
+    }
+
+    return confirmAsSerializable({replacements});
+  }
+
+  override async globalMeta(
+    combinedData: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable(combinedData);
+  }
+
+  override async stats(globalMetadata: CompilationUnitData) {
+    return confirmAsSerializable({
+      removedBindings: globalMetadata.replacements.length,
+    });
+  }
+
+  override async migrate(globalData: CompilationUnitData) {
+    return {replacements: globalData.replacements};
+  }
+}

--- a/packages/core/schematics/migrations/ng-template-unclaimed-bindings/ng-template-unclaimed-bindings.spec.ts
+++ b/packages/core/schematics/migrations/ng-template-unclaimed-bindings/ng-template-unclaimed-bindings.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {absoluteFrom} from '@angular/compiler-cli';
+import {initMockFileSystem} from '@angular/compiler-cli/private/testing';
+import {runTsurgeMigration} from '../../utils/tsurge/testing';
+import {NgTemplateUnclaimedBindingsMigration} from './migration';
+
+describe('NgTemplateUnclaimedBindingsMigration', () => {
+  beforeEach(() => {
+    initMockFileSystem('Native');
+  });
+
+  async function migrateSingleFile(contents: string): Promise<string> {
+    const {fs} = await runTsurgeMigration(new NgTemplateUnclaimedBindingsMigration(), [
+      {
+        name: absoluteFrom('/app.component.ts'),
+        isProgramRootFile: true,
+        contents,
+      },
+    ]);
+
+    return fs.readFile(absoluteFrom('/app.component.ts'));
+  }
+
+  it('should remove a property binding on an ng-template not claimed by any directive', async () => {
+    const content = await migrateSingleFile(`
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '<ng-template [someDir]="value">content</ng-template>',
+      })
+      export class AppComponent {
+        value = 1;
+      }
+    `);
+
+    expect(content).toContain(`template: '<ng-template>content</ng-template>'`);
+  });
+
+  it('should remove a two-way binding on an ng-template not claimed by any directive', async () => {
+    const content = await migrateSingleFile(`
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '<ng-template [(someDir)]="value">content</ng-template>',
+      })
+      export class AppComponent {
+        value = 1;
+      }
+    `);
+
+    expect(content).toContain(`template: '<ng-template>content</ng-template>'`);
+  });
+
+  it('should not remove a binding claimed by an imported directive', async () => {
+    const content = await migrateSingleFile(`
+      import {Component, Directive, Input} from '@angular/core';
+
+      @Directive({selector: '[someDir]'})
+      export class SomeDirective {
+        @Input() someDir: any;
+      }
+
+      @Component({
+        imports: [SomeDirective],
+        template: '<ng-template [someDir]="value">content</ng-template>',
+      })
+      export class AppComponent {
+        value = 1;
+      }
+    `);
+
+    expect(content).toContain(`template: '<ng-template [someDir]="value">content</ng-template>'`);
+  });
+
+  it('should not remove a binding that matches a directive selector without a corresponding input', async () => {
+    const content = await migrateSingleFile(`
+      import {Component, Directive} from '@angular/core';
+
+      @Directive({selector: '[foobar]'})
+      export class FoobarDirective {}
+
+      @Component({
+        imports: [FoobarDirective],
+        template: '<ng-template #foo [foobar]>content</ng-template>',
+      })
+      export class AppComponent {}
+    `);
+
+    expect(content).toContain(`template: '<ng-template #foo [foobar]>content</ng-template>'`);
+  });
+
+  it('should only remove the unclaimed bindings when the ng-template has multiple bindings', async () => {
+    const content = await migrateSingleFile(`
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '<ng-template let-item [someDir]="value" #ref>content</ng-template>',
+      })
+      export class AppComponent {
+        value = 1;
+      }
+    `);
+
+    expect(content).toContain(`template: '<ng-template let-item #ref>content</ng-template>'`);
+  });
+
+  it('should not touch bindings on regular elements', async () => {
+    const content = await migrateSingleFile(`
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '<div [unknownProp]="value"></div>',
+      })
+      export class AppComponent {
+        value = 1;
+      }
+    `);
+
+    expect(content).toContain(`template: '<div [unknownProp]="value"></div>'`);
+  });
+
+  it('should remove unclaimed bindings in an external template', async () => {
+    const {fs} = await runTsurgeMigration(new NgTemplateUnclaimedBindingsMigration(), [
+      {
+        name: absoluteFrom('/app.component.ts'),
+        isProgramRootFile: true,
+        contents: `
+          import {Component} from '@angular/core';
+
+          @Component({
+            templateUrl: './app.component.html',
+          })
+          export class AppComponent {
+            value = 1;
+          }
+        `,
+      },
+      {
+        name: absoluteFrom('/app.component.html'),
+        contents: [`<h1>Hello</h1>`, `<ng-template [someDir]="value">content</ng-template>`].join(
+          '\n',
+        ),
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/app.component.html'));
+    expect(content).toContain('<ng-template>content</ng-template>');
+    expect(content).toContain('<h1>Hello</h1>');
+  });
+
+  it('should remove a binding that spans its own line', async () => {
+    const {fs} = await runTsurgeMigration(new NgTemplateUnclaimedBindingsMigration(), [
+      {
+        name: absoluteFrom('/app.component.ts'),
+        isProgramRootFile: true,
+        contents: `
+          import {Component} from '@angular/core';
+
+          @Component({
+            templateUrl: './app.component.html',
+          })
+          export class AppComponent {
+            value = 1;
+          }
+        `,
+      },
+      {
+        name: absoluteFrom('/app.component.html'),
+        contents: [`<ng-template`, `  [someDir]="value"`, `  #ref>content</ng-template>`].join(
+          '\n',
+        ),
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/app.component.html'));
+    expect(content).toBe(['<ng-template', '  #ref>content</ng-template>'].join('\n'));
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Adds a migration that detects and removes property/two-way
bindings (e.g. `[foo]="..."`, `[(foo)]="..."`) on `ng-template` elements that are not recognized as known properties.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No