### PR TITLE
refactor(devtools): format code

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -598,9 +598,7 @@ const getTransferStateCallback = (messageBus: MessageBus<Events>) => () => {
     if (!injector) continue;
 
     const rootData = ng.ɵgetTransferState?.(injector) as
-      | Record<string, TransferStateValue>
-      | null
-      | undefined;
+      Record<string, TransferStateValue> | null | undefined;
     if (rootData && typeof rootData === 'object') {
       Object.assign(merged, rootData);
       collected = true;

--- a/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/docs-ref-button.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/docs-ref-button.component.ts
@@ -11,10 +11,7 @@ import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
 
 type Docs =
-  | 'view-encapsulation'
-  | 'change-detection'
-  | 'dependency-injection'
-  | 'injector-hierarchies';
+  'view-encapsulation' | 'change-detection' | 'dependency-injection' | 'injector-hierarchies';
 
 const URLS: {[key in Docs]: string} = {
   'change-detection': 'https://angular.dev/api/core/ChangeDetectionStrategy',

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.ts
@@ -422,8 +422,7 @@ export class SignalsGraphVisualizer {
           updatedNodes.push(n.id);
         } else if (isClusterNode(n) && !this.expandedClustersIds.has(n.id)) {
           const previewNode = signalGraph.nodes[n.previewNode ?? -1] as
-            | DevtoolsSignalNode
-            | undefined;
+            DevtoolsSignalNode | undefined;
 
           if (previewNode && previewNode.epoch !== existingNode.epoch) {
             this.updateDagreNode(previewNode, existingNode, signalGraph);

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -223,9 +223,7 @@ export interface WizComponentMetadata extends BaseDirectiveMetadata {
 
 /** Directive metadata for all supported frameworks. */
 export type DirectiveMetadata =
-  | AngularDirectiveMetadata
-  | AcxDirectiveMetadata
-  | WizComponentMetadata;
+  AngularDirectiveMetadata | AcxDirectiveMetadata | WizComponentMetadata;
 
 export interface SerializedInjectedService {
   token: string;
@@ -383,13 +381,7 @@ export interface SupportedApis {
 }
 
 export type TransferStateValue =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | Record<string, unknown>
-  | unknown[];
+  string | number | boolean | null | undefined | Record<string, unknown> | unknown[];
 
 export interface Events {
   handshake: () => void;

--- a/devtools/src/app/transfer-state.ts
+++ b/devtools/src/app/transfer-state.ts
@@ -146,8 +146,7 @@ export function serializeTransferState(): void {
   doc.body.appendChild(script);
 
   const root = doc.querySelector('app-root') as
-    | (Element & {__ngDebugHydrationInfo__?: unknown})
-    | null;
+    (Element & {__ngDebugHydrationInfo__?: unknown}) | null;
   if (root) {
     root.__ngDebugHydrationInfo__ = {};
   }


### PR DESCRIPTION
Format (`ng-dev format`) DevTools TypeScript files.

We are getting some failed lint jobs on the CI in other PRs.