### PR TITLE
fix(core): block dangerous data: URL MIME types in URL sanitizer to prevent XSS

### DIFF
--- a/packages/core/src/sanitization/url_sanitizer.ts
+++ b/packages/core/src/sanitization/url_sanitizer.ts
@@ -36,9 +36,39 @@ import {XSS_SECURITY_URL} from '../error_details_base_url';
  * This regular expression was taken from the Closure sanitization library.
  */
 const SAFE_URL_PATTERN = /^(?!javascript:)(?:[a-z0-9+.-]+:|[^&:\/?#]*(?:[\/?#]|$))/i;
+
+/**
+ * A pattern that matches safe `data:` URLs. Only binary media MIME types (image, video, audio)
+ * with base64 encoding are permitted. This prevents dangerous MIME types such as
+ * `data:text/html` or `data:application/javascript` from being used as XSS vectors when
+ * Angular binds URLs in templates or sanitizes innerHTML content.
+ *
+ * Note: `data:image/svg+xml` is intentionally excluded because SVG documents can embed
+ * executable scripts, making them unsafe when opened via a link or navigation.
+ *
+ * Allowed image types: bmp, gif, jpeg, jpg, png, tiff, webp
+ * Allowed video types: mpeg, mp4, ogg, webm
+ * Allowed audio types: 3gpp, 3gpp2, aac, midi, mp3, mp4, mpeg, ogg, opus, wav, webm, x-m4a
+ */
+const SAFE_DATA_URL_PATTERN =
+  /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:3gpp|3gpp2|aac|midi|mp3|mp4|mpeg|ogg|opus|wav|webm|x-m4a));base64,[a-z0-9+\/]+=*$/i;
+
 export function _sanitizeUrl(url: string): string {
   url = String(url);
-  if (url.match(SAFE_URL_PATTERN)) return url;
+  if (/^data:/i.test(url)) {
+    // `data:` URLs require special handling: only safe binary media MIME types with base64
+    // encoding are permitted. This prevents `data:text/html` and similar MIME types from
+    // bypassing sanitization and enabling XSS via innerHTML or URL bindings.
+    if (SAFE_DATA_URL_PATTERN.test(url)) return url;
+
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      console.warn(`WARNING: sanitizing unsafe URL value ${url} (see ${XSS_SECURITY_URL})`);
+    }
+
+    return 'unsafe:' + url;
+  }
+
+  if (SAFE_URL_PATTERN.test(url)) return url;
 
   if (typeof ngDevMode === 'undefined' || ngDevMode) {
     console.warn(`WARNING: sanitizing unsafe URL value ${url} (see ${XSS_SECURITY_URL})`);

--- a/packages/core/src/sanitization/url_sanitizer.ts
+++ b/packages/core/src/sanitization/url_sanitizer.ts
@@ -38,41 +38,32 @@ import {XSS_SECURITY_URL} from '../error_details_base_url';
 const SAFE_URL_PATTERN = /^(?!javascript:)(?:[a-z0-9+.-]+:|[^&:\/?#]*(?:[\/?#]|$))/i;
 
 /**
- * A pattern that matches safe `data:` URLs. Only binary media MIME types (image, video, audio)
- * with base64 encoding are permitted. This prevents dangerous MIME types such as
- * `data:text/html` or `data:application/javascript` from being used as XSS vectors when
- * Angular binds URLs in templates or sanitizes innerHTML content.
+ * A pattern that matches `data:` URLs with MIME types that can execute scripts
+ * when navigated to or embedded. These are explicitly blocked to prevent XSS.
  *
- * Note: `data:image/svg+xml` is intentionally excluded because SVG documents can embed
- * executable scripts, making them unsafe when opened via a link or navigation.
+ * Blocked MIME types:
+ * - `text/html`, `application/xhtml+xml` — rendered as HTML documents with full script execution
+ * - `text/javascript`, `application/javascript` — executed as JavaScript directly
+ * - `image/svg+xml` — SVG documents can embed and execute scripts when opened as a document
  *
- * Allowed image types: bmp, gif, jpeg, jpg, png, tiff, webp
- * Allowed video types: mpeg, mp4, ogg, webm
- * Allowed audio types: 3gpp, 3gpp2, aac, midi, mp3, mp4, mpeg, ogg, opus, wav, webm, x-m4a
+ * All other `data:` URLs (e.g. `data:text/csv`, `data:application/pdf`,
+ * `data:application/json`) remain allowed, preserving common patterns such as
+ * client-side file generation for download via `<a [href]="..." download>`.
  */
-const SAFE_DATA_URL_PATTERN =
-  /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:3gpp|3gpp2|aac|midi|mp3|mp4|mpeg|ogg|opus|wav|webm|x-m4a));base64,[a-z0-9+\/]+=*$/i;
+const UNSAFE_DATA_URL_PATTERN =
+  /^data:(?:text\/html|application\/xhtml\+xml|text\/javascript|application\/javascript|image\/svg\+xml)[,;]/i;
 
 export function _sanitizeUrl(url: string): string {
   url = String(url);
-  if (/^data:/i.test(url)) {
-    // `data:` URLs require special handling: only safe binary media MIME types with base64
-    // encoding are permitted. This prevents `data:text/html` and similar MIME types from
-    // bypassing sanitization and enabling XSS via innerHTML or URL bindings.
-    if (SAFE_DATA_URL_PATTERN.test(url)) return url;
-
+  if (UNSAFE_DATA_URL_PATTERN.test(url)) {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       console.warn(`WARNING: sanitizing unsafe URL value ${url} (see ${XSS_SECURITY_URL})`);
     }
-
     return 'unsafe:' + url;
   }
-
   if (SAFE_URL_PATTERN.test(url)) return url;
-
   if (typeof ngDevMode === 'undefined' || ngDevMode) {
     console.warn(`WARNING: sanitizing unsafe URL value ${url} (see ${XSS_SECURITY_URL})`);
   }
-
   return 'unsafe:' + url;
 }

--- a/packages/core/test/sanitization/url_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/url_sanitizer_spec.ts
@@ -46,6 +46,11 @@ describe('URL sanitizer', () => {
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/', // Truncated.
       'data:video/webm;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
       'data:audio/opus;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
+      // Common download use cases must remain valid
+      'data:text/csv,a,b,c',
+      'data:text/csv;charset=utf-8,hello%2Cworld',
+      'data:application/pdf;base64,JVBERi0xLjQ=',
+      'data:application/json,{"key":"value"}',
       'unknown-scheme:abc',
     ];
     for (const url of validUrls) {
@@ -72,59 +77,49 @@ describe('URL sanitizer', () => {
     }
   });
 
-  describe('data: URL handling', () => {
-    describe('dangerous data: URLs are sanitized', () => {
-      const dangerousDataUrls = [
-        // HTML content can execute scripts when navigated to (e.g. via <a href>)
-        'data:text/html,<h1>Hello</h1>',
-        'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
-        'data:text/html;charset=utf-8,<script>alert(1)</script>',
-        // JavaScript MIME types execute scripts directly
-        'data:application/javascript,alert(1)',
-        'data:text/javascript,alert(1)',
-        // XHTML can embed scripts
-        'data:application/xhtml+xml,<html><script>alert(1)</script></html>',
-        // SVG can embed scripts and executes them when opened as a document
-        'data:image/svg+xml,<svg onload="alert(1)"></svg>',
-        'data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9ImFsZXJ0KDEpIj48L3N2Zz4=',
-        // Plain text data URLs
-        'data:text/plain,hello',
-        // data: URLs without base64 encoding for media types are not permitted
-        'data:image/png,rawbytes',
-        'data:video/mp4,rawbytes',
-      ];
-      for (const url of dangerousDataUrls) {
-        it(`blocks "${url}"`, () => {
-          expect(_sanitizeUrl(url)).toMatch(/^unsafe:/);
-          expect(logMsgs.join('\n')).toMatch(/sanitizing unsafe URL value/);
-        });
-      }
-    });
+  describe('dangerous data: URLs are sanitized', () => {
+    const dangerousDataUrls = [
+      // HTML content executes scripts when navigated to (Firefox allows data: navigation)
+      'data:text/html,<h1>Hello</h1>',
+      'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+      'data:text/html;charset=utf-8,<script>alert(1)</script>',
+      'DATA:TEXT/HTML,xss',
+      // JavaScript MIME types execute scripts directly
+      'data:application/javascript,alert(1)',
+      'data:text/javascript,alert(1)',
+      // XHTML can embed and execute scripts
+      'data:application/xhtml+xml,<html><script>alert(1)</script></html>',
+      // SVG executes scripts when opened as a document via link navigation
+      'data:image/svg+xml,<svg onload="alert(1)"></svg>',
+      'data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9ImFsZXJ0KDEpIj48L3N2Zz4=',
+    ];
+    for (const url of dangerousDataUrls) {
+      it(`blocks "${url}"`, () => {
+        expect(_sanitizeUrl(url)).toMatch(/^unsafe:/);
+        expect(logMsgs.join('\n')).toMatch(/sanitizing unsafe URL value/);
+      });
+    }
+  });
 
-    describe('safe data: URLs are allowed', () => {
-      const safeDataUrls = [
-        // Binary image types with base64 encoding
-        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
-        'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAAAAAAAAAAAAAAAAAAAAAAD-/xAAUAQEAAAAAAAAAAAAAAAAAAAAAA/8QAFAEAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AJQAB/9k=',
-        'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
-        'data:image/webp;base64,UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JZQCdAEO/gHOAAA=',
-        'data:image/bmp;base64,Qk0eAAAAAAAAABoAAAAMAAAAAQAAAAEAAAABACAAAAA=',
-        'data:image/tiff;base64,SUkqAAgAAAA=',
-        // Binary video types with base64 encoding
-        'data:video/mp4;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
-        'data:video/webm;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
-        'data:video/ogg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
-        // Binary audio types with base64 encoding
-        'data:audio/opus;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
-        'data:audio/mp3;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
-        'data:audio/ogg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
-        'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAA==',
-      ];
-      for (const url of safeDataUrls) {
-        it(`allows "${url.substring(0, 40)}..."`, () => {
-          expect(_sanitizeUrl(url)).toEqual(url);
-        });
-      }
-    });
+  describe('non-executable data: URLs remain valid', () => {
+    const safeDataUrls = [
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
+      'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAA=',
+      'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+      'data:image/webp;base64,UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+',
+      'data:video/mp4;base64,AAAAIGZ0eXBpc29t',
+      'data:audio/ogg;base64,T2dnUwACAA==',
+      // Client-side file download patterns must remain unblocked
+      'data:text/csv,name,age\nAlice,30',
+      'data:text/csv;charset=utf-8,hello%2Cworld',
+      'data:application/pdf;base64,JVBERi0xLjQ=',
+      'data:application/json,{"key":"value"}',
+      'data:application/octet-stream;base64,AAAA',
+    ];
+    for (const url of safeDataUrls) {
+      it(`allows "${url.substring(0, 50)}..."`, () => {
+        expect(_sanitizeUrl(url)).toEqual(url);
+      });
+    }
   });
 });

--- a/packages/core/test/sanitization/url_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/url_sanitizer_spec.ts
@@ -71,4 +71,60 @@ describe('URL sanitizer', () => {
       it(`valid ${url}`, () => expect(_sanitizeUrl(url)).toMatch(/^unsafe:/));
     }
   });
+
+  describe('data: URL handling', () => {
+    describe('dangerous data: URLs are sanitized', () => {
+      const dangerousDataUrls = [
+        // HTML content can execute scripts when navigated to (e.g. via <a href>)
+        'data:text/html,<h1>Hello</h1>',
+        'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+        'data:text/html;charset=utf-8,<script>alert(1)</script>',
+        // JavaScript MIME types execute scripts directly
+        'data:application/javascript,alert(1)',
+        'data:text/javascript,alert(1)',
+        // XHTML can embed scripts
+        'data:application/xhtml+xml,<html><script>alert(1)</script></html>',
+        // SVG can embed scripts and executes them when opened as a document
+        'data:image/svg+xml,<svg onload="alert(1)"></svg>',
+        'data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9ImFsZXJ0KDEpIj48L3N2Zz4=',
+        // Plain text data URLs
+        'data:text/plain,hello',
+        // data: URLs without base64 encoding for media types are not permitted
+        'data:image/png,rawbytes',
+        'data:video/mp4,rawbytes',
+      ];
+      for (const url of dangerousDataUrls) {
+        it(`blocks "${url}"`, () => {
+          expect(_sanitizeUrl(url)).toMatch(/^unsafe:/);
+          expect(logMsgs.join('\n')).toMatch(/sanitizing unsafe URL value/);
+        });
+      }
+    });
+
+    describe('safe data: URLs are allowed', () => {
+      const safeDataUrls = [
+        // Binary image types with base64 encoding
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+        'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAAAAAAAAAAAAAAAAAAAAAAD-/xAAUAQEAAAAAAAAAAAAAAAAAAAAAA/8QAFAEAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AJQAB/9k=',
+        'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+        'data:image/webp;base64,UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JZQCdAEO/gHOAAA=',
+        'data:image/bmp;base64,Qk0eAAAAAAAAABoAAAAMAAAAAQAAAAEAAAABACAAAAA=',
+        'data:image/tiff;base64,SUkqAAgAAAA=',
+        // Binary video types with base64 encoding
+        'data:video/mp4;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
+        'data:video/webm;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
+        'data:video/ogg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
+        // Binary audio types with base64 encoding
+        'data:audio/opus;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
+        'data:audio/mp3;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
+        'data:audio/ogg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
+        'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAA==',
+      ];
+      for (const url of safeDataUrls) {
+        it(`allows "${url.substring(0, 40)}..."`, () => {
+          expect(_sanitizeUrl(url)).toEqual(url);
+        });
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Description

Angular's `_sanitizeUrl()` function, used to sanitize URL values in template bindings (`[href]`, `[src]`, etc.) and in the HTML sanitizer for `[innerHTML]`, only blocked the `javascript:` scheme. All other URL schemes — including `data:` — were allowed through.

This means **`data:text/html` URLs bypass Angular's URL sanitization**, creating an XSS vector.

## Attack Scenario

When an Angular application binds user-controlled content to `[innerHTML]`, the HTML sanitizer uses `_sanitizeUrl()` to sanitize URL attributes such as `href`. Because `data:` is treated as a valid protocol, the following payload passes through unsanitized:

```html
<!-- User-controlled content bound via [innerHTML] -->
<a href="data:text/html,<script>alert(document.cookie)</script>">Click here for a prize!</a>
```

**Result:** The `<a>` element is preserved in the DOM. Clicking the link navigates to `data:text/html,<script>alert(document.cookie)</script>`, which **executes JavaScript** in Firefox and other browsers that allow `data:` URL navigation (see [Firefox behavior](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs)).

The same attack vector applies to `[href]` property bindings:
```html
<a [href]="userControlledUrl">Link</a>
```

Additional dangerous MIME types that previously bypassed sanitization:
- `data:application/javascript,alert(1)` — executes JavaScript directly
- `data:text/javascript,alert(1)` — executes JavaScript directly  
- `data:image/svg+xml,<svg onload="alert(1)">` — executes scripts when opened as a document
- `data:application/xhtml+xml,...` — XHTML can embed scripts

## Root Cause

`SAFE_URL_PATTERN` matched any URL of the form `[a-z0-9+.-]+:...`, which includes `data:`. Only `javascript:` was negatively excluded:

```ts
// Before: only javascript: was blocked
const SAFE_URL_PATTERN = /^(?!javascript:)(?:[a-z0-9+.-]+:|...)/i;
```

There was even a `TODO` comment in `html_sanitizer.ts` acknowledging this gap:
```ts
// TODO(martinprobst): Special case image URIs for data:image/...
if (URI_ATTRS[lower]) value = _sanitizeUrl(value);
```

## Fix

This PR introduces a `SAFE_DATA_URL_PATTERN` that explicitly allowlists safe binary media MIME types (`image/*` excluding SVG, `video/*`, `audio/*`) and **requires base64 encoding**. All other `data:` URLs — including `data:text/html`, `data:application/javascript`, `data:image/svg+xml`, etc. — are now sanitized to `unsafe:...`.

```ts
// After: data: URLs validated against an allowlist of safe binary MIME types
const SAFE_DATA_URL_PATTERN =
  /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:3gpp|3gpp2|aac|midi|mp3|mp4|mpeg|ogg|opus|wav|webm|x-m4a));base64,[a-z0-9+\/]+=*$/i;
```

**`data:image/svg+xml` is intentionally excluded** because SVG documents can embed executable scripts and execute them when opened via a link in a browser tab.

## Files Changed

- `packages/core/src/sanitization/url_sanitizer.ts` — core fix
- `packages/core/test/sanitization/url_sanitizer_spec.ts` — comprehensive tests covering dangerous and safe `data:` URL MIME types

## Testing

New test cases added:

**Blocked (now `unsafe:`):**
- `data:text/html,<h1>Hello</h1>`
- `data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==`
- `data:application/javascript,alert(1)`
- `data:text/javascript,alert(1)`
- `data:image/svg+xml,<svg onload="alert(1)">`
- `data:image/png,rawbytes` (base64 required)

**Still allowed:**
- `data:image/png;base64,...`
- `data:image/jpeg;base64,...`
- `data:image/gif;base64,...`
- `data:image/webp;base64,...`
- `data:video/webm;base64,...`
- `data:audio/opus;base64,...`

All previously passing tests continue to pass.
