### PR TITLE
fix(router): limit absolute redirects from redirect functions

### DIFF
--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -143,6 +143,18 @@ export class Recognizer {
       return {children, rootSnapshot};
     } catch (e: any) {
       if (e instanceof AbsoluteRedirect) {
+        // Count at the actual root-restart boundary so redirects returned from functions are
+        // subject to the same limit as static redirects.
+        this.absoluteRedirectCount++;
+        if (this.absoluteRedirectCount > MAX_ALLOWED_REDIRECTS) {
+          if (ngDevMode) {
+            throw new RuntimeError(
+              RuntimeErrorCode.INFINITE_REDIRECT,
+              `Detected possible infinite redirect when redirecting from '${this.urlTree}' to '${e.urlTree}'.`,
+            );
+          }
+          this.allowRedirects = false;
+        }
         this.urlTree = e.urlTree;
         return this.match(e.urlTree.root);
       }
@@ -334,22 +346,6 @@ export class Recognizer {
       match(segmentGroup, route, segments);
     if (!matched) throw new NoMatch(segmentGroup);
 
-    // TODO(atscott): Move all of this under an if(ngDevMode) as a breaking change and allow stack
-    // size exceeded in production
-    if (typeof route.redirectTo === 'string' && route.redirectTo[0] === '/') {
-      this.absoluteRedirectCount++;
-      if (this.absoluteRedirectCount > MAX_ALLOWED_REDIRECTS) {
-        if (ngDevMode) {
-          throw new RuntimeError(
-            RuntimeErrorCode.INFINITE_REDIRECT,
-            `Detected possible infinite redirect when redirecting from '${this.urlTree}' to '${route.redirectTo}'.\n` +
-              `This is currently a dev mode only error but will become a` +
-              ` call stack size exceeded error in production in a future major version.`,
-          );
-        }
-        this.allowRedirects = false;
-      }
-    }
     const currentSnapshot = this.createSnapshot(injector, route, segments, parameters, parentRoute);
     if (this.abortSignal.aborted) {
       throw new Error(this.abortSignal.reason);

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -1595,6 +1595,89 @@ describe('redirects', () => {
       );
     });
 
+    it('should limit absolute strings returned by a function', async () => {
+      const firstRedirectOverLimit = 32;
+      let redirects = 0;
+
+      await checkRedirect(
+        [
+          {
+            path: 'loop',
+            redirectTo: () => {
+              redirects++;
+              return redirects <= firstRedirectOverLimit ? '/loop' : '/done';
+            },
+          },
+          {path: 'done', component: ComponentC},
+        ],
+        '/loop',
+        () => fail('expected recognition to reject'),
+        'emptyOnly',
+        (e) => {
+          expect((e as Error).message).toMatch(/NG04016: Detected possible infinite redirect/);
+        },
+      );
+
+      expect(redirects).toBe(firstRedirectOverLimit);
+    });
+
+    it('should limit UrlTrees returned by a function', async () => {
+      const firstRedirectOverLimit = 32;
+      let redirects = 0;
+
+      await checkRedirect(
+        [
+          {
+            path: 'loop',
+            redirectTo: () => {
+              redirects++;
+              const target = redirects <= firstRedirectOverLimit ? '/loop' : '/done';
+              return createUrlTree(target);
+            },
+          },
+          {path: 'done', component: ComponentC},
+        ],
+        '/loop',
+        () => fail('expected recognition to reject'),
+        'emptyOnly',
+        (e) => {
+          expect((e as Error).message).toMatch(/NG04016: Detected possible infinite redirect/);
+        },
+      );
+
+      expect(redirects).toBe(firstRedirectOverLimit);
+    });
+
+    it('should stop applying redirects over the limit in production mode', async () => {
+      const firstRedirectOverLimit = 32;
+      const previousNgDevMode = (globalThis as any).ngDevMode;
+      let redirects = 0;
+
+      try {
+        (globalThis as any).ngDevMode = false;
+        await checkRedirect(
+          [
+            {
+              path: 'loop',
+              redirectTo: () => {
+                redirects++;
+                return redirects <= firstRedirectOverLimit ? '/loop' : '/done';
+              },
+            },
+            {path: 'loop', component: ComponentC},
+            {path: 'done', component: ComponentC},
+          ],
+          '/loop',
+          (t: UrlTree) => expectTreeToBe(t, '/loop'),
+          'emptyOnly',
+        );
+
+        expect(redirects).toBe(firstRedirectOverLimit);
+      } finally {
+        (globalThis as any).ngDevMode = previousNgDevMode;
+      }
+    });
+
     it('with a simple function returning a UrlTree', async () => {
       await checkRedirect(
         [


### PR DESCRIPTION
Count redirects at the root recognition restart rather than before evaluating redirectTo. This ensures absolute strings and UrlTrees returned by RedirectFunction consume the existing redirect budget.

Without this accounting, cyclic functional redirects can cause a denial of service in SSR applications.
 

More context https://issuetracker.google.com/issues/533186096

We could say it's similar to https://github.com/angular/angular/security/advisories/GHSA-48r7-hpm6-gfxm