### PR TITLE
fix(language-server): recover project for external templates in solution-style workspaces

### DIFF
--- a/vscode-ng-language-service/server/src/session.ts
+++ b/vscode-ng-language-service/server/src/session.ts
@@ -535,7 +535,21 @@ export class Session {
     // If they are already part of a ConfiguredProject then the following is
     // not needed.
     if (!project || project.projectKind !== ts.server.ProjectKind.Configured) {
-      const {configFileName} = this.projectService.openClientFile(scriptInfo.fileName);
+      let {configFileName} = this.projectService.openClientFile(scriptInfo.fileName);
+      if (configFileName === undefined && isExternalTemplate(scriptInfo.fileName)) {
+        // When an external template loses its configured project after it was opened (e.g.
+        // because the corresponding component file was closed and the project graph was updated),
+        // the same best-effort used in `onDidOpenTextDocument` is needed here.
+        if (this.loadProjectForExternalTemplate(scriptInfo.fileName)) {
+          ({configFileName} = this.projectService.openClientFile(scriptInfo.fileName));
+        }
+        if (configFileName === undefined) {
+          const componentProject = this.attachToComponentProject(scriptInfo);
+          if (componentProject) {
+            return componentProject;
+          }
+        }
+      }
       if (!configFileName) {
         // Failed to find a config file. There is nothing we could do.
         this.error(`No config file for ${scriptInfo.fileName}`);
@@ -550,6 +564,49 @@ export class Session {
     }
 
     return project;
+  }
+
+  /**
+   * In a composite/solution-style project with references, TypeScript will _not_ open a project
+   * for an HTML file unless the file is explicitly included in the files/includes list. This is
+   * quite unlikely to be the case for HTML files. As a best-effort to fix this, we attempt to open
+   * a TS file with the same name so that its project is loaded. Most of the time, this is going to
+   * be the component file for the external template.
+   * https://github.com/angular/vscode-ng-language-service/issues/2149
+   *
+   * Returns whether the component file was opened, i.e. whether the config lookup for the template
+   * is worth retrying.
+   */
+  private loadProjectForExternalTemplate(templatePath: string): boolean {
+    const maybeComponentTsPath = componentPathForTemplate(templatePath);
+    if (
+      this.projectService.openFiles.has(this.projectService.toPath(maybeComponentTsPath)) ||
+      // Non-component HTML files (e.g. `src/index.html`) have no sibling `.ts`; skip the
+      // open/close so we don't walk directory trees looking for a config that can't exist.
+      !this.host.fileExists(maybeComponentTsPath)
+    ) {
+      return false;
+    }
+    this.projectService.openClientFile(maybeComponentTsPath);
+    this.projectService.closeClientFile(maybeComponentTsPath);
+    return true;
+  }
+
+  /**
+   * Attaches an external template to the configured project of its component. Needed because
+   * `openClientFile` does not repeat the config lookup for a file that is already open, so it can
+   * still report no config file even though the component's project has since been loaded.
+   */
+  private attachToComponentProject(scriptInfo: ts.server.ScriptInfo): ts.server.Project | null {
+    const componentProject = this.projectService
+      .getScriptInfo(componentPathForTemplate(scriptInfo.fileName))
+      ?.containingProjects.find(isConfiguredProject);
+    if (!componentProject) {
+      return null;
+    }
+    scriptInfo.detachAllProjects();
+    scriptInfo.attachToProject(componentProject);
+    return componentProject;
   }
 
   private onDidOpenTextDocument(params: lsp.DidOpenTextDocumentParams) {
@@ -568,18 +625,15 @@ export class Session {
       // buffer in the user's editor which has not been saved to disk.
       // See https://github.com/angular/vscode-ng-language-service/issues/632
       let result = this.projectService.openClientFile(filePath, text, scriptKind);
-      // If the first opened file is an HTML file and the project is a composite/solution-style
-      // project with references, TypeScript will _not_ open a project unless the file is explicitly
-      // included in the files/includes list. This is quite unlikely to be the case for HTML files.
-      // As a best-effort to fix this, we attempt to open a TS file with the same name. Most of the
-      // time, this is going to be the component file for the external template.
-      // https://github.com/angular/vscode-ng-language-service/issues/2149
       if (result.configFileName === undefined && languageId === LanguageId.HTML) {
-        const maybeComponentTsPath = filePath.replace(/\.html$/, '.ts');
-        if (!this.projectService.openFiles.has(this.projectService.toPath(maybeComponentTsPath))) {
-          this.projectService.openClientFile(maybeComponentTsPath);
-          this.projectService.closeClientFile(maybeComponentTsPath);
+        if (this.loadProjectForExternalTemplate(filePath)) {
           result = this.projectService.openClientFile(filePath, text, scriptKind);
+        }
+        if (result.configFileName === undefined) {
+          const scriptInfo = this.projectService.getScriptInfo(filePath);
+          if (scriptInfo) {
+            this.attachToComponentProject(scriptInfo);
+          }
         }
       }
 
@@ -789,4 +843,8 @@ function isTypeScriptFile(path: string): boolean {
 
 function isExternalTemplate(path: string): boolean {
   return !isTypeScriptFile(path);
+}
+
+function componentPathForTemplate(templatePath: string): string {
+  return templatePath.replace(/\.html$/, '.ts');
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows [our guidelines](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md)
- [ ] Tests for the changes have been added (see note below)
- [ ] Docs have been added / updated (not applicable)

## PR Type

- [x] Bugfix

## What is the current behavior?

In solution-style workspaces (the default Nx layout, where an app's `tsconfig.json` contains only project references), an external template that loses its configured-project association after being opened — e.g. because its component `.ts` file was closed and the project graph updated — permanently loses all language service features. Every subsequent request on the template hits `getDefaultProjectForScriptInfo`, whose bare `openClientFile` lookup can never resolve a config file for an HTML file, so it logs `No config file for ...` and returns `null` indefinitely until the user manually reopens the component file.

angular/vscode-ng-language-service#2165 fixed this same failure mode for the document-open path only; the request-time recovery path was left unpatched.

Reproduced in VS Code itself (Angular extension v22.0.1, server 22.x) with a template-opened-first session, in Zed, and with a raw LSP stdio client — details and Angular Language Service logs in #69768.

Issue Number: Fixes #69768

## What is the new behavior?

`getDefaultProjectForScriptInfo` applies the same best-effort as `onDidOpenTextDocument` when the config lookup comes back empty for an external template: briefly open/close the sibling `.ts` file (guarded by `projectService.openFiles`, same as #2165) and retry. If the lookup still fails — `openClientFile` does not repeat the config search for an already-open file — the template's script info is attached directly to the configured project of its component.

Validated against a large Nx monorepo (Angular 19, ~30 projects) by driving `@angular/language-server` over raw LSP: with stock 21.1.5, definition requests on an orphaned template fail with `No config file` indefinitely (40+ consecutive failures reproduced); with this change the template re-attaches on the next request and features recover every time. This patch has also been in daily editor use (Zed) on that workspace.

Note on tests: `server/src/session.ts` currently has no unit spec, and the integration fixtures under `integration/project` are not solution-style. Happy to add a solution-style fixture + integration test if the reviewers can point me at the preferred shape.

## Does this PR introduce a breaking change?

- [x] No
