### PR TITLE
feat(forms): allow permanent hidden fields in signal forms

### DIFF
--- a/adev/src/content/guide/forms/signals/form-logic.md
+++ b/adev/src/content/guide/forms/signals/form-logic.md
@@ -221,6 +221,45 @@ export class Profile {
 }
 ```
 
+### Always hidden
+
+To make a field permanently hidden, call `hidden()` with just the field path:
+
+```angular-ts
+import {Component, signal} from '@angular/core';
+import {form, FormField, hidden} from '@angular/forms/signals';
+
+@Component({
+  selector: 'app-profile',
+  imports: [FormField],
+  template: `
+    <label>
+      <input type="checkbox" [formField]="profileForm.isPublic" />
+      Make profile public
+    </label>
+
+    <!-- The publicUrl is permanently hidden, so this block never renders -->
+    @if (!profileForm.publicUrl().hidden()) {
+      <label>
+        Public URL
+        <input [formField]="profileForm.publicUrl" />
+      </label>
+    }
+  `,
+})
+export class Profile {
+  profileModel = signal({
+    isPublic: false,
+    publicUrl: '',
+  });
+
+  profileForm = form(this.profileModel, (schemaPath) => {
+    // This field is now permanently hidden and excluded from active validation
+    hidden(schemaPath.publicUrl);
+  });
+}
+```
+
 ## Display uneditable fields with `readonly()`
 
 The `readonly()` rule prevents users from updating a field. The `[FormField]` directive automatically binds this state to the HTML `readonly` attribute, which prevents editing while still allowing users to focus and select text.

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -274,12 +274,12 @@ export interface FormValueControl<TValue> extends FormUiControl<TValue> {
 }
 
 // @public
-export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, config: {
-    when: NoInfer<LogicFn<TValue, boolean, TPathKind>>;
+export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, config?: {
+    when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>;
 }): void;
 
 // @public @deprecated
-export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, logic: NoInfer<LogicFn<TValue, boolean, TPathKind>>): void;
+export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, logic?: NoInfer<LogicFn<TValue, boolean, TPathKind>>): void;
 
 // @public
 export interface HttpValidatorOptions<TValue, TResult, TPathKind extends PathKind = PathKind.Root> {

--- a/packages/forms/signals/src/api/rules/hidden.ts
+++ b/packages/forms/signals/src/api/rules/hidden.ts
@@ -36,7 +36,7 @@ import type {LogicFn, PathKind, SchemaPath, SchemaPathRules} from '../types';
  */
 export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
-  config: {when: NoInfer<LogicFn<TValue, boolean, TPathKind>>},
+  config?: {when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>},
 ): void;
 
 /**
@@ -46,20 +46,21 @@ export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(
  */
 export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
-  logic: NoInfer<LogicFn<TValue, boolean, TPathKind>>,
+  logic?: NoInfer<LogicFn<TValue, boolean, TPathKind>>,
 ): void;
 
 export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
-  configOrLogic:
-    | {when: NoInfer<LogicFn<TValue, boolean, TPathKind>>}
+  configOrLogic?:
+    | {when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>}
     | NoInfer<LogicFn<TValue, boolean, TPathKind>>,
 ): void {
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
 
-  const logic = typeof configOrLogic === 'function' ? configOrLogic : configOrLogic.when;
+  const logic =
+    typeof configOrLogic === 'function' ? configOrLogic : (configOrLogic?.when ?? (() => true));
 
   pathNode.builder.addHiddenRule(logic);
 }

--- a/packages/forms/signals/test/node/api/hidden.spec.ts
+++ b/packages/forms/signals/test/node/api/hidden.spec.ts
@@ -139,4 +139,20 @@ describe('hidden', () => {
     f.name().value.set('hidden-cat');
     expect(f.name().hidden()).toBe(true);
   });
+
+  it('it returns true when configOrLogic is omitted', () => {
+    const cat = signal({name: 'Pirojok-the-cat', age: 5});
+    const f = form(
+      cat,
+      (p) => {
+        hidden(p.name);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    expect(f.name().hidden()).withContext('Name is permanently hidden').toBeTrue();
+
+    f.name().value.set('some-other-cat');
+    expect(f.name().hidden()).toBeTrue();
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

- #68278 

## What is the new behavior?

- Allow permanent hidden fields in signal forms 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- This change is similar to `readonly()` and `disabled()` signal form rules
