### PR TITLE
fix(docs-infra): render the Console tab error badge in the embedded e…

### DIFF
--- a/adev/src/app/editor/embedded-editor.component.ts
+++ b/adev/src/app/editor/embedded-editor.component.ts
@@ -22,7 +22,7 @@ import {
 } from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {IconComponent, TutorialType} from '@angular/docs';
-import {MatTab, MatTabGroup} from '@angular/material/tabs';
+import {MatTab, MatTabGroup, MatTabLabel} from '@angular/material/tabs';
 import {map} from 'rxjs';
 
 import {MAX_RECOMMENDED_WEBCONTAINERS_INSTANCES} from './alert-manager.service';
@@ -44,7 +44,16 @@ export const LARGE_EDITOR_HEIGHT_BREAKPOINT = 550;
 
 @Component({
   selector: EMBEDDED_EDITOR_SELECTOR,
-  imports: [AngularSplitModule, CodeEditor, Preview, Terminal, MatTab, MatTabGroup, IconComponent],
+  imports: [
+    AngularSplitModule,
+    CodeEditor,
+    Preview,
+    Terminal,
+    MatTab,
+    MatTabGroup,
+    MatTabLabel,
+    IconComponent,
+  ],
   templateUrl: './embedded-editor.component.html',
   styleUrls: ['./embedded-editor.component.scss'],
   providers: [EditorUiState],


### PR DESCRIPTION
The Console tab's error-count badge lives in an `<ng-template mat-tab-label>`, but the component didn't import `MatTabLabel`, so Material ignored the templated label and fell back to the plain "Console" text. Import it so the badge renders when there are errors.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The Console tab's error-count badge never shows, even when the playground or tutorial has console errors.

## What is the new behavior?

The badge shows the error count when there are console errors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No