### PR TITLE
fix(http): run root interceptors in the terminal request chain

### DIFF
--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -47,6 +47,17 @@ export abstract class HttpBackend implements HttpHandler {
   abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
 
+/**
+ * An `HttpBackend` that delegates requests to the parent injector's `HttpHandler`.
+ */
+export class HttpParentBackend implements HttpBackend {
+  constructor(private parent: HttpHandler) {}
+
+  handle(req: HttpRequest<any>): Observable<HttpEvent<any>> {
+    return this.parent.handle(req);
+  }
+}
+
 let fetchBackendWarningDisplayed = false;
 
 /** Internal function to reset the flag in tests */
@@ -99,11 +110,13 @@ export class HttpInterceptorHandler implements HttpHandler {
 
   handle(initialRequest: HttpRequest<any>): Observable<HttpEvent<any>> {
     if (this.chain === null) {
+      const rootInterceptorFns = this.injector.get(
+        HTTP_ROOT_INTERCEPTOR_FNS,
+        [],
+        this.backend instanceof HttpParentBackend ? {self: true} : undefined,
+      );
       const dedupedInterceptorFns = Array.from(
-        new Set([
-          ...this.injector.get(HTTP_INTERCEPTOR_FNS),
-          ...this.injector.get(HTTP_ROOT_INTERCEPTOR_FNS, []),
-        ]),
+        new Set([...this.injector.get(HTTP_INTERCEPTOR_FNS), ...rootInterceptorFns]),
       );
 
       // Note: interceptors are wrapped right-to-left so that final execution order is

--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -12,6 +12,7 @@ import {
   EnvironmentInjector,
   inject,
   Injectable,
+  InjectionToken,
   untracked,
   ɵConsole as Console,
   ɵformatRuntimeError as formatRuntimeError,
@@ -47,16 +48,10 @@ export abstract class HttpBackend implements HttpHandler {
   abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
 
-/**
- * An `HttpBackend` that delegates requests to the parent injector's `HttpHandler`.
- */
-export class HttpParentBackend implements HttpBackend {
-  constructor(private parent: HttpHandler) {}
-
-  handle(req: HttpRequest<any>): Observable<HttpEvent<any>> {
-    return this.parent.handle(req);
-  }
-}
+/** Indicates that the current `HttpClient` delegates requests to its parent. */
+export const ɵHTTP_CLIENT_IS_DELEGATING = new InjectionToken<boolean>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'ɵHTTP_CLIENT_IS_DELEGATING ' : '',
+);
 
 let fetchBackendWarningDisplayed = false;
 
@@ -110,10 +105,11 @@ export class HttpInterceptorHandler implements HttpHandler {
 
   handle(initialRequest: HttpRequest<any>): Observable<HttpEvent<any>> {
     if (this.chain === null) {
+      const isDelegating = this.injector.get(ɵHTTP_CLIENT_IS_DELEGATING, false, {self: true});
       const rootInterceptorFns = this.injector.get(
         HTTP_ROOT_INTERCEPTOR_FNS,
         [],
-        this.backend instanceof HttpParentBackend ? {self: true} : undefined,
+        isDelegating ? {self: true} : undefined,
       );
       const dedupedInterceptorFns = Array.from(
         new Set([...this.injector.get(HTTP_INTERCEPTOR_FNS), ...rootInterceptorFns]),

--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -12,7 +12,6 @@ import {
   EnvironmentInjector,
   inject,
   Injectable,
-  InjectionToken,
   untracked,
   ɵConsole as Console,
   ɵformatRuntimeError as formatRuntimeError,
@@ -47,11 +46,6 @@ import {
 export abstract class HttpBackend implements HttpHandler {
   abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
-
-/** Indicates that the current `HttpClient` delegates requests to its parent. */
-export const ɵHTTP_CLIENT_IS_DELEGATING = new InjectionToken<boolean>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'ɵHTTP_CLIENT_IS_DELEGATING ' : '',
-);
 
 let fetchBackendWarningDisplayed = false;
 
@@ -105,7 +99,8 @@ export class HttpInterceptorHandler implements HttpHandler {
 
   handle(initialRequest: HttpRequest<any>): Observable<HttpEvent<any>> {
     if (this.chain === null) {
-      const isDelegating = this.injector.get(ɵHTTP_CLIENT_IS_DELEGATING, false, {self: true});
+      const parentHandler = this.injector.get(HttpHandler, null, {skipSelf: true});
+      const isDelegating = parentHandler !== null && this.backend === parentHandler;
       const rootInterceptorFns = this.injector.get(
         HTTP_ROOT_INTERCEPTOR_FNS,
         [],

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -14,7 +14,12 @@ import {
   Provider,
 } from '@angular/core';
 
-import {HttpBackend, HttpHandler, HttpInterceptorHandler, HttpParentBackend} from './backend';
+import {
+  ɵHTTP_CLIENT_IS_DELEGATING,
+  HttpBackend,
+  HttpHandler,
+  HttpInterceptorHandler,
+} from './backend';
 import {HttpClient} from './client';
 import {FetchBackend} from './fetch';
 import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, legacyInterceptorFnFactory} from './interceptor';
@@ -106,9 +111,15 @@ export function provideHttpClient(
       featureKinds.has(HttpFeatureKind.CustomXsrfConfiguration)
     ) {
       throw new Error(
-        ngDevMode
-          ? `Configuration error: found both withXsrfConfiguration() and withNoXsrfProtection() in the same call to provideHttpClient(), which is a contradiction.`
-          : '',
+        `Configuration error: found both withXsrfConfiguration() and withNoXsrfProtection() in the same call to provideHttpClient(), which is a contradiction.`,
+      );
+    }
+
+    const hasBackendOverride =
+      featureKinds.has(HttpFeatureKind.Fetch) || featureKinds.has(HttpFeatureKind.Xhr);
+    if (featureKinds.has(HttpFeatureKind.RequestsMadeViaParent) && hasBackendOverride) {
+      throw new Error(
+        `Configuration error: withRequestsMadeViaParent() cannot be combined with withFetch() or withXhr() in the same call to provideHttpClient().`,
       );
     }
   }
@@ -267,6 +278,8 @@ export function withJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport> {
  * "bubble up" until either reaching the root level or an `HttpClient` which was not configured with
  * this option.
  *
+ * This feature is incompatible with the `withFetch` and `withXhr` features.
+ *
  * @see [HTTP client setup](guide/http/setup#withrequestsmadeviaparent)
  * @see {@link provideHttpClient}
  * @publicApi 19.0
@@ -282,8 +295,15 @@ export function withRequestsMadeViaParent(): HttpFeature<HttpFeatureKind.Request
             'withRequestsMadeViaParent() can only be used when the parent injector also configures HttpClient',
           );
         }
-        return new HttpParentBackend(handlerFromParent!);
+        return handlerFromParent!;
       },
+    },
+    {
+      provide: ɵHTTP_CLIENT_IS_DELEGATING,
+      // `HttpBackend` can be overridden by later providers, so derive this flag from the
+      // effective backend rather than assuming that this feature's backend is still active.
+      useFactory: () =>
+        inject(HttpBackend) === inject(HttpHandler, {skipSelf: true, optional: true}),
     },
   ]);
 }

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -14,7 +14,7 @@ import {
   Provider,
 } from '@angular/core';
 
-import {HttpBackend, HttpHandler, HttpInterceptorHandler} from './backend';
+import {HttpBackend, HttpHandler, HttpInterceptorHandler, HttpParentBackend} from './backend';
 import {HttpClient} from './client';
 import {FetchBackend} from './fetch';
 import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, legacyInterceptorFnFactory} from './interceptor';
@@ -282,7 +282,7 @@ export function withRequestsMadeViaParent(): HttpFeature<HttpFeatureKind.Request
             'withRequestsMadeViaParent() can only be used when the parent injector also configures HttpClient',
           );
         }
-        return handlerFromParent;
+        return new HttpParentBackend(handlerFromParent!);
       },
     },
   ]);

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -14,12 +14,7 @@ import {
   Provider,
 } from '@angular/core';
 
-import {
-  ɵHTTP_CLIENT_IS_DELEGATING,
-  HttpBackend,
-  HttpHandler,
-  HttpInterceptorHandler,
-} from './backend';
+import {HttpBackend, HttpHandler, HttpInterceptorHandler} from './backend';
 import {HttpClient} from './client';
 import {FetchBackend} from './fetch';
 import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, legacyInterceptorFnFactory} from './interceptor';
@@ -297,13 +292,6 @@ export function withRequestsMadeViaParent(): HttpFeature<HttpFeatureKind.Request
         }
         return handlerFromParent!;
       },
-    },
-    {
-      provide: ɵHTTP_CLIENT_IS_DELEGATING,
-      // `HttpBackend` can be overridden by later providers, so derive this flag from the
-      // effective backend rather than assuming that this feature's backend is still active.
-      useFactory: () =>
-        inject(HttpBackend) === inject(HttpHandler, {skipSelf: true, optional: true}),
     },
   ]);
 }

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -290,7 +290,7 @@ export function withRequestsMadeViaParent(): HttpFeature<HttpFeatureKind.Request
             'withRequestsMadeViaParent() can only be used when the parent injector also configures HttpClient',
           );
         }
-        return handlerFromParent!;
+        return handlerFromParent;
       },
     },
   ]);

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -273,7 +273,8 @@ export function withJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport> {
  * "bubble up" until either reaching the root level or an `HttpClient` which was not configured with
  * this option.
  *
- * This feature is incompatible with the `withFetch` and `withXhr` features.
+ * This feature cannot be combined with `withFetch` or `withXhr` in the same
+ * `provideHttpClient()` call.
  *
  * @see [HTTP client setup](guide/http/setup#withrequestsmadeviaparent)
  * @see {@link provideHttpClient}

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -44,6 +44,7 @@ import {
   HttpFeature,
   HttpFeatureKind,
   provideHttpClient,
+  withFetch,
   withInterceptors,
   withInterceptorsFromDi,
   withJsonpSupport,
@@ -53,7 +54,6 @@ import {
   withXsrfConfiguration,
 } from '../src/provider';
 import {resetFetchBackendWarningFlag} from '../src/backend';
-import {MockXhrFactory} from './xhr_mock';
 
 describe('without provideHttpClientTesting', () => {
   it('should contribute to stability', async () => {
@@ -526,33 +526,32 @@ describe('provideHttpClient', () => {
             'child:response',
           ]);
         });
-
-        it('should be able to connect to a legacy-provided HttpClient context', () => {
-          TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [provideLegacyInterceptor('parent')],
-          });
-
-          const child = createEnvironmentInjector(
-            [
-              provideHttpClient(
-                ...commonHttpFeatures,
-                withRequestsMadeViaParent(),
-                withInterceptors([makeLiteralTagInterceptorFn('child')]),
-              ),
-            ],
-            TestBed.inject(EnvironmentInjector),
-          );
-
-          child.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
-          const req = TestBed.inject(HttpTestingController).expectOne('/test');
-          expect(req.request.headers.get('X-Tag')).toEqual('child,parent');
-          req.flush('');
-        });
       });
     }
 
-    it('should inherit root interceptors when withXhr overrides parent delegation', () => {
+    it('should be able to connect to a legacy-provided HttpClient context', () => {
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [provideLegacyInterceptor('parent')],
+      });
+
+      const child = createEnvironmentInjector(
+        [
+          provideHttpClient(
+            withRequestsMadeViaParent(),
+            withInterceptors([makeLiteralTagInterceptorFn('child')]),
+          ),
+        ],
+        TestBed.inject(EnvironmentInjector),
+      );
+
+      child.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+      const req = TestBed.inject(HttpTestingController).expectOne('/test');
+      expect(req.request.headers.get('X-Tag')).toEqual('child,parent');
+      req.flush('');
+    });
+
+    it('should not inherit the delegation marker in independent child contexts', () => {
       TestBed.configureTestingModule({
         providers: [
           provideHttpClient(),
@@ -561,22 +560,62 @@ describe('provideHttpClient', () => {
             useValue: makeLiteralTagInterceptorFn('root'),
             multi: true,
           },
+          provideHttpClientTesting(),
+        ],
+      });
+
+      const delegatingParent = createEnvironmentInjector(
+        [provideHttpClient(withRequestsMadeViaParent())],
+        TestBed.inject(EnvironmentInjector),
+      );
+      const independentChild = createEnvironmentInjector(
+        [
+          provideHttpClient(withInterceptors([makeLiteralTagInterceptorFn('child')])),
+          {provide: HttpBackend, useValue: TestBed.inject(HttpBackend)},
+        ],
+        delegatingParent,
+      );
+
+      try {
+        independentChild.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+        const req = TestBed.inject(HttpTestingController).expectOne('/test');
+        expect(req.request.headers.get('X-Tag')).toEqual('child,root');
+        req.flush('');
+      } finally {
+        independentChild.destroy();
+        delegatingParent.destroy();
+      }
+    });
+
+    it('should inherit root interceptors when a custom provider overrides delegation', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(),
+          {
+            provide: HTTP_ROOT_INTERCEPTOR_FNS,
+            useValue: makeLiteralTagInterceptorFn('root'),
+            multi: true,
+          },
+          provideHttpClientTesting(),
         ],
       });
 
       const child = createEnvironmentInjector(
         [
-          provideHttpClient(withRequestsMadeViaParent(), withXhr()),
-          {provide: XhrFactory, useClass: MockXhrFactory},
+          provideHttpClient(
+            withRequestsMadeViaParent(),
+            withInterceptors([makeLiteralTagInterceptorFn('child')]),
+          ),
+          {provide: HttpBackend, useValue: TestBed.inject(HttpBackend)},
         ],
         TestBed.inject(EnvironmentInjector),
       );
 
       try {
-        child.get(HttpClient).get('/test').subscribe();
-        const factory = child.get(XhrFactory) as MockXhrFactory;
-        expect(factory.mock.mockHeaders['X-Tag']).toBe('root');
-        factory.mock.mockFlush(200, 'OK', '{}');
+        child.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+        const req = TestBed.inject(HttpTestingController).expectOne('/test');
+        expect(req.request.headers.get('X-Tag')).toEqual('child,root');
+        req.flush('');
       } finally {
         child.destroy();
       }

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -53,6 +53,7 @@ import {
   withXsrfConfiguration,
 } from '../src/provider';
 import {resetFetchBackendWarningFlag} from '../src/backend';
+import {MockXhrFactory} from './xhr_mock';
 
 describe('without provideHttpClientTesting', () => {
   it('should contribute to stability', async () => {
@@ -550,6 +551,36 @@ describe('provideHttpClient', () => {
         });
       });
     }
+
+    it('should inherit root interceptors when withXhr overrides parent delegation', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(),
+          {
+            provide: HTTP_ROOT_INTERCEPTOR_FNS,
+            useValue: makeLiteralTagInterceptorFn('root'),
+            multi: true,
+          },
+        ],
+      });
+
+      const child = createEnvironmentInjector(
+        [
+          provideHttpClient(withRequestsMadeViaParent(), withXhr()),
+          {provide: XhrFactory, useClass: MockXhrFactory},
+        ],
+        TestBed.inject(EnvironmentInjector),
+      );
+
+      try {
+        child.get(HttpClient).get('/test').subscribe();
+        const factory = child.get(XhrFactory) as MockXhrFactory;
+        expect(factory.mock.mockHeaders['X-Tag']).toBe('root');
+        factory.mock.mockFlush(200, 'OK', '{}');
+      } finally {
+        child.destroy();
+      }
+    });
   });
 
   describe('compatibility with Http NgModules', () => {

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -551,7 +551,7 @@ describe('provideHttpClient', () => {
       req.flush('');
     });
 
-    it('should not inherit the delegation marker in independent child contexts', () => {
+    it('should inherit root interceptors in independent child contexts', () => {
       TestBed.configureTestingModule({
         providers: [
           provideHttpClient(),

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -37,8 +37,9 @@ import {
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {EMPTY, Observable, from} from 'rxjs';
+import {tap} from 'rxjs/operators';
 
-import {HttpInterceptorFn} from '../src/interceptor';
+import {HTTP_ROOT_INTERCEPTOR_FNS, HttpInterceptorFn} from '../src/interceptor';
 import {
   HttpFeature,
   HttpFeatureKind,
@@ -452,6 +453,79 @@ describe('provideHttpClient', () => {
           req.flush('');
         });
 
+        it('should include root interceptors in independent child contexts', () => {
+          TestBed.configureTestingModule({
+            providers: [
+              provideHttpClient(...commonHttpFeatures),
+              {
+                provide: HTTP_ROOT_INTERCEPTOR_FNS,
+                useValue: makeLiteralTagInterceptorFn('root'),
+                multi: true,
+              },
+              provideHttpClientTesting(),
+            ],
+          });
+
+          const child = createEnvironmentInjector(
+            [
+              provideHttpClient(withInterceptors([makeLiteralTagInterceptorFn('child')])),
+              {
+                provide: HttpBackend,
+                useFactory: () => inject(HttpBackend, {skipSelf: true}),
+              },
+            ],
+            TestBed.inject(EnvironmentInjector),
+          );
+
+          child.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+          const req = TestBed.inject(HttpTestingController).expectOne('/test');
+          expect(req.request.headers.get('X-Tag')).toEqual('child,root');
+          req.flush('');
+        });
+
+        it('should run root interceptors once in the parent request and response chain', () => {
+          const order: string[] = [];
+
+          TestBed.configureTestingModule({
+            providers: [
+              provideHttpClient(
+                ...commonHttpFeatures,
+                withInterceptors([makeOrderedTagInterceptorFn('parent', order)]),
+              ),
+              {
+                provide: HTTP_ROOT_INTERCEPTOR_FNS,
+                useValue: makeOrderedTagInterceptorFn('root', order),
+                multi: true,
+              },
+              provideHttpClientTesting(),
+            ],
+          });
+
+          const child = createEnvironmentInjector(
+            [
+              provideHttpClient(
+                withRequestsMadeViaParent(),
+                withInterceptors([makeOrderedTagInterceptorFn('child', order)]),
+              ),
+            ],
+            TestBed.inject(EnvironmentInjector),
+          );
+
+          child.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+          const req = TestBed.inject(HttpTestingController).expectOne('/test');
+          expect(req.request.headers.get('X-Tag')).toEqual('child,parent,root');
+          expect(order).toEqual(['child:request', 'parent:request', 'root:request']);
+          req.flush('');
+          expect(order).toEqual([
+            'child:request',
+            'parent:request',
+            'root:request',
+            'root:response',
+            'parent:response',
+            'child:response',
+          ]);
+        });
+
         it('should be able to connect to a legacy-provided HttpClient context', () => {
           TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
@@ -664,6 +738,19 @@ function provideLegacyInterceptor(tag: string): Provider {
 
 function makeLiteralTagInterceptorFn(tag: string): HttpInterceptorFn {
   return (req, next) => next(addTagToRequest(req, tag));
+}
+
+function makeOrderedTagInterceptorFn(tag: string, order: string[]): HttpInterceptorFn {
+  return (req, next) => {
+    order.push(`${tag}:request`);
+    return next(addTagToRequest(req, tag)).pipe(
+      tap((event) => {
+        if (event instanceof HttpResponse) {
+          order.push(`${tag}:response`);
+        }
+      }),
+    );
+  };
 }
 
 function makeTokenTagInterceptorFn(tag: InjectionToken<string>): HttpInterceptorFn {

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -377,6 +377,14 @@ describe('provideHttpClient', () => {
   });
 
   describe('withRequestsMadeViaParent()', () => {
+    it('should error when combined with a backend override', () => {
+      for (const backendFeature of [withFetch(), withXhr()]) {
+        expect(() => provideHttpClient(withRequestsMadeViaParent(), backendFeature)).toThrowError(
+          'Configuration error: withRequestsMadeViaParent() cannot be combined with withFetch() or withXhr() in the same call to provideHttpClient().',
+        );
+      }
+    });
+
     for (const backend of ['fetch', 'xhr']) {
       describe(`given '${backend}' backend`, () => {
         const commonHttpFeatures: HttpFeature<HttpFeatureKind>[] = [];

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -10,6 +10,8 @@ import {DOCUMENT} from '../../index';
 import {
   ApplicationRef,
   Component,
+  createEnvironmentInjector,
+  EnvironmentInjector,
   Injectable,
   PLATFORM_ID,
   TransferState,
@@ -26,6 +28,8 @@ import {
   HttpRequest,
   HttpResponse,
   provideHttpClient,
+  withInterceptors,
+  withRequestsMadeViaParent,
 } from '../public_api';
 import {
   BODY,
@@ -292,6 +296,124 @@ describe('TransferCache', () => {
 
       expect(firstNext).toHaveBeenCalledTimes(1);
       expect(secondNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('withRequestsMadeViaParent()', () => {
+    let childInjector: EnvironmentInjector;
+
+    beforeEach(() => {
+      globalThis['ngServerMode'] = true;
+
+      TestBed.configureTestingModule({
+        providers: [
+          TransferState,
+          withHttpTransferCache({
+            filter: (request) => !request.headers.has('X-API-Key'),
+          }),
+          provideHttpClient(
+            withInterceptors([
+              (request, next) => {
+                if (request.url === '/private') {
+                  request = request.clone({
+                    setHeaders: {Authorization: 'Bearer server-token'},
+                  });
+                } else if (request.url === '/secret') {
+                  request = request.clone({setHeaders: {'X-API-Key': 'secret-a'}});
+                } else if (request.url === '/public-alias') {
+                  request = request.clone({url: '/public'});
+                }
+
+                return next(request);
+              },
+            ]),
+          ),
+          provideHttpClientTesting(),
+        ],
+      });
+
+      childInjector = createEnvironmentInjector(
+        [
+          provideHttpClient(
+            withInterceptors([
+              (request, next) =>
+                next(request.clone({setHeaders: {'X-Trace-Id': 'feature-request'}})),
+            ]),
+            withRequestsMadeViaParent(),
+          ),
+        ],
+        TestBed.inject(EnvironmentInjector),
+      );
+    });
+
+    afterEach(() => {
+      childInjector.destroy();
+      TestBed.inject(HttpTestingController).verify();
+      globalThis['ngServerMode'] = undefined;
+    });
+
+    it('should evaluate cache eligibility and keys after parent interceptors', () => {
+      const httpClient = childInjector.get(HttpClient);
+      const httpTestingController = TestBed.inject(HttpTestingController);
+      const transferState = TestBed.inject(TransferState);
+
+      let privateResponse: unknown;
+      httpClient.get('/private').subscribe((response) => (privateResponse = response));
+      const privateRequest = httpTestingController.expectOne('/private');
+      expect(privateRequest.request.headers.get('Authorization')).toBe('Bearer server-token');
+      expect(privateRequest.request.headers.get('X-Trace-Id')).toBe('feature-request');
+      privateRequest.flush({internalSecret: 'server-only'});
+
+      expect(privateResponse).toEqual({internalSecret: 'server-only'});
+      expect(JSON.parse(transferState.toJson())).toEqual({});
+
+      let publicResponse: unknown;
+      httpClient.get('/public-alias').subscribe((response) => (publicResponse = response));
+      httpTestingController.expectOne('/public').flush({message: 'public'});
+
+      publicResponse = undefined;
+      httpClient.get('/public-alias').subscribe((response) => (publicResponse = response));
+      httpTestingController.expectNone('/public');
+      expect(publicResponse).toEqual({message: 'public'});
+    });
+
+    it('should evaluate cache filters after parent interceptors', () => {
+      const httpClient = childInjector.get(HttpClient);
+      const httpTestingController = TestBed.inject(HttpTestingController);
+      const transferState = TestBed.inject(TransferState);
+
+      let response: unknown;
+      httpClient.get('/secret').subscribe((value) => (response = value));
+      const request = httpTestingController.expectOne('/secret');
+      expect(request.request.headers.get('X-API-KEY')).toBe('secret-a');
+      request.flush({internalSecret: 'secret-only'});
+
+      expect(response).toEqual({internalSecret: 'secret-only'});
+      expect(JSON.parse(transferState.toJson())).toEqual({});
+    });
+
+    it('should evaluate cache eligibility through multiple parent clients', () => {
+      const grandchildInjector = createEnvironmentInjector(
+        [provideHttpClient(withRequestsMadeViaParent())],
+        childInjector,
+      );
+
+      try {
+        const httpClient = grandchildInjector.get(HttpClient);
+        const httpTestingController = TestBed.inject(HttpTestingController);
+        const transferState = TestBed.inject(TransferState);
+
+        let privateResponse: unknown;
+        httpClient.get('/private').subscribe((response) => (privateResponse = response));
+        const privateRequest = httpTestingController.expectOne('/private');
+        expect(privateRequest.request.headers.get('Authorization')).toBe('Bearer server-token');
+        privateRequest.flush({internalSecret: 'server-only'});
+
+        expect(privateResponse).toEqual({internalSecret: 'server-only'});
+        expect(JSON.parse(transferState.toJson())).toEqual({});
+      } finally {
+        grandchildInjector.destroy();
+      }
     });
   });
 


### PR DESCRIPTION
Represent `withRequestsMadeViaParent()` with an internal delegating backend so the interceptor handler can distinguish delegated clients from independent child configurations.

Delegated clients leave inherited root interceptors to the parent chain. This prevents duplicate execution and lets `HttpTransferCache` evaluate authentication and cache filters after parent request interceptors, while independent child clients continue to inherit framework root interceptors.

Add coverage for independent root inheritance, request and response ordering, authenticated requests, cache filters, and public cache hits.

Fixes #69777

This seems similar to  https://github.com/angular/angular/security/advisories/GHSA-q6f4-qqrg-jv6x ( In fact, no filter or exclusion is currently applied ) 
