### PR TITLE
fix(core): preserve change detection strategy when overriding component

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -679,7 +679,7 @@ export interface Component extends Directive {
  */
 export const Component: ComponentDecorator = makeDecorator(
   'Component',
-  (c: Component = {}) => ({changeDetection: ChangeDetectionStrategy.Eager, ...c}),
+  (c: Component = {}) => ({...c}),
   Directive,
   undefined,
   (type: Type<any>, meta: Component) => compileComponent(type, meta),

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -428,6 +428,20 @@ describe('TestBed with Standalone types', () => {
     expect(fixture.nativeElement.innerHTML).toBe('Overridden');
   });
 
+  it('should preserve default change detection when overriding components', () => {
+    @Component({
+      template: 'Original',
+    })
+    class DefaultCmp {}
+
+    const onPushBefore = (DefaultCmp as any).ɵcmp.onPush;
+    TestBed.overrideComponent(DefaultCmp, {set: {template: 'Overridden'}});
+    TestBed.createComponent(DefaultCmp);
+    const onPushAfter = (DefaultCmp as any).ɵcmp.onPush;
+
+    expect(onPushAfter).withContext('ɵcmp.OnPush after override').toBe(onPushBefore);
+  });
+
   it('should allow overriding the set of directives and pipes used in a standalone component', () => {
     @Directive({
       selector: '[dir]',


### PR DESCRIPTION
TestBed.overrideComponent previously caused JIT recompilation to overwrite a component's original ChangeDetectionStrategy. This ensures the component's existing ChangeDetectionStrategy is preserved when metadata overrides are applied.


Disclaimer: Note that the root cause analysis of the bug and the solution were identified with the help of AI. I implemented the change, tests, and ran it against our codebase. The problem is in my opinion very much genuine but a different solution may be more appropriate.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When a component without explicit changeDetection strategy is overridden with TestBed.overrideComponent, the change detection strategy changes from OnPush (default) to Eager. This causes a mismatch between prod and test component behavior.
 
AI's explanation: When `TestBed.overrideComponent` is called on a component, the component is added to `TestBed`'s `pendingComponents` queue, forcing runtime JIT recompilation (`compileTypesSync()`). During this JIT recompilation, `TestBed` reconstructs the component metadata. Previously, the metadata decorator resolution defaulted `changeDetection` to `ChangeDetectionStrategy.Eager`, overwriting the component's existing (`ɵcmp`) Change Detection Strategy.
As a result, an overridden component whose pre-compiled definition used `ChangeDetectionStrategy.OnPush` would unexpectedly run with `ChangeDetectionStrategy.Default` (`Eager`) in tests.


Issue Number: N/A

## What is the new behavior?

When compiling component overrides in `TestBed`, the implicit `ChangeDetectionStrategy` (`onPush` property on the pre-compiled `ɵcmp` definition) is preserved.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Note on potential behavioral impact: While this is a bugfix restoring expected component behavior during testing, it could affect existing tests if consumers unknowingly relied on `TestBed.overrideComponent` silently reverting an `OnPush` component to `Eager` (`Default`) change detection. No such issue was found across our codebase.

## Other information

1. **Revealed during migration:** This issue was discovered when removing redundant `changeDetection: ChangeDetectionStrategy.OnPush` declarations across our codebase. Removing the explicit declaration caused existing tests using `TestBed.overrideComponent` to fail, revealing that the JIT override path was silently altering the component's runtime change detection behavior.
2. **Why eager by default:** I don't know if the Component decorator definition was left as `Eager` after the OnPush-as-default migration on purpose or accidentally.