### PR TITLE
feat(docs-infra): show Angie in the error snack bar

### DIFF
--- a/adev/src/app/core/services/errors-handling/error-handler.ts
+++ b/adev/src/app/core/services/errors-handling/error-handler.ts
@@ -49,6 +49,7 @@ export class CustomErrorHandler implements ErrorHandler {
         data: {
           message: `Our docs have been updated, reload the page to see the latest.`,
           actionText: `Reload`,
+          pose: 'greeting',
         } satisfies ErrorSnackBarData,
       })
       .onAction()

--- a/adev/src/app/core/services/errors-handling/error-snack-bar.spec.ts
+++ b/adev/src/app/core/services/errors-handling/error-snack-bar.spec.ts
@@ -1,0 +1,84 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_SNACK_BAR_DATA, MatSnackBarRef} from '@angular/material/snack-bar';
+
+import {ErrorSnackBar, ErrorSnackBarData} from './error-snack-bar';
+
+describe('ErrorSnackBar', () => {
+  let fixture: ComponentFixture<ErrorSnackBar>;
+  let data: ErrorSnackBarData;
+  const snackBarRef = jasmine.createSpyObj<MatSnackBarRef<ErrorSnackBar>>('MatSnackBarRef', [
+    'dismissWithAction',
+  ]);
+
+  beforeEach(() => {
+    data = {message: 'Something went wrong', pose: 'error'};
+    snackBarRef.dismissWithAction.calls.reset();
+
+    TestBed.configureTestingModule({
+      imports: [ErrorSnackBar],
+      providers: [
+        {provide: MAT_SNACK_BAR_DATA, useValue: data},
+        {provide: MatSnackBarRef, useValue: snackBarRef},
+      ],
+    });
+  });
+
+  it('should render the message and the action button', async () => {
+    data.message = 'Our docs have been updated, reload the page to see the latest.';
+    data.actionText = 'Reload';
+    await initComponent();
+
+    expect(getMessage()).toContain('Our docs have been updated');
+    expect(getActionButton().textContent).toContain('Reload');
+  });
+
+  it('should build the mascot image source from the pose', async () => {
+    data.pose = 'error';
+    await initComponent();
+
+    expect(getAngie().getAttribute('src')).toBe('assets/images/angie/error.svg');
+  });
+
+  it('should follow the pose passed in the data', async () => {
+    data.pose = 'greeting';
+    await initComponent();
+
+    expect(getAngie().getAttribute('src')).toBe('assets/images/angie/greeting.svg');
+  });
+
+  it('should dismiss with action when the button is clicked', async () => {
+    data.actionText = 'Reload';
+    await initComponent();
+
+    getActionButton().click();
+    await fixture.whenStable();
+
+    expect(snackBarRef.dismissWithAction).toHaveBeenCalled();
+  });
+
+  // Helpers
+  function getMessage() {
+    return (fixture.nativeElement as HTMLElement).querySelector('p')?.textContent ?? '';
+  }
+
+  function getAngie() {
+    return (fixture.nativeElement as HTMLElement).querySelector('img.error-snack-bar-angie')!;
+  }
+
+  function getActionButton() {
+    return (fixture.nativeElement as HTMLElement).querySelector('button')!;
+  }
+
+  async function initComponent() {
+    fixture = TestBed.createComponent(ErrorSnackBar);
+    await fixture.whenStable();
+  }
+});

--- a/adev/src/app/core/services/errors-handling/error-snack-bar.ts
+++ b/adev/src/app/core/services/errors-handling/error-snack-bar.ts
@@ -9,15 +9,21 @@
 import {Component, inject} from '@angular/core';
 import {MAT_SNACK_BAR_DATA, MatSnackBarAction, MatSnackBarRef} from '@angular/material/snack-bar';
 
+const ANGIE_DIR = 'assets/images/angie';
+
+export type ErrorSnackBarPose = 'error' | 'sad' | 'question' | 'greeting';
+
 export interface ErrorSnackBarData {
   message: string;
   actionText?: string;
+  pose: ErrorSnackBarPose;
 }
 
 @Component({
   selector: 'error-snack-bar',
   template: `
-    {{ message }}
+    <img class="error-snack-bar-angie" [src]="poseSrc" alt="" aria-hidden="true" />
+    <p>{{ message }}</p>
     <button
       class="docs-primary-btn"
       type="button"
@@ -33,8 +39,22 @@ export interface ErrorSnackBarData {
     :host {
       display: flex;
       align-items: center;
+      .error-snack-bar-angie {
+        width: 40px;
+        height: auto;
+        margin-right: 16px;
+        flex-shrink: 0;
+        transform: scale(1.53);
+        transform-origin: center;
+      }
+      p {
+        margin: 0;
+        flex: 1;
+        font: inherit;
+      }
       button {
         margin-left: 16px;
+        flex-shrink: 0;
       }
     }
   `,
@@ -44,10 +64,12 @@ export class ErrorSnackBar {
 
   protected message: string;
   protected actionText?: string;
+  protected poseSrc: string;
 
   constructor() {
     const data = inject(MAT_SNACK_BAR_DATA) as ErrorSnackBarData;
     this.message = data.message;
     this.actionText = data.actionText;
+    this.poseSrc = `${ANGIE_DIR}/${data.pose}.svg`;
   }
 }

--- a/adev/src/app/editor/alert-manager.service.ts
+++ b/adev/src/app/editor/alert-manager.service.ts
@@ -9,7 +9,11 @@
 import {inject, Service} from '@angular/core';
 import {LOCAL_STORAGE, WINDOW, isMobile} from '@angular/docs';
 import {MatSnackBar} from '@angular/material/snack-bar';
-import {ErrorSnackBar, ErrorSnackBarData} from '../core/services/errors-handling/error-snack-bar';
+import {
+  ErrorSnackBar,
+  ErrorSnackBarData,
+  ErrorSnackBarPose,
+} from '../core/services/errors-handling/error-snack-bar';
 
 export const MAX_RECOMMENDED_WEBCONTAINERS_INSTANCES = 3;
 export const WEBCONTAINERS_COUNTER_KEY = 'numberOfWebcontainers';
@@ -85,12 +89,15 @@ export class AlertManager {
 
   private openSnackBar(reason: AlertReason) {
     let message = '';
+    let pose: ErrorSnackBarPose = 'greeting';
     switch (reason) {
       case AlertReason.OUT_OF_MEMORY:
         message = `Your browser is currently limiting the memory available to run the Angular Tutorials or Playground. If you have multiple tabs open with Tutorials or Playground, please close some of them and refresh this page.`;
+        pose = 'error';
         break;
       case AlertReason.MOBILE:
         message = `You are running the embedded editor in a mobile device, this may result in an Out of memory error.`;
+        pose = 'greeting';
         break;
     }
 
@@ -99,6 +106,7 @@ export class AlertManager {
       data: {
         message,
         actionText: 'I understand',
+        pose,
       } satisfies ErrorSnackBarData,
     });
   }


### PR DESCRIPTION
The error snack bar (the chunk-load reload prompt and the embedded editor's memory / mobile alerts) showed only text and an action button. Add an Angie press-kit pose to the left of the message so the failure state matches the mascot treatment already used for the preview error card and the empty search states.

The pose is data-driven: ErrorSnackBarData gains a required `pose` field so each caller picks the mascot that fits the message tone (`greeting` for the docs-updated reload prompt and the mobile notice, `error` for the out-of-memory warning). The message moves into a `<p>` that flexes to fill the row, keeping the action button aligned to the right.

Presentation only; when and why the snack bar appears is unchanged.

<img width="726" height="142" alt="Screenshot 2026-07-13 at 22 59 11" src="https://github.com/user-attachments/assets/fadfa556-2fb4-4ccc-8932-031d72d6d56e" />

<img width="802" height="139" alt="Screenshot 2026-07-13 at 23 09 15" src="https://github.com/user-attachments/assets/56286d77-104e-461b-aadf-4f3cfed57252" />
