### PR TITLE
fix(http): prevent transfer cache key collisions

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -421,7 +421,10 @@ function makeCacheKey(
     serializedBody = '';
   }
 
-  const key = [method, responseType, mappedRequestUrl, serializedBody, encodedParams].join('|');
+  // Joining with `|` lets a shifted field boundary (url `/a` + body `b|c` vs url `/a|b` + body `c`)
+  // collapse to the same string and thus the same hash. `\0` cannot occur in a valid url or in
+  // encoded params, so the field boundaries can't be forged by field content.
+  const key = [method, responseType, mappedRequestUrl, serializedBody, encodedParams].join('\0');
   const hash = generateHash(key);
 
   return makeStateKey(hash);

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -419,7 +419,7 @@ describe('TransferCache', () => {
 
       const transferState = TestBed.inject(TransferState);
       expect(JSON.parse(transferState.toJson()) as Record<string, unknown>).toEqual({
-        '2da5dfaf112523258ec9c26a0abe9a093b59ed7dbe5f43e4b5ee25a407ac9cf0': {
+        'd501aa2d57b63a95df74e3b0558782b71b077974e968ed303cd30b27e4b70702': {
           [BODY]: 'foo',
           [HEADERS]: {},
           [STATUS]: 200,
@@ -427,7 +427,7 @@ describe('TransferCache', () => {
           [REQ_URL]: '/test-1',
           [RESPONSE_TYPE]: 'json',
         },
-        '869485290d9385f3c0a9ba571918c335bbca9e03373bf8260d02f2b7dd335849': {
+        'ceddc6689dc1f2fc3a0b8c364b6e00a79b99a149f27e84da87cec03d44c150c8': {
           [BODY]: 'buzz',
           [HEADERS]: {},
           [STATUS]: 200,
@@ -762,6 +762,15 @@ describe('TransferCache', () => {
       makeRequestAndExpectOne('/test-1', null, {method: 'POST', transferCache: true, body: 'foo'});
       makeRequestAndExpectNone('/test-1', 'POST', {transferCache: true, body: 'foo'});
       makeRequestAndExpectOne('/test-1', null, {method: 'POST', transferCache: true, body: 'bar'});
+    });
+
+    it('should differentiate POST requests with an ambiguous url/body boundary', () => {
+      // `/items/a` with body `b|c` and `/items/a|b` with body `c` are different requests, but a
+      // cache key that concatenates the fields with `|` maps both to the same string. The second
+      // request must be treated as a cache miss and hit the network.
+      makeRequestAndExpectOne('/items/a', null, {method: 'POST', transferCache: true, body: 'b|c'});
+      makeRequestAndExpectNone('/items/a', 'POST', {transferCache: true, body: 'b|c'});
+      makeRequestAndExpectOne('/items/a|b', null, {method: 'POST', transferCache: true, body: 'c'});
     });
 
     it('should cache POST with the differing body in object form', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`makeCacheKey` in `packages/common/http/src/transfer_cache.ts` builds the transfer-cache `StateKey` by joining `[method, responseType, mappedRequestUrl, serializedBody, encodedParams]` with a single `|` and then SHA-256 hashing the result. The request url and the serialized body can themselves contain `|`, so a shifted field boundary yields an identical joined string. A `POST` to `/items/a` with body `b|c` and a `POST` to `/items/a|b` with body `c` both serialize to `POST|json|/items/a|b|c|` and hash to the same key, so during SSR the two requests share one cache slot and the second request is served the first one's cached response on the client.

The SHA-256 hashing that was recently added was meant to make these keys collision resistant, but the collision is introduced while the key string is assembled, before it reaches the hash, so the guarantee does not hold once a field carries the separator.

Issue Number: N/A

## What is the new behavior?

The fields are serialized with `JSON.stringify` instead of a raw join, so each field is escaped and the array boundaries cannot be forged by field content. Distinct requests now always map to distinct key strings and distinct hashes, while behavior for any single request is unchanged. Added a regression test that caches one `POST` and confirms the boundary-shifted request is treated as a separate cache entry.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The key is recomputed identically on the server and the client from the same build, so the format change needs no migration.
