### PR TITLE
fix(forms): ignore stale value accessor callbacks after control is rebound

### DIFF
--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -265,6 +265,12 @@ export function cleanUpValidators(
 
 function setUpViewChangePipeline(control: FormControl, dir: NgControl): void {
   dir.valueAccessor!.registerOnChange((newValue: any) => {
+    // The directive may have been reattached to a different control since this callback was
+    // registered. `cleanUpControl` disconnects the previous pipeline by registering a noop,
+    // but value accessors that accumulate callbacks passed to `registerOnChange` (instead of
+    // replacing them) may still invoke this stale callback. See #68744.
+    if (dir.control !== control) return;
+
     control._pendingValue = newValue;
     control._pendingChange = true;
     control._pendingDirty = true;
@@ -275,6 +281,9 @@ function setUpViewChangePipeline(control: FormControl, dir: NgControl): void {
 
 function setUpBlurPipeline(control: FormControl, dir: NgControl): void {
   dir.valueAccessor!.registerOnTouched(() => {
+    // See the comment in `setUpViewChangePipeline` on why this check is needed.
+    if (dir.control !== control) return;
+
     control._pendingTouched = true;
 
     if (control.updateOn === 'blur' && control._pendingChange) updateControl(control, dir);

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -4912,6 +4912,62 @@ describe('reactive forms integration tests', () => {
       expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: sharedControl, count: 1});
     });
 
+    it('should not sync the previously bound control when the `formControl` input changes and the value accessor accumulates `registerOnChange` callbacks', () => {
+      @Component({
+        selector: 'accumulating-cva',
+        template: '<input type="text" [formControl]="innerControl" />',
+        providers: [
+          {provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => AccumulatingCva), multi: true},
+        ],
+        standalone: false,
+      })
+      class AccumulatingCva implements ControlValueAccessor {
+        innerControl = new FormControl('');
+        writeValue(value: any): void {
+          this.innerControl.setValue(value);
+        }
+        // Callbacks are accumulated (instead of replaced) on each `registerOnChange` call,
+        // mimicking value accessors that subscribe to an inner control's `valueChanges`.
+        registerOnChange(fn: (value: any) => void): void {
+          this.innerControl.valueChanges.subscribe(fn);
+        }
+        registerOnTouched(fn: () => void): void {}
+      }
+
+      @Component({
+        template: '<accumulating-cva [formControl]="control"></accumulating-cva>',
+        standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class App {
+        control = new FormControl('A');
+      }
+
+      const fixture = initTest(App, AccumulatingCva);
+      fixture.detectChanges();
+
+      const controlA = fixture.componentInstance.control;
+      const controlB = new FormControl('B');
+
+      fixture.componentInstance.control = controlB;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      // Rebinding the directive writes `controlB`'s value into the view. The stale
+      // view-to-model callback registered for `controlA` must not pick that value up.
+      expect(controlA.value).toBe('A');
+      expect(controlB.value).toBe('B');
+      expect(controlB.dirty).toBe(false);
+
+      // View changes should only be propagated to the currently bound control.
+      const cva: AccumulatingCva = fixture.debugElement.query(
+        By.directive(AccumulatingCva),
+      ).componentInstance;
+      cva.innerControl.setValue('C');
+      expect(controlA.value).toBe('A');
+      expect(controlB.value).toBe('C');
+    });
+
     it('should clean up callbacks when FormControlDirective is destroyed (simple)', () => {
       // Scenario:
       // ---------


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #68744

When the `FormControl` bound via `[formControl]` (or resolved by `formControlName` after a
`FormGroup` swap) is replaced with a different instance, the previously bound control can be
silently overwritten with the new control's value.

`cleanUpControl` disconnects the old view-to-model pipeline by calling
`valueAccessor.registerOnChange(noop)` / `registerOnTouched(noop)`, which assumes the value
accessor **replaces** the previously registered callback. Custom `ControlValueAccessor`
implementations commonly **accumulate** callbacks instead — e.g.:

```ts
registerOnChange(fn: any): void {
  this.innerControl.valueChanges.subscribe(fn);
}
```

With such an accessor, the stale callback registered for the old control stays alive. During
re-setup, `setUpControlValueAccessor` calls `writeValue(newControl.value)`, the inner control
emits, the stale callback fires, and `updateControl` writes the **new** control's value into the
**old** control (also marking it dirty). See the minimal reproduction in the issue.

## What is the new behavior?

The callbacks registered by `setUpViewChangePipeline` and `setUpBlurPipeline` now check that the
directive is still attached to the control they were created for (`dir.control !== control`) and
become inert otherwise. Swapping the bound control no longer corrupts the previously bound
control's value, dirty, or touched state, regardless of how the value accessor implements
`registerOnChange`/`registerOnTouched`.

Directives affected were verified for correct sequencing:

- `FormControlDirective`: `this.form` already points at the new control when `ngOnChanges` runs.
- `FormControlName`: `_setupWithForm` assigns `this.control` before setting up the pipelines.
- `NgModel`: its control never changes instance, so behavior is unchanged.

A regression test reproducing the issue's scenario was added to `reactive_integration_spec.ts`
(fails without the fix, passes with it).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

An alternative considered was to document that `registerOnChange` must replace previously
registered callbacks, but the accumulating pattern is widespread in existing applications and the
guard makes the cleanup mechanism robust for both semantics at the cost of a single identity
check.

Closes #68744
