### PR TITLE
fix(router): prevent protocol-relative serialized URLs

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -453,7 +453,8 @@ export class DefaultUrlSerializer implements UrlSerializer {
 
   /** Converts a `UrlTree` into a url */
   serialize(tree: UrlTree): string {
-    const segment = `/${serializeSegment(tree.root, true)}`;
+    // Empty leading path segments would make the result protocol-relative in browsers.
+    const segment = `/${serializeSegment(tree.root, true).replace(/^\/+/, '')}`;
     const query = serializeQueryParams(tree.queryParams);
     const fragment =
       typeof tree.fragment === `string` ? `#${encodeUriFragment(tree.fragment)}` : '';

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -107,6 +107,12 @@ describe('createUrlTree', () => {
     expect(serializer.serialize(t)).toEqual('/');
   });
 
+  it('should not serialize leading empty path commands as a protocol-relative URL', async () => {
+    const p = serializer.parse('/');
+    const t = await createRoot(p, ['/', '', 'attacker.example', 'collect'], {session: 'secret'});
+    expect(serializer.serialize(t)).toEqual('/attacker.example/collect?session=secret');
+  });
+
   it('should error when navigating to the root segment with params', async () => {
     const p = serializer.parse('/');
     await expectAsync(createRoot(p, ['/', {p: 11}])).toBeRejectedWithError(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (no public API or documented behavior changes)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

A `UrlTree` containing an empty leading path segment serializes with two leading slashes. For
example, RouterLink commands such as `['/', '', 'attacker.example', 'collect']` produce
`//attacker.example/collect`. Browsers interpret that `href` as a protocol-relative external URL,
even though the commands describe an internal route. Preserved or merged query parameters are
also appended to that external URL.

Issue Number: #69700

## What is the new behavior?

`DefaultUrlSerializer` removes empty leading path segments while serializing, so the example above
becomes `/attacker.example/collect`. This mirrors the parser's existing normalization of repeated
leading slashes and keeps the generated URL on the application's origin.

The regression test covers the command-array path and an appended query parameter. A differential
local harness also compared 4,096 ordinary command arrays with the released serializer; their
serialized output remained byte-for-byte identical.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Formatting and whitespace checks pass. The focused source harness covers ordinary paths, query
parameters, fragments, named outlets, multiple empty leading segments, and browser-origin
resolution.
