### PR TITLE
fix(common): skip zero-height warning for detached fill images

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -1247,7 +1247,11 @@ function assertNonZeroRenderedHeight(
     removeLoadListenerFn();
     removeErrorListenerFn();
     const renderedHeight = img.clientHeight;
-    if (dir.fill && renderedHeight === 0) {
+    // A cached image may fire `load` while the element is still detached from
+    // the DOM (for example a duplicate `ngSrc` inside a `@defer` block), and a
+    // detached element always reports a zero height. Skip the check in that
+    // case to avoid a false-positive warning.
+    if (dir.fill && renderedHeight === 0 && img.isConnected) {
       console.warn(
         formatRuntimeError(
           RuntimeErrorCode.INVALID_INPUT,

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1160,6 +1160,43 @@ describe('Image directive', () => {
           `${IMG_BASE_URL}/path/img.png 2048w, ${IMG_BASE_URL}/path/img.png 3840w`,
       );
     });
+
+    it('should not warn about a zero rendered height when a fill image loads while detached from the DOM', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      // A cached image can fire `load` before its view is attached to the DOM,
+      // and a detached element always reports a zero height.
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      Object.defineProperty(img, 'isConnected', {value: false, configurable: true});
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+      expect(consoleWarnSpy.calls.count()).toBe(0);
+    });
+
+    it('should warn about a zero rendered height when a fill image is connected to the DOM', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      Object.defineProperty(img, 'isConnected', {value: true, configurable: true});
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+      expect(consoleWarnSpy.calls.count()).toBe(1);
+      expect(consoleWarnSpy.calls.argsFor(0)[0]).toMatch(
+        /NG02952:.*the height of the fill-mode image is zero/,
+      );
+    });
   });
 
   describe('placeholder attribute', () => {


### PR DESCRIPTION
`NgOptimizedImage` logs NG02952 ("the height of the fill-mode image is zero") when a `fill` image renders with a zero height, checked on the image's `load` event. When the same URL is used more than once (for example a duplicate `ngSrc` across `@defer` blocks), later instances are served from the browser memory cache and their `load` can fire before Angular attaches the deferred view to the document. A detached element always reports a `clientHeight` of zero, so the warning is emitted even though the container is styled correctly.

Guard the check with `img.isConnected` so it is skipped while the image is not attached to the document. Images that are actually rendered inside a broken zero-height container are still connected, so the warning keeps firing for them.

Fixes #69636
