### PR TITLE
fix(migrations): preserve NgClass import when unconverted bindings re…

### DIFF
--- a/packages/core/schematics/ng-generate/ngclass-to-class-migration/ngclass-to-class-migration.ts
+++ b/packages/core/schematics/ng-generate/ngclass-to-class-migration/ngclass-to-class-migration.ts
@@ -33,6 +33,16 @@ export interface NgClassMigrationData {
   replacements: Replacement[];
 }
 
+/** Result of migrating a single class declaration. */
+interface ClassMigrationResult {
+  replacements: Replacement[];
+  replacementCount: number;
+  /** Whether every `[ngClass]` binding in this class's template(s) was migrated. */
+  canRemoveNgClass: boolean;
+  /** Whether this class's template(s) no longer need any `CommonModule` directive. */
+  canRemoveCommonModule: boolean;
+}
+
 export interface NgClassCompilationUnitData {
   ngClassReplacements: Array<NgClassMigrationData>;
   importReplacements: Record<ProjectFileID, {add: Replacement[]; addAndRemove: Replacement[]}>;
@@ -55,17 +65,25 @@ export class NgClassMigration extends TsurgeFunnelMigration<
   ): {
     replacements: Replacement[];
     replacementCount: number;
+    canRemoveNgClass: boolean;
     canRemoveCommonModule: boolean;
-  } | null {
-    const {migrated, changed, replacementCount, canRemoveCommonModule} = migrateNgClassBindings(
-      template.content,
-      this.config,
-      node,
-      typeChecker,
-    );
+  } {
+    const {migrated, changed, replacementCount, canRemoveNgClass, canRemoveCommonModule} =
+      migrateNgClassBindings(template.content, this.config, node, typeChecker);
 
     if (!changed) {
-      return null;
+      // Even when no replacements were made, we must propagate the real `canRemoveNgClass`
+      // value. If the template contained [ngClass] bindings that could not be migrated (e.g.
+      // dynamic variable or array bindings), the visitor's `skippedNgClassCount` will be > 0
+      // and `canRemoveNgClass` will be false. Returning `true` here unconditionally would
+      // cause the migration to incorrectly strip `NgClass` from the component's `imports`
+      // array and from the top-level import statement.
+      return {
+        replacements: [],
+        replacementCount: 0,
+        canRemoveNgClass,
+        canRemoveCommonModule,
+      };
     }
 
     const fileToMigrate = template.inline
@@ -76,8 +94,54 @@ export class NgClassMigration extends TsurgeFunnelMigration<
     return {
       replacements: [prepareTextReplacement(fileToMigrate, migrated, template.start, end)],
       replacementCount,
+      canRemoveNgClass,
       canRemoveCommonModule,
     };
+  }
+
+  /** Migrates a single class declaration, if it has a component template using `[ngClass]`. */
+  private processClass(
+    node: ts.ClassDeclaration,
+    file: ProjectFile,
+    info: ProgramInfo,
+    typeChecker: ts.TypeChecker,
+  ): ClassMigrationResult | null {
+    const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
+    templateVisitor.visitNode(node);
+
+    if (templateVisitor.resolvedTemplates.length === 0) {
+      return null;
+    }
+
+    const replacements: Replacement[] = [];
+    let replacementCount = 0;
+    let canRemoveNgClass = true;
+    let canRemoveCommonModule = true;
+
+    for (const template of templateVisitor.resolvedTemplates) {
+      const result = this.processTemplate(template, node, file, info, typeChecker);
+
+      replacements.push(...result.replacements);
+      replacementCount += result.replacementCount;
+      canRemoveNgClass = canRemoveNgClass && result.canRemoveNgClass;
+      canRemoveCommonModule = canRemoveCommonModule && result.canRemoveCommonModule;
+    }
+
+    // Handle the `@Component({ imports: [...] })` array.
+    // Only remove NgClass from this class's own imports array if all of its [ngClass] bindings were migrated.
+    if (canRemoveNgClass) {
+      const importsRemoval = createNgClassImportsArrayRemoval(
+        node,
+        file,
+        typeChecker,
+        canRemoveCommonModule,
+      );
+      if (importsRemoval) {
+        replacements.push(importsRemoval);
+      }
+    }
+
+    return {replacements, replacementCount, canRemoveNgClass, canRemoveCommonModule};
   }
 
   override async analyze(info: ProgramInfo): Promise<Serializable<NgClassCompilationUnitData>> {
@@ -88,59 +152,42 @@ export class NgClassMigration extends TsurgeFunnelMigration<
     const filesToRemoveCommonModule = new Set<ProjectFileID>();
 
     for (const sf of sourceFiles) {
+      const file = projectFile(sf, info);
+      const classResults: ClassMigrationResult[] = [];
+
       ts.forEachChild(sf, (node: ts.Node) => {
         if (!ts.isClassDeclaration(node)) {
           return;
         }
-
-        const file = projectFile(sf, info);
-
         if (this.config.shouldMigrate && !this.config.shouldMigrate(file)) {
           return;
         }
 
-        const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
-        templateVisitor.visitNode(node);
-
-        const replacementsForClass: Replacement[] = [];
-        let replacementCountForClass = 0;
-        let canRemoveCommonModuleForFile = true;
-
-        for (const template of templateVisitor.resolvedTemplates) {
-          const result = this.processTemplate(template, node, file, info, typeChecker);
-          if (result) {
-            replacementsForClass.push(...result.replacements);
-            replacementCountForClass += result.replacementCount;
-            if (!result.canRemoveCommonModule) {
-              canRemoveCommonModuleForFile = false;
-            }
-          }
-        }
-
-        if (replacementsForClass.length > 0) {
-          if (canRemoveCommonModuleForFile) {
-            filesToRemoveCommonModule.add(file.id);
-          }
-
-          // Handle the `@Component({ imports: [...] })` array.
-          const importsRemoval = createNgClassImportsArrayRemoval(
-            node,
-            file,
-            typeChecker,
-            canRemoveCommonModuleForFile,
-          );
-          if (importsRemoval) {
-            replacementsForClass.push(importsRemoval);
-          }
-
-          ngClassReplacements.push({
-            file,
-            replacementCount: replacementCountForClass,
-            replacements: replacementsForClass,
-          });
-          filesWithNgClassDeclarations.add(sf);
+        const result = this.processClass(node, file, info, typeChecker);
+        if (result !== null) {
+          classResults.push(result);
         }
       });
+
+      if (classResults.length === 0) {
+        continue;
+      }
+
+      for (const {replacements, replacementCount} of classResults) {
+        if (replacements.length > 0) {
+          ngClassReplacements.push({file, replacementCount, replacements});
+        }
+      }
+
+      // A single source file may declare multiple classes/components. The top-level
+      // `NgClass`/`CommonModule` import statements are shared across all of them, so they can
+      // only be removed once every class in the file no longer needs them.
+      if (classResults.every((result) => result.canRemoveNgClass)) {
+        filesWithNgClassDeclarations.add(sf);
+      }
+      if (classResults.every((result) => result.canRemoveCommonModule)) {
+        filesToRemoveCommonModule.add(file.id);
+      }
     }
 
     const importReplacements = calculateImportReplacements(

--- a/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
+++ b/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
@@ -39,11 +39,18 @@ export function migrateNgClassBindings(
   replacementCount: number;
   migrated: string;
   changed: boolean;
+  canRemoveNgClass: boolean;
   canRemoveCommonModule: boolean;
 } {
   const parsed = parseTemplate(template);
   if (!parsed.tree || !parsed.tree.rootNodes.length) {
-    return {migrated: template, changed: false, replacementCount: 0, canRemoveCommonModule: false};
+    return {
+      migrated: template,
+      changed: false,
+      replacementCount: 0,
+      canRemoveNgClass: true,
+      canRemoveCommonModule: false,
+    };
   }
 
   const visitor = new NgClassCollector(template, componentNode, typeChecker);
@@ -66,6 +73,7 @@ export function migrateNgClassBindings(
     migrated: newTemplate,
     changed,
     replacementCount,
+    canRemoveNgClass: visitor.skippedNgClassCount === 0,
     canRemoveCommonModule: changed ? canRemoveCommonModule(newTemplate) : false,
   };
 }
@@ -249,6 +257,7 @@ function replaceTemplate(
  */
 export class NgClassCollector extends RecursiveVisitor {
   readonly replacements: {start: number; end: number; replacement: string}[] = [];
+  skippedNgClassCount = 0;
   private originalTemplate: string;
   private isNgClassImported: boolean = true; // Default to true (permissive)
 
@@ -290,6 +299,7 @@ export class NgClassCollector extends RecursiveVisitor {
         const staticMatch = tryParseStaticObjectLiteral(expr);
 
         if (staticMatch === null) {
+          this.skippedNgClassCount++;
           continue;
         }
 

--- a/packages/core/schematics/test/ngclass_to_class_migration_spec.ts
+++ b/packages/core/schematics/test/ngclass_to_class_migration_spec.ts
@@ -102,6 +102,144 @@ describe('NgClass migration', () => {
     expect(content).not.toContain('imports:');
   });
 
+  it('should preserve NgClass import when unconverted [ngClass] bindings remain', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+          imports: [NgClass],
+          template: \`
+            <div [ngClass]="{ active: isActive }">migrated</div>
+            <div [ngClass]="['class-a', condition ? 'class-b' : '']">skipped (array)</div>
+          \`,
+        })
+        export class App {
+          isActive = true;
+          condition = true;
+        }
+      `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/app.component.ts');
+
+    // The object literal binding should be migrated.
+    expect(content).toContain('[class.active]="isActive"');
+    // The array binding should remain as [ngClass].
+    expect(content).toContain("[ngClass]=\"['class-a', condition ? 'class-b' : '']\"");
+    // NgClass import must be preserved since [ngClass] still exists in the template.
+    expect(content).toContain("import {NgClass} from '@angular/common';");
+    expect(content).toContain('imports: [NgClass]');
+  });
+
+  it('should preserve the shared NgClass import when one of several components in the same file is only partially migrated', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+
+        @Component({
+          selector: 'fully-migrated',
+          imports: [NgClass],
+          template: \`<div [ngClass]="{ active: isActive }">migrated</div>\`,
+        })
+        export class FullyMigrated {
+          isActive = true;
+        }
+
+        @Component({
+          selector: 'partially-migrated',
+          imports: [NgClass],
+          template: \`
+            <div [ngClass]="{ active: isActive }">migrated</div>
+            <div [ngClass]="['class-a', condition ? 'class-b' : '']">skipped (array)</div>
+          \`,
+        })
+        export class PartiallyMigrated {
+          isActive = true;
+          condition = true;
+        }
+      `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/app.component.ts');
+    // Split the file so each component's decorator/template can be asserted on independently -
+    // both components still contain the literal text `imports: [NgClass]` in their source before
+    // migration, so a plain `content.includes(...)` check on the whole file can't distinguish
+    // between them.
+    const partiallyMigratedIndex = content.indexOf("selector: 'partially-migrated'");
+    const fullyMigratedSection = content.slice(0, partiallyMigratedIndex);
+    const partiallyMigratedSection = content.slice(partiallyMigratedIndex);
+
+    // The fully migratable component's [ngClass] should be converted, and its own `imports`
+    // array should no longer list `NgClass` since it doesn't need it anymore.
+    expect(fullyMigratedSection).toContain('[class.active]="isActive"');
+    expect(fullyMigratedSection).not.toContain('imports:');
+
+    // The partially migrated component keeps its unconvertible binding as [ngClass], and its
+    // own `imports` array must still list `NgClass`.
+    expect(partiallyMigratedSection).toContain('[class.active]="isActive"');
+    expect(partiallyMigratedSection).toContain(
+      "[ngClass]=\"['class-a', condition ? 'class-b' : '']\"",
+    );
+    expect(partiallyMigratedSection).toContain('imports: [NgClass]');
+
+    // Because `PartiallyMigrated` still needs `NgClass`, the shared top-level import statement
+    // must be preserved even though `FullyMigrated` no longer needs it.
+    expect(content).toContain("import {NgClass} from '@angular/common';");
+  });
+
+  it('should preserve the shared NgClass import when one of several components in the same file is completely skipped', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+
+        @Component({
+          selector: 'fully-migrated',
+          imports: [NgClass],
+          template: \`<div [ngClass]="{ active: isActive }">migrated</div>\`,
+        })
+        export class FullyMigrated {
+          isActive = true;
+        }
+
+        @Component({
+          selector: 'completely-skipped',
+          imports: [NgClass],
+          template: \`
+            <div [ngClass]="dynamicVar">skipped (dynamic)</div>
+          \`,
+        })
+        export class CompletelySkipped {
+          dynamicVar = 'class-a';
+        }
+      `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/app.component.ts');
+    const skippedIndex = content.indexOf("selector: 'completely-skipped'");
+    const fullyMigratedSection = content.slice(0, skippedIndex);
+    const completelySkippedSection = content.slice(skippedIndex);
+
+    expect(fullyMigratedSection).toContain('[class.active]="isActive"');
+    expect(fullyMigratedSection).not.toContain('imports:');
+
+    expect(completelySkippedSection).toContain('[ngClass]="dynamicVar"');
+    expect(completelySkippedSection).toContain('imports: [NgClass]');
+
+    expect(content).toContain("import {NgClass} from '@angular/common';");
+  });
+
   describe('No change cases', () => {
     it('should not change static HTML elements', async () => {
       writeFile(
@@ -656,6 +794,82 @@ describe('NgClass migration', () => {
       expect(content).toContain(`[class]="{'admin': isAdmin, dense: density === 'high'}"`);
       expect(content).toContain('imports: [CommonModule]');
       expect(content).toContain("import {CommonModule} from '@angular/common';");
+    });
+
+    it('should not remove CommonModule when a component has no [ngClass] but still uses *ngIf', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {CommonModule} from '@angular/common';
+        @Component({
+          standalone: true,
+          imports: [CommonModule],
+          template: \`
+            <div *ngIf="condition">
+              <p>{{item}}</p>
+            </div>
+          \`
+        })
+        export class Cmp {
+          condition = true;
+        }
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      // No [ngClass] binding exists, so nothing should be migrated in the template...
+      expect(content).toContain('*ngIf="condition"');
+      // ...but the component still needs `CommonModule` for `*ngIf`, so it must not be removed
+      // from either the `imports` array or the top-level import statement.
+      expect(content).toContain('imports: [CommonModule]');
+      expect(content).toContain("import {CommonModule} from '@angular/common';");
+    });
+
+    it('should not remove CommonModule from a skipped component (no [ngClass]) when another component in the same file is migrated', async () => {
+      // Regression test: when ComponentA is fully migrated and ComponentB has no [ngClass]
+      // at all but uses *ngIf (via CommonModule), the migration must not strip CommonModule
+      // from ComponentB because it was "completely skipped" (zero ngClass bindings).
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgClass, CommonModule} from '@angular/common';
+
+        @Component({
+          standalone: true,
+          imports: [NgClass],
+          template: \`<div [ngClass]="{'admin': isAdmin}"></div>\`
+        })
+        export class CmpA {}
+
+        @Component({
+          standalone: true,
+          imports: [CommonModule],
+          template: \`<div *ngIf="condition"><p>{{item}}</p></div>\`
+        })
+        export class CmpB {
+          condition = true;
+        }
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      // CmpA should have been migrated — NgClass removed, [class.admin] used
+      expect(content).toContain('[class.admin]="isAdmin"');
+      expect(content).not.toContain('imports: [NgClass]');
+
+      // CmpB was completely skipped (no [ngClass]), so CommonModule must be preserved
+      expect(content).toContain('imports: [CommonModule]');
+      expect(content).toContain("import {CommonModule} from '@angular/common';");
+      // The *ngIf binding must remain untouched
+      expect(content).toContain('*ngIf="condition"');
     });
   });
 


### PR DESCRIPTION

When the ngclass-to-class migration partially converts a component's template (e.g. object literals migrate but array expressions or space-separated keys are skipped), the NgClass import was unconditionally removed from both the @Component({ imports }) array and the TypeScript import statement, breaking the build with NG8002.

Fix: track skippedNgClassCount in NgClassCollector for every [ngClass] binding that is skipped (non-object-literal expressions, and space-separated keys when migrateSpaceSeparatedKey=false). Only remove the NgClass import when all [ngClass] bindings in the template were successfully migrated.

Also add import-preservation assertions to the existing 'Non-migratable' edge case tests, and add four new partial-migration regression tests covering array expressions, dynamic variables, function calls, and space-separated keys mixed with a migratable binding.

Fixes #69844

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
