### PR TITLE
fix(platform-server): enforce allowOriginChange for protocol-relative urls

### DIFF
--- a/packages/platform-server/src/url.ts
+++ b/packages/platform-server/src/url.ts
@@ -102,7 +102,16 @@ export function resolveUrl(
       );
     }
 
-    return new URL(urlStr, origin);
+    resolved = new URL(urlStr, origin);
+
+    // A protocol-relative URL inherits the base scheme, so the only origin-sensitive
+    // change it can introduce is the host. Honor `allowOriginChange` here too, the same
+    // way every other return path does.
+    if (!allowOriginChange && resolved.origin !== originUrl.origin) {
+      throwSuspiciousUrlError(urlStr);
+    }
+
+    return resolved;
   }
 
   resolved = new URL(urlStr, origin);

--- a/packages/platform-server/test/url_spec.ts
+++ b/packages/platform-server/test/url_spec.ts
@@ -48,6 +48,30 @@ describe('resolveUrl', () => {
       expect(url.href).toBe('http://test.com/other-path');
     });
 
+    it('should throw for a protocol-relative url that changes origin when allowOriginChange is false', () => {
+      expect(() =>
+        resolveUrl('//evil.com/path', 'http://test.com', {
+          allowProtocolRelative: true,
+          allowOriginChange: false,
+        }),
+      ).toThrowError(/NG05703/);
+    });
+
+    it('should resolve a same-origin protocol-relative url when allowOriginChange is false', () => {
+      const url = resolveUrl('//test.com/other-path', 'http://test.com', {
+        allowProtocolRelative: true,
+        allowOriginChange: false,
+      });
+      expect(url.href).toBe('http://test.com/other-path');
+    });
+
+    it('should resolve a cross-origin protocol-relative url when origin changes are allowed', () => {
+      const url = resolveUrl('//other.com/path', 'http://test.com', {
+        allowProtocolRelative: true,
+      });
+      expect(url.origin).toBe('http://other.com');
+    });
+
     it('should throw an error for malformed absolute URLs', () => {
       const malformedUrls = [
         'http://evil.com:80:80/path',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`resolveUrl` funnels every return path through `isSafeOriginChange`, except the protocol-relative branch (an input starting with `//`), which returns `new URL(urlStr, origin)` directly. So a caller that passes `{allowProtocolRelative: true, allowOriginChange: false}` still gets a cross-origin result for `//other.com/path`, even though it asked for origin changes to be disallowed. The `allowOriginChange` option is silently ignored on that one path.

## What is the new behavior?

The protocol-relative branch now compares the resolved origin against the base origin and throws the same suspicious-URL error as the other paths when `allowOriginChange` is `false` and the origin actually differs. A protocol-relative URL inherits the base scheme, so host is the only origin-sensitive part to guard. Same-origin protocol-relative URLs and the default `allowOriginChange: true` behavior (used by the relative-URL HTTP interceptor) are unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
