### PR TITLE
fix(forms):  ensure `pending` status propagates to the root form in s…

### DIFF
--- a/packages/forms/signals/src/field/validation.ts
+++ b/packages/forms/signals/src/field/validation.ts
@@ -293,7 +293,7 @@ export class FieldValidationState implements ValidationState {
   readonly pending = computed(() =>
     this.node.structure.reduceChildren(
       this.asyncErrors().includes('pending'),
-      (child, value) => value || child.validationState.asyncErrors().includes('pending'),
+      (child, value) => value || child.validationState.pending(),
     ),
   );
 

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -443,6 +443,42 @@ describe('validation status', () => {
       expect(f().invalid()).toBe(true);
     });
 
+    it('pending should flow from child to grandparent', async () => {
+      let res: Resource<unknown>;
+
+      const f = form(
+        signal({grandparent: {parent: {child: 'VALID'}}}),
+        (p) => {
+          validateAsync(p.grandparent.parent.child, {
+            params: ({value}) => value(),
+            factory: (params) =>
+              (res = resource({
+                params,
+                loader: ({params}) =>
+                  new Promise<ValidationError[]>((r) =>
+                    setTimeout(() => r(validateValueForChild(params, undefined))),
+                  ),
+              })),
+            onSuccess: (results) => results,
+            onError: () => null,
+          });
+        },
+        {injector},
+      );
+
+      expect(f.grandparent.parent.child().pending()).toBe(true);
+      expect(f.grandparent.parent().pending()).toBe(true);
+      expect(f.grandparent().pending()).toBe(true);
+      expect(f().pending()).toBe(true);
+
+      await appRef.whenStable();
+
+      expect(f.grandparent.parent.child().pending()).toBe(false);
+      expect(f.grandparent.parent().pending()).toBe(false);
+      expect(f.grandparent().pending()).toBe(false);
+      expect(f().pending()).toBe(false);
+    });
+
     it('should produce pending status during debounce period', async () => {
       let res: Resource<unknown>;
 


### PR DESCRIPTION
…ignal forms

Previously, the `pending()` status on a field's `ValidationState` only checked if the field itself or its immediate children had a pending asynchronous validator by directly inspecting `asyncErrors()`. This meant that a pending asynchronous validator deep within a nested form (e.g. on a grand-child) would not correctly bubble the `pending` state up to the root form.

fixes #69840
