### PR TITLE
fix(migrations): preserve NgClass import when unconverted bindings remain

### DIFF
--- a/packages/core/schematics/ng-generate/ngclass-to-class-migration/ngclass-to-class-migration.ts
+++ b/packages/core/schematics/ng-generate/ngclass-to-class-migration/ngclass-to-class-migration.ts
@@ -33,6 +33,16 @@ export interface NgClassMigrationData {
   replacements: Replacement[];
 }
 
+/** Result of migrating a single class declaration. */
+interface ClassMigrationResult {
+  replacements: Replacement[];
+  replacementCount: number;
+  /** Whether every `[ngClass]` binding in this class's template(s) was migrated. */
+  canRemoveNgClass: boolean;
+  /** Whether this class's template(s) no longer need any `CommonModule` directive. */
+  canRemoveCommonModule: boolean;
+}
+
 export interface NgClassCompilationUnitData {
   ngClassReplacements: Array<NgClassMigrationData>;
   importReplacements: Record<ProjectFileID, {add: Replacement[]; addAndRemove: Replacement[]}>;
@@ -55,14 +65,11 @@ export class NgClassMigration extends TsurgeFunnelMigration<
   ): {
     replacements: Replacement[];
     replacementCount: number;
+    canRemoveNgClass: boolean;
     canRemoveCommonModule: boolean;
   } | null {
-    const {migrated, changed, replacementCount, canRemoveCommonModule} = migrateNgClassBindings(
-      template.content,
-      this.config,
-      node,
-      typeChecker,
-    );
+    const {migrated, changed, replacementCount, canRemoveNgClass, canRemoveCommonModule} =
+      migrateNgClassBindings(template.content, this.config, node, typeChecker);
 
     if (!changed) {
       return null;
@@ -76,8 +83,57 @@ export class NgClassMigration extends TsurgeFunnelMigration<
     return {
       replacements: [prepareTextReplacement(fileToMigrate, migrated, template.start, end)],
       replacementCount,
+      canRemoveNgClass,
       canRemoveCommonModule,
     };
+  }
+
+  /** Migrates a single class declaration, if it has a component template using `[ngClass]`. */
+  private processClass(
+    node: ts.ClassDeclaration,
+    file: ProjectFile,
+    info: ProgramInfo,
+    typeChecker: ts.TypeChecker,
+  ): ClassMigrationResult | null {
+    const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
+    templateVisitor.visitNode(node);
+
+    const replacements: Replacement[] = [];
+    let replacementCount = 0;
+    let canRemoveNgClass = true;
+    let canRemoveCommonModule = true;
+
+    for (const template of templateVisitor.resolvedTemplates) {
+      const result = this.processTemplate(template, node, file, info, typeChecker);
+      if (result === null) {
+        continue;
+      }
+      replacements.push(...result.replacements);
+      replacementCount += result.replacementCount;
+      canRemoveNgClass = canRemoveNgClass && result.canRemoveNgClass;
+      canRemoveCommonModule = canRemoveCommonModule && result.canRemoveCommonModule;
+    }
+
+    if (replacements.length === 0) {
+      return null;
+    }
+
+    // Handle the `@Component({ imports: [...] })` array.
+    // Only remove NgClass from this class's own imports array if all of its [ngClass]
+    // bindings were migrated.
+    if (canRemoveNgClass) {
+      const importsRemoval = createNgClassImportsArrayRemoval(
+        node,
+        file,
+        typeChecker,
+        canRemoveCommonModule,
+      );
+      if (importsRemoval) {
+        replacements.push(importsRemoval);
+      }
+    }
+
+    return {replacements, replacementCount, canRemoveNgClass, canRemoveCommonModule};
   }
 
   override async analyze(info: ProgramInfo): Promise<Serializable<NgClassCompilationUnitData>> {
@@ -88,59 +144,40 @@ export class NgClassMigration extends TsurgeFunnelMigration<
     const filesToRemoveCommonModule = new Set<ProjectFileID>();
 
     for (const sf of sourceFiles) {
+      const file = projectFile(sf, info);
+      const classResults: ClassMigrationResult[] = [];
+
       ts.forEachChild(sf, (node: ts.Node) => {
         if (!ts.isClassDeclaration(node)) {
           return;
         }
-
-        const file = projectFile(sf, info);
-
         if (this.config.shouldMigrate && !this.config.shouldMigrate(file)) {
           return;
         }
 
-        const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
-        templateVisitor.visitNode(node);
-
-        const replacementsForClass: Replacement[] = [];
-        let replacementCountForClass = 0;
-        let canRemoveCommonModuleForFile = true;
-
-        for (const template of templateVisitor.resolvedTemplates) {
-          const result = this.processTemplate(template, node, file, info, typeChecker);
-          if (result) {
-            replacementsForClass.push(...result.replacements);
-            replacementCountForClass += result.replacementCount;
-            if (!result.canRemoveCommonModule) {
-              canRemoveCommonModuleForFile = false;
-            }
-          }
-        }
-
-        if (replacementsForClass.length > 0) {
-          if (canRemoveCommonModuleForFile) {
-            filesToRemoveCommonModule.add(file.id);
-          }
-
-          // Handle the `@Component({ imports: [...] })` array.
-          const importsRemoval = createNgClassImportsArrayRemoval(
-            node,
-            file,
-            typeChecker,
-            canRemoveCommonModuleForFile,
-          );
-          if (importsRemoval) {
-            replacementsForClass.push(importsRemoval);
-          }
-
-          ngClassReplacements.push({
-            file,
-            replacementCount: replacementCountForClass,
-            replacements: replacementsForClass,
-          });
-          filesWithNgClassDeclarations.add(sf);
+        const result = this.processClass(node, file, info, typeChecker);
+        if (result !== null) {
+          classResults.push(result);
         }
       });
+
+      if (classResults.length === 0) {
+        continue;
+      }
+
+      for (const {replacements, replacementCount} of classResults) {
+        ngClassReplacements.push({file, replacementCount, replacements});
+      }
+
+      // A single source file may declare multiple classes/components. The top-level
+      // `NgClass`/`CommonModule` import statements are shared across all of them, so they can
+      // only be removed once every class in the file no longer needs them.
+      if (classResults.every((result) => result.canRemoveNgClass)) {
+        filesWithNgClassDeclarations.add(sf);
+      }
+      if (classResults.every((result) => result.canRemoveCommonModule)) {
+        filesToRemoveCommonModule.add(file.id);
+      }
     }
 
     const importReplacements = calculateImportReplacements(

--- a/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
+++ b/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
@@ -39,11 +39,18 @@ export function migrateNgClassBindings(
   replacementCount: number;
   migrated: string;
   changed: boolean;
+  canRemoveNgClass: boolean;
   canRemoveCommonModule: boolean;
 } {
   const parsed = parseTemplate(template);
   if (!parsed.tree || !parsed.tree.rootNodes.length) {
-    return {migrated: template, changed: false, replacementCount: 0, canRemoveCommonModule: false};
+    return {
+      migrated: template,
+      changed: false,
+      replacementCount: 0,
+      canRemoveNgClass: true,
+      canRemoveCommonModule: false,
+    };
   }
 
   const visitor = new NgClassCollector(template, componentNode, typeChecker);
@@ -66,6 +73,7 @@ export function migrateNgClassBindings(
     migrated: newTemplate,
     changed,
     replacementCount,
+    canRemoveNgClass: visitor.skippedNgClassCount === 0,
     canRemoveCommonModule: changed ? canRemoveCommonModule(newTemplate) : false,
   };
 }
@@ -249,6 +257,7 @@ function replaceTemplate(
  */
 export class NgClassCollector extends RecursiveVisitor {
   readonly replacements: {start: number; end: number; replacement: string}[] = [];
+  skippedNgClassCount = 0;
   private originalTemplate: string;
   private isNgClassImported: boolean = true; // Default to true (permissive)
 
@@ -290,6 +299,7 @@ export class NgClassCollector extends RecursiveVisitor {
         const staticMatch = tryParseStaticObjectLiteral(expr);
 
         if (staticMatch === null) {
+          this.skippedNgClassCount++;
           continue;
         }
 

--- a/packages/core/schematics/test/ngclass_to_class_migration_spec.ts
+++ b/packages/core/schematics/test/ngclass_to_class_migration_spec.ts
@@ -102,6 +102,99 @@ describe('NgClass migration', () => {
     expect(content).not.toContain('imports:');
   });
 
+  it('should preserve NgClass import when unconverted [ngClass] bindings remain', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+          imports: [NgClass],
+          template: \`
+            <div [ngClass]="{ active: isActive }">migrated</div>
+            <div [ngClass]="['class-a', condition ? 'class-b' : '']">skipped (array)</div>
+          \`,
+        })
+        export class App {
+          isActive = true;
+          condition = true;
+        }
+      `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/app.component.ts');
+
+    // The object literal binding should be migrated.
+    expect(content).toContain('[class.active]="isActive"');
+    // The array binding should remain as [ngClass].
+    expect(content).toContain("[ngClass]=\"['class-a', condition ? 'class-b' : '']\"");
+    // NgClass import must be preserved since [ngClass] still exists in the template.
+    expect(content).toContain("import {NgClass} from '@angular/common';");
+    expect(content).toContain('imports: [NgClass]');
+  });
+
+  it('should preserve the shared NgClass import when one of several components in the same file is only partially migrated', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+
+        @Component({
+          selector: 'fully-migrated',
+          imports: [NgClass],
+          template: \`<div [ngClass]="{ active: isActive }">migrated</div>\`,
+        })
+        export class FullyMigrated {
+          isActive = true;
+        }
+
+        @Component({
+          selector: 'partially-migrated',
+          imports: [NgClass],
+          template: \`
+            <div [ngClass]="{ active: isActive }">migrated</div>
+            <div [ngClass]="['class-a', condition ? 'class-b' : '']">skipped (array)</div>
+          \`,
+        })
+        export class PartiallyMigrated {
+          isActive = true;
+          condition = true;
+        }
+      `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/app.component.ts');
+    // Split the file so each component's decorator/template can be asserted on independently -
+    // both components still contain the literal text `imports: [NgClass]` in their source before
+    // migration, so a plain `content.includes(...)` check on the whole file can't distinguish
+    // between them.
+    const partiallyMigratedIndex = content.indexOf("selector: 'partially-migrated'");
+    const fullyMigratedSection = content.slice(0, partiallyMigratedIndex);
+    const partiallyMigratedSection = content.slice(partiallyMigratedIndex);
+
+    // The fully migratable component's [ngClass] should be converted, and its own `imports`
+    // array should no longer list `NgClass` since it doesn't need it anymore.
+    expect(fullyMigratedSection).toContain('[class.active]="isActive"');
+    expect(fullyMigratedSection).not.toContain('imports:');
+
+    // The partially migrated component keeps its unconvertible binding as [ngClass], and its
+    // own `imports` array must still list `NgClass`.
+    expect(partiallyMigratedSection).toContain('[class.active]="isActive"');
+    expect(partiallyMigratedSection).toContain(
+      "[ngClass]=\"['class-a', condition ? 'class-b' : '']\"",
+    );
+    expect(partiallyMigratedSection).toContain('imports: [NgClass]');
+
+    // Because `PartiallyMigrated` still needs `NgClass`, the shared top-level import statement
+    // must be preserved even though `FullyMigrated` no longer needs it.
+    expect(content).toContain("import {NgClass} from '@angular/common';");
+  });
+
   describe('No change cases', () => {
     it('should not change static HTML elements', async () => {
       writeFile(


### PR DESCRIPTION

Fixes https://github.com/angular/angular/issues/69844
\ which the migration intentionally skips). This breaks the build with:

\\\
NG8002: Can't bind to 'ngClass' since it isn't a known property of 'div'.
\\\

### Root Cause

In \util.ts\, the \NgClassCollector\ visitor skips bindings it can't convert (returns \continue\), but nothing tracked how many were skipped. The migration then unconditionally removed the \NgClass\ import.

### Fix

- Added \skippedNgClassCount\ to \NgClassCollector\ — incremented whenever a \[ngClass]\ binding is skipped.
- \migrateNgClassBindings\ now returns \canRemoveNgClass: visitor.skippedNgClassCount === 0\.
- In \nalyze()\, the \NgClass\ import removal (both decorator array and TS import) is now **only performed when all bindings were successfully migrated**.
- Added a regression test covering the mixed-binding scenario from the issue.

### Testing

Added a regression test: a component with one migratable object-literal binding and one non-migratable array binding — after migration the object binding is converted, the array binding remains, and **both** the \NgClass\ decorator import and TypeScript import are preserved.