### PR TITLE
fix(common): avoid prototype lookups in date format caches

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -33,7 +33,8 @@ import {RuntimeErrorCode} from '../errors';
 export const ISO8601_DATE_REGEX =
   /^(\d{4,})-?(\d\d)-?(\d\d)(?:T(\d\d)(?::?(\d\d)(?::?(\d\d)(?:\.(\d+))?)?)?(Z|([+-])(\d\d):?(\d\d))?)?$/;
 //    1        2       3         4          5          6          7          8  9     10      11
-const NAMED_FORMATS: {[localeId: string]: {[format: string]: string}} = {};
+// tslint:disable-next-line:no-toplevel-property-access
+const NAMED_FORMATS: {[localeId: string]: {[format: string]: string}} = Object.create(null);
 const DATE_FORMATS_SPLIT =
   /((?:[^BEGHLMOSWYZabcdhmswyz']+)|(?:'(?:[^']|'')*')|(?:G{1,5}|y{1,4}|Y{1,4}|M{1,5}|L{1,5}|w{1,2}|W{1}|d{1,2}|E{1,6}|c{1,6}|a{1,5}|b{1,5}|B{1,5}|h{1,2}|H{1,2}|m{1,2}|s{1,2}|S{1,3}|z{1,4}|Z{1,5}|O{1,4}))([\s\S]*)/;
 const MAX_DATE_FORMAT_LENGTH = 256;
@@ -201,7 +202,7 @@ function createDate(year: number, month: number, date: number): Date {
 
 function getNamedFormat(locale: string, format: string): string {
   const localeId = getLocaleId(locale);
-  NAMED_FORMATS[localeId] ??= {};
+  NAMED_FORMATS[localeId] ??= Object.create(null);
 
   if (NAMED_FORMATS[localeId][format]) {
     return NAMED_FORMATS[localeId][format];
@@ -570,7 +571,8 @@ function weekNumberingYearGetter(size: number, trim = false): DateFormatter {
 
 type DateFormatter = (date: Date, locale: string, offset: number) => string;
 
-const DATE_FORMATS: {[format: string]: DateFormatter} = {};
+// tslint:disable-next-line:no-toplevel-property-access
+const DATE_FORMATS: {[format: string]: DateFormatter} = Object.create(null);
 
 // Based on CLDR formats:
 // See complete list: http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -361,6 +361,15 @@ describe('Format date', () => {
       );
     });
 
+    it('should treat format tokens that collide with Object.prototype members as literals', () => {
+      // A format token that matches an inherited property name (e.g. `__proto__`) must not
+      // resolve to a value off the prototype of the internal format caches. Before the caches
+      // were given a null prototype, `__proto__` read back `Object.prototype`, garbling the
+      // named-format lookup and crashing the token lookup (it was invoked as a formatter).
+      expect(formatDate(date, '__proto__', ɵDEFAULT_LOCALE_ID)).toEqual('__proto__');
+      expect(formatDate(date, 'y__proto__', ɵDEFAULT_LOCALE_ID)).toEqual('2015__proto__');
+    });
+
     it('should format invalid in IE ISO date', () =>
       expect(formatDate('2017-01-11T12:00:00.014-0500', defaultFormat, ɵDEFAULT_LOCALE_ID)).toEqual(
         'Jan 11, 2017',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`getNamedFormat` and `getDateFormatter` in `packages/common/src/i18n/format_date.ts` read the module-level `NAMED_FORMATS` and `DATE_FORMATS` caches (plain `{}` objects) with a truthy check, keyed by a token taken from the `format` argument passed to `formatDate` / `DatePipe`. When a token matches an inherited `Object.prototype` member, the read returns that inherited value instead of `undefined`. With `formatDate(date, '__proto__', 'en')` the named-format lookup returns `Object.prototype` and the output is garbled; with a token like `y__proto__` the per-token lookup returns `Object.prototype` and it is then invoked as a formatter, throwing `TypeError: dateFormatter is not a function`. This is reachable whenever the format string is bound from data rather than a static literal.

## What is the new behavior?

Both caches, and the per-locale sub-cache, are created with `Object.create(null)`, so a format token that happens to share a name with an inherited member no longer resolves to anything off the prototype. Such tokens now fall through to their literal handling, so the two cases above produce `__proto__` and `2015__proto__` respectively.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
