### PR TITLE
fix(docs-infra): don't show `$` prompt on empty lines

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -199,11 +199,9 @@ $code-font-size: 0.875rem;
 
     &:not([hideDollar]) {
       .shiki {
-        .line {
-          &::before {
-            content: '$';
-            padding-inline-end: 0.5rem;
-          }
+        .line:not(:empty)::before {
+          content: '$';
+          padding-inline-end: 0.5rem;
         }
       }
     }


### PR DESCRIPTION
Fenced shell code blocks prepended a `$` prompt to every rendered line  via a CSS `::before`, including blank lines are not commands to run.

### What is the current behavior?

<img width="1406" height="742" alt="image" src="https://github.com/user-attachments/assets/fe179b86-820f-49d0-b2e7-6abed94c2078" />

### What is the new behavior?
<img width="1634" height="728" alt="image" src="https://github.com/user-attachments/assets/01169280-cf4c-4006-8893-a20c764bb4a5" />

