### PR TITLE
fix(http): keep `=` encoded in HttpParams keys

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -44,7 +44,7 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
    * @returns The encoded key name.
    */
   encodeKey(key: string): string {
-    return standardEncoding(key);
+    return standardEncoding(key, KEY_ENCODING_REPLACEMENTS);
   }
 
   /**
@@ -53,7 +53,7 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
    * @returns The encoded value.
    */
   encodeValue(value: string): string {
-    return standardEncoding(value);
+    return standardEncoding(value, VALUE_ENCODING_REPLACEMENTS);
   }
 
   /**
@@ -100,22 +100,24 @@ function paramParser(rawParams: string, codec: HttpParameterCodec): Map<string, 
  * Encode input string with standard encodeURIComponent and then un-encode specific characters.
  */
 const STANDARD_ENCODING_REGEX = /%(\d[a-f0-9])/gi;
-const STANDARD_ENCODING_REPLACEMENTS: {[x: string]: string} = {
+const KEY_ENCODING_REPLACEMENTS: {[x: string]: string} = {
   '40': '@',
   '3A': ':',
   '24': '$',
   '2C': ',',
   '3B': ';',
-  '3D': '=',
   '3F': '?',
   '2F': '/',
 };
+// A pair is split at its first `=`, so that character only carries its literal meaning in a
+// value and has to stay percent-encoded in a key.
+const VALUE_ENCODING_REPLACEMENTS: {[x: string]: string} = {
+  ...KEY_ENCODING_REPLACEMENTS,
+  '3D': '=',
+};
 
-function standardEncoding(v: string): string {
-  return encodeURIComponent(v).replace(
-    STANDARD_ENCODING_REGEX,
-    (s, t) => STANDARD_ENCODING_REPLACEMENTS[t] ?? s,
-  );
+function standardEncoding(v: string, replacements: {[x: string]: string}): string {
+  return encodeURIComponent(v).replace(STANDARD_ENCODING_REGEX, (s, t) => replacements[t] ?? s);
 }
 
 function valueToString(value: string | number | boolean): string {

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -180,6 +180,15 @@ describe('HttpUrlEncodedParams', () => {
       const body2 = new HttpParams({fromString: 'a=1 2 3&b=mail@test&c=3_^[]$&d=eq=1&e=1+1'});
       expect(body2.toString()).toEqual('a=1%202%203&b=mail@test&c=3_%5E%5B%5D$&d=eq=1&e=1%2B1');
     });
+
+    it('should keep `=` encoded in a key so the pair round-trips', () => {
+      const body = new HttpParams().set('filter=admin', 'true');
+      expect(body.toString()).toEqual('filter%3Dadmin=true');
+
+      const reparsed = new HttpParams({fromString: body.toString()});
+      expect(reparsed.keys()).toEqual(['filter=admin']);
+      expect(reparsed.get('filter=admin')).toEqual('true');
+    });
   });
 
   describe('toString', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #11058

`HttpUrlEncodingCodec.encodeKey` and `encodeValue` in `packages/common/http/src/params.ts` share `standardEncoding`, which runs `encodeURIComponent` and then restores the characters listed in `STANDARD_ENCODING_REPLACEMENTS`. That list includes `=`, but `paramParser` splits every pair at its first `=`, so a parameter *name* containing one is written out unencoded and reads back as a different name. `new HttpParams().set('filter=admin', 'true').toString()` gives `filter=admin=true`, which reparses as key `filter` with value `admin=true`, so `HttpParams` does not round-trip through its own parser. The gap matters wherever the name is not a literal, for example `params.set(facetNameFromApi, value)` or params rebuilt from `location.search`: the request then carries a parameter the caller never asked for. `&` is already left encoded, so this shifts the key/value boundary rather than adding a whole pair.

## What is the new behavior?

`=` is restored only when encoding a value, where the pair has already been delimited and the character is unambiguous. Keys keep it percent-encoded, so the example above serializes as `filter%3Dadmin=true` and reparses to the key it started from. Value encoding is unchanged, including the existing `d=eq=1` expectation.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

The serialized output changes for any key that contains `=`: `filter=admin=true` becomes `filter%3Dadmin=true`. A backend that was reading the old, ambiguous output will see a different query string, so this needs to ride a major. The commit message carries a `BREAKING CHANGE:` footer describing it.

## Other information

A custom `HttpParameterCodec` is unaffected; only the default codec changes, and applications that want the old output can supply their own codec.

