### PR TITLE
Patch 2

### DIFF
--- a/packages/zone.js/lib/browser/event-target.ts
+++ b/packages/zone.js/lib/browser/event-target.ts
@@ -7,7 +7,8 @@
  */
 
 export function eventTargetPatch(_global: any, api: _ZonePrivate) {
-  if ((Zone as any)[api.symbol('patchEventTarget')]) {
+  const patchSym = api.symbol('patchEventTarget');
+  if ((Zone as any).hasOwnProperty(patchSym) && (Zone as any)[patchSym]) {
     // EventTarget is already patched.
     return;
   }

--- a/packages/zone.js/lib/common/events.ts
+++ b/packages/zone.js/lib/common/events.ts
@@ -488,7 +488,11 @@ export function patchEventTarget(
 
     const compare = patchOptions?.diff || compareTaskCallbackVsDelegate;
 
-    const unpatchedEvents: string[] = (Zone as any)[zoneSymbol('UNPATCHED_EVENTS')];
+    const unpatchedSymbol = zoneSymbol('UNPATCHED_EVENTS');
+    const unpatchedEvents: string[] = (Zone as any).hasOwnProperty(unpatchedSymbol)
+      ? (Zone as any)[unpatchedSymbol]
+      : [];
+
     const passiveEvents: string[] = _global[zoneSymbol('PASSIVE_EVENTS')];
 
     function copyEventListenerOptions(options: any) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

Zone.js stores the internal flags `UNPATCHED_EVENTS` (in `events.ts`) and
`patchEventTarget` (in `event-target.ts`) as string-keyed properties on the
`Zone` object. Because these keys are plain strings, they can be inherited
from `Object.prototype` via prototype pollution. An attacker who pollutes
`Object.prototype` before Zone.js loads can:

- inject arbitrary event names into the unpatched list, selectively
  disabling change detection for those events (security bypass);
- set `patchEventTarget` to `true`, causing the entire event patching to
  be skipped and the application to become unresponsive (DoS).

Issue Number: N/A

## What is the new behavior?

Before reading the flags, we now check that they are own properties of the
`Zone` object using `hasOwnProperty`. Inherited values from the prototype
chain are ignored, closing the prototype pollution vector.

The fix is limited to two files:

- `packages/zone.js/lib/common/events.ts`
- `packages/zone.js/lib/browser/event-target.ts`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I manually tested these changes on Zone.js 0.16.2 (latest stable) in a real
browser. Without the patch, polluting `Object.prototype` with the relevant
keys disabled event tracking as expected. With the patch, the polluted
values are ignored and Angular change detection continues to work normally.
No existing functionality is affected.

This vulnerability was previously reported to Google Bug Hunters (OSS VRP)
and is tracked as issue 524605344. The fix is coordinated with the Angular
team.