### PR TITLE
refactor(devtools): rename timing API to performance track

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -51,7 +51,7 @@ import {
   updateState,
 } from './directive-forest/component-tree/component-tree';
 import {start as startProfiling, stop as stopProfiling} from './profiling/capture';
-import {disableTimingAPI, enableTimingAPI} from './profiling/timing-api';
+import {disablePerformanceTrack, enablePerformanceTrack} from './profiling/performance-track';
 import {getProfiler, Profiler} from './profiling/profiler';
 import {ComponentTreeNode} from './shared/interfaces';
 import {
@@ -111,8 +111,8 @@ export const subscribeToClientEvents = (
   messageBus.on('updateState', updateState);
   messageBus.on('logValue', logValue);
 
-  messageBus.on('enableTimingAPI', enableTimingAPI);
-  messageBus.on('disableTimingAPI', disableTimingAPI);
+  messageBus.on('enablePerformanceTrack', enablePerformanceTrack);
+  messageBus.on('disablePerformanceTrack', disablePerformanceTrack);
 
   messageBus.on('getInjectorProviders', getInjectorProvidersCallback(messageBus));
 

--- a/devtools/projects/ng-devtools-backend/src/lib/profiling/performance-track.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/profiling/performance-track.ts
@@ -13,13 +13,16 @@ import type {ComponentInstance, DirectiveInstance} from '../shared/interfaces';
 
 type Method = keyof LifecycleProfile | 'changeDetection' | string;
 
-// Timing API global flag.
-let timingAPIFlag = false;
+// Performance track global flag.
+let chromeDevToolsPerformanceTrackEnabled = false;
 
-export const enableTimingAPI = () => (timingAPIFlag = true);
-export const disableTimingAPI = () => (timingAPIFlag = false);
+/** Enable Angular's performance track in the Chrome DevTools profiler. */
+export const enablePerformanceTrack = () => (chromeDevToolsPerformanceTrackEnabled = true);
 
-const timingAPIEnabled = () => timingAPIFlag;
+/** Disable Angular's performance track in the Chrome DevTools profiler. */
+export const disablePerformanceTrack = () => (chromeDevToolsPerformanceTrackEnabled = false);
+
+const performanceTrackEnabled = () => chromeDevToolsPerformanceTrackEnabled;
 
 const markName = (s: string, method: Method) => `🅰️ ${s}#${method}`;
 
@@ -63,37 +66,37 @@ const endMark = (nodeName: string, method: Method) => {
 
 getProfiler().subscribe({
   onChangeDetectionStart(component: ComponentInstance): void {
-    if (!timingAPIEnabled()) {
+    if (!performanceTrackEnabled()) {
       return;
     }
     recordMark(getDirectiveName(component), 'changeDetection');
   },
   onChangeDetectionEnd(component: ComponentInstance): void {
-    if (!timingAPIEnabled()) {
+    if (!performanceTrackEnabled()) {
       return;
     }
     endMark(getDirectiveName(component), 'changeDetection');
   },
   onLifecycleHookStart(component: DirectiveInstance, lifecyle: keyof LifecycleProfile): void {
-    if (!timingAPIEnabled()) {
+    if (!performanceTrackEnabled()) {
       return;
     }
     recordMark(getDirectiveName(component), lifecyle);
   },
   onLifecycleHookEnd(component: DirectiveInstance, lifecyle: keyof LifecycleProfile): void {
-    if (!timingAPIEnabled()) {
+    if (!performanceTrackEnabled()) {
       return;
     }
     endMark(getDirectiveName(component), lifecyle);
   },
   onOutputStart(component: DirectiveInstance, output: string): void {
-    if (!timingAPIEnabled()) {
+    if (!performanceTrackEnabled()) {
       return;
     }
     recordMark(getDirectiveName(component), output);
   },
   onOutputEnd(component: DirectiveInstance, output: string): void {
-    if (!timingAPIEnabled()) {
+    if (!performanceTrackEnabled()) {
       return;
     }
     endMark(getDirectiveName(component), output);

--- a/devtools/projects/ng-devtools/src/lib/application-providers/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ts_test_library", "zoneless_web_test_suite")
+load("//devtools/tools:defaults.bzl", "ng_project", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -14,10 +14,19 @@ ng_project(
     name = "settings",
     srcs = ["settings_provider.ts"],
     deps = [
+        ":settings_versions",
         "//:node_modules/@angular/core",
         "//devtools/projects/ng-devtools/src/lib/application-operations",
         "//devtools/projects/ng-devtools/src/lib/application-services:settings",
         "//devtools/projects/ng-devtools/src/lib/application-services:settings_store",
+    ],
+)
+
+ts_project(
+    name = "settings_versions",
+    srcs = ["settings_versions.ts"],
+    deps = [
+        "//devtools/projects/ng-devtools/src/lib/application-services:theme_types_lib",
     ],
 )
 
@@ -52,6 +61,7 @@ ts_test_library(
     deps = [
         ":app_data",
         ":settings",
+        ":settings_versions",
         ":supported_apis",
         "//:node_modules/@angular/core",
         "//devtools/projects/ng-devtools/src/lib/application-operations",

--- a/devtools/projects/ng-devtools/src/lib/application-providers/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/BUILD.bazel
@@ -51,8 +51,10 @@ ts_test_library(
     srcs = glob(["*_spec.ts"]),
     deps = [
         ":app_data",
+        ":settings",
         ":supported_apis",
         "//:node_modules/@angular/core",
+        "//devtools/projects/ng-devtools/src/lib/application-operations",
     ],
 )
 

--- a/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider.ts
@@ -10,12 +10,12 @@ import {provideAppInitializer, inject, Provider, EnvironmentProviders} from '@an
 import {SETTINGS_STORE_KEY, SettingsStore} from '../application-services/settings_store';
 import {ApplicationOperations} from '../application-operations';
 import {Settings} from '../application-services/settings';
-
-export const DATA_VERSION_KEY = '__v';
-
-// Note: Any changes to the settings items should be accompanied
-// by a migration along with a version bump.
-const LATEST_DATA_VERSION = 2;
+import {
+  DATA_VERSION_KEY,
+  LATEST_DATA_VERSION,
+  SettingsDataV1,
+  SettingsDataV2,
+} from './settings_versions';
 
 export function provideSettings(): (Provider | EnvironmentProviders)[] {
   let savedSettings: {[key: string]: unknown};
@@ -47,7 +47,7 @@ export function applyMigrations(
   data: {[key: string]: unknown},
   appOperations: ApplicationOperations,
 ): {[key: string]: unknown} {
-  const dataCopy = structuredClone(data);
+  let dataCopy = structuredClone(data);
   const dataVer = dataCopy[DATA_VERSION_KEY];
 
   if (dataVer === LATEST_DATA_VERSION) {
@@ -95,26 +95,30 @@ export function applyMigrations(
 
   // V1 -> V2 migration
   if (dataVer === 1) {
-    const newData = dataCopy;
-    // Convert `timing_api_enabled` (cat: `general`) key to `performance_track` (cat: `profiling`).
-    newData['performance_track@profiling'] = dataCopy['timing_api_enabled@general'];
-    delete dataCopy['timing_api_enabled@general'];
+    const currData = dataCopy as unknown as SettingsDataV1;
+    const newData: SettingsDataV2 = {
+      [DATA_VERSION_KEY]: 2,
 
-    // Convert `activeTab` (cat: `general`) key to `active_tab` (cat: `general`).
-    dataCopy['active_tab@general'] = dataCopy['activeTab@general'];
-    delete dataCopy['activeTab@general'];
+      // No change
+      'theme@general': currData['theme@general'],
+      'show_hydration_overlays@components': currData['show_hydration_overlays@components'],
 
-    // Flag no logner needed. The feature has been promoted to stable.
-    delete dataCopy['router_graph_enabled@general'];
+      // Convert `timing_api_enabled` (cat: `general`) key to `performance_track` (cat: `profiling`).
+      'performance_track@profiling': currData['timing_api_enabled@general'],
 
-    // Flag no logner needed. The feature has been promoted to stable.
-    delete dataCopy['signal_graph_enabled@general'];
+      // Convert `activeTab` (cat: `general`) key to `active_tab` (cat: `general`).
+      'active_tab@general': currData['activeTab@general'],
 
-    // Flag no logner needed. The feature has been promoted to stable.
-    delete dataCopy['transfer_state_enabled@general'];
+      // Change the category of `show_comment_nodes` (from `general` to `components`).
+      'show_comment_nodes@components': currData['show_comment_nodes@general'],
 
-    // Update the data instance version to V2.
-    dataCopy[DATA_VERSION_KEY] = 2;
+      // Flags that are no longer needed:
+      // - router_graph_enabled@general
+      // - signal_graph_enabled@general
+      // - transfer_state_enabled@general
+    };
+
+    dataCopy = newData as unknown as {[key: string]: unknown};
   }
 
   dataCopy[DATA_VERSION_KEY] = LATEST_DATA_VERSION;

--- a/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider.ts
@@ -11,11 +11,11 @@ import {SETTINGS_STORE_KEY, SettingsStore} from '../application-services/setting
 import {ApplicationOperations} from '../application-operations';
 import {Settings} from '../application-services/settings';
 
-const DATA_VERSION_KEY = '__v';
+export const DATA_VERSION_KEY = '__v';
 
 // Note: Any changes to the settings items should be accompanied
 // by a migration along with a version bump.
-const LATEST_DATA_VERSION = 1;
+const LATEST_DATA_VERSION = 2;
 
 export function provideSettings(): (Provider | EnvironmentProviders)[] {
   let savedSettings: {[key: string]: unknown};
@@ -43,13 +43,14 @@ export function provideSettings(): (Provider | EnvironmentProviders)[] {
  * @param appOperations
  * @returns New migrated data object
  */
-function applyMigrations(
+export function applyMigrations(
   data: {[key: string]: unknown},
   appOperations: ApplicationOperations,
 ): {[key: string]: unknown} {
   const dataCopy = structuredClone(data);
+  const dataVer = dataCopy[DATA_VERSION_KEY];
 
-  if (dataCopy[DATA_VERSION_KEY] === LATEST_DATA_VERSION) {
+  if (dataVer === LATEST_DATA_VERSION) {
     return dataCopy;
   }
 
@@ -91,6 +92,30 @@ function applyMigrations(
    */
 
   // APPLY ANY MIGRATIONS TO THE DATA HERE.
+
+  // V1 -> V2 migration
+  if (dataVer === 1) {
+    const newData = dataCopy;
+    // Convert `timing_api_enabled` (cat: `general`) key to `performance_track` (cat: `profiling`).
+    newData['performance_track@profiling'] = dataCopy['timing_api_enabled@general'];
+    delete dataCopy['timing_api_enabled@general'];
+
+    // Convert `activeTab` (cat: `general`) key to `active_tab` (cat: `general`).
+    dataCopy['active_tab@general'] = dataCopy['activeTab@general'];
+    delete dataCopy['activeTab@general'];
+
+    // Flag no logner needed. The feature has been promoted to stable.
+    delete dataCopy['router_graph_enabled@general'];
+
+    // Flag no logner needed. The feature has been promoted to stable.
+    delete dataCopy['signal_graph_enabled@general'];
+
+    // Flag no logner needed. The feature has been promoted to stable.
+    delete dataCopy['transfer_state_enabled@general'];
+
+    // Update the data instance version to V2.
+    dataCopy[DATA_VERSION_KEY] = 2;
+  }
 
   dataCopy[DATA_VERSION_KEY] = LATEST_DATA_VERSION;
   appOperations.setStorageItems({[SETTINGS_STORE_KEY]: dataCopy});

--- a/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider_spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider_spec.ts
@@ -7,7 +7,8 @@
  */
 
 import {ApplicationOperations} from '../application-operations';
-import {applyMigrations, DATA_VERSION_KEY} from './settings_provider';
+import {applyMigrations} from './settings_provider';
+import {DATA_VERSION_KEY, SettingsData, SettingsDataV1, SettingsDataV2} from './settings_versions';
 
 function migrate(data: SettingsData) {
   return applyMigrations(
@@ -34,7 +35,7 @@ describe('applyMigrations', () => {
 
     expect(migrate(v1)).toEqual({
       [DATA_VERSION_KEY]: 2,
-      'show_comment_nodes@general': true,
+      'show_comment_nodes@components': true,
       'performance_track@profiling': true,
       'theme@general': 'dark',
       'active_tab@general': 'Profiler',
@@ -42,29 +43,3 @@ describe('applyMigrations', () => {
     } satisfies SettingsDataV2);
   });
 });
-
-// We keep all versions because:
-// 1. We can validate the correctness of our migrations via unit tests.
-// 2. We have a complete historical record of legacy data objects.
-type SettingsData = SettingsDataV1 | SettingsDataV2;
-
-interface SettingsDataV2 {
-  [DATA_VERSION_KEY]: 2;
-  'show_comment_nodes@general': boolean;
-  'performance_track@profiling': boolean;
-  'theme@general': string;
-  'active_tab@general': string;
-  'show_hydration_overlays@components': boolean;
-}
-
-interface SettingsDataV1 {
-  [DATA_VERSION_KEY]: 1;
-  'show_comment_nodes@general': boolean;
-  'timing_api_enabled@general': boolean;
-  'theme@general': string;
-  'activeTab@general': string;
-  'show_hydration_overlays@components': boolean;
-  'router_graph_enabled@general': boolean;
-  'signal_graph_enabled@general': boolean;
-  'transfer_state_enabled@general': boolean;
-}

--- a/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider_spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider_spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ApplicationOperations} from '../application-operations';
+import {applyMigrations, DATA_VERSION_KEY} from './settings_provider';
+
+function migrate(data: SettingsData) {
+  return applyMigrations(
+    data as unknown as {[key: string]: string},
+    {
+      setStorageItems: () => {},
+    } as unknown as ApplicationOperations,
+  );
+}
+
+describe('applyMigrations', () => {
+  it('should successfully migrate from V1 to V2', () => {
+    const v1: SettingsDataV1 = {
+      [DATA_VERSION_KEY]: 1,
+      'show_comment_nodes@general': true,
+      'timing_api_enabled@general': true,
+      'theme@general': 'dark',
+      'activeTab@general': 'Profiler',
+      'show_hydration_overlays@components': false,
+      'router_graph_enabled@general': true,
+      'signal_graph_enabled@general': false,
+      'transfer_state_enabled@general': true,
+    };
+
+    expect(migrate(v1)).toEqual({
+      [DATA_VERSION_KEY]: 2,
+      'show_comment_nodes@general': true,
+      'performance_track@profiling': true,
+      'theme@general': 'dark',
+      'active_tab@general': 'Profiler',
+      'show_hydration_overlays@components': false,
+    } satisfies SettingsDataV2);
+  });
+});
+
+// We keep all versions because:
+// 1. We can validate the correctness of our migrations via unit tests.
+// 2. We have a complete historical record of legacy data objects.
+type SettingsData = SettingsDataV1 | SettingsDataV2;
+
+interface SettingsDataV2 {
+  [DATA_VERSION_KEY]: 2;
+  'show_comment_nodes@general': boolean;
+  'performance_track@profiling': boolean;
+  'theme@general': string;
+  'active_tab@general': string;
+  'show_hydration_overlays@components': boolean;
+}
+
+interface SettingsDataV1 {
+  [DATA_VERSION_KEY]: 1;
+  'show_comment_nodes@general': boolean;
+  'timing_api_enabled@general': boolean;
+  'theme@general': string;
+  'activeTab@general': string;
+  'show_hydration_overlays@components': boolean;
+  'router_graph_enabled@general': boolean;
+  'signal_graph_enabled@general': boolean;
+  'transfer_state_enabled@general': boolean;
+}

--- a/devtools/projects/ng-devtools/src/lib/application-providers/settings_versions.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/settings_versions.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ThemePreference} from '../application-services/theme_types';
+
+export const DATA_VERSION_KEY = '__v';
+
+// Note: Any changes to the settings items should be accompanied
+// by a migration along with a version bump.
+export const LATEST_DATA_VERSION = 2;
+
+// We keep all versions because:
+// 1. We can validate the correctness of our migrations via unit tests.
+// 2. We have a complete historical record of legacy data objects.
+export type SettingsData = SettingsDataV1 | SettingsDataV2;
+
+interface SettingsDataBase {
+  [DATA_VERSION_KEY]: number;
+}
+
+// Please refer to this doc before updating the settings items:
+// https://github.com/angular/angular/blob/main/devtools/docs/settings.md
+//
+// WARNING: Please do NOT change or delete existing version items (only addition is allowed).
+// Create a new one instead.
+// Any changes to the settings items should be accompanied by a migration.
+// Check `settings_provider.ts`.
+
+export interface SettingsDataV2 extends SettingsDataBase {
+  [DATA_VERSION_KEY]: 2;
+  'show_comment_nodes@components': boolean;
+  'performance_track@profiling': boolean;
+  'theme@general': ThemePreference;
+  'active_tab@general': string;
+  'show_hydration_overlays@components': boolean;
+}
+
+export interface SettingsDataV1 extends SettingsDataBase {
+  [DATA_VERSION_KEY]: 1;
+  'show_comment_nodes@general': boolean;
+  'timing_api_enabled@general': boolean;
+  'theme@general': ThemePreference;
+  'activeTab@general': string;
+  'show_hydration_overlays@components': boolean;
+  'router_graph_enabled@general': boolean;
+  'signal_graph_enabled@general': boolean;
+  'transfer_state_enabled@general': boolean;
+}

--- a/devtools/projects/ng-devtools/src/lib/application-services/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/application-services/BUILD.bazel
@@ -49,6 +49,7 @@ ng_project(
     deps = [
         "//:node_modules/@angular/core",
         "//devtools/projects/ng-devtools/src/lib/application-operations",
+        "//devtools/projects/ng-devtools/src/lib/application-providers:settings_versions",
     ],
 )
 
@@ -59,6 +60,7 @@ ng_project(
         ":settings_store",
         ":theme_types_lib",
         "//:node_modules/@angular/core",
+        "//devtools/projects/ng-devtools/src/lib/application-providers:settings_versions",
     ],
 )
 

--- a/devtools/projects/ng-devtools/src/lib/application-services/settings.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/settings.ts
@@ -8,17 +8,16 @@
 
 import {inject} from '@angular/core';
 import {SettingsStore} from './settings_store';
-import {ThemePreference} from './theme_types';
+import {SettingsDataV2} from '../application-providers/settings_versions';
 
-// WARNING: Any changes to the settings items should be accompanied by a migration.
-// Check settings_provider.ts
-// Please keep in sync the validation tests in settings_provider_spec.ts as well.
+// If you need to update an item, please refer to `settings_versions.ts` and this doc:
+// https://github.com/angular/angular/blob/main/devtools/docs/settings.md
 export class Settings {
-  private readonly settingsStore = inject(SettingsStore);
+  private readonly settingsStore = inject(SettingsStore<SettingsDataV2>);
 
   readonly showCommentNodes = this.settingsStore.create({
     key: 'show_comment_nodes',
-    category: 'general', // Good candidate for migration to `components`
+    category: 'components',
     initialValue: false,
   });
 
@@ -28,7 +27,7 @@ export class Settings {
     initialValue: false,
   });
 
-  readonly theme = this.settingsStore.create<ThemePreference>({
+  readonly theme = this.settingsStore.create({
     key: 'theme',
     category: 'general',
     initialValue: 'system',

--- a/devtools/projects/ng-devtools/src/lib/application-services/settings.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/settings.ts
@@ -10,8 +10,9 @@ import {inject} from '@angular/core';
 import {SettingsStore} from './settings_store';
 import {ThemePreference} from './theme_types';
 
-// Note: Any changes to the settings items should be accompanied by a migration.
+// WARNING: Any changes to the settings items should be accompanied by a migration.
 // Check settings_provider.ts
+// Please keep in sync the validation tests in settings_provider_spec.ts as well.
 export class Settings {
   private readonly settingsStore = inject(SettingsStore);
 
@@ -21,9 +22,9 @@ export class Settings {
     initialValue: false,
   });
 
-  readonly timingAPIEnabled = this.settingsStore.create({
-    key: 'timing_api_enabled',
-    category: 'general', // Good candidate for migration to `profiler`
+  readonly performanceTrack = this.settingsStore.create({
+    key: 'performance_track',
+    category: 'profiling',
     initialValue: false,
   });
 
@@ -34,7 +35,7 @@ export class Settings {
   });
 
   readonly activeTab = this.settingsStore.create({
-    key: 'activeTab',
+    key: 'active_tab',
     category: 'general',
     initialValue: 'Components',
   });

--- a/devtools/projects/ng-devtools/src/lib/application-services/settings_store.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/settings_store.ts
@@ -11,33 +11,44 @@ import {ApplicationOperations} from '../application-operations';
 
 export const SETTINGS_STORE_KEY = 'ng-dt-settings';
 
+type KeyCategoryPair<Key extends string, Category extends string> = `${Key}@${Category}`;
+
+type ValueFor<T, Key extends string, Category extends string> =
+  KeyCategoryPair<Key, Category> extends keyof T ? T[KeyCategoryPair<Key, Category>] : never;
+
 /** Provides an API for storing and preserving settings values. */
-export class SettingsStore {
+export class SettingsStore<T extends object> {
   private readonly appOperations = inject(ApplicationOperations);
   private readonly injector = inject(Injector);
   private readonly signals = new Map<string, WritableSignal<unknown>>();
 
-  constructor(private data: {[key: string]: unknown}) {}
+  constructor(private data: T) {}
 
   /**
    * Create a settings value a provided key, as a writable signal.
    * If the item doesn't exist, a new one will be created.
    * Updates to the signal value are automatically stored in the storage.
    */
-  create<T>(config: {key: string; category: string; initialValue: T}): WritableSignal<T> {
+  create<Key extends string, Category extends string>(config: {
+    key: Key;
+    category: Category;
+    initialValue: ValueFor<T, Key, Category>;
+  }): WritableSignal<ValueFor<T, Key, Category>> {
+    const data = this.data as {[key: string]: unknown};
     const storeKey = `${config.key}@${config.category}`;
     const existing = this.signals.get(storeKey);
     if (existing) {
-      return existing as WritableSignal<T>;
+      return existing as WritableSignal<ValueFor<T, Key, Category>>;
     }
 
-    const initialValue = storeKey in this.data ? (this.data[storeKey] as T) : config.initialValue;
-    const value = signal<T>(initialValue);
+    const initialValue =
+      storeKey in this.data ? (data[storeKey] as ValueFor<T, Key, Category>) : config.initialValue;
+    const value = signal(initialValue);
     this.signals.set(storeKey, value);
 
     effect(
       () => {
-        this.data[storeKey] = value();
+        data[storeKey] = value();
         this.appOperations.setStorageItems({[SETTINGS_STORE_KEY]: this.data});
       },
       {injector: this.injector},

--- a/devtools/projects/ng-devtools/src/lib/application-services/settings_store_spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/settings_store_spec.ts
@@ -12,8 +12,14 @@ import {ApplicationOperations} from '../application-operations';
 import {AppOperationsMock} from './test-utils/app_operations_mock';
 import {ApplicationRef} from '@angular/core';
 
+interface MockSettingsData {
+  'item@test': string;
+  'first@test': string;
+  'second@test': string;
+}
+
 describe('SettingsStore', () => {
-  let settingsStore: SettingsStore;
+  let settingsStore: SettingsStore<MockSettingsData>;
   let getStoredSettings: () => {[key: string]: unknown};
 
   beforeEach(() => {
@@ -29,7 +35,7 @@ describe('SettingsStore', () => {
       ],
     });
 
-    settingsStore = TestBed.inject(SettingsStore);
+    settingsStore = TestBed.inject<SettingsStore<MockSettingsData>>(SettingsStore);
     getStoredSettings = () => appOperationsMock.getStoredSettings();
   });
 

--- a/devtools/projects/ng-devtools/src/lib/application-services/test-utils/settings_mock.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/test-utils/settings_mock.ts
@@ -13,7 +13,7 @@ import {ThemePreference} from '../theme_types';
 
 export class SettingsMock extends Settings {
   showCommentNodes = signal(false);
-  timingAPIEnabled = signal(false);
+  performanceTrack = signal(false);
   theme = signal<ThemePreference>('system');
   activeTab = signal('Components');
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/settings/settings.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/settings/settings.component.html
@@ -37,16 +37,18 @@
     </li>
   </ul>
 
-  <h3>Profiler</h3>
+  <h3>Profiling</h3>
   <ul>
     <li>
       <input
-        id="enable-timing-api"
+        id="enable-performance-track"
         type="checkbox"
-        (change)="settings.timingAPIEnabled.set($event.target.checked)"
-        [checked]="settings.timingAPIEnabled()"
+        (change)="settings.performanceTrack.set($event.target.checked)"
+        [checked]="settings.performanceTrack()"
       />
-      <label for="enable-timing-api">Enable timing API</label>
+      <label for="enable-performance-track"
+        >Enable Angular’s performance track in the Chrome DevTools profiler</label
+      >
     </li>
   </ul>
 </div>

--- a/devtools/projects/ng-devtools/src/lib/devtools.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.ts
@@ -108,12 +108,12 @@ export class DevToolsComponent implements OnDestroy {
   }
 
   private syncBackendWithSettings() {
-    // Keep BE in sync with timing API.
+    // Keep BE in sync with the performance track setting.
     effect(() => {
-      if (this.settings.timingAPIEnabled()) {
-        this.messageBus.emit('enableTimingAPI');
+      if (this.settings.performanceTrack()) {
+        this.messageBus.emit('enablePerformanceTrack');
       } else {
-        this.messageBus.emit('disableTimingAPI');
+        this.messageBus.emit('disablePerformanceTrack');
       }
     });
 

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -434,8 +434,8 @@ export interface Events {
   selectComponent: (id: number) => void;
   removeComponentHighlight: () => void;
 
-  enableTimingAPI: () => void;
-  disableTimingAPI: () => void;
+  enablePerformanceTrack: () => void;
+  disablePerformanceTrack: () => void;
 
   // todo: type properly
   getInjectorProviders: (injector: SerializedInjector) => void;

--- a/devtools/projects/shell-browser/src/app/app.component.ts
+++ b/devtools/projects/shell-browser/src/app/app.component.ts
@@ -22,10 +22,10 @@ export class AppComponent implements OnInit, OnDestroy {
   private readonly _messageBus = inject<MessageBus<Events>>(MessageBus);
   private readonly _deepLinkInstanceId = inject(DEEP_LINK_INSTANCE_ID);
   private onProfilingStartedListener = () => {
-    this._messageBus.emit('enableTimingAPI');
+    this._messageBus.emit('enablePerformanceTrack');
   };
   private onProfilingStoppedListener = () => {
-    this._messageBus.emit('disableTimingAPI');
+    this._messageBus.emit('disablePerformanceTrack');
   };
 
   private readonly _deepLinkListener = (event: MessageEvent) => {


### PR DESCRIPTION
- Rename Timing API to Performance Track to better reflect the purpose of the actual feature
- Migrate the settings data object to match the new name and drop some redundant keys