### PR TITLE
fix(docs-infra): only claim a search on the 404 page when results exist

### DIFF
--- a/adev/src/app/features/not-found/not-found.html
+++ b/adev/src/app/features/not-found/not-found.html
@@ -4,8 +4,10 @@
     <div class="docs-not-found__bubble">
       <h1 tabindex="-1">Page Not Found</h1>
       <p>
-        We couldn't find what you were looking for. We have initiated a search for the term
-        extracted from the URL.
+        We couldn't find what you were looking for.
+        @if (searchResults().length > 0) {
+          We have initiated a search for the term extracted from the URL.
+        }
       </p>
       <p>
         If you think this is a mistake, please


### PR DESCRIPTION
The "Page Not Found" page always rendered the sentence "We have initiated a search for the term extracted from the URL", but the NotFound component only runs a search when a term can be extracted, and only renders results when there is at least one hit. On a 404 with no extractable term or no matching results, the page asserted a search it never backed up.

Gate the sentence behind the same searchResults() check that guards the results list, so the empty state simply reads "We couldn't find what you were looking for."

Before:
<img width="1020" height="449" alt="image" src="https://github.com/user-attachments/assets/22346efb-d6cf-4657-8e62-2302161f300c" />

After:
<img width="1023" height="456" alt="image" src="https://github.com/user-attachments/assets/13726e2a-28d0-494b-a292-9ecb26eb4781" />

<img width="1000" height="594" alt="image" src="https://github.com/user-attachments/assets/7c29a9ea-bba5-4233-868b-da7773ba59bb" />
