### PR TITLE
fix(service-worker): revalidate when cache headers cannot be parsed

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -209,6 +209,11 @@ export abstract class AssetGroup {
       }
       try {
         const maxAge = 1000 * parseInt(cacheAge);
+        if (isNaN(maxAge)) {
+          // The max-age value is not a number, so its freshness cannot be determined. Assume the
+          // response is stale.
+          return true;
+        }
 
         // Determine the origin time of this request. If the SW has metadata on the request (which
         // it
@@ -228,6 +233,10 @@ export abstract class AssetGroup {
             return true;
           }
           ts = Date.parse(date);
+          if (isNaN(ts)) {
+            // The Date header could not be parsed. Assume that it's stale, and revalidate it.
+            return true;
+          }
         }
         const age = this.adapter.time - ts;
         return age < 0 || age > maxAge;
@@ -238,14 +247,13 @@ export abstract class AssetGroup {
     } else if (res.headers.has('Expires')) {
       // Determine if the expiration time has passed.
       const expiresStr = res.headers.get('Expires')!;
-      try {
-        // The request needs to be revalidated if the current time is later than the expiration
-        // time, if it parses correctly.
-        return this.adapter.time > Date.parse(expiresStr);
-      } catch {
+      const expires = Date.parse(expiresStr);
+      if (isNaN(expires)) {
         // The expiration date failed to parse, so revalidate as a precaution.
         return true;
       }
+      // The request needs to be revalidated if the current time is later than the expiration time.
+      return this.adapter.time > expires;
     } else {
       // No way to evaluate staleness, so assume the response is already stale.
       return true;

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -43,6 +43,7 @@ import {envIsSupported} from '../testing/utils';
     .addFile('/lazy/redirect-target.txt', 'this was a redirect too')
     .addUnhashedFile('/unhashed/a.txt', 'this is unhashed', {'Cache-Control': 'max-age=10'})
     .addUnhashedFile('/unhashed/b.txt', 'this is unhashed b', {'Cache-Control': 'no-cache'})
+    .addUnhashedFile('/unhashed/c.txt', 'this is unhashed c', {'Cache-Control': 'max-age=invalid'})
     .addUnhashedFile('/api/foo', 'this is api foo', {'Cache-Control': 'no-cache'})
     .addUnhashedFile('/api-static/bar', 'this is static api bar', {'Cache-Control': 'no-cache'})
     .build();
@@ -58,6 +59,7 @@ import {envIsSupported} from '../testing/utils';
     .addFile('/lazy/unchanged1.txt', 'this is unchanged (1)')
     .addFile('/lazy/unchanged2.txt', 'this is unchanged (2)')
     .addUnhashedFile('/unhashed/a.txt', 'this is unhashed v2', {'Cache-Control': 'max-age=10'})
+    .addUnhashedFile('/unhashed/c.txt', 'this is unhashed c v2', {'Cache-Control': 'max-age=invalid'})
     .addUnhashedFile('/ignored/file1', 'this is not handled by the SW')
     .addUnhashedFile('/ignored/dir/file2', 'this is not handled by the SW either')
     .build();
@@ -1889,6 +1891,26 @@ import {envIsSupported} from '../testing/utils';
         // Now the new version of the resource should be served.
         expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed v2');
         server.assertNoOtherRequests();
+      });
+
+      it('revalidate when Cache-Control max-age cannot be parsed', async () => {
+        expect(await makeRequest(scope, '/unhashed/c.txt')).toEqual('this is unhashed c');
+        server.clearRequests();
+
+        // Update the resource on the server.
+        scope.updateServerState(serverUpdate);
+
+        // Move far ahead in time. A malformed max-age carries no usable TTL, so the cached
+        // response must be treated as stale and revalidated rather than served forever.
+        scope.advance(10 * 60 * 60 * 1000);
+
+        expect(await makeRequest(scope, '/unhashed/c.txt')).toEqual('this is unhashed c');
+        await driver.idle.empty;
+        await new Promise((resolve) => setTimeout(resolve)); // Wait for async operations to complete.
+        serverUpdate.assertSawRequestFor('/unhashed/c.txt');
+
+        // Now the new version of the resource should be served.
+        expect(await makeRequest(scope, '/unhashed/c.txt')).toEqual('this is unhashed c v2');
       });
 
       it('survive serialization', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`AssetGroup.needToRevalidate` decides whether a cached unhashed resource is stale from its `Cache-Control: max-age`, `Date`, and `Expires` headers. It reads those with `parseInt` and `Date.parse`, both of which return `NaN` rather than throwing on malformed values, so the `try/catch` around them never fires. When a header cannot be parsed the comparisons become `age > NaN` and `time > NaN`, which are `false`, and the method returns `false`. That is the opposite of the intent: every other uncertain branch returns `true` to force revalidation. A response served with something like `Cache-Control: max-age=none` (or an unparseable `Expires`) is therefore treated as fresh forever and never revalidated, so a later update to that resource is not picked up.

## What is the new behavior?

An unparseable `max-age`, `Date`, or `Expires` value now returns `true`, so the cached copy is revalidated instead of pinned. Valid caching headers behave exactly as before. Added a regression test under the unhashed-request suite in `happy_spec.ts` that caches a resource with a malformed `max-age`, updates it on the server, and confirms the worker now refetches and serves the new version.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The `Expires` branch previously wrapped `Date.parse` in a `try/catch` whose comment promised to "revalidate as a precaution" on a parse failure, but `Date.parse` returns `NaN` instead of throwing, so that path was unreachable. It is now an explicit `isNaN` check.
