### PR TITLE
feat(http): expose fetch implementation for public usage

### DIFF
--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -14,7 +14,7 @@ export {
 } from './src/backend';
 export {HttpClient, HttpClientCommonOptions} from './src/client';
 export {HttpContext, HttpContextToken} from './src/context';
-export {FetchBackend} from './src/fetch';
+export {FetchBackend, HTTP_FETCH_IMPLEMENTATION} from './src/fetch';
 export {HttpHeaders} from './src/headers';
 export {
   HTTP_INTERCEPTORS,

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -60,6 +60,24 @@ export const HTTP_FETCH_MAX_RESPONSE_SIZE = new InjectionToken<number | null>(
 );
 
 /**
+ * Configures which function should be used by the `FetchBackend` when using `fetch`.
+ *
+ * By default it uses `globalThis.fetch`
+ *
+ * @publicApi
+ */
+export const HTTP_FETCH_IMPLEMENTATION = new InjectionToken<typeof globalThis.fetch>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'HTTP_FETCH_IMPLEMENTATION' : '',
+  {
+    providedIn: 'platform',
+    factory:
+      () =>
+      (...args) =>
+        globalThis.fetch(...args),
+  },
+);
+
+/**
  * Uses `fetch` to send requests to a backend server.
  *
  * This `FetchBackend` requires the support of the
@@ -75,8 +93,7 @@ export class FetchBackend implements HttpBackend {
   // We use an arrow function to always reference the current global implementation of `fetch`.
   // This is helpful for cases when the global `fetch` implementation is modified by external code,
   // see https://github.com/angular/angular/issues/57527.
-  private readonly fetchImpl =
-    inject(FetchFactory, {optional: true})?.fetch ?? ((...args) => globalThis.fetch(...args));
+  private readonly fetchImpl = inject(HTTP_FETCH_IMPLEMENTATION);
   private readonly ngZone = inject(NgZone);
   private readonly destroyRef = inject(DestroyRef);
   private readonly maxResponseSize = inject(HTTP_FETCH_MAX_RESPONSE_SIZE);
@@ -414,13 +431,6 @@ export class FetchBackend implements HttpBackend {
 
     return chunksAll;
   }
-}
-
-/**
- * Abstract class to provide a mocked implementation of `fetch()`
- */
-export abstract class FetchFactory {
-  abstract fetch: typeof fetch;
 }
 
 function noop(): void {}

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -70,6 +70,9 @@ export const HTTP_FETCH_IMPLEMENTATION = new InjectionToken<typeof globalThis.fe
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'HTTP_FETCH_IMPLEMENTATION' : '',
   {
     providedIn: 'platform',
+    // We use an arrow function to always reference the current global implementation of `fetch`.
+    // This is helpful for cases when the global `fetch` implementation is modified by external code,
+    // see https://github.com/angular/angular/issues/57527.
     factory:
       () =>
       (...args) =>
@@ -90,9 +93,6 @@ export const HTTP_FETCH_IMPLEMENTATION = new InjectionToken<typeof globalThis.fe
  */
 @Service()
 export class FetchBackend implements HttpBackend {
-  // We use an arrow function to always reference the current global implementation of `fetch`.
-  // This is helpful for cases when the global `fetch` implementation is modified by external code,
-  // see https://github.com/angular/angular/issues/57527.
   private readonly fetchImpl = inject(HTTP_FETCH_IMPLEMENTATION);
   private readonly ngZone = inject(NgZone);
   private readonly destroyRef = inject(DestroyRef);

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -21,7 +21,7 @@ import {
   provideHttpClient,
 } from '../public_api';
 import {RuntimeErrorCode} from '../src/errors';
-import {FetchBackend, FetchFactory, HTTP_FETCH_MAX_RESPONSE_SIZE} from '../src/fetch';
+import {FetchBackend, HTTP_FETCH_IMPLEMENTATION, HTTP_FETCH_MAX_RESPONSE_SIZE} from '../src/fetch';
 
 function trackEvents(obs: Observable<any>): Promise<any[]> {
   return obs
@@ -63,12 +63,13 @@ describe('FetchBackend', () => {
   }
 
   beforeEach(() => {
+    fetchMock = new MockFetchFactory();
+    fetchSpy = spyOn(fetchMock, 'fetch').and.callThrough();
+
     TestBed.configureTestingModule({
-      providers: [{provide: FetchFactory, useClass: MockFetchFactory}, FetchBackend],
+      providers: [{provide: HTTP_FETCH_IMPLEMENTATION, useValue: fetchSpy}, FetchBackend],
     });
 
-    fetchMock = TestBed.inject(FetchFactory) as MockFetchFactory;
-    fetchSpy = spyOn(fetchMock, 'fetch').and.callThrough();
     backend = TestBed.inject(FetchBackend);
   });
 
@@ -635,17 +636,18 @@ describe('FetchBackend', () => {
     let infiniteStreamFactory: InfiniteStreamFetchFactory = null!;
 
     beforeEach(() => {
+      infiniteStreamFactory = new InfiniteStreamFetchFactory();
+
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         providers: [
-          {provide: FetchFactory, useClass: InfiniteStreamFetchFactory},
+          {provide: HTTP_FETCH_IMPLEMENTATION, useValue: infiniteStreamFactory.fetch},
           {provide: HTTP_FETCH_MAX_RESPONSE_SIZE, useValue: 2048},
           FetchBackend,
         ],
       });
 
       backend = TestBed.inject(FetchBackend);
-      infiniteStreamFactory = TestBed.inject(FetchFactory) as InfiniteStreamFetchFactory;
     });
 
     it('aborts a never-ending response stream once the configured size limit is exceeded', async () => {
@@ -663,7 +665,7 @@ describe('FetchBackend', () => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         providers: [
-          {provide: FetchFactory, useClass: FiniteChunkFetchFactory},
+          {provide: HTTP_FETCH_IMPLEMENTATION, useValue: finiteChunkFetch},
           {provide: HTTP_FETCH_MAX_RESPONSE_SIZE, useValue: null},
           FetchBackend,
         ],
@@ -680,6 +682,13 @@ describe('FetchBackend', () => {
     });
   });
 });
+
+/**
+ * Abstract class to provide a common implementation of `fetch()`
+ */
+export abstract class FetchFactory {
+  abstract fetch: typeof fetch;
+}
 
 export class MockFetchFactory extends FetchFactory {
   public readonly response = new MockFetchResponse();
@@ -801,22 +810,40 @@ class InfiniteStreamFetchFactory extends FetchFactory {
   };
 }
 
-class FiniteChunkFetchFactory extends FetchFactory {
-  override fetch = async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
-    const stream = new ReadableStream<Uint8Array>({
-      start: (controller) => {
-        controller.enqueue(new TextEncoder().encode('ok'));
-        controller.close();
-      },
-    });
+// class FiniteChunkFetchFactory extends FetchFactory {
+//   override fetch = async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+//     const stream = new ReadableStream<Uint8Array>({
+//       start: (controller) => {
+//         controller.enqueue(new TextEncoder().encode('ok'));
+//         controller.close();
+//       },
+//     });
 
-    return new Response(stream, {
-      status: HttpStatusCode.Ok,
-      statusText: 'OK',
-      headers: {'Content-Type': 'text/plain'},
-    });
-  };
-}
+//     return new Response(stream, {
+//       status: HttpStatusCode.Ok,
+//       statusText: 'OK',
+//       headers: {'Content-Type': 'text/plain'},
+//     });
+//   };
+// }
+
+const finiteChunkFetch = async (
+  _input: RequestInfo | URL,
+  _init?: RequestInit,
+): Promise<Response> => {
+  const stream = new ReadableStream<Uint8Array>({
+    start: (controller) => {
+      controller.enqueue(new TextEncoder().encode('ok'));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: HttpStatusCode.Ok,
+    statusText: 'OK',
+    headers: {'Content-Type': 'text/plain'},
+  });
+};
 
 class MockFetchResponse {
   public url?: string;

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -810,23 +810,6 @@ class InfiniteStreamFetchFactory extends FetchFactory {
   };
 }
 
-// class FiniteChunkFetchFactory extends FetchFactory {
-//   override fetch = async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
-//     const stream = new ReadableStream<Uint8Array>({
-//       start: (controller) => {
-//         controller.enqueue(new TextEncoder().encode('ok'));
-//         controller.close();
-//       },
-//     });
-
-//     return new Response(stream, {
-//       status: HttpStatusCode.Ok,
-//       statusText: 'OK',
-//       headers: {'Content-Type': 'text/plain'},
-//     });
-//   };
-// }
-
 const finiteChunkFetch = async (
   _input: RequestInfo | URL,
   _init?: RequestInit,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Developers could not change the `fetch` function that angular used for `FetchBackend`, requiring them to implement their own `FetchBackend` if they wanted to use HttpClient with a custom `fetch` function (such as the one provided by the npm package @tauri-apps/plugin-http)

Issue Number: #62011

## What is the new behavior?

The public `HTTP_FETCH_IMPLEMENTATION` injection token exposes the `fetch` implementation that should be used by `FetchBackend`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- `HTTP_FETCH_IMPLEMENTATION` is provided as `platform` and has `(...args) => globalThis.fetch(...args)` as the default implementation
- Previous tests used `FetchFactory`, a non exposed internal class of @angular/common/http meant for testing, declared on the source files. That class has been moved to the test files and now `HTTP_FETCH_IMPLEMENTATION` does the job of the class at a public level
  - The testing classes that extended `FetchFactory` still extend the class but now are no longer provided on the TestBed and are instantiated manually on beforeEach, with their `FetchFactory.fetch` methods given to `HTTP_FETCH_IMPLEMENTATION`