### PR TITLE
docs: fix first heading rendering as paragraph on two template guides

### DIFF
--- a/adev/shared-docs/pipeline/guides/index.mts
+++ b/adev/shared-docs/pipeline/guides/index.mts
@@ -55,6 +55,16 @@ async function main() {
       }
 
       const markdownContent = await readFile(filePath, {encoding: 'utf8'});
+
+      // A leading byte order mark (U+FEFF) stops the first Markdown heading from being
+      // recognized, so the page title renders as a paragraph and loses its header. Fail
+      // the build so the BOM has to be removed from the source file instead.
+      if (markdownContent.charCodeAt(0) === 0xfeff) {
+        throw new Error(
+          `The file "${filePath}" starts with a byte order mark (BOM). Remove it so the leading heading is parsed correctly.`,
+        );
+      }
+
       const htmlOutputContent = await parseMarkdownAsync(markdownContent, {
         markdownFilePath: filePath,
         apiEntries: mapManifestToEntries(apiManifest),

--- a/adev/src/content/guide/templates/binding.md
+++ b/adev/src/content/guide/templates/binding.md
@@ -1,4 +1,4 @@
-﻿# Binding dynamic text, properties and attributes
+# Binding dynamic text, properties and attributes
 
 In Angular, a **binding** creates a dynamic connection between a component's template and its data. This connection ensures that changes to the component's data automatically update the rendered template.
 

--- a/adev/src/content/guide/templates/ng-container.md
+++ b/adev/src/content/guide/templates/ng-container.md
@@ -1,4 +1,4 @@
-﻿# Grouping elements with ng-container
+# Grouping elements with ng-container
 
 `<ng-container>` is a special element in Angular that groups multiple elements together or marks a location in a template without rendering a real element in the DOM.
 


### PR DESCRIPTION
Fixes #69889

Before:

<img width="1115" height="306" alt="image" src="https://github.com/user-attachments/assets/0e499b69-0937-4862-bcac-accf6d1d1f53" />

<img width="1109" height="410" alt="image" src="https://github.com/user-attachments/assets/7dac77fd-cdf8-4cc0-9702-5500d5191c28" />

After:

<img width="1124" height="323" alt="image" src="https://github.com/user-attachments/assets/298e1cac-85f3-45a5-b895-5c47adcb214e" />

<img width="1126" height="287" alt="image" src="https://github.com/user-attachments/assets/ad25a9d5-c02d-4f91-b034-1f6d4f7e41fa" />

Urls:

https://angular.dev/guide/templates/ng-container
https://angular.dev/guide/templates/binding