### PR TITLE
fix(common): prevent non-string date formats from bypassing the length guard

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -136,7 +136,9 @@ export function formatDate(
 }
 
 function assertValidDateFormatLength(format: string) {
-  if (format.length > MAX_DATE_FORMAT_LENGTH) {
+  // `format` may not be a string at runtime (e.g. an array from untrusted input); the parser
+  // coerces it via `String()`, so measure the coerced length to avoid bypassing this guard.
+  if (String(format).length > MAX_DATE_FORMAT_LENGTH) {
     throw new RuntimeError(
       RuntimeErrorCode.SUSPICIOUS_DATE_FORMAT,
       ngDevMode &&

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -361,6 +361,15 @@ describe('Format date', () => {
       );
     });
 
+    it('should reject a non-string format whose coerced length exceeds 256 characters', () => {
+      // A non-string format (e.g. an array from untrusted input) has a small `length` but
+      // coerces to a long string, which previously bypassed the length guard.
+      const format = ['y'.repeat(300)] as unknown as string;
+      expect(() => formatDate(date, format, ɵDEFAULT_LOCALE_ID)).toThrowError(
+        /Exceeded maximum length of 256 characters/,
+      );
+    });
+
     it('should treat format tokens that collide with Object.prototype members as literals', () => {
       // A format token that matches an inherited property name (e.g. `__proto__`) must not
       // resolve to a value off the prototype of the internal format caches. Before the caches


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not applicable)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: #69863

The date-format length guard added in #69000 (CVE-2026-54268) checks `format.length`. A non-string format, for example an array parsed from untrusted query parameters, has a small element count but a long string form, so it passes the guard and reaches the O(n^2) parser, reintroducing the denial of service on patched versions.

## What is the new behavior?

The guard measures `String(format).length`, the length the parser actually processes, so a non-string format whose coerced length exceeds 256 characters is rejected. String inputs are unaffected. A regression test is added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Completes the fix for CVE-2026-54268 (GHSA-48r7-hpm6-gfxm), which addressed string inputs only.
