### PR TITLE
docs: remove outdated section in the `Signal Forms | Custom controls` page

### DIFF
--- a/adev/src/content/guide/forms/signals/custom-controls.md
+++ b/adev/src/content/guide/forms/signals/custom-controls.md
@@ -338,10 +338,6 @@ export class Login {
 
 When the user types an invalid email, the FormField directive automatically updates `invalid()` and `errors()`. Your control can display the validation feedback.
 
-### Signal types for state properties
-
-Most state properties use `input()` (read-only from the form). Use `model()` for `touched` when your control updates it on user interaction. The `touched` property uniquely supports `model()`, `input()`, or `OutputRef` depending on your needs.
-
 ### Working with `debounce('blur')`
 
 The [`debounce('blur')`](api/forms/signals/debounce) rule delays updates from the UI to the form model until the field is blurred, instead of applying them on every keystroke. Built-in controls report a blur to the form automatically. A custom control only participates if it emits its `touch` output in response to the native [`blur` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event):


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
[Documentation](https://angular.dev/guide/forms/signals/custom-controls#signal-types-for-state-properties) contains oudated information about implementing of signal-based CVA

**Angular 21:**
https://github.com/angular/angular/blob/5d00aa2bd41883e0eda6594c4290c9fa88a6ee15/packages/forms/signals/src/api/control.ts#L64-L65

⬇️ 

**Angular 22:**
https://github.com/angular/angular/blob/49672c437b440564e9c20b77a7ff151fbf316706/packages/forms/signals/src/api/control.ts#L62-L66

Explore:
- https://github.com/angular/angular/pull/67100

## What is the new behavior?
No more relevant section is removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

