### PR TITLE
fix(core): Ensure JIT components also use `OnPush` by default.

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -679,7 +679,7 @@ export interface Component extends Directive {
  */
 export const Component: ComponentDecorator = makeDecorator(
   'Component',
-  (c: Component = {}) => ({changeDetection: ChangeDetectionStrategy.Eager, ...c}),
+  (c: Component = {}) => ({changeDetection: ChangeDetectionStrategy.OnPush, ...c}),
   Directive,
   undefined,
   (type: Type<any>, meta: Component) => compileComponent(type, meta),

--- a/packages/core/test/metadata/directives_spec.ts
+++ b/packages/core/test/metadata/directives_spec.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+
+describe('Component decorator', () => {
+  it('should default changeDetection to OnPush', () => {
+    const comp = new Component({});
+    expect(comp.changeDetection).toBe(ChangeDetectionStrategy.OnPush);
+  });
+});

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -557,6 +557,20 @@ describe('TestBed with Standalone types', () => {
     expect(hostElement.textContent).toBe('transformed original value using Overridden A token');
   });
 
+  it('should preserve default change detection when overriding components', () => {
+    @Component({
+      template: 'Original',
+    })
+    class DefaultCmp {}
+
+    const onPushBefore = (DefaultCmp as any).ɵcmp.onPush;
+    TestBed.overrideComponent(DefaultCmp, {set: {template: 'Overridden'}});
+    TestBed.createComponent(DefaultCmp);
+    const onPushAfter = (DefaultCmp as any).ɵcmp.onPush;
+
+    expect(onPushAfter).withContext('ɵcmp.OnPush after override').toBe(onPushBefore);
+  });
+
   describe('NgModules as dependencies', () => {
     @Component({
       selector: 'test-cmp',


### PR DESCRIPTION
Unfortunate oversight when landing #67687, it was missed here that OnPush should also be the default for JIT compiled component.

This behavior also affects tests that run in JIT mode (which is the default with Karma) 