### PR TITLE
fix(core): reparse current markup in sanitizer stabilization loop

### DIFF
--- a/packages/core/src/sanitization/html_sanitizer.ts
+++ b/packages/core/src/sanitization/html_sanitizer.ts
@@ -307,7 +307,6 @@ export function _sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): Trusted
     inertBodyHelper = inertBodyHelper || getInertBodyHelper(defaultDoc);
     // Make sure unsafeHtml is actually a string (TypeScript types are not enforced at runtime).
     let unsafeHtml = unsafeHtmlInput ? String(unsafeHtmlInput) : '';
-    inertBodyElement = inertBodyHelper.getInertBodyElement(unsafeHtml);
 
     // mXSS protection. Repeatedly parse the document to make sure it stabilizes, so that a browser
     // trying to auto-correct incorrect HTML cannot cause formerly inert HTML to become dangerous.
@@ -321,8 +320,8 @@ export function _sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): Trusted
       mXSSAttempts--;
 
       unsafeHtml = parsedHtml;
-      parsedHtml = inertBodyElement!.innerHTML;
       inertBodyElement = inertBodyHelper.getInertBodyElement(unsafeHtml);
+      parsedHtml = inertBodyElement!.innerHTML;
     } while (unsafeHtml !== parsedHtml);
 
     const sanitizer = new SanitizingHtmlSerializer();

--- a/packages/core/src/sanitization/inert_body.ts
+++ b/packages/core/src/sanitization/inert_body.ts
@@ -39,10 +39,10 @@ class DOMParserHelper implements InertBodyHelper {
     // e.g. leading whitespace is maintained and tags like `<meta>` do not get hoisted to the
     // `<head>` tag. Note that the `<body>` tag is closed implicitly to prevent unclosed tags
     // in `html` from consuming the otherwise explicit `</body>` tag.
-    html = '<body><remove></remove>' + html;
+    const prefixedHtml = '<body><remove></remove>' + html;
     try {
       const body = new window.DOMParser().parseFromString(
-        trustedHTMLFromString(html) as string,
+        trustedHTMLFromString(prefixedHtml) as string,
         'text/html',
       ).body as HTMLBodyElement;
       if (body === null) {

--- a/packages/core/test/sanitization/html_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/html_sanitizer_spec.ts
@@ -297,6 +297,14 @@ describe('HTML sanitizer', () => {
   });
 
   if (isDOMParserAvailable()) {
+    it('should reject markup that never stabilizes when reparsed', () => {
+      // The tokenizer never leaves the PLAINTEXT state, so every reparse appends another
+      // literal `</plaintext>` and the markup has no fixed point.
+      expect(() => sanitizeHtml(defaultDoc, '<plaintext>a')).toThrowError(
+        /Failed to sanitize html because the input is unstable/,
+      );
+    });
+
     it('should work even if DOMParser returns a null body', () => {
       // Simulate `DOMParser.parseFromString()` returning a null body.
       // See https://github.com/angular/angular/issues/39834


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

1. In `_sanitizeHtml`, `parsedHtml` is read from an `inertBodyElement` that was parsed from the *previous* iteration's string. From the second iteration onward it recomputes the value just assigned to `unsafeHtml`, so `while (unsafeHtml !== parsedHtml)` compares a value against itself and the loop always exits after exactly two iterations, whether or not the markup reached a parse fixed point. A consequence worth calling out: `mXSSAttempts` can never reach 0, so the `input is unstable` throw is unreachable today.

2. `DOMParserHelper.getInertBodyElement` reassigns `html` to the `<body><remove></remove>` prefixed form and then passes that prefixed string to the `InertDocumentHelper` fallback, which never strips the sentinel. Each call adds another `<remove>`, so the fallback path has no fixed point either. The broken loop above was masking this.

`<plaintext>a` shows the first one: the tokenizer never leaves the PLAINTEXT state, so each reparse appends another literal `</plaintext>` and the markup never stabilizes, but sanitization currently reports it as stable and serializes a tree it never re-checked.

## What is the new behavior?

The loop reparses the current string before comparing, so stabilization is measured against the value actually being tested, and the attempt guard becomes reachable. The fallback keeps the prefix in a separate local and receives the original markup.

I checked the blast radius before/after over 20k generated tag-soup inputs against the real sanitizer: for every input that stabilizes, output is byte-identical. The only inputs whose behavior changes are ones that genuinely have no fixed point (`<plaintext>`), which now hit the guard instead of silently returning. Excluding `<plaintext>` from the generator, 20000/20000 are identical. Existing `html_sanitizer_spec` and `url_sanitizer_spec` pass unchanged; the added spec fails on `main` and passes here.

Happy to drop the added `<plaintext>` spec if you would rather not pin that behavior, since it is the one case where callers see a throw they did not see before.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
