### PR TITLE
fix(docs-infra): avoid search dialog empty-state flicker while re-que…

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -65,7 +65,7 @@
       <docs-search-history />
     } @else {
       <div class="docs-search-results docs-mini-scroll-track">
-        @if (!resultsResource.hasValue()) {
+        @if (emptyState() === 'start') {
           <div class="docs-search-results__start-typing">
             <img
               src="assets/images/angie/magnifying-glass.svg"
@@ -74,7 +74,7 @@
             />
             <span>Start typing to see results</span>
           </div>
-        } @else if (searchResults().length === 0) {
+        } @else {
           <div class="docs-search-results__no-results">
             <img
               src="assets/images/angie/question.svg"

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.spec.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.spec.ts
@@ -113,6 +113,35 @@ describe('SearchDialog', () => {
     expect(startTypingContainer).toBeTruthy();
   });
 
+  it('should keep the `No results found` message while re-querying instead of flickering back to `Start typing`', async () => {
+    const appRef = TestBed.inject(ApplicationRef);
+
+    // Settle on an empty result set so `No results found` is shown.
+    search.searchQuery.set('foobarbaz');
+    searchResults.and.returnValue(Promise.resolve({results: [{hits: []}]}));
+    appRef.tick();
+    await timeout(300);
+    await appRef.whenStable();
+
+    expect(fixture.debugElement.query(By.css('.docs-search-results__no-results'))).toBeTruthy();
+
+    // Edit the query so a new search goes in flight and stays pending.
+    let resolveReload!: (value: unknown) => void;
+    searchResults.and.returnValue(new Promise((resolve) => (resolveReload = resolve)));
+    search.searchQuery.set('foobarba');
+    appRef.tick();
+
+    // The delay from debounced (200ms), after which the pending request is loading.
+    await timeout(300);
+
+    // While the re-query is loading it must not revert to the `Start typing` state.
+    expect(fixture.debugElement.query(By.css('.docs-search-results__start-typing'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.docs-search-results__no-results'))).toBeTruthy();
+
+    resolveReload({results: [{hits: []}]});
+    await appRef.whenStable();
+  });
+
   it('should display list of the search results when results exist', async () => {
     search.searchQuery.set('fakeQuery');
     searchResults.and.returnValue(Promise.resolve({results: [{hits: fakeSearchResults}]}));

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.ts
@@ -67,6 +67,7 @@ export class SearchDialog {
 
   readonly resultsResource = this.search.resultsResource;
   readonly searchResults = this.search.searchResults;
+  readonly emptyState = this.search.emptyState;
 
   searchForm = form(this.search.searchQuery);
 

--- a/adev/shared-docs/services/search.service.ts
+++ b/adev/shared-docs/services/search.service.ts
@@ -59,6 +59,20 @@ export class Search {
     computation: (next, prev) => (!next && this.searchQuery() ? prev?.value : next) ?? [],
   });
 
+  readonly emptyState = linkedSignal<{query: string; pending: boolean}, 'start' | 'no-results'>({
+    source: () => ({
+      query: this.searchQuery(),
+      pending:
+        this.searchQuery() !== this.debounceParams.value() || this.resultsResource.isLoading(),
+    }),
+    computation: ({query, pending}, prev) => {
+      if (!query) {
+        return 'start';
+      }
+      return pending ? (prev?.value ?? 'start') : 'no-results';
+    },
+  });
+
   private getUniqueSearchResultItems(items: SearchResult[]): SearchResult[] {
     const uniqueUrls = new Set<string>();
 


### PR DESCRIPTION
It seems like the flicker issue was pre-existed before Angie, after Angie it became more obvious.

Before

https://github.com/user-attachments/assets/196a9d12-faae-430d-aa73-9367e19719f9

https://github.com/user-attachments/assets/99652e80-8a3f-4c20-bcf8-a26e1c411244

After

https://github.com/user-attachments/assets/2986231d-5654-437e-b53a-a1f46fb85aea



