### PR TITLE
fix(core): ensure SVG animation attributeName is checked case-insensitively

### DIFF
--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -277,7 +277,6 @@ function getSanitizer(): Sanitizer | null {
  * Set of attributes that are sensitive and should be sanitized.
  */
 const SECURITY_SENSITIVE_ATTRIBUTE_NAMES: ReadonlySet<string> = new Set(['href', 'xlink:href']);
-const SVG_ANIMATION_ATTRIBUTE_NAME_CANDIDATES = ['attributeName', 'attributename'] as const;
 
 /**
  * @remarks Keep this in sync with DOM Security Schema.
@@ -394,7 +393,11 @@ function getSecuritySensitiveSVGAnimationAttributeName(
   element: SVGAnimateElement,
   validationConfig: ReadonlySet<string>,
 ): string | null {
-  for (const attributeName of SVG_ANIMATION_ATTRIBUTE_NAME_CANDIDATES) {
+  for (const attributeName of element.getAttributeNames()) {
+    if (attributeName.toLowerCase() !== 'attributename') {
+      continue;
+    }
+
     const attributeNameValue = element.getAttribute(attributeName);
     if (attributeNameValue !== null && validationConfig.has(attributeNameValue.toLowerCase())) {
       return attributeNameValue;

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -662,22 +662,6 @@ describe('sanitization', () => {
     );
   });
 
-  it('should throw when binding to set element with attributeName="href"', () => {
-    @Component({
-      selector: 'test-comp',
-      template: `<svg><set attributeName="href" [to]="'foo'"></set></svg>`,
-    })
-    class TestComp {}
-
-    TestBed.configureTestingModule({
-      providers: [provideZoneChangeDetection()],
-    });
-    const fixture = TestBed.createComponent(TestComp);
-    expect(() => fixture.detectChanges()).toThrowError(
-      /Angular has detected that the `to` was applied/,
-    );
-  });
-
   // The SVG `attributeName` is case-sensitive when accessed via the DOM API
   // (i.e. `setAttribute('attributename', ...)` and `setAttribute('attributeName', ...)`
   // create two distinct attributes). However, the browser tokenizer normalizes
@@ -686,21 +670,23 @@ describe('sanitization', () => {
   // The SSR renderer (Domino) does not perform this normalization, so we
   // explicitly look up the lowercase form as well to make sure the sanitizer
   // is triggered consistently in both environments.
-  it('should throw when binding to set element with attributename="href"', () => {
-    @Component({
-      selector: 'test-comp',
-      template: `<svg><set attributename="href" [attr.to]="'foo'"></set></svg>`,
-    })
-    class TestComp {}
+  for (const attr of ['attributeName', 'attributename', 'attributenAme']) {
+    it(`should throw when binding to set element with ${attr}="href"`, () => {
+      @Component({
+        selector: 'test-comp',
+        template: `<svg><set ${attr}="href" [attr.to]="'foo'"></set></svg>`,
+      })
+      class TestComp {}
 
-    TestBed.configureTestingModule({
-      providers: [provideZoneChangeDetection()],
+      TestBed.configureTestingModule({
+        providers: [provideZoneChangeDetection()],
+      });
+      const fixture = TestBed.createComponent(TestComp);
+      expect(() => fixture.detectChanges()).toThrowError(
+        /Angular has detected that the `to` was applied/,
+      );
     });
-    const fixture = TestBed.createComponent(TestComp);
-    expect(() => fixture.detectChanges()).toThrowError(
-      /Angular has detected that the `to` was applied/,
-    );
-  });
+  }
 
   it('should not throw when binding to animate element when attributeName is not href', () => {
     @Component({


### PR DESCRIPTION
Currently, the SVG sanitizer checks a static set of candidate attribute names (`attributeName` and `attributename`). This approach misses other case variations (such as `attributenAme` or others), which could potentially bypass sanitization when binding sensitive attributes like `href` on `<set>` or `<animate>` elements.

This change retrieves all attribute names of the SVG element, performs a case-insensitive comparison with `'attributename'`, and sanitizes the value if a match is found.