### PR TITLE
docs: update stale Twitter reference to X in the URL matcher guide

### DIFF
--- a/adev/src/content/guide/routing/routing-with-urlmatcher.md
+++ b/adev/src/content/guide/routing/routing-with-urlmatcher.md
@@ -5,7 +5,7 @@ This matching strategy supports static routes, variable routes with parameters, 
 Also, build your own custom pattern matching for situations in which the URLs are more complicated.
 
 In this tutorial, you'll build a custom route matcher using Angular's `UrlMatcher`.
-This matcher looks for a Twitter handle in the URL.
+This matcher looks for an X (formerly Twitter) handle in the URL.
 
 ## Objectives
 
@@ -46,7 +46,7 @@ In addition to the default Angular application framework, you will also create a
 ## Configure your routes for your application
 
 With your application framework in place, you next need to add routing capabilities to the `app.config.ts` file.
-As a part of this process, you will create a custom URL matcher that looks for a Twitter handle in the URL.
+As a part of this process, you will create a custom URL matcher that looks for an X handle in the URL.
 This handle is identified by a preceding `@` symbol.
 
 1. In your code editor, open your `app.config.ts` file.
@@ -113,4 +113,4 @@ To learn more about the Angular Router, see the following topics:
   <docs-pill href="api/router/Router" title="Router API"/>
 </docs-pill-row>
 
-HELPFUL: This content is based on [Custom Route Matching with the Angular Router](https://medium.com/@brandontroberts/custom-route-matching-with-the-angular-router-fbdd48665483), by [Brandon Roberts](https://twitter.com/brandontroberts).
+HELPFUL: This content is based on [Custom Route Matching with the Angular Router](https://medium.com/@brandontroberts/custom-route-matching-with-the-angular-router-fbdd48665483), by [Brandon Roberts](https://x.com/brandontroberts).


### PR DESCRIPTION
In the custom-route-matcher guide, point the author-credit link at x.com and refer to an "X (formerly Twitter) handle" (clarified once, then "X handle"), matching the "X (formerly Twitter)" wording already used in the footer, navigation, and update guide.