### PR TITLE
refactor(core): use native `Promise.withResolvers()` in tests

### DIFF
--- a/packages/forms/signals/test/node/api/debounce.spec.ts
+++ b/packages/forms/signals/test/node/api/debounce.spec.ts
@@ -104,7 +104,7 @@ describe('debounce', () => {
     });
 
     it('should synchronize value after promise resolves', async () => {
-      const {promise, resolve} = promiseWithResolvers<void>();
+      const {promise, resolve} = Promise.withResolvers<void>();
       const address = signal({street: ''});
       const addressForm = form(
         address,
@@ -126,8 +126,8 @@ describe('debounce', () => {
     });
 
     it('should synchronize value after most recently returned promise resolves', async () => {
-      const first = promiseWithResolvers();
-      const second = promiseWithResolvers();
+      const first = Promise.withResolvers<void>();
+      const second = Promise.withResolvers<void>();
       const debounceFn = jasmine
         .createSpy('debounceFn')
         .and.returnValues(first.promise, second.promise);
@@ -158,7 +158,7 @@ describe('debounce', () => {
     });
 
     it('should be ignored if value is directly set before it resolves', async () => {
-      const debounceResult = promiseWithResolvers();
+      const debounceResult = Promise.withResolvers<void>();
       const debounceFn = jasmine.createSpy('debounceFn').and.returnValues(debounceResult.promise);
 
       const address = signal({street: ''});
@@ -188,7 +188,7 @@ describe('debounce', () => {
 
     describe('abort signal', () => {
       it('should be aborted if control value is set again', async () => {
-        const {promise, resolve} = promiseWithResolvers();
+        const {promise, resolve} = Promise.withResolvers<void>();
         const abortSpy = jasmine.createSpy('abort');
 
         const address = signal({street: ''});
@@ -518,26 +518,4 @@ function timeout(durationInMilliseconds: number): Promise<void> {
 /** Returns a promise that will never resolve. */
 function forever(): Promise<never> {
   return new Promise(() => {});
-}
-
-/**
- * Replace with `Promise.withResolvers()` once it's available.
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
- */
-// TODO: share this with submit.spec.ts
-function promiseWithResolvers<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
 }

--- a/packages/forms/signals/test/node/compat/compat.spec.ts
+++ b/packages/forms/signals/test/node/compat/compat.spec.ts
@@ -25,22 +25,6 @@ import {
   validateTree,
 } from '../../../public_api';
 
-function promiseWithResolvers<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
-}
-
 describe('Forms compat', () => {
   it('should not error on a valid value', () => {
     const cat = signal({
@@ -349,7 +333,7 @@ describe('Forms compat', () => {
       expect(f().submitting()).toBe(false);
       expect(f.age().submitting()).toBe(false);
 
-      const {promise, resolve} = promiseWithResolvers<TreeValidationResult>();
+      const {promise, resolve} = Promise.withResolvers<TreeValidationResult>();
 
       const result = submit(f, {
         action: (field) => {

--- a/packages/forms/signals/test/node/compat/signal_form_control.spec.ts
+++ b/packages/forms/signals/test/node/compat/signal_form_control.spec.ts
@@ -26,20 +26,6 @@ function createSignalFormControl<T>(initialValue: T, schema?: SchemaFn<T>) {
   return new SignalFormControl(initialValue, schema, {injector});
 }
 
-function promiseWithResolvers<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return {promise, resolve, reject};
-}
-
 describe('SignalFormControl', () => {
   describe('value and state access', () => {
     it('should have the same value as the signal', () => {
@@ -93,11 +79,11 @@ describe('SignalFormControl', () => {
     });
 
     it('should expose pending status for async validators', async () => {
-      let deferred = promiseWithResolvers<ValidationError[]>();
+      let deferred = Promise.withResolvers<ValidationError[]>();
       const resolveNext = (errors: ValidationError[]) => {
         TestBed.tick();
         deferred.resolve(errors);
-        deferred = promiseWithResolvers<ValidationError[]>();
+        deferred = Promise.withResolvers<ValidationError[]>();
       };
 
       const form = createSignalFormControl('initial', (p) => {

--- a/packages/forms/signals/test/node/submit.spec.ts
+++ b/packages/forms/signals/test/node/submit.spec.ts
@@ -51,7 +51,7 @@ describe('submit', () => {
   describe('while pending', () => {
     it('should not block', async () => {
       const data = signal('');
-      const {promise} = promiseWithResolvers();
+      const {promise} = Promise.withResolvers();
       const f = form(
         data,
         (p) => {
@@ -81,7 +81,7 @@ describe('submit', () => {
     it('should retain submit errors after pending validation resolves', async () => {
       const appRef = TestBed.inject(ApplicationRef);
       const data = signal('foo');
-      const {promise, resolve} = promiseWithResolvers<boolean>();
+      const {promise, resolve} = Promise.withResolvers<boolean>();
       const f = form(
         data,
         (p) => {
@@ -110,7 +110,7 @@ describe('submit', () => {
     it('should resolve pending validation on subfield', async () => {
       const appRef = TestBed.inject(ApplicationRef);
       const data = signal({first: 'foo', last: 'bar'});
-      const {promise, resolve} = promiseWithResolvers<boolean>();
+      const {promise, resolve} = Promise.withResolvers<boolean>();
       const f = form(
         data,
         (p) => {
@@ -142,7 +142,7 @@ describe('submit', () => {
     it('should resolve pending validation after successful submit', async () => {
       const appRef = TestBed.inject(ApplicationRef);
       const data = signal('foo');
-      const {promise, resolve} = promiseWithResolvers();
+      const {promise, resolve} = Promise.withResolvers<boolean>();
       const f = form(
         data,
         (p) => {
@@ -287,7 +287,7 @@ describe('submit', () => {
     );
     expect(f().submitting()).toBe(false);
 
-    const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+    const {promise, resolve} = Promise.withResolvers<ValidationError[]>();
     const result = submit(f, {action: () => promise});
     expect(f().submitting()).toBe(true);
 
@@ -297,7 +297,7 @@ describe('submit', () => {
 
   it('prohibits concurrent submits', async () => {
     const f = form(signal(0), {injector});
-    const {promise, resolve} = promiseWithResolvers<undefined>();
+    const {promise, resolve} = Promise.withResolvers<undefined>();
     const submitSpy = jasmine.createSpy('submit').and.callFake(() => promise);
 
     const result1 = submit(f, {action: submitSpy});
@@ -319,7 +319,7 @@ describe('submit', () => {
     const f = form(data, {injector});
     expect(f.a.b().submitting()).toBe(false);
 
-    const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+    const {promise, resolve} = Promise.withResolvers<ValidationError[]>();
     const result = submit(f, {action: () => promise});
     expect(f.a.b().submitting()).toBe(true);
 
@@ -383,7 +383,7 @@ describe('submit', () => {
     const f = form(signal(0), {injector});
     expect(f().submitting()).toBe(false);
 
-    const {promise, reject} = promiseWithResolvers<ValidationError[]>();
+    const {promise, reject} = Promise.withResolvers<ValidationError[]>();
     const submitPromise = submit(f, {action: () => promise});
     expect(f().submitting()).toBe(true);
 
@@ -540,7 +540,7 @@ describe('submit', () => {
 
   it('fails with pending validators with ignoreValidators: none', async () => {
     const data = signal('');
-    const resolvers = promiseWithResolvers();
+    const resolvers = Promise.withResolvers();
     const f = form(
       data,
       (p) => {
@@ -642,24 +642,3 @@ describe('submit', () => {
     expect(submitSpy).toHaveBeenCalledWith({name: 'Alice'}, {name: 'Alice'}, 'Alice');
   });
 });
-
-/**
- * Replace with `Promise.withResolvers()` once it's available.
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
- */
-function promiseWithResolvers<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
-}

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -1645,7 +1645,7 @@ describe('field directive', () => {
 
     describe('pending', () => {
       it('should bind to custom control', async () => {
-        const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+        const {promise, resolve} = Promise.withResolvers<ValidationError[]>();
 
         @Component({
           selector: 'custom-control',
@@ -1690,7 +1690,7 @@ describe('field directive', () => {
       });
 
       it('should bind to a custom control when composed as a host directive', async () => {
-        const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+        const {promise, resolve} = Promise.withResolvers<ValidationError[]>();
 
         @Component({
           selector: 'custom-control',
@@ -1736,7 +1736,7 @@ describe('field directive', () => {
       });
 
       it('should be reset when field changes on custom control', async () => {
-        const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+        const {promise, resolve} = Promise.withResolvers<ValidationError[]>();
 
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
@@ -1780,7 +1780,7 @@ describe('field directive', () => {
       });
 
       it('should bind to directive input on native control', async () => {
-        const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+        const {promise, resolve} = Promise.withResolvers<ValidationError[]>();
 
         @Directive({selector: '[testDir]'})
         class TestDir {
@@ -1818,7 +1818,7 @@ describe('field directive', () => {
       });
 
       it('should bind to directive input on custom control', async () => {
-        const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+        const {promise, resolve} = Promise.withResolvers<ValidationError[]>();
 
         @Directive({selector: '[testDir]'})
         class TestDir {
@@ -5032,7 +5032,7 @@ describe('field directive', () => {
   });
 
   it('should synchronize pending status', async () => {
-    const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+    const {promise, resolve} = Promise.withResolvers<ValidationError[]>();
 
     @Component({
       selector: 'my-input',
@@ -5927,7 +5927,7 @@ describe('field directive', () => {
 
   describe('debounce', () => {
     it('should support native control', async () => {
-      const {promise, resolve} = promiseWithResolvers<void>();
+      const {promise, resolve} = Promise.withResolvers<void>();
 
       @Component({
         imports: [FormField],
@@ -5954,7 +5954,7 @@ describe('field directive', () => {
     });
 
     it('should support custom control', async () => {
-      const {promise, resolve} = promiseWithResolvers<void>();
+      const {promise, resolve} = Promise.withResolvers<void>();
 
       @Component({
         selector: 'my-input',
@@ -5986,7 +5986,7 @@ describe('field directive', () => {
     });
 
     it('should reset control when debounced update is reset', async () => {
-      const {promise, resolve} = promiseWithResolvers<void>();
+      const {promise, resolve} = Promise.withResolvers<void>();
 
       @Component({
         imports: [FormField],
@@ -6024,7 +6024,7 @@ describe('field directive', () => {
     });
 
     it('should reset child control when debounced update is reset at root', async () => {
-      const {promise, resolve} = promiseWithResolvers<void>();
+      const {promise, resolve} = Promise.withResolvers<void>();
 
       @Component({
         imports: [FormField],
@@ -6218,7 +6218,7 @@ describe('field directive', () => {
   });
 
   it('should create & bind input when a macro task is running', async () => {
-    const {promise, resolve} = promiseWithResolvers<void>();
+    const {promise, resolve} = Promise.withResolvers<void>();
 
     @Component({
       selector: 'app-form',
@@ -6489,26 +6489,4 @@ function act<T>(fn: () => T): T {
   } finally {
     TestBed.tick();
   }
-}
-
-/**
- * Replace with `Promise.withResolvers()` once it's available.
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
- */
-// TODO: share this with submit.spec.ts
-function promiseWithResolvers<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
 }

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -313,7 +313,7 @@ describe('ControlValueAccessor', () => {
   });
 
   it('should support debounce', async () => {
-    const {promise, resolve} = promiseWithResolvers<void>();
+    const {promise, resolve} = Promise.withResolvers<void>();
 
     @Component({
       imports: [CustomControl, FormField],
@@ -936,7 +936,7 @@ describe('ControlValueAccessor', () => {
 
     describe('pending', () => {
       it('should bind to directive input', async () => {
-        const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+        const {promise, resolve} = Promise.withResolvers<ValidationError[]>();
 
         @Directive({selector: '[testDir]'})
         class TestDir {
@@ -1519,26 +1519,4 @@ async function actAsync<T>(fn: () => T): Promise<T> {
   } finally {
     await TestBed.inject(ApplicationRef).whenStable();
   }
-}
-
-/**
- * Replace with `Promise.withResolvers()` once it's available.
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
- */
-// TODO: share this with submit.spec.ts
-function promiseWithResolvers<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: any) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: any) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {promise, resolve, reject};
 }

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -19,7 +19,7 @@
     "moduleResolution": "bundler",
     "module": "esnext",
     "target": "es2022",
-    "lib": ["es2020", "es2022", "dom", "dom.iterable"],
+    "lib": ["es2022", "dom", "dom.iterable", "es2024.promise"],
     "skipLibCheck": true,
     // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
     "types": [],
@@ -36,9 +36,9 @@
       "@angular/common/locales/*": ["./common/locales/*"],
       "@angular/compiler-cli": ["./compiler-cli"],
       "@angular/compiler-cli/*": ["./compiler-cli/*"],
-      "@angular/compiler-cli/src/ngtsc/reflection":  ["./compiler-cli/src/ngtsc/reflection/index"],
-      "@angular/compiler-cli/src/ngtsc/metadata":  ["./compiler-cli/src/ngtsc/metadata/index"],
-      "@angular/compiler-cli/private/migrations":  ["./compiler-cli/private/migrations"],
+      "@angular/compiler-cli/src/ngtsc/reflection": ["./compiler-cli/src/ngtsc/reflection/index"],
+      "@angular/compiler-cli/src/ngtsc/metadata": ["./compiler-cli/src/ngtsc/metadata/index"],
+      "@angular/compiler-cli/private/migrations": ["./compiler-cli/private/migrations"],
       "@angular/core/schematics/utils/tsurge/*": ["./core/schematics/utils/tsurge/*"]
     }
   },


### PR DESCRIPTION
Based on https://github.com/angular/angular/pull/69686#issuecomment-4921894298

> Since Promise.withResolvers() is available natively now, we should use that instead of introducing a new utility.

Replaces the temporary `promiseWithResolvers` polyfill with the native `Promise.withResolvers()` API now that it is supported by both the runtime and TypeScript.

Also removes the polyfill and its exports, and updates the TypeScript configuration to include the `es2024` library.

