### PR TITLE
fix(security): add URL sanitization context for SVG image, feImage, and use elements

### DIFF
--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -107,7 +107,15 @@ export function SECURITY_SCHEMA(): SecuritySchema {
     ['object', ['codebase', 'data']],
   ]);
 
-  registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]]);
+  registerContext(SecurityContext.URL, SVG_NAMESPACE, [
+    ['a', ['href', 'xlink:href']],
+    // SVG elements that load external resources require URL sanitization.
+    // `<image>` and `<feImage>` load external images (analogous to HTML <img src>).
+    // `<use>` loads external SVG fragments which may include scripted content.
+    ['image', ['href', 'xlink:href']],
+    ['feImage', ['href', 'xlink:href']],
+    ['use', ['href', 'xlink:href']],
+  ]);
 
   // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
   // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -178,6 +178,20 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     expect(registry.securityContext(':svg:a', 'href', true)).toBe(SecurityContext.URL);
     expect(registry.securityContext(':svg:a', 'xlink:href', true)).toBe(SecurityContext.URL);
 
+    // SVG elements that load external resources (image, feImage, use)
+    expect(registry.securityContext(':svg:image', 'href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:image', 'xlink:href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:image', 'href', true)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:image', 'xlink:href', true)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:feImage', 'href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:feImage', 'xlink:href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:feImage', 'href', true)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:feImage', 'xlink:href', true)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:use', 'href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:use', 'xlink:href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:use', 'href', true)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':svg:use', 'xlink:href', true)).toBe(SecurityContext.URL);
+
     // MathML link attributes
     expect(registry.securityContext(':math:math', 'href', false)).toBe(SecurityContext.URL);
     expect(registry.securityContext(':math:math', 'xlink:href', false)).toBe(SecurityContext.URL);

--- a/packages/core/src/sanitization/dom_security_schema.ts
+++ b/packages/core/src/sanitization/dom_security_schema.ts
@@ -107,7 +107,15 @@ export function SECURITY_SCHEMA(): SecuritySchema {
     ['object', ['codebase', 'data']],
   ]);
 
-  registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]]);
+  registerContext(SecurityContext.URL, SVG_NAMESPACE, [
+    ['a', ['href', 'xlink:href']],
+    // SVG elements that load external resources require URL sanitization.
+    // `<image>` and `<feImage>` load external images (analogous to HTML <img src>).
+    // `<use>` loads external SVG fragments which may include scripted content.
+    ['image', ['href', 'xlink:href']],
+    ['feImage', ['href', 'xlink:href']],
+    ['use', ['href', 'xlink:href']],
+  ]);
 
   // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
   // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -27,7 +27,11 @@ import {
   ɵɵtrustConstantHtml,
   ɵɵtrustConstantResourceUrl,
 } from '../../src/sanitization/sanitization';
-import {SECURITY_SCHEMA, SecurityContext} from '../../src/sanitization/dom_security_schema';
+import {
+  checkSecurityContext,
+  SECURITY_SCHEMA,
+  SecurityContext,
+} from '../../src/sanitization/dom_security_schema';
 
 function fakeLView(): LView {
   const fake = [null, {}] as LView;
@@ -200,6 +204,22 @@ describe('sanitization', () => {
     expect(
       ɵɵsanitizeUrlOrResourceUrl(bypassSanitizationTrustUrl('javascript:true'), 'a', 'href'),
     ).toEqual('javascript:true');
+  });
+
+  it('should apply URL security context to SVG elements that load external resources', () => {
+    // svg:image and svg:feImage load external images (analogous to HTML <img src>)
+    expect(checkSecurityContext('image', 'href', 'svg')).toBe(SecurityContext.URL);
+    expect(checkSecurityContext('image', 'xlink:href', 'svg')).toBe(SecurityContext.URL);
+    expect(checkSecurityContext('feImage', 'href', 'svg')).toBe(SecurityContext.URL);
+    expect(checkSecurityContext('feImage', 'xlink:href', 'svg')).toBe(SecurityContext.URL);
+    // svg:use loads external SVG fragments which may include scripted content
+    expect(checkSecurityContext('use', 'href', 'svg')).toBe(SecurityContext.URL);
+    expect(checkSecurityContext('use', 'xlink:href', 'svg')).toBe(SecurityContext.URL);
+    // Verify svg:a still has URL context (no regression)
+    expect(checkSecurityContext('a', 'href', 'svg')).toBe(SecurityContext.URL);
+    // Verify non-SVG elements with same tag names are unaffected
+    expect(checkSecurityContext('use', 'href', null)).toBe(SecurityContext.NONE);
+    expect(checkSecurityContext('image', 'href', null)).toBe(SecurityContext.NONE);
   });
 
   it('should only trust constant strings from template literal tags without interpolation', () => {


### PR DESCRIPTION
## Summary

SVG elements that load external resources via `href`/`xlink:href` had **no security context** (`SecurityContext.NONE`) in Angular's DOM security schema. This means Angular applied **no sanitization** when developers bound user-controlled values to these attributes in templates.

## Affected elements

| Element | Purpose | Context before | Context after |
|---|---|---|---|
| `<svg:image [href]>` | Loads external image (like HTML `<img src>`) | NONE ❌ | URL ✅ |
| `<svg:feImage [href]>` | Loads external image for SVG filters | NONE ❌ | URL ✅ |
| `<svg:use [href]>` | Loads external SVG fragment (may contain scripts) | NONE ❌ | URL ✅ |

Both `href` and `xlink:href` (deprecated SVG 1.1) are covered.

## Impact

Without this fix, an Angular template binding like:

```html
<svg><use [href]="userInput"></use></svg>
```

received **no URL sanitization from Angular**. A `javascript:` URL passed as `userInput` would reach the attribute unmodified, with no `console.warn` and no `unsafe:` prefix.

After this fix, Angular applies `ɵɵsanitizeUrl()` — consistent with `svg:a[href]` and `img[src]` — so `javascript:` URLs are sanitized to `unsafe:javascript:...` with a warning logged.

## Changes

- `packages/compiler/src/schema/dom_security_schema.ts` — adds URL context for `svg:image`, `svg:feImage`, `svg:use`
- `packages/core/src/sanitization/dom_security_schema.ts` — same (kept in sync per existing convention)
- `packages/compiler/test/schema/dom_element_schema_registry_spec.ts` — 12 new test assertions
- `packages/core/test/sanitization/sanitization_spec.ts` — new `it` block covering `checkSecurityContext` for these elements

## Non-breaking

This changes SecurityContext from NONE → URL (not RESOURCE_URL), so no runtime error is thrown. Existing legitimate resource URLs continue to work; only `javascript:` scheme is affected.
