### PR TITLE
test(compiler-cli): cover DOM-only vs full instruction set across compilation modes

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/GOLDEN_PARTIAL.js
@@ -1,0 +1,34 @@
+/****************************************************************************************************
+ * PARTIAL FILE: dom_only_instruction_set.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+// A standalone component with a plain-DOM template and no directive/pipe dependencies.
+// Whether it is compiled to the DOM-only instruction set depends solely on the compilation
+// mode:
+//   - Full compile: the compiler can see that the template has no directive dependencies, so
+//     it takes the DOM-only fast path (`ɵɵdomElementStart`/`ɵɵdomElementEnd`).
+//   - Local compile: the compiler cannot inspect the component's dependencies, so it assumes
+//     directive dependencies may exist and emits the full instruction set
+//     (`ɵɵelementStart`/`ɵɵelementEnd`).
+export class DomOnlyCmp {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: DomOnlyCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: DomOnlyCmp, isStandalone: true, selector: "ng-component", ngImport: i0, template: '<div><span>hi</span></div>', isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: DomOnlyCmp, decorators: [{
+            type: Component,
+            args: [{
+                    standalone: true,
+                    template: '<div><span>hi</span></div>',
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: dom_only_instruction_set.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class DomOnlyCmp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<DomOnlyCmp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<DomOnlyCmp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/TEST_CASES.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../test_case_schema.json",
+  "cases": [
+    {
+      "description": "should use the DOM-only instruction set in full compilation but the full instruction set in local compilation",
+      "inputFiles": ["dom_only_instruction_set.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect instruction set for a directive-free standalone component",
+          "files": ["dom_only_instruction_set.js"]
+        }
+      ],
+      "compilationModeFilter": ["full compile", "local compile"]
+    }
+  ]
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/dom_only_instruction_set.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/dom_only_instruction_set.js
@@ -1,0 +1,14 @@
+export class DomOnlyCmp {
+  // ...
+  static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
+    // ...
+    template: function DomOnlyCmp_Template(rf, ctx) {
+      if (rf & 1) {
+        i0.ɵɵdomElementStart(0, "div")(1, "span");
+        i0.ɵɵtext(2, "hi");
+        i0.ɵɵdomElementEnd()();
+      }
+    },
+    // ...
+  });
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/dom_only_instruction_set.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/dom_only_instruction_set.local.js
@@ -1,0 +1,14 @@
+export class DomOnlyCmp {
+  // ...
+  static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
+    // ...
+    template: function DomOnlyCmp_Template(rf, ctx) {
+      if (rf & 1) {
+        i0.ɵɵelementStart(0, "div")(1, "span");
+        i0.ɵɵtext(2, "hi");
+        i0.ɵɵelementEnd()();
+      }
+    },
+    // ...
+  });
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/dom_only_instruction_set.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_dom_only/dom_only_instruction_set.ts
@@ -1,0 +1,15 @@
+import {Component} from '@angular/core';
+
+// A standalone component with a plain-DOM template and no directive/pipe dependencies.
+// Whether it is compiled to the DOM-only instruction set depends solely on the compilation
+// mode:
+//   - Full compile: the compiler can see that the template has no directive dependencies, so
+//     it takes the DOM-only fast path (`ɵɵdomElementStart`/`ɵɵdomElementEnd`).
+//   - Local compile: the compiler cannot inspect the component's dependencies, so it assumes
+//     directive dependencies may exist and emits the full instruction set
+//     (`ɵɵelementStart`/`ɵɵelementEnd`).
+@Component({
+  standalone: true,
+  template: '<div><span>hi</span></div>',
+})
+export class DomOnlyCmp {}


### PR DESCRIPTION
Added a test for local vs. full compilation mode.