### PR TITLE
test(elements): disambiguate the setTimeout spy type

### DIFF
--- a/packages/elements/test/utils_spec.ts
+++ b/packages/elements/test/utils_spec.ts
@@ -23,10 +23,7 @@ describe('utils', () => {
       let clearTimeoutSpy: jasmine.Spy;
 
       beforeEach(() => {
-        // TODO: @JiaLiPassion, need to wait @types/jasmine to fix the wrong return
-        // type infer issue.
-        // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/43486
-        setTimeoutSpy = spyOn(window, 'setTimeout').and.returnValue(42 as any);
+        setTimeoutSpy = spyOn<Window, 'setTimeout'>(window, 'setTimeout').and.returnValue(42);
         clearTimeoutSpy = spyOn(window, 'clearTimeout');
       });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the new behavior?

Bind spyOn explicitly to Window so Jasmine uses the DOM setTimeout signature that returns a number instead of the Node.js Timeout type. Remove the unsafe any cast and the obsolete TODO.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
