### PR TITLE
docs(core): align I18nCreateOpCode pseudocode comment with implementation

### DIFF
--- a/packages/core/src/render3/interfaces/i18n.ts
+++ b/packages/core/src/render3/interfaces/i18n.ts
@@ -123,8 +123,7 @@ export const enum IcuCreateOpCode {
  * ```
  */
 export interface IcuCreateOpCodes
-  extends Array<number | string | ELEMENT_MARKER | ICU_MARKER | null>,
-    I18nDebug {
+  extends Array<number | string | ELEMENT_MARKER | ICU_MARKER | null>, I18nDebug {
   __brand__: 'I18nCreateOpCodes';
 }
 

--- a/packages/core/src/render3/interfaces/i18n.ts
+++ b/packages/core/src/render3/interfaces/i18n.ts
@@ -213,7 +213,7 @@ export interface I18nDebug {
  *
  * for(var i=0; i<i18nCreateOpCodes.length; i++) {
  *   const opcode = i18NCreateOpCodes[i++];
- *   const index = opcode >> I18nCreateOpCode.SHIFT;
+ *   const index = opcode >>> I18nCreateOpCode.SHIFT;
  *   const text = i18NCreateOpCodes[i];
  *   let node: Text|Comment;
  *   if (opcode & I18nCreateOpCode.COMMENT === I18nCreateOpCode.COMMENT) {


### PR DESCRIPTION
## Problem

The JSDoc pseudocode example in the `I18nCreateOpCodes` interface documentation uses `>>` (signed right shift) to extract the node index from an opcode:

```ts
// packages/core/src/render3/interfaces/i18n.ts — comment line
const index = opcode >> I18nCreateOpCode.SHIFT;  // ⚠️ uses signed shift
```

However, the actual runtime implementation in `i18n_apply.ts` and `i18n_debug.ts` consistently uses `>>>` (unsigned right shift) for this exact operation:

```ts
// i18n_apply.ts
const index = opCode >>> I18nCreateOpCode.SHIFT;   // ✅
// i18n_debug.ts
const index = opCode >>> I18nCreateOpCode.SHIFT;   // ✅
```

A reader consulting the comment pseudocode when implementing a similar decode loop could introduce a subtle signed-shift bug.

## Fix

Align the comment pseudocode with the implementation: change `>>` to `>>>`.

This is a **docs-only** change; no runtime behaviour is affected.