### PR TITLE
refactor: remove obsolete @types/babel__core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,8 +86,6 @@
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@schematics/angular": "22.1.0-next.3",
     "@types/angular": "^1.6.47",
-    "@types/babel__core": "7.20.5",
-    "@types/babel__generator": "7.27.0",
     "@types/chrome": "^0.2.0",
     "@types/dom-navigation": "^1.0.5",
     "@types/jasmine": "^6.0.0",

--- a/packages/compiler-cli/linker/babel/BUILD.bazel
+++ b/packages/compiler-cli/linker/babel/BUILD.bazel
@@ -16,7 +16,6 @@ ts_project(
     ]),
     deps = [
         "//:node_modules/@babel/core",
-        "//:node_modules/@types/babel__core",
         "//packages/compiler",
         "//packages/compiler-cli/linker",
         "//packages/compiler-cli/src/ngtsc/file_system",

--- a/packages/compiler-cli/linker/babel/test/BUILD.bazel
+++ b/packages/compiler-cli/linker/babel/test/BUILD.bazel
@@ -12,9 +12,8 @@ ts_project(
         "**/*.ts",
     ]),
     deps = [
+        "//:node_modules/@babel/core",
         "//:node_modules/@babel/generator",
-        "//:node_modules/@types/babel__core",
-        "//:node_modules/@types/babel__generator",
         "//packages:types",
         "//packages/compiler",
         "//packages/compiler-cli/linker",

--- a/packages/compiler-cli/test/compliance/linked/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/linked/BUILD.bazel
@@ -5,7 +5,7 @@ ts_project(
     testonly = True,
     srcs = ["linked_compile_spec.ts"],
     deps = [
-        "//:node_modules/@types/babel__core",
+        "//:node_modules/@babel/core",
         "//packages/compiler-cli/linker",
         "//packages/compiler-cli/linker/babel",
         "//packages/compiler-cli/private",

--- a/packages/localize/BUILD.bazel
+++ b/packages/localize/BUILD.bazel
@@ -51,9 +51,6 @@ api_golden_test_npm_package(
     # The logic for the localize function is exported in the primary entry-point, but users
     # are not supposed to import it from there. We still want to guard these exports though.
     strip_export_pattern = "^ɵ(?!.localize|LocalizeFn|TranslateFn)",
-    types = {
-        "//:node_modules/@types/babel__core": "babel",
-    },
 )
 
 filegroup(

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -34,7 +34,6 @@
   ],
   "dependencies": {
     "@babel/core": "8.0.1",
-    "@types/babel__core": "7.20.5",
     "tinyglobby": "^0.2.12",
     "yargs": "^18.0.0"
   },

--- a/packages/localize/tools/BUILD.bazel
+++ b/packages/localize/tools/BUILD.bazel
@@ -21,7 +21,6 @@ ts_project(
     visibility = ["//packages/localize/tools:__subpackages__"],
     deps = [
         "//:node_modules/@babel/core",
-        "//:node_modules/@types/babel__core",
         "//:node_modules/@types/node",
         "//:node_modules/@types/yargs",
         "//:node_modules/tinyglobby",

--- a/packages/localize/tools/test/BUILD.bazel
+++ b/packages/localize/tools/test/BUILD.bazel
@@ -8,9 +8,8 @@ ts_project(
     ),
     visibility = ["//packages/localize/tools/test:__subpackages__"],
     deps = [
+        "//:node_modules/@babel/core",
         "//:node_modules/@babel/generator",
-        "//:node_modules/@types/babel__core",
-        "//:node_modules/@types/babel__generator",
         "//:node_modules/tinyglobby",
         "//packages:types",
         "//packages/compiler",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,12 +105,6 @@ importers:
       '@types/angular':
         specifier: ^1.6.47
         version: 1.8.9
-      '@types/babel__core':
-        specifier: 7.20.5
-        version: 7.20.5
-      '@types/babel__generator':
-        specifier: 7.27.0
-        version: 7.27.0
       '@types/chrome':
         specifier: ^0.2.0
         version: 0.2.2
@@ -1092,9 +1086,6 @@ importers:
       '@babel/core':
         specifier: 8.0.1
         version: 8.0.1
-      '@types/babel__core':
-        specifier: 7.20.5
-        version: 7.20.5
       tinyglobby:
         specifier: ^0.2.12
         version: 0.2.17


### PR DESCRIPTION
Remove the obsolete @types/babel__core dependency from packages/compiler-cli and packages/localize. This dependency is no longer needed as Babel v8 ships with its own built-in TypeScript definitions.
