### PR TITLE
build: require pinned PR head for benchmark comparisons

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -18,52 +18,121 @@ jobs:
           token: ${{secrets.BENCHMARK_COMPARE_MEMBERSHIP_GITHUB_TOKEN}}
           exit: true
 
+      - name: Resolve pull request head
+        id: pr-head
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          command_line="${COMMENT_BODY%%$'\n'*}"
+          command_line="${command_line%$'\r'}"
+          pr_api="repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"
+          head_repo="$(gh api "$pr_api" --jq '.head.repo.full_name')"
+          current_head_sha="$(gh api "$pr_api" --jq '.head.sha' | tr '[:upper:]' '[:lower:]')"
+
+          {
+            echo "repository=${head_repo}"
+            echo "sha=${current_head_sha}"
+            echo "command_line=${command_line}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [[ ! "$command_line" =~ (^|[[:space:]])sha=([0-9a-fA-F]{40})([[:space:]]|$) ]]; then
+            confirmation_command="${command_line} sha=${current_head_sha}"
+            delimiter="CONFIRMATION_COMMAND_${current_head_sha}"
+            {
+              echo "confirmed=false"
+              echo "confirmation-command<<${delimiter}"
+              echo "$confirmation_command"
+              echo "${delimiter}"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          expected_head_sha="${BASH_REMATCH[2],,}"
+          if [[ "$current_head_sha" != "$expected_head_sha" ]]; then
+            confirmation_command="${command_line//sha=${BASH_REMATCH[2]}/sha=${current_head_sha}}"
+            delimiter="CONFIRMATION_COMMAND_${current_head_sha}"
+            {
+              echo "confirmed=false"
+              echo "confirmation-command<<${delimiter}"
+              echo "$confirmation_command"
+              echo "${delimiter}"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "confirmed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Request pinned benchmark confirmation
+        if: steps.pr-head.outputs.confirmed != 'true'
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        with:
+          issue-number: ${{github.event.issue.number}}
+          token: '${{secrets.BENCHMARK_POST_RESULTS_GITHUB_TOKEN}}'
+          body: |
+            To run this benchmark, confirm the current PR head with:
+
+            ```
+            ${{steps.pr-head.outputs.confirmation-command}}
+            ```
+
+            If the PR changes before the command is re-run, this workflow will ask for a new confirmation.
+
       # Indicate that the benchmark command was received.
       - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        if: steps.pr-head.outputs.confirmed == 'true'
         with:
           comment-id: ${{github.event.comment.id}}
           token: '${{secrets.BENCHMARK_POST_RESULTS_GITHUB_TOKEN}}'
           reactions: 'rocket'
 
-      - uses: alessbell/pull-request-comment-branch@ef3408c9757d05f89cb525036383033a313758a0 # v2.1.0
-        id: comment-branch
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: steps.pr-head.outputs.confirmed == 'true'
         with:
           # Specify repository as the PR branch might be from a fork.
-          repository: ${{steps.comment-branch.outputs.head_owner}}/${{steps.comment-branch.outputs.head_repo}}
-          # Checkout the pull request and assume it being trusted given we've checked
-          # that the action was triggered by a team member.
-          ref: ${{steps.comment-branch.outputs.head_sha}}
+          repository: ${{steps.pr-head.outputs.repository}}
+          # Checkout the PR head SHA that was explicitly authorized in the benchmark command.
+          ref: ${{steps.pr-head.outputs.sha}}
 
       # We cannot use `angular/dev-infra/github-actions/npm/checkout-and-setup-node` here
       # because it does not support checking out from a fork (as it lacks a `repository` input).
       # Thus, we checkout and setup Node/pnpm manually.
       - name: Setup Node.js
+        if: steps.pr-head.outputs.confirmed == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
 
       - name: Install pnpm
+        if: steps.pr-head.outputs.confirmed == 'true'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
-      - run: pnpm install --frozen-lockfile
+      - if: steps.pr-head.outputs.confirmed == 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Setup Bazel
+        if: steps.pr-head.outputs.confirmed == 'true'
         uses: angular/dev-infra/github-actions/bazel/setup@442c2fcbf06a321b5196b4c5fc70e78a49242958
 
       - uses: angular/dev-infra/github-actions/bazel/configure-remote@442c2fcbf06a321b5196b4c5fc70e78a49242958
+        if: steps.pr-head.outputs.confirmed == 'true'
         with:
           bazelrc: ./.bazelrc.user
 
       - name: Preparing benchmark for GitHub action
+        if: steps.pr-head.outputs.confirmed == 'true'
         id: info
         env:
           # Untrusted input used in an executable code, must be wrapped as an env var to prevent injections
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_BODY: ${{ steps.pr-head.outputs.command_line }}
         run: pnpm benchmarks prepare-for-github-action "$COMMENT_BODY"
 
-      - env:
+      - if: steps.pr-head.outputs.confirmed == 'true'
+        env:
           COMPARE_SHA: ${{steps.info.outputs.compareSha}}
           BENCHMARK_TARGET: ${{steps.info.outputs.benchmarkTarget}}
         run: pnpm benchmarks run-compare "$COMPARE_SHA" "$BENCHMARK_TARGET"
@@ -71,6 +140,7 @@ jobs:
         name: Running benchmark
 
       - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        if: steps.pr-head.outputs.confirmed == 'true'
         with:
           issue-number: ${{github.event.issue.number}}
           token: '${{secrets.BENCHMARK_POST_RESULTS_GITHUB_TOKEN}}'

--- a/scripts/benchmarks/index.mts
+++ b/scripts/benchmarks/index.mts
@@ -82,7 +82,7 @@ async function promptForBenchmarkTarget(): Promise<string> {
  * e.g. command information or fetching/resolving Git refs of the comparison range.
  *
  * This is a helper used by the GitHub action to perform benchmark
- * comparisons. Commands follow the format of: `/benchmark-compare <sha> <target>`.
+ * comparisons. Commands follow the format of: `/benchmark-compare <sha> <target> sha=<pr-head-sha>`.
  */
 async function prepareForGitHubAction(commentBody: string): Promise<void> {
   const matches = /\/[^ ]+ ([^ ]+) ([^ ]+)/.exec(commentBody);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

This fixes an approval-to-checkout TOCTOU where an external fork author can cause unreviewed fork-controlled code to execute in Angular's privileged `issue_comment` benchmark workflow after a team member's `/benchmark-compare` comment. The workflow is currently triggered by a trusted commenter, but it resolves the PR head SHA at runtime rather than pinning the authorization to the commit the commenter saw.

Because the job installs the checked-out fork tree with `pnpm install --frozen-lockfile` and does not disable lifecycle scripts, a stale approval can allow attacker-controlled `preinstall` code to execute in the privileged workflow and capture repository secrets delivered to later steps, including the workflow token used by the final comment-update step.

The current vulnerable sequence is:

1. A fork PR is at benign head commit `X`.
2. An Angular team member comments `/benchmark-compare ...`, intending to run the benchmark for `X`.
3. Before the workflow resolves/checks out the PR head, the fork author pushes commit `Y`.
4. The workflow resolves the current PR head at runtime and checks out/runs `Y` in the privileged benchmark workflow.

## What is the new behavior?

This PR makes benchmark comparison approval commit-bound.

The workflow now requires `/benchmark-compare` comments to include the current PR head SHA:

```text
/benchmark-compare <target> sha=<pr-head-sha>
```

If the command is missing `sha=...`, the workflow stops before checkout/install/benchmark execution and posts a ready-to-use confirmation command containing the current PR head SHA.

If the command includes a SHA that no longer matches the current PR head, the workflow stops before checkout/install/benchmark execution and posts an updated confirmation command for the new head SHA.

Only when the requested SHA matches the current PR head does the workflow continue to checkout and benchmark execution. This prevents a post-approval PR head update from authorizing an unintended commit.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This changes the benchmark chatops confirmation flow, but it does not affect Angular package APIs or application behavior.

## Other information

Expected reviewer-visible behavior:

- First unpinned `/benchmark-compare ...` comment: workflow posts the exact pinned command to rerun.
- Matching pinned command: workflow proceeds.
- Stale pinned command after a force-push: workflow refuses to run the old approval and posts a fresh pinned command for the current head.

**Threat model**

- **Attacker:** external fork author who can push commits to their fork after a trusted team member posts `/benchmark-compare`.
- **Impact:** attacker-controlled lifecycle scripts can execute in the privileged `issue_comment` job.
- **Confirmed:** the workflow installs the fork workspace with lifecycle scripts enabled.

**CVSS v4.0:** `CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H/AU:A` = **8.9 (High)** 
**CVSS v3.1:** `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N` = **9.3 (Critical)**

(Updated the CVSS v4.0 vector to correct the User Interaction metric. I had forgotten to set UI, so the calculator defaulted to UI:N.)


**Validation**

- Reproduced locally and in a hosted replica using sentinel-only secrets, including capture of fake sentinel tokens in the privileged workflow.
- Confirmed the workflow token capture chain is reachable through attacker-controlled lifecycle execution.
- Ran actionlint .github/workflows/benchmark-compare.yml
- Ran git diff --check
- Tested the confirmation flow locally with Git Bash for unpinned, matching pinned, stale pinned, uppercase SHA, and multiline comment cases
- Verified the benchmark command parser still extracts the compare ref and target from the pinned command format

**Mitigation rationale**


This PR pins `/benchmark-compare` approvals to an explicit commit SHA to close the TOCTOU window. 

Additional reproduction artifacts, and validation evidence are available upon request.