### PR TITLE
fix(core): escape comment markers which share characters

### DIFF
--- a/packages/core/src/util/dom.ts
+++ b/packages/core/src/util/dom.ts
@@ -7,11 +7,16 @@
  */
 
 /**
- * Disallowed strings in the comment.
+ * Matches the `<` or `>` of a disallowed string in the comment.
+ *
+ * The delimiter is matched together with the surrounding context rather than the disallowed string
+ * as a whole, so that disallowed strings sharing characters (such as the `--` of `<!--` and `--!>`
+ * in `<!--!>`) are all escaped. A pattern matching the whole string would consume the shared
+ * characters with the first match and never see the second one.
  *
  * see: https://html.spec.whatwg.org/multipage/syntax.html#comments
  */
-const COMMENT_DISALLOWED = /^>|^->|<!--|-->|--!>|<!-$/g;
+const COMMENT_DISALLOWED = /(^-?|--!?)>|<(?=!--|!-$)/g;
 /**
  * Delimiter in the disallowed strings which needs to be wrapped with zero with character.
  */

--- a/packages/core/test/util/dom_spec.ts
+++ b/packages/core/test/util/dom_spec.ts
@@ -45,5 +45,23 @@ describe('comment node text escaping', () => {
       expect(escapeCommentText('.->')).toEqual('.->');
       expect(escapeCommentText('<!-.')).toEqual('<!-.');
     });
+
+    it('should escape markers which share characters', () => {
+      // The `--` belongs to both the `<!--` and the `--!>`/`-->` marker.
+      expect(escapeCommentText('<!--!>')).toEqual('\u200b<\u200b!--!\u200b>\u200b');
+      expect(escapeCommentText('<!--->')).toEqual('\u200b<\u200b!---\u200b>\u200b');
+      expect(escapeCommentText('<!--!><img src="x">')).toEqual(
+        '\u200b<\u200b!--!\u200b>\u200b<img src="x">',
+      );
+    });
+
+    it('should not escape a bare ">" or "->" in the middle of the text', () => {
+      // A previous attempt dropped the anchors and escaped these mid-text, which changed the
+      // serialized output of any comment containing a plain `>`. They must stay untouched.
+      expect(escapeCommentText('a>b')).toEqual('a>b');
+      expect(escapeCommentText('a->b')).toEqual('a->b');
+      expect(escapeCommentText('.>')).toEqual('.>');
+      expect(escapeCommentText('.->')).toEqual('.->');
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`escapeCommentText` matches each disallowed marker as a whole with a single global regex. Since `String.replace` with `/g` moves `lastIndex` past each match, a marker that overlaps one already consumed is never seen, and its delimiters stay unescaped.

`<!--!>` is the shortest case: the scanner takes `<!--` at offset 0 and resumes at offset 4, so the `--!>` sitting at offset 2 (it shares the `--`) is skipped. Only the leading `<` gets wrapped:

```ts
escapeCommentText('<!--!>');  // '​<​!--!>'  <- still ends the comment
escapeCommentText('<!--->');  // '​<​!--->'  <- same thing via '-->'
```

Walking the tokenizer over `<!--` + `​<​!--!><img src=x onerror=alert(1)>` + `-->`, the `!>` puts it in comment-end-bang and then back to the data state, so the comment closes early and the `<img>` after it parses as a live element. That is the round-trip the docstring on this function says it protects.

The existing spec covers each marker on its own (`'>'`, `'->'`, `'<!--'`, `'-->'`, `'--!>'`, `'<!-'`) but never two that share characters, which is why this slipped through.

## What is the new behavior?

The pattern matches the `<`/`>` delimiter along with its surrounding context rather than the whole marker, so nothing a later marker needs is consumed and overlapping markers are all escaped:

```ts
escapeCommentText('<!--!>');  // '​<​!--!​>​'
escapeCommentText('<!--->');  // '​<​!---​>​'
```

The accepted language is unchanged, so output for every case already in `dom_spec.ts` is byte-identical, including the ones that must stay untouched (`.>`, `.->`, `<!-.`). The three new expectations fail on `main` and pass here.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The reachable call site today is the `ngReflect` binding comment in `shared.ts`, which is dev-mode and opt-in, so the live blast radius is small. Fixing it in `escapeCommentText` anyway since the escaping contract is what the rest of the comment-node path relies on.
