### PR TITLE
fix(compiler): prevent ReDoS in i18n placeholder name extraction

### DIFF
--- a/packages/compiler/src/i18n/i18n_parser.ts
+++ b/packages/compiler/src/i18n/i18n_parser.ts
@@ -453,8 +453,11 @@ ${nodes.map((node) => `"${node.sourceSpan.toString()}"`).join('\n')}
   }
 }
 
-const _CUSTOM_PH_EXP =
-  /\/\/[\s\S]*i18n[\s\S]*\([\s\S]*ph[\s\S]*=[\s\S]*("|')([\s\S]*?)\1[\s\S]*\)/g;
+// The separators inside a `//i18n(ph="name")` annotation are only ever whitespace, so bind them
+// to `\s*` and stop the name at the delimiter quote. The previous `[\s\S]*` between each token let
+// a run of `i18n(ph=` characters be partitioned in many ways, so an unterminated annotation made
+// this match backtrack catastrophically.
+const _CUSTOM_PH_EXP = /\/\/\s*i18n\s*\(\s*ph\s*=\s*("|')((?:(?!\1)[\s\S])*)\1\s*\)/g;
 
 function extractPlaceholderName(input: string): string {
   return input.split(_CUSTOM_PH_EXP)[2];

--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -147,6 +147,17 @@ describe('I18nParser', () => {
         [[`[before, <ph name="TEST"> exp //i18n(ph='teSt') </ph>, after]`], 'm', 'd', ''],
       ]);
     });
+
+    it('should not backtrack on an unterminated placeholder annotation', () => {
+      // A `//i18n(ph=...` annotation that never closes must fall back to the default
+      // INTERPOLATION placeholder quickly instead of hanging while extracting the name.
+      const expression = '//' + 'i18n(ph='.repeat(200);
+      const start = Date.now();
+      expect(_humanizeMessages(`<div i18n="m|d">before{{ ${expression} }}after</div>`)).toEqual([
+        [[`[before, <ph name="INTERPOLATION"> ${expression} </ph>, after]`], 'm', 'd', ''],
+      ]);
+      expect(Date.now() - start).toBeLessThan(2000);
+    });
   });
 
   describe('blocks', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: N/A

`extractPlaceholderName` reads the name out of a `//i18n(ph="NAME")` annotation on an interpolation expression with `_CUSTOM_PH_EXP`:

1. the regex chains five greedy `[\s\S]*` segments between the short literals `i18n`, `(`, `ph`, `=` and the opening quote.
2. when the prefix matches but the closing quote/paren is absent, a run of `i18n(ph=` characters can be partitioned across those wildcards in exponentially many ways, so the match backtracks catastrophically.

An interpolation expression of `'//' + 'i18n(ph='.repeat(200)` (about 1.6 KB) takes ~96s to extract. This runs at template-compile time and, under JIT, in the browser when the interpolation text inside an i18n element comes from an untrusted source.

## What is the new behavior?

1. the inter-token separators are only ever whitespace, so they are bound to `\s*` instead of `[\s\S]*`.
2. the placeholder name stops at its delimiter quote via a tempered `((?:(?!\1)[\s\S])*)` group, so the name scan no longer runs to end-of-input.

Recognized annotations are unchanged for valid input (the existing named-interpolation cases still pass); the same 1.6 KB input now resolves in well under a millisecond. Added a regression test covering an unterminated annotation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
