### PR TITLE
fix(compiler): prevent ReDoS in ShadowCss selector paren matching

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -983,10 +983,14 @@ const _polyfillHost = '-shadowcsshost';
 const _polyfillHostContext = '-shadowcsscontext';
 // Matches text content with no parentheses, e.g., "foo"
 const _noParens = '[^)(]*';
-// Matches content with at most ONE level of nesting, e.g., "a(b)c"
-const _level1Parens = String.raw`(?:\(${_noParens}\)|${_noParens})+?`;
+// Matches content with at most ONE level of nesting, e.g., "a(b)c". Each run of
+// non-paren characters is anchored between the mandatory `(`/`)` delimiters, so the
+// alternatives never overlap. The previous `(?:\(x\)|x)+?` form let the inner `[^)(]*`
+// match the same characters in exponentially many ways, so a selector with an
+// unbalanced `(` (e.g. `:host(aaaa…`) forced catastrophic backtracking.
+const _level1Parens = String.raw`${_noParens}(?:\(${_noParens}\)${_noParens})*`;
 // Matches content with at most TWO levels of nesting, e.g., "a(b(c)d)e"
-const _level2Parens = String.raw`(?:\(${_level1Parens}\)|${_noParens})+?`;
+const _level2Parens = String.raw`${_noParens}(?:\(${_level1Parens}\)${_noParens})*`;
 const _parenSuffix = String.raw`(?:\((${_level2Parens})\))`;
 const nthRegex = new RegExp(String.raw`(:nth-[-\w]+)` + _parenSuffix, 'g');
 const _cssColonHostRe = new RegExp(_polyfillHost + _parenSuffix + '?([^,{]*)', 'gim');

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -26,6 +26,19 @@ describe('ShadowCss', () => {
     expect(shim(css, 'contenta')).toEqualCss(expected);
   });
 
+  it('should not backtrack catastrophically on an unterminated pseudo-class paren', () => {
+    // The `:host(...)`, `:host-context(...)` and `:nth-*(...)` scoping regexes match the
+    // parenthesized selector body. A selector that opens a paren but never closes it, followed
+    // by a long run of characters, used to trigger exponential backtracking (ReDoS) and hang
+    // the compiler/JIT. Scoping must stay fast on such malformed input.
+    const tail = 'a'.repeat(60);
+    for (const selector of [`:host(${tail}`, `:host-context(${tail}`, `div:nth-child(${tail}`]) {
+      const start = Date.now();
+      shim(`${selector} {color: red;}`, 'contenta', 'a-host');
+      expect(Date.now() - start).toBeLessThan(1000);
+    }
+  });
+
   it('should add an attribute to every selector', () => {
     const css = 'one, two {color: red;}';
     const expected = 'one[contenta], two[contenta] {color:red;}';


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

The paren-matching fragments shared by the `:host()`, `:host-context()` and `:nth-*()` scoping regexes in `shadow_css.ts` (`_level1Parens`/`_level2Parens`) are built as `(?:\(x\)|x)+?`, where the inner `[^)(]*` can partition a run of characters in exponentially many ways. When a component selector opens one of those pseudo-classes but never closes the paren, `shimCssText` falls into catastrophic backtracking: `:host(` followed by ~30 characters takes roughly two minutes here, and `:host-context(` similar, while `:nth-child(` is a few seconds.

## What is the new behavior?

The two shared fragments are rewritten as an unrolled loop that anchors each run of non-paren characters between the mandatory `(`/`)` delimiters, so the alternatives no longer overlap. Matching stays identical for valid selectors (verified against the existing shadow_css specs and by diffing `shimCssText` output across `:host`, `:host-context`, `:nth-*` and nested `:not`/`:is` cases), and the malformed case now completes in under 2ms. Added a regression test covering the three affected pseudo-classes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
