### PR TITLE
fix(migrations): correctly migrate ngClass keys mixing space-separated and regular class names

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -203,6 +203,7 @@ rollup.rollup(
         "bundles",
     ],
     visibility = [
+        "//packages/core/schematics/ng-generate/ngclass-to-class-migration:__pkg__",
         "//packages/core/schematics/test:__pkg__",
     ],
 )

--- a/packages/core/schematics/ng-generate/ngclass-to-class-migration/BUILD.bazel
+++ b/packages/core/schematics/ng-generate/ngclass-to-class-migration/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "copy_to_bin", "ts_project")
+load("//tools:defaults.bzl", "copy_to_bin", "jasmine_test", "ts_project")
 
 package(
     default_visibility = [
@@ -14,7 +14,10 @@ copy_to_bin(
 
 ts_project(
     name = "ngclass-to-class-migration",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["*_spec.ts"],
+    ),
     data = ["schema.json"],
     deps = [
         "//:node_modules/@angular-devkit/schematics",
@@ -26,5 +29,30 @@ ts_project(
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tsurge",
         "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+    ],
+)
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(["*_spec.ts"]),
+    deps = [
+        "//:node_modules/@angular-devkit/core",
+        "//:node_modules/@angular-devkit/schematics",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+    ],
+)
+
+jasmine_test(
+    name = "test",
+    timeout = "moderate",
+    data = [
+        ":static_files",
+        ":test_lib",
+        "//:node_modules/@angular/compiler",
+        "//:node_modules/@angular/compiler-cli",
+        "//packages/core/schematics:bundles",
+        "//packages/core/schematics:schematics_jsons",
     ],
 )

--- a/packages/core/schematics/ng-generate/ngclass-to-class-migration/ngclass_to_class_migration_spec.ts
+++ b/packages/core/schematics/ng-generate/ngclass-to-class-migration/ngclass_to_class_migration_spec.ts
@@ -25,7 +25,7 @@ describe('NgClass migration', () => {
     return runner.runSchematic('ngclass-to-class', options, tree);
   }
 
-  const collectionJsonPath = resolve('../collection.json');
+  const collectionJsonPath = resolve('../../collection.json');
   beforeEach(() => {
     runner = new SchematicTestRunner('test', collectionJsonPath);
     host = new TempScopedNodeJsSyncHost();
@@ -126,7 +126,6 @@ describe('NgClass migration', () => {
 
     const content = tree.readContent('/app.component.ts');
 
-    // The object literal binding should be migrated.
     expect(content).toContain('[class.active]="isActive"');
     // The array binding should remain as [ngClass].
     expect(content).toContain("[ngClass]=\"['class-a', condition ? 'class-b' : '']\"");
@@ -505,7 +504,10 @@ describe('NgClass migration', () => {
   });
 
   describe('Complex and multi-element migrations', () => {
-    it('should migrate complex object literals with mixed class keys to [class] binding', async () => {
+    it('should not migrate a space-separated key mixed with a regular key to [class] binding by default', async () => {
+      // Regression test for https://github.com/angular/angular/issues/69833 — [class]="{...}"
+      // object syntax does not support space-separated key names, so without
+      // `migrateSpaceSeparatedKey` the binding must be left as [ngClass].
       writeFile(
         '/app.component.ts',
         `
@@ -525,8 +527,9 @@ describe('NgClass migration', () => {
       const content = tree.readContent('/app.component.ts');
 
       expect(content).toContain(
-        `<div [class]="{'class1 class2': condition, 'class3': anotherCondition}"></div>`,
+        `<div [ngClass]="{'class1 class2': condition, 'class3': anotherCondition}"></div>`,
       );
+      expect(content).not.toContain('[class]=');
     });
 
     it('should migrate keys with extra whitespace for multiple conditions', async () => {
@@ -1039,7 +1042,7 @@ describe('migrateSpaceSeparatedKey option', () => {
     return runner.runSchematic('ngclass-to-class', options, tree);
   }
 
-  const collectionJsonPath = resolve('../collection.json');
+  const collectionJsonPath = resolve('../../collection.json');
   beforeEach(() => {
     runner = new SchematicTestRunner('test', collectionJsonPath);
     host = new TempScopedNodeJsSyncHost();
@@ -1074,5 +1077,225 @@ describe('migrateSpaceSeparatedKey option', () => {
     const content = tree.readContent('/app.component.ts');
 
     expect(content).toContain(`<div [class.class1]="condition" [class.class2]="condition"></div>`);
+  });
+
+  it('should expand mixed space-separated and regular keys individually', async () => {
+    // Regression test for https://github.com/angular/angular/issues/69833
+    // The object has one key with spaces ('class1 class2') and one plain key ('class3'),
+    // each with a different condition. The [class]="..." fallback cannot represent
+    // space-separated key names, so every entry must be emitted as [class.X]="condition".
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{'class1 class2': condition, 'class3': condition2}"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({migrateSpaceSeparatedKey: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(
+      `<div [class.class1]="condition" [class.class2]="condition" [class.class3]="condition2"></div>`,
+    );
+  });
+
+  it('should not expand when a space-separated key is mixed with an empty-string key', async () => {
+    // Expanding every binding as [class.${key}] would produce the invalid `[class.]` binding
+    // for the empty key, so the whole binding must be left unchanged instead.
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{'class1 class2': condition, '': condition2}"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({migrateSpaceSeparatedKey: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(
+      `<div [ngClass]="{'class1 class2': condition, '': condition2}"></div>`,
+    );
+    expect(content).not.toContain('[class.]');
+  });
+
+  it('should not expand when a space-separated key expansion produces a duplicate class name', async () => {
+    // 'class1 class2': first expands to class1/class2, and the separate 'class1' key would
+    // collide with the expanded class1 binding, producing two conflicting [class.class1]
+    // bindings on the same element. The binding must be left unchanged instead.
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{'class1 class2': first, class1: second}"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({migrateSpaceSeparatedKey: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(`<div [ngClass]="{'class1 class2': first, class1: second}"></div>`);
+  });
+
+  it('should not expand a space-separated key whose expanded class name contains a dot', async () => {
+    // `[class.a.b]` is parsed by Angular as binding to property `a`, silently discarding
+    // everything after the first dot — expanding 'a.b c' would produce a binding that
+    // silently applies the wrong class. The whole binding must be left unchanged instead.
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{'a.b c': condition, 'd': condition2}"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({migrateSpaceSeparatedKey: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(`<div [ngClass]="{'a.b c': condition, 'd': condition2}"></div>`);
+    expect(content).not.toContain('[class.a');
+  });
+
+  it('should treat a tab as a class-name separator', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{'class1\\tclass2': condition}"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({migrateSpaceSeparatedKey: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(`<div [class.class1]="condition" [class.class2]="condition"></div>`);
+  });
+
+  it('should treat a newline as a class-name separator', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{'class1\\nclass2': condition}"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({migrateSpaceSeparatedKey: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(`<div [class.class1]="condition" [class.class2]="condition"></div>`);
+  });
+
+  it('should not expand when a shorthand property collides with an expanded space-separated key', async () => {
+    // The shorthand `class1` binding and the `class1` produced by splitting
+    // 'class1 class2' would collide, producing two conflicting [class.class1] bindings.
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{class1, 'class1 class2': condition}"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({migrateSpaceSeparatedKey: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(`<div [ngClass]="{class1, 'class1 class2': condition}"></div>`);
+  });
+
+  it('should expand a space-separated key mixed with a numeric-looking class name', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{'1foo bar': condition}"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({migrateSpaceSeparatedKey: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(`<div [class.1foo]="condition" [class.bar]="condition"></div>`);
+  });
+
+  it('should not migrate when a computed property key is mixed with a space-separated key', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{[dynamicKey]: condition, 'class1 class2': condition2}"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({migrateSpaceSeparatedKey: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(
+      `<div [ngClass]="{[dynamicKey]: condition, 'class1 class2': condition2}"></div>`,
+    );
   });
 });

--- a/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
+++ b/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
@@ -296,12 +296,14 @@ export class NgClassCollector extends RecursiveVisitor {
           attr.valueSpan.end.offset,
         );
 
-        const staticMatch = tryParseStaticObjectLiteral(expr);
+        const parseResult = tryParseStaticObjectLiteral(expr);
 
-        if (staticMatch === null) {
+        if (parseResult === null) {
           this.skippedNgClassCount++;
           continue;
         }
+
+        const {bindings: staticMatch, hasSpaceSeparatedKeys} = parseResult;
 
         let replacement: string;
 
@@ -317,26 +319,32 @@ export class NgClassCollector extends RecursiveVisitor {
             replacement = `[class.${key}]="${value}"`;
           }
         } else {
-          // Check if all entries have the same value (condition)
-          const allSameValue = staticMatch.every((entry) => entry.value === staticMatch[0].value);
-          if (
-            allSameValue &&
-            staticMatch.length > 1 &&
-            // Check if this was originally a single key with multiple classes
-            expr.includes('{') &&
-            expr.includes('}') &&
-            expr.split(':').length === 2
-          ) {
-            // Multiple classes with the same condition: use [class.class1]="condition" [class.class2]="condition"
-            if (config.migrateSpaceSeparatedKey) {
+          // Multiple bindings. If any original key contained spaces, [class]="{...}" object
+          // syntax cannot be used because [class] does not support space-separated key names
+          // (only [ngClass] does). Either expand every binding individually, or skip.
+          if (hasSpaceSeparatedKeys) {
+            // Expanding is only safe if every binding maps to a distinct, non-empty class
+            // name that doesn't contain a dot: an empty key would produce the invalid
+            // `[class.]` binding, duplicate keys would produce multiple conflicting
+            // `[class.foo]` bindings on one element, and a dot in the class name (e.g.
+            // 'a.b') would silently bind to the wrong property since `[class.a.b]` is
+            // parsed as `[class.a]` — everything after the first dot is discarded.
+            const expandedKeys = staticMatch.map(({key}) => key);
+            const canExpand =
+              expandedKeys.every((key) => key !== '' && !key.includes('.')) &&
+              new Set(expandedKeys).size === expandedKeys.length;
+
+            if (config.migrateSpaceSeparatedKey && canExpand) {
               replacement = staticMatch
                 .map(({key, value}) => `[class.${key}]="${value}"`)
                 .join(' ');
             } else {
+              // Cannot produce valid [class]="..." output — leave binding as-is.
+              this.skippedNgClassCount++;
               continue;
             }
           } else {
-            // Multiple conditions with different values: use [class]="{'class1': condition1, 'class2': condition2}"
+            // All keys are single class names: [class]="{'cls1': cond1, 'cls2': cond2}" is valid.
             replacement = `[class]="${expr}"`;
           }
         }
@@ -362,11 +370,14 @@ export class NgClassCollector extends RecursiveVisitor {
   }
 }
 
-function tryParseStaticObjectLiteral(expr: string): {key: string; value: string}[] | null {
+function tryParseStaticObjectLiteral(expr: string): {
+  bindings: {key: string; value: string}[];
+  hasSpaceSeparatedKeys: boolean;
+} | null {
   const trimmedExpr = expr.trim();
 
   if (trimmedExpr === '{}' || trimmedExpr === '[]') {
-    return [];
+    return {bindings: [], hasSpaceSeparatedKeys: false};
   }
 
   if (!isObjectLiteralSyntax(trimmedExpr)) {
@@ -427,12 +438,16 @@ function parseAsObjectLiteral(expr: string): ts.ObjectLiteralExpression | null {
 }
 
 /**
- * Extracts class bindings from object literal properties
+ * Extracts class bindings from object literal properties.
+ * Returns the list of individual `{key, value}` bindings (space-separated keys are expanded)
+ * along with a flag indicating whether any original key contained spaces.
  */
-function extractClassBindings(
-  objectLiteral: ts.ObjectLiteralExpression,
-): {key: string; value: string}[] | null {
-  const result: {key: string; value: string}[] = [];
+function extractClassBindings(objectLiteral: ts.ObjectLiteralExpression): {
+  bindings: {key: string; value: string}[];
+  hasSpaceSeparatedKeys: boolean;
+} | null {
+  const bindings: {key: string; value: string}[] = [];
+  let hasSpaceSeparatedKeys = false;
 
   for (const property of objectLiteral.properties) {
     if (ts.isShorthandPropertyAssignment(property)) {
@@ -440,13 +455,13 @@ function extractClassBindings(
       if (key.includes(' ')) {
         return null;
       }
-      result.push({key, value: key});
+      bindings.push({key, value: key});
     } else if (ts.isPropertyAssignment(property)) {
       const keyText = extractPropertyKey(property.name);
       const valueText = extractPropertyValue(property.initializer);
 
       if (keyText === '' && valueText) {
-        result.push({key: '', value: valueText});
+        bindings.push({key: '', value: valueText});
       } else {
         if (!keyText || !valueText) {
           return null;
@@ -454,9 +469,12 @@ function extractClassBindings(
 
         // Handle multiple CSS classes in single key (e.g., 'class1 class2': condition)
         const classNames = keyText.split(/\s+/).filter(Boolean);
+        if (classNames.length > 1) {
+          hasSpaceSeparatedKeys = true;
+        }
 
         for (const className of classNames) {
-          result.push({key: className, value: valueText});
+          bindings.push({key: className, value: valueText});
         }
       }
     } else {
@@ -464,7 +482,7 @@ function extractClassBindings(
     }
   }
 
-  return result;
+  return {bindings, hasSpaceSeparatedKeys};
 }
 
 /**

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -25,7 +25,6 @@ jasmine_test(
         "//packages/core/schematics/ng-generate/common-to-standalone-migration:static_files",
         "//packages/core/schematics/ng-generate/control-flow-migration:static_files",
         "//packages/core/schematics/ng-generate/inject-migration:static_files",
-        "//packages/core/schematics/ng-generate/ngclass-to-class-migration:static_files",
         "//packages/core/schematics/ng-generate/ngstyle-to-style-migration:static_files",
         "//packages/core/schematics/ng-generate/output-migration:static_files",
         "//packages/core/schematics/ng-generate/route-lazy-loading:static_files",


### PR DESCRIPTION
## Description

The `ngclass-to-class` migration schematic used a fragile heuristic — checking whether all values in a multi-binding `[ngClass]` object were equal and whether the expression contained exactly one colon — to decide whether the object could be safely rewritten as `[class]="..."`.

This heuristic incorrectly matched objects that mix a space-separated class key with a regular key, e.g.:

```html
[ngClass]="{'class1 class2': condition, 'class3': condition2}"
```

producing invalid output:

```html
[class]="{'class1 class2': condition, 'class3': condition2}"
```

`[class]` object syntax does not support space-separated key names (only `[ngClass]` does), so this output is broken and fails at build/runtime.

## Fix

The migration now explicitly tracks whether any original key contained spaces (`hasSpaceSeparatedKeys`). When it does:

- If `migrateSpaceSeparatedKey` is enabled **and** the expansion is safe (every resulting class name is non-empty and unique), the binding is expanded into individual `[class.foo]="cond"` bindings.
- Otherwise, the binding is left unchanged as `[ngClass]` rather than emitting invalid output.

This also guards two related edge cases that could otherwise produce invalid output during expansion:
- An empty-string key expanding to the invalid `[class.]` binding.
- Duplicate class names (e.g. `'class1 class2'` mixed with a separate `class1` key) expanding into conflicting duplicate `[class.class1]` bindings.

## Testing

Added regression tests covering:
- The exact case from the issue (mixed space-separated + regular key), both with and without `migrateSpaceSeparatedKey`.
- Expansion being skipped when it would produce an empty `[class.]` binding.
- Expansion being skipped when it would produce a duplicate `[class.foo]` binding.
- Corrected a pre-existing test that asserted the old, invalid `[class]="..."` output.

Fixes #69833
