### PR TITLE
fix(platform-server): escape values inlined into the event replay bootstrap script

### DIFF
--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -51,6 +51,29 @@ export function createScript(
   return script;
 }
 
+/**
+ * Serializes a value to a JSON string that is safe to embed as a literal
+ * inside inline `<script>` content that gets built up via string
+ * concatenation (as opposed to being set as the sole `textContent` of a
+ * dedicated `<script type="application/json">`, which `TransferState` uses).
+ *
+ * Without this, a value containing `</script` (or other markup) could
+ * prematurely close the enclosing `<script>` element once the server-rendered
+ * DOM is serialized back to an HTML string, letting attacker-influenced
+ * content (e.g. a custom `APP_ID` provided per-request) inject arbitrary
+ * markup/script into the response.
+ *
+ * Mirrors the escaping performed by `TransferState.toJson()` in
+ * `packages/core/src/transfer_state.ts`.
+ */
+export function toInlineScriptJson(value: unknown): string {
+  // Escape `<` so a `</script>` sequence embedded in `value` cannot close the
+  // surrounding `<script>` tag when the document is serialized to a string.
+  // Escaping `/` additionally avoids crawlers misinterpreting embedded
+  // relative URLs.
+  return JSON.stringify(value).replace(/</g, '\\u003C').replace(/\//g, '\\u002F');
+}
+
 function warnIfStateTransferHappened(injector: Injector): void {
   const transferStateStatus = injector.get(TRANSFER_STATE_STATUS);
 

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -30,7 +30,7 @@ import {RuntimeErrorCode} from './errors';
 import {platformServer} from './server';
 import {PlatformState} from './platform_state';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
-import {createScript} from './transfer_state';
+import {createScript, toInlineScriptJson} from './transfer_state';
 import {resolveUrl} from './url';
 
 /**
@@ -168,12 +168,21 @@ function insertEventRecordScript(
   // Note: this is only true when build with the CLI tooling, which inserts the script in the HTML
   if (eventDispatchScript) {
     // This is defined in packages/core/primitives/event-dispatch/contract_binary.ts
+    //
+    // Note: every interpolated value is passed through `toInlineScriptJson`
+    // (rather than a raw string or a bare `JSON.stringify`) because this
+    // script is built via string concatenation and then serialized back to
+    // an HTML string. `APP_ID` in particular can be overridden per-render
+    // (e.g. `{provide: APP_ID, useValue: ...}` in per-request providers), so
+    // it must not be trusted to be free of characters like `"` or `</script`
+    // that could otherwise break out of the string literal, or out of the
+    // `<script>` tag itself.
     const replayScriptContents =
       `window.__jsaction_bootstrap(` +
       `document.body,` +
-      `"${appId}",` +
-      `${JSON.stringify(Array.from(regular))},` +
-      `${JSON.stringify(Array.from(capture))}` +
+      `${toInlineScriptJson(appId)},` +
+      `${toInlineScriptJson(Array.from(regular))},` +
+      `${toInlineScriptJson(Array.from(capture))}` +
       `);`;
 
     const replayScript = createScript(doc, replayScriptContents, nonce);

--- a/packages/platform-server/test/transfer_state_spec.ts
+++ b/packages/platform-server/test/transfer_state_spec.ts
@@ -20,6 +20,7 @@ import {
 import {BrowserModule, withEventReplay, withIncrementalHydration} from '@angular/platform-browser';
 import {renderModule, ServerModule} from '../index';
 import {getHydrationInfoFromTransferState, ssr} from './hydration_utils';
+import {toInlineScriptJson} from '../src/transfer_state';
 import domino from '../third_party/domino/bundled-domino';
 
 describe('transfer_state', () => {
@@ -105,6 +106,32 @@ describe('transfer_state', () => {
 
     const output = await renderModule(TransferStoreModule, {document: '<app></app>'});
     expect(output).toBe(defaultExpectedOutput);
+  });
+
+  describe('toInlineScriptJson', () => {
+    it('matches plain JSON.stringify for values with no special characters', () => {
+      expect(toInlineScriptJson('ng')).toBe(JSON.stringify('ng'));
+      expect(toInlineScriptJson(['click', 'input'])).toBe(JSON.stringify(['click', 'input']));
+    });
+
+    it('escapes `<` so a `</script>` sequence cannot break out of a <script> tag', () => {
+      const malicious = '</script><script>alert(1)</script>';
+      const result = toInlineScriptJson(malicious);
+
+      expect(result).not.toContain('<');
+      // The escaping must be reversible: decoding the unicode escapes back
+      // to their original characters must reproduce the original value.
+      expect(JSON.parse(result.replace(/\\u003C/g, '<').replace(/\\u002F/g, '/'))).toBe(malicious);
+    });
+
+    it('relies on JSON.stringify to escape a `"` so it cannot break out of a string literal', () => {
+      const malicious = '"); alert(1); //';
+      const result = toInlineScriptJson(malicious);
+
+      expect(JSON.parse(result.replace(/\\u003C/g, '<').replace(/\\u002F/g, '/'))).toBe(malicious);
+      // A raw, unescaped quote would terminate the JSON string early.
+      expect(result.startsWith('"') && result.endsWith('"')).toBeTrue();
+    });
   });
 
   describe('getTransferState', () => {


### PR DESCRIPTION
## What

`insertEventRecordScript()` in `packages/platform-server/src/utils.ts` builds the SSR event-replay bootstrap script (`window.__jsaction_bootstrap(...)`) by concatenating values directly into inline `<script>` content:

```ts
const replayScriptContents =
  `window.__jsaction_bootstrap(` +
  `document.body,` +
  `"${appId}",` +
  `${JSON.stringify(Array.from(regular))},` +
  `${JSON.stringify(Array.from(capture))}` +
  `);`;
```

This is set as a `<script>` element's `textContent`, and the resulting document is then serialized back into an HTML string (`PlatformState.renderToString`). Two issues:

1. `"${appId}"` is a raw string interpolation with no escaping at all, so a `"` in `appId` breaks out of the JS string literal.
2. `JSON.stringify(...)` does not escape `<`, so a value containing `</script` in any of the three interpolated values can prematurely close the surrounding `<script>` element once serialized to HTML.

`APP_ID` is not a fixed, compiler-controlled constant — it can be supplied per render via `{provide: APP_ID, useValue: ...}` in the `platformProviders`/`extraProviders` passed to `renderApplication`/`renderModule` (a real pattern for avoiding `APP_ID`/`TransferState` collisions across concurrent requests in multi-tenant or micro-frontend SSR setups), so it shouldn't be assumed to only ever contain "safe" characters.

I also want to flag one thing so reviewers have the full picture: there is an existing alphanumeric check on `APP_ID` (`validAppIdInitializer`, `/^[a-zA-Z0-9\-_]+$/`), but it's gated behind `ngDevMode`:

```ts
...(ngDevMode ? [validAppIdInitializer] : []),
```

so it doesn't run in production builds, and it exists for collision-prevention (documented rationale: "prefixing application attributes and CSS styles"), not as a security boundary. It shouldn't be the only thing standing between an interpolated `APP_ID` and unescaped script content.

This is exactly the pattern `TransferState.toJson()` already handles correctly a few lines away in `packages/core/src/transfer_state.ts`:

```ts
return JSON.stringify(this.store).replace(/</g, '\\u003C').replace(/\//g, '\\u002F');
```

## The fix

Adds `toInlineScriptJson()` next to `createScript()` in `packages/platform-server/src/transfer_state.ts`, applying the same `<`/`/` escaping as `TransferState.toJson()`, and uses it for all three values interpolated into the event-replay script (`appId`, `regular`, `capture`) instead of the raw string interpolation / bare `JSON.stringify`.

For any value with no `<` or `/` (i.e. every existing test fixture and any typical `APP_ID`), the output is byte-for-byte identical to before, so this is a non-breaking, defense-in-depth change.

## Testing

- Added unit tests for `toInlineScriptJson()` in `transfer_state_spec.ts` covering: (a) parity with plain `JSON.stringify` for ordinary values, (b) `<`/`</script>` escaping with a round-trip check back to the original value, (c) that quote-embedding values remain a single valid string literal.
- Manually verified against a real `domino` (the library platform-server uses to serialize the DOM) that:
  - The existing expected output `window.__jsaction_bootstrap(document.body,"ng",["click"],[]);` (see `event_replay_spec.ts`) is unchanged after this fix.
  - Before the fix, an `APP_ID` containing `</script>` breaks out of the `<script>` tag in the serialized HTML; after the fix it does not.
  - Before the fix, an `APP_ID` containing `"` breaks out of the JS string literal; after the fix it round-trips safely through the escaped JSON.
- I was not able to run the full Bazel test suite in my environment (no network access to fetch Bazel/deps), so I'd appreciate CI confirming the existing `platform-server` suite (in particular `event_replay_spec.ts` and `transfer_state_spec.ts`) still passes unmodified for the non-adversarial cases.

## Why this matters

Even setting aside the (dev-only) `APP_ID` format check, this a good example of an "error-prone" pattern worth eliminating on its own: building executable inline-script content via ad hoc string concatenation, with a mix of "no escaping" and "JSON.stringify but that's not actually enough for a `<script>` context." Centralizing on `toInlineScriptJson()` (matching the existing, already-reviewed `TransferState.toJson()` convention) removes that foot-gun for this call site and gives future call sites in this file an obvious, safe default to reach for.
