### PR TITLE
refactor(compiler): enforce exhaustive defer trigger handling

### DIFF
--- a/packages/compiler/src/template/pipeline/src/phases/defer_resolve_targets.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/defer_resolve_targets.ts
@@ -52,7 +52,9 @@ export function resolveDeferTargetNames(job: ComponentCompilationJob): void {
     op: ir.DeferOnOp,
     placeholderView: ir.XrefId | null,
   ): void {
-    switch (op.trigger.kind) {
+    const triggerKind = op.trigger.kind;
+
+    switch (triggerKind) {
       case ir.DeferTriggerKind.Idle:
       case ir.DeferTriggerKind.Never:
       case ir.DeferTriggerKind.Immediate:
@@ -106,8 +108,11 @@ export function resolveDeferTargetNames(job: ComponentCompilationJob): void {
           step++;
         }
         break;
-      default:
-        throw new Error(`Trigger kind ${(op.trigger as any).kind} not handled`);
+      default: {
+        const unhandledTriggerKind: never = triggerKind;
+
+        throw new Error(`Trigger kind ${unhandledTriggerKind} not handled`);
+      }
     }
   }
 

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -403,7 +403,9 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
         break;
       case ir.OpKind.DeferOn:
         let args: o.Expression[] = [];
-        switch (op.trigger.kind) {
+        const triggerKind = op.trigger.kind;
+
+        switch (triggerKind) {
           case ir.DeferTriggerKind.Never:
           case ir.DeferTriggerKind.Immediate:
             break;
@@ -447,12 +449,13 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
               }
             }
             break;
-          default:
+          default: {
+            const unhandledTriggerKind: never = triggerKind;
+
             throw new Error(
-              `AssertionError: Unsupported reification of defer trigger kind ${
-                (op.trigger as any).kind
-              }`,
+              `AssertionError: Unsupported reification of defer trigger kind ${unhandledTriggerKind}`,
             );
+          }
         }
         ir.OpList.replace(op, ng.deferOn(op.trigger.kind, args, op.modifier, op.sourceSpan));
         break;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The defer trigger handling in `resolveDeferTargetNames` and `reifyCreateOperations` uses `as any` in the fallback branches.

This prevents TypeScript from checking that all `DeferTriggerKind` variants are handled. Adding a new trigger kind can therefore compile successfully while remaining unsupported in these phases.

## What is the new behavior?

Store the trigger kind before each switch and assign the value to `never` in the fallback branch.

This removes the `any` casts and makes the switches exhaustive. Adding a new `DeferTriggerKind` without handling it in either phase now produces a TypeScript compilation error.

Runtime behavior and error messages remain unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
