### PR TITLE
fix(language-service): account for strictTemplates being enabled by default

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -899,7 +899,7 @@ export class LanguageService {
         project.readFile(path),
       );
 
-      if (!this.options.strictTemplates) {
+      if (this.options.strictTemplates === false) {
         diagnostics.push({
           messageText:
             'Some language features are not available. ' +

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -107,9 +107,11 @@ describe('language service adapter', () => {
   });
 
   describe('compiler options diagnostics', () => {
-    it('suggests turning on strict flag', () => {
+    it('suggests turning on strict flag when strictTemplates is explicitly false', () => {
       configFileFs.overwriteConfigFile(TSCONFIG, {
-        angularCompilerOptions: {},
+        angularCompilerOptions: {
+          strictTemplates: false,
+        },
       });
       const diags = ngLS.getCompilerOptionsDiagnostics();
       const diag = diags.find(isSuggestStrictTemplatesDiag);
@@ -128,6 +130,16 @@ describe('language service adapter', () => {
       const diag = diags.find(isSuggestStrictTemplatesDiag);
       expect(diag).toBeUndefined();
     });
+
+    it('does not suggest turning on strict mode is strictTemplates flag is ommitted', () => {
+      configFileFs.overwriteConfigFile(TSCONFIG, {
+        angularCompilerOptions: {},
+      });
+      const diags = ngLS.getCompilerOptionsDiagnostics();
+      const diag = diags.find(isSuggestStrictTemplatesDiag);
+      expect(diag).toBeUndefined();
+    });
+
     function isSuggestStrictTemplatesDiag(diag: ts.Diagnostic) {
       return diag.code === ngErrorCode(ErrorCode.SUGGEST_STRICT_TEMPLATES);
     }


### PR DESCRIPTION
We were raising the suggestion about enabling `strictTemplates` when `strictTemplates` is ommitted, however the option is now enabled by default.

Fixes #69905.
