### PR TITLE
Update WebMCP tool registration to be asynchronous

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -541,7 +541,7 @@ export class DebugNode {
 }
 
 // @public
-export function declareExperimentalWebMcpTool<const InputSchema extends JsonSchemaForInference>(tool: WebMcpToolDescriptor<InputSchema>, injector?: Injector): void;
+export function declareExperimentalWebMcpTool<const InputSchema extends JsonSchemaForInference>(tool: WebMcpToolDescriptor<InputSchema>, injector?: Injector): Promise<void>;
 
 // @public
 export const DEFAULT_CURRENCY_CODE: InjectionToken<string>;

--- a/packages/core/src/webmcp/declare_tool.ts
+++ b/packages/core/src/webmcp/declare_tool.ts
@@ -29,10 +29,9 @@ import type {ModelContext, ToolDescriptor} from './types';
  *     `injector` argument provided.
  * @experimental
  */
-export function declareExperimentalWebMcpTool<const InputSchema extends JsonSchemaForInference>(
-  tool: ToolDescriptor<InputSchema>,
-  injector?: Injector,
-): void {
+export async function declareExperimentalWebMcpTool<
+  const InputSchema extends JsonSchemaForInference,
+>(tool: ToolDescriptor<InputSchema>, injector?: Injector): Promise<void> {
   // SSR may not have a document yet, so we abort before checking it.
   if (typeof ngServerMode !== 'undefined' && ngServerMode) return;
 
@@ -69,8 +68,8 @@ export function declareExperimentalWebMcpTool<const InputSchema extends JsonSche
       ),
   };
 
-  modelContext.registerTool(wrappedTool, {signal: abortCtrl.signal});
-
   // Unregister when the associated `Injector` is destroyed.
   destroyRef.onDestroy(() => void abortCtrl.abort());
+
+  await modelContext.registerTool(wrappedTool, {signal: abortCtrl.signal});
 }

--- a/packages/core/src/webmcp/types.ts
+++ b/packages/core/src/webmcp/types.ts
@@ -90,11 +90,4 @@ export interface ModelContext {
     tool: ToolDescriptor<InputSchema>,
     options?: ToolRegistrationOptions,
   ): Promise<void>;
-
-  /**
-   * Unregister a tool.
-   *
-   * @deprecated Only exists for out-of-date `@mcp-b/webmcp-polyfill` testing tool.
-   */
-  unregisterTool(tool: {name: string}): void;
 }

--- a/packages/core/src/webmcp/types.ts
+++ b/packages/core/src/webmcp/types.ts
@@ -89,7 +89,7 @@ export interface ModelContext {
   registerTool<const InputSchema extends JsonSchemaForInference>(
     tool: ToolDescriptor<InputSchema>,
     options?: ToolRegistrationOptions,
-  ): void;
+  ): Promise<void>;
 
   /**
    * Unregister a tool.

--- a/packages/core/test/webmcp/declare_tool_spec.ts
+++ b/packages/core/test/webmcp/declare_tool_spec.ts
@@ -33,7 +33,7 @@ describe('declareExperimentalWebMcpTool', () => {
       content: [{type: 'text', text: 'Hello!'}],
     });
 
-    declareExperimentalWebMcpTool(
+    await declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',
@@ -62,10 +62,10 @@ describe('declareExperimentalWebMcpTool', () => {
     });
   });
 
-  it('should throw if the tool is already registered', () => {
+  it('should throw if the tool is already registered', async () => {
     const injector = Injector.create({providers: []});
 
-    declareExperimentalWebMcpTool(
+    await declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',
@@ -75,7 +75,7 @@ describe('declareExperimentalWebMcpTool', () => {
       injector,
     );
 
-    expect(() => {
+    await expectAsync(
       declareExperimentalWebMcpTool(
         {
           name: 'testTool',
@@ -84,14 +84,14 @@ describe('declareExperimentalWebMcpTool', () => {
           execute: async () => ({content: []}),
         },
         injector,
-      );
-    }).toThrowError(/already registered/);
+      ),
+    ).toBeRejectedWithError(/already registered/);
   });
 
-  it('should unregister the tool when its `Injector` is destroyed', () => {
+  it('should unregister the tool when its `Injector` is destroyed', async () => {
     const injector = Injector.create({providers: []});
 
-    declareExperimentalWebMcpTool(
+    await declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',
@@ -110,11 +110,11 @@ describe('declareExperimentalWebMcpTool', () => {
     expect(globalThis.navigator.modelContextTesting!.listTools()).toEqual([]);
   });
 
-  it('should unregister the tool when its injection context is destroyed and no `injector` is provided', () => {
+  it('should unregister the tool when its injection context is destroyed and no `injector` is provided', async () => {
     const injector = Injector.create({providers: []});
 
-    runInInjectionContext(injector, () => {
-      declareExperimentalWebMcpTool({
+    await runInInjectionContext(injector, async () => {
+      await declareExperimentalWebMcpTool({
         name: 'testTool',
         description: 'A test tool',
         inputSchema: {type: 'object', properties: {}},
@@ -131,15 +131,17 @@ describe('declareExperimentalWebMcpTool', () => {
     expect(globalThis.navigator.modelContextTesting!.listTools()).toEqual([]);
   });
 
-  it('should throw when called outside an injection context and no `injector` is provided', () => {
-    expect(() => {
+  it('should throw when called outside an injection context and no `injector` is provided', async () => {
+    await expectAsync(
       declareExperimentalWebMcpTool({
         name: 'testTool',
         description: 'A test tool',
         inputSchema: {type: 'object', properties: {}},
         execute: async () => ({content: []}),
-      });
-    }).toThrowMatching((err) => err.code === RuntimeErrorCode.MISSING_INJECTION_CONTEXT);
+      }),
+    ).toBeRejectedWith(
+      jasmine.objectContaining({code: RuntimeErrorCode.MISSING_INJECTION_CONTEXT}),
+    );
   });
 
   it('should pass an `AbortSignal` to the tool and abort it when the injector is destroyed', async () => {
@@ -148,7 +150,7 @@ describe('declareExperimentalWebMcpTool', () => {
       .createSpy<Execute<JsonSchemaForInference>>('execute')
       .and.returnValue({content: []});
 
-    declareExperimentalWebMcpTool(
+    await declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',
@@ -175,7 +177,7 @@ describe('declareExperimentalWebMcpTool', () => {
     });
 
     let injectedService!: TestService;
-    declareExperimentalWebMcpTool(
+    await declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',

--- a/packages/forms/signals/src/webmcp/registration.ts
+++ b/packages/forms/signals/src/webmcp/registration.ts
@@ -21,19 +21,21 @@ import {FieldTree} from '../api/types';
 import {FieldNode} from '../field/node';
 import {REGISTER_WEBMCP_FORM, RegisterWebMcpForm} from './tokens';
 
-const registerWebMcpForm: RegisterWebMcpForm = async (formTree, options) => {
+const registerWebMcpForm: RegisterWebMcpForm = (formTree, options) => {
   const injector = inject(Injector);
 
   // we want to defer the registration until the context is fully initialized,
   // This is especially useful if the form model is a derivation of a required input
-  effect(() => {
-    untracked(() => {
-      initWebMcpForm(formTree, options, injector);
+  return new Promise<void>((resolve, reject) => {
+    effect(() => {
+      untracked(() => {
+        initWebMcpForm(formTree, options, injector).then(resolve, reject);
+      });
     });
   });
 };
 
-function initWebMcpForm(
+async function initWebMcpForm(
   formTree: FieldTree<unknown>,
   options: {name: string; description: string},
   injector: Injector,
@@ -48,7 +50,7 @@ function initWebMcpForm(
     );
   }
 
-  declareExperimentalWebMcpTool(
+  await declareExperimentalWebMcpTool(
     {
       name: options.name,
       description: options.description,

--- a/packages/forms/signals/src/webmcp/tokens.ts
+++ b/packages/forms/signals/src/webmcp/tokens.ts
@@ -23,4 +23,4 @@ export const REGISTER_WEBMCP_FORM = new InjectionToken<RegisterWebMcpForm>(
 export type RegisterWebMcpForm = (
   form: FieldTree<unknown>,
   options: {name: string; description: string},
-) => void;
+) => Promise<void>;

--- a/packages/forms/signals/test/web/webmcp.spec.ts
+++ b/packages/forms/signals/test/web/webmcp.spec.ts
@@ -10,6 +10,7 @@ import {ApplicationRef, Component, input, linkedSignal, signal} from '@angular/c
 import {TestBed} from '@angular/core/testing';
 import {form, provideExperimentalWebMcpForms, required} from '@angular/forms/signals';
 import {cleanupWebMCPPolyfill, initializeWebMCPPolyfill} from '@mcp-b/webmcp-polyfill';
+import {REGISTER_WEBMCP_FORM, RegisterWebMcpForm} from '../../src/webmcp/tokens';
 
 describe('Signal Forms WebMCP Integration', () => {
   beforeEach(() => {
@@ -266,35 +267,34 @@ describe('Signal Forms WebMCP Integration', () => {
       ).toBeRejectedWithError(/Database connection lost/);
     });
 
-    it('should throw an error if schema cannot be inferred accurately', () => {
+    it('should throw an error if schema cannot be inferred accurately', async () => {
+      const registerWebMcpForm = TestBed.inject<RegisterWebMcpForm>(REGISTER_WEBMCP_FORM);
       // 1. Null value
-      TestBed.runInInjectionContext(() => {
-        expect(() => {
-          form(signal({value: null}), {
-            experimentalWebMcpTool: {
-              name: 'nullTool',
-              description: 'A null tool',
-            },
+      await expectAsync(
+        TestBed.runInInjectionContext(() => {
+          const promise = registerWebMcpForm(form(signal({value: null})), {
+            name: 'nullTool',
+            description: 'A null tool',
           });
           TestBed.inject(ApplicationRef).tick();
-        }).toThrowError(/Could not accurately infer WebMCP schema/);
-      });
+          return promise;
+        }),
+      ).toBeRejectedWithError(/Could not accurately infer WebMCP schema/);
       expect(
         globalThis.navigator.modelContextTesting!.listTools().some((t) => t.name === 'nullTool'),
       ).toBeFalse();
 
       // 2. Empty array value
-      TestBed.runInInjectionContext(() => {
-        expect(() => {
-          form(signal({value: [] as string[]}), {
-            experimentalWebMcpTool: {
-              name: 'emptyArrayTool',
-              description: 'An empty array tool',
-            },
+      await expectAsync(
+        TestBed.runInInjectionContext(() => {
+          const promise = registerWebMcpForm(form(signal({value: [] as string[]})), {
+            name: 'emptyArrayTool',
+            description: 'An empty array tool',
           });
           TestBed.inject(ApplicationRef).tick();
-        }).toThrowError(/Could not accurately infer WebMCP schema/);
-      });
+          return promise;
+        }),
+      ).toBeRejectedWithError(/Could not accurately infer WebMCP schema/);
       expect(
         globalThis.navigator
           .modelContextTesting!.listTools()
@@ -302,17 +302,16 @@ describe('Signal Forms WebMCP Integration', () => {
       ).toBeFalse();
 
       // 3. Unsupported type (symbol)
-      TestBed.runInInjectionContext(() => {
-        expect(() => {
-          form(signal({value: Symbol('test')}), {
-            experimentalWebMcpTool: {
-              name: 'symbolTool',
-              description: 'A symbol tool',
-            },
+      await expectAsync(
+        TestBed.runInInjectionContext(() => {
+          const promise = registerWebMcpForm(form(signal({value: Symbol('test')})), {
+            name: 'symbolTool',
+            description: 'A symbol tool',
           });
           TestBed.inject(ApplicationRef).tick();
-        }).toThrowError(/Could not accurately infer WebMCP schema/);
-      });
+          return promise;
+        }),
+      ).toBeRejectedWithError(/Could not accurately infer WebMCP schema/);
       expect(
         globalThis.navigator.modelContextTesting!.listTools().some((t) => t.name === 'symbolTool'),
       ).toBeFalse();


### PR DESCRIPTION
In the latest WebMCP specification and Chromium preview builds, `document.modelContext.registerTool` was updated to be asynchronous and return a `Promise`: https://groups.google.com/a/chromium.org/g/chrome-ai-dev-preview/c/xQWt0b1sZIE/m/UJznbNCIAwAJ?utm_medium=email&utm_source=footer

This commit update adjusts Angular's experimental WebMCP implementation (`declareExperimentalWebMcpTool` and form registration) to be async as well, returning `Promise<void>`.

Also removes unused `unregisterTool` as a separate cleanup.