### PR TITLE
fix(platform-browser): prevent ReDoS in SOURCEMAP_URL_REGEXP

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -46,7 +46,7 @@ export const NAMESPACE_URIS: {[ns: string]: string} = {
 };
 
 const COMPONENT_REGEX = /%COMP%/g;
-const SOURCEMAP_URL_REGEXP = /\/\*#\s*sourceMappingURL=(.+?)\s*\*\//;
+const SOURCEMAP_URL_REGEXP = /\/\*#\s*sourceMappingURL=([^\s*]+)\s*\*\//;
 const PROTOCOL_REGEXP = /^https?:/;
 
 export const COMPONENT_VARIABLE = '%COMP%';


### PR DESCRIPTION
## Problem

`SOURCEMAP_URL_REGEXP` in `@angular/platform-browser` uses a lazy quantifier (`.+?`) that causes polynomial O(n²) backtracking when CSS contains unclosed `/*# sourceMappingURL=` fragments.

```ts
// Before (vulnerable):
const SOURCEMAP_URL_REGEXP = /\/\*#\s*sourceMappingURL=(.+?)\s*\*\//;
```

When `k` unclosed fragments exist in a CSS string of length `L`, each fragment at position `i` costs O(L − i) steps, giving O(k × L) = **O(L²)** total — a classic ReDoS pattern.

**Impact on Angular SSR / Universal:** `addBaseHrefToCssSourceMap` is called server-side on every render request for components that have a non-empty `baseHref`. At k=2000 fragments (~48 KB CSS), a single call blocks the Node.js event loop for ~71 ms, enabling event-loop saturation under moderate traffic.

**Benchmark (Node.js 24 / V8):**

| k (fragments) | CSS length | Time |
|---|---|---|
| 100 | 2 400 chars | 0.31 ms |
| 500 | 12 000 chars | 4.26 ms |
| 1 000 | 24 000 chars | 16.55 ms |
| 2 000 | 48 000 chars | 71.15 ms |

10× input → ~54× time → **O(n²) confirmed**.

## Fix

Replace the lazy quantifier with a negated character class that excludes whitespace and `*`. Source map URLs never contain either character, so the fix is semantically equivalent.

```ts
// After (O(n), safe):
const SOURCEMAP_URL_REGEXP = /\/\*#\s*sourceMappingURL=([^\s*]+)\s*\*\//;
```

## Testing

Verified against the published `@angular/platform-browser@22.0.4` npm bundle (`fesm2022/_dom_renderer-chunk.mjs`).

## Related

Reported to Google OSS VRP — referred to Angular GitHub for fix.