### PR TITLE
docs: add v23 release and change to yearly release cycle

### DIFF
--- a/adev/src/content/reference/releases.md
+++ b/adev/src/content/reference/releases.md
@@ -60,11 +60,13 @@ HELPFUL: Dates are offered as general guidance and are subject to change.
 
 In general, expect the following release cycle:
 
-- A major release every 6 months
-- 1-3 minor releases for each major release
+- A major release every 12 months
+- 4-6 minor releases for each major release
 - A patch release and pre-release \(`next` or `rc`\) build almost every week
 
 This cadence of releases gives eager developers access to new features as soon as they are fully developed and pass through our code review and integration testing processes, while maintaining the stability and reliability of the platform for production users that prefer to receive features after they have been validated by Google and other developers that use the pre-release builds.
+
+HELPFUL: Until Angular v22, Angular had a 6-month major release cycle, with 1-3 minor releases for each major release
 
 ## Support policy and schedule
 
@@ -72,32 +74,33 @@ HELPFUL: Approximate dates are offered as general guidance and are subject to ch
 
 ### Release schedule
 
-Release schedule for upcoming versions will be announced soon.
-
-<!-- | Version | Date               |
+| Version | Date               |
 | :------ | :----------------- |
-| v21.1   | Week of 2026-01-12 |
-| v21.2   | Week of 2026-02-23 |
-| v22.0   | Week of 2026-06-01 | -->
+| v22.1   | Week of 2026-07-27 |
+| v22.2   | ~ September 2026   |
+| v22.3   | ~ November 2026    |
+| v22.4   | ~ January 2027     |
+| v22.5   | ~ March 2027       |
+| v23.0   | ~ June 2027        |
 
 ### Support window
 
-All major releases are typically supported for 18 months.
+All major releases are typically supported for 24 months.
 
 | Support stage     | Support Timing | Details                                                             |
 | :---------------- | :------------- | :------------------------------------------------------------------ |
-| Active            | 6 months       | Regularly-scheduled updates and patches are released                |
+| Active            | 12 months      | Regularly-scheduled updates and patches are released                |
 | Long-term \(LTS\) | 12 months      | Only [critical fixes and security patches](#lts-fixes) are released |
 
 ### Actively supported versions
 
 The following table provides the status for Angular versions under support.
 
-| Version | Status | Released   | Active ends     | LTS ends        |
-| :------ | :----- | :--------- | :-------------- | :-------------- |
-| ^22.0.0 | Active | 2026-06-03 | To be announced | To be announced |
-| ^21.0.0 | LTS    | 2025-11-19 | 2026-06-03      | To be announced |
-| ^20.0.0 | LTS    | 2025-05-28 | 2025-11-19      | 2026-11-28      |
+| Version | Status | Released   | Active ends | LTS ends   |
+| :------ | :----- | :--------- | :---------- | :--------- |
+| ^22.0.0 | Active | 2026-06-03 | 2027-06     | 2028-06    |
+| ^21.0.0 | LTS    | 2025-11-19 | 2026-06-03  | 2027-06    |
+| ^20.0.0 | LTS    | 2025-05-28 | 2025-11-19  | 2026-11-28 |
 
 Angular versions v2 to v19 are no longer supported.
 
@@ -110,14 +113,14 @@ As a general rule, a fix is considered for an LTS version if it resolves one of:
 
 ## Deprecation policy
 
-When the Angular team intends to remove an API or feature, it will be marked as _deprecated_. This occurs when an API is obsolete, superseded by another API, or otherwise discontinued. Deprecated API remain available through their deprecated phase, which lasts a minimum two major versions (approximately one year).
+When the Angular team intends to remove an API or feature, it will be marked as _deprecated_. This occurs when an API is obsolete, superseded by another API, or otherwise discontinued. Deprecated API remain available through their deprecated phase, which lasts a minimum one major version (approximately one year).
 
 To help ensure that you have sufficient time and a clear path to update, this is our deprecation policy:
 
 | Deprecation stages | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Announcement       | We announce deprecated APIs and features in the [change log](https://github.com/angular/angular/blob/main/CHANGELOG.md 'Angular change log'). Deprecated APIs appear in the [documentation](api?status=8) with ~~strikethrough~~. When we announce a deprecation, we also announce a recommended update path. Additionally, all deprecated APIs are annotated with `@deprecated` in the corresponding documentation, which enables text editors and IDEs to provide hints if your project depends on them. |
-| Deprecation period | When an API or a feature is deprecated, it is still present in at least the next two major releases (period of at least 12 months). After that, deprecated APIs and features are candidates for removal. A deprecation can be announced in any release, but the removal of a deprecated API or feature happens only in major release. Until a deprecated API or feature is removed, it is maintained according to the LTS support policy, meaning that only critical and security issues are fixed.        |
+| Deprecation period | When an API or a feature is deprecated, it is still present in at least the next major release (period of at least 12 months). After that, deprecated APIs and features are candidates for removal. A deprecation can be announced in any release, but the removal of a deprecated API or feature happens only in major release. Until a deprecated API or feature is removed, it is maintained according to the LTS support policy, meaning that only critical and security issues are fixed.             |
 | npm dependencies   | We only make npm dependency updates that require changes to your applications in a major release. In minor releases, we update peer dependencies by expanding the supported versions, but we do not require projects to update these dependencies until a future major version. This means that during minor Angular releases, npm dependency updates within Angular applications and libraries are optional.                                                                                              |
 
 ## Compatibility policy

--- a/contributing-docs/branches-and-versioning.md
+++ b/contributing-docs/branches-and-versioning.md
@@ -28,23 +28,26 @@ referred to as the **active patch branch**.
 
 ## Major releases lifecycle
 
-Angular releases a major version roughly every six months. Following a major release, we move
+Angular releases a major version roughly every twelve months. Following a major release, we move
 through a consistent lifecycle to the next major release, and repeat. At a high level, this
 process proceeds as follows:
 
 - A major release occurs. The `main` branch now represents the next minor version.
-- Six weeks later, a minor release occurs. The `main` branch now represents the next minor
-  version.
-- Six weeks later, a second minor release occurs. The `main` branch now represents the next major
+- Eight weeks later, a minor release occurs. The `main` branch now represents the next minor
+  version. This process repeats 4 times.
+- Eight weeks later, the last minor release occurs. The `main` branch now represents the next major
   version.
 - Three months later, a major release occurs and the process repeats.
 
+NOTE: Until Angular v22, Angular had a major release every six months, with 1-3 minor releases for each major release.
+
 ### Example
 
-- Angular publishes `11.0.0`. At this point in time, the `main` branch represents `11.1.0`.
-- Six weeks later, we publish `11.1.0` and `main` represents `11.2.0`.
-- Six weeks later, we publish `11.2.0` and `main` represents `12.0.0`.
-- Three months later, this cycle repeats with the publication of `12.0.0`.
+- Angular publishes `22.0.0`. At this point in time, the `main` branch represents `22.1.0`.
+- Eight weeks later, we publish `22.1.0` and `main` represents `22.2.0`.
+- The last step repeats until 22.4.0 is published and `main` represents `22.5.0`.
+- Eight weeks later, we publish `22.5.0` and `main` represents `23.0.0`.
+- Three months later, this cycle repeats with the publication of `23.0.0`.
 
 ### Feature freeze and release candidates
 


### PR DESCRIPTION
## Summary

This PR adds v22.x and v23 release dates. It also changes Angular's release cadence to a yearly cycle.

## Why we are making this change

The community has long requested less frequent major releases due to the impact of breaking changes and upgrades for their projects as well as for enterprise customers. Additionally, a longer release cycle provides increased API stability for developers using agentic workflows, while still delivering a reasonable cadence of API upgrades and migrations.

This PR will not affect how features are released in general, features can and will continue to be shipped in minor versions. Only breaking changes are restricted to major versions.

