### PR TITLE
fix(core): use unsigned right shift when extracting bit-packed index fields

### DIFF
--- a/packages/core/src/render3/di_setup.ts
+++ b/packages/core/src/render3/di_setup.ts
@@ -108,7 +108,7 @@ function resolveProvider(
     const beginIndex = tNode.providerIndexes & TNodeProviderIndexes.ProvidersStartIndexMask;
     const endIndex = tNode.directiveStart;
     const cptViewProvidersCount =
-      tNode.providerIndexes >> TNodeProviderIndexes.CptViewProvidersCountShift;
+      tNode.providerIndexes >>> TNodeProviderIndexes.CptViewProvidersCountShift;
 
     if (isTypeProvider(provider) || !provider.multi) {
       const factory = new NodeInjectorFactory(

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -308,11 +308,11 @@ function callHook(currentView: LView, initPhase: InitPhaseState, arr: HookData, 
   const directiveIndex = isInitHook ? -arr[i] : (arr[i] as number);
   const directive = currentView[directiveIndex];
   if (isInitHook) {
-    const indexWithintInitPhase = currentView[FLAGS] >> LViewFlags.IndexWithinInitPhaseShift;
+    const indexWithintInitPhase = currentView[FLAGS] >>> LViewFlags.IndexWithinInitPhaseShift;
     // The init phase state must be always checked here as it may have been recursively updated.
     if (
       indexWithintInitPhase <
-        currentView[PREORDER_HOOK_FLAGS] >> PreOrderHookFlags.NumberOfInitHooksCalledShift &&
+        currentView[PREORDER_HOOK_FLAGS] >>> PreOrderHookFlags.NumberOfInitHooksCalledShift &&
       (currentView[FLAGS] & LViewFlags.InitPhaseStateMask) === initPhase
     ) {
       currentView[FLAGS] += LViewFlags.IndexWithinInitPhaseIncrementer;


### PR DESCRIPTION
## Problem

JavaScript bitwise operators coerce their operands to **signed 32-bit integers**. The signed right-shift operator `>>` preserves the sign bit, so when an extracted field could have bit 31 set, the result is a negative number.

Angular packs multiple fields into a single 32-bit integer in a few places in `render3`. Two of those places use `>>` (signed) instead of `>>>` (unsigned) to extract those fields:

### `packages/core/src/render3/hooks.ts`

```ts
// bits 14+ of LView[FLAGS] store the init-phase counter
const indexWithintInitPhase =
  currentView[FLAGS] >> LViewFlags.IndexWithinInitPhaseShift;   // ⚠️

// bits 16+ of PREORDER_HOOK_FLAGS store the number of called init hooks
  currentView[PREORDER_HOOK_FLAGS] >> PreOrderHookFlags.NumberOfInitHooksCalledShift  // ⚠️
```

If `indexWithintInitPhase` becomes negative (bit 31 set when counter ≥ 2¹⁷ = 131 072), the guard `indexWithintInitPhase < numberOfInitHooksCalled` can never be satisfied and **init-hook execution stops silently**.

### `packages/core/src/render3/di_setup.ts`

```ts
// bits 20+ of tNode.providerIndexes store the component-view provider count
const cptViewProvidersCount =
  tNode.providerIndexes >> TNodeProviderIndexes.CptViewProvidersCountShift;  // ⚠️
```

A negative count would pass the wrong value into provider-slot calculations.

## Fix

Replace `>>` with `>>>` (unsigned right shift) at all three sites. The unsigned shift zeros the sign bit unconditionally, returning a non-negative value regardless of what the high bits contain.

This is already the practice used throughout the codebase for identical patterns — `i18n_apply.ts`, `i18n_debug.ts`, and `i18n_util.ts` all use `>>>` when unpacking opcodes.

## Files changed

| File | Change |
|------|--------|
| `packages/core/src/render3/hooks.ts` | `>>` → `>>>` (×2) |
| `packages/core/src/render3/di_setup.ts` | `>>` → `>>>` (×1) |