### PR TITLE
[Backport 21.2.X] fix(http): enable xsrf for root-provided HttpClient

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -20,6 +20,7 @@ import type {HttpHandler} from './backend';
 
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
+import {xsrfInterceptorFn} from './xsrf';
 
 /**
  * Intercepts and handles an `HttpRequest` or `HttpResponse`.
@@ -200,7 +201,7 @@ export const HTTP_INTERCEPTORS = new InjectionToken<readonly HttpInterceptor[]>(
  */
 export const HTTP_INTERCEPTOR_FNS = new InjectionToken<readonly HttpInterceptorFn[]>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'HTTP_INTERCEPTOR_FNS' : '',
-  {factory: () => []},
+  {factory: () => [xsrfInterceptorFn]},
 );
 
 /**

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -16,8 +16,8 @@ import {
 } from '@angular/core';
 import {Observable} from 'rxjs';
 
-import {HttpHandler} from './backend';
-import {HttpHandlerFn, HttpInterceptor} from './interceptor';
+import type {HttpHandler} from './backend';
+import type {HttpHandlerFn, HttpInterceptor} from './interceptor';
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
 

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -264,6 +264,19 @@ describe('provideHttpClient', () => {
   });
 
   describe('xsrf protection', () => {
+    it('should enable xsrf protection for the root-provided HttpClient', () => {
+      TestBed.configureTestingModule({
+        providers: [provideHttpClientTesting(), {provide: PLATFORM_ID, useValue: 'test'}],
+      });
+
+      setXsrfToken('abcdefg');
+
+      TestBed.inject(HttpClient).post('/test', '', {responseType: 'text'}).subscribe();
+      const req = TestBed.inject(HttpTestingController).expectOne('/test');
+      expect(req.request.headers.get('X-XSRF-TOKEN')).toEqual('abcdefg');
+      req.flush('');
+    });
+
     it('should enable xsrf protection by default', () => {
       TestBed.configureTestingModule({
         providers: [
@@ -314,7 +327,7 @@ describe('provideHttpClient', () => {
 
       TestBed.inject(HttpClient).post('/test', '', {responseType: 'text'}).subscribe();
       const req = TestBed.inject(HttpTestingController).expectOne('/test');
-      expect(req.request.headers.has('X-Custom-Xsrf-Header')).toBeFalse();
+      expect(req.request.headers.has('X-XSRF-TOKEN')).toBeFalse();
       req.flush('');
     });
 


### PR DESCRIPTION
 Backport of https://github.com/angular/angular/pull/69823