### PR TITLE
feat(upgrade): add option to initialize inputs synchronously

### DIFF
--- a/goldens/public-api/upgrade/static/index.api.md
+++ b/goldens/public-api/upgrade/static/index.api.md
@@ -25,6 +25,7 @@ export function downgradeComponent(info: {
     component: Type<any>;
     downgradedModule?: string;
     propagateDigest?: boolean;
+    initializeInputsSynchronously?: boolean;
     inputs?: string[];
     outputs?: string[];
     selectors?: string[];

--- a/packages/upgrade/src/common/src/downgrade_component.ts
+++ b/packages/upgrade/src/common/src/downgrade_component.ts
@@ -92,6 +92,13 @@ export function downgradeComponent(info: {
   component: Type<any>;
   downgradedModule?: string;
   propagateDigest?: boolean;
+  /**
+   * Whether to initialize the component inputs synchronously.
+   * If set to `true`, component inputs are initialized synchronously during component creation.
+   * Otherwise, they are initialized asynchronously during the first digest cycle.
+   * (Default: false)
+   */
+  initializeInputsSynchronously?: boolean;
   /** @deprecated since v4. This parameter is no longer used */
   inputs?: string[];
   /** @deprecated since v4. This parameter is no longer used */
@@ -106,6 +113,7 @@ export function downgradeComponent(info: {
   ): IDirective {
     const unsafelyOverwriteSignalInputs =
       (info as {unsafelyOverwriteSignalInputs?: boolean}).unsafelyOverwriteSignalInputs ?? false;
+    const initializeInputsSynchronously = info.initializeInputsSynchronously ?? false;
     // When using `downgradeModule()`, we need to handle certain things specially. For example:
     // - We always need to attach the component view to the `ApplicationRef` for it to be
     //   dirty-checked.
@@ -208,6 +216,7 @@ export function downgradeComponent(info: {
             info.component,
             wrapCallback,
             unsafelyOverwriteSignalInputs,
+            initializeInputsSynchronously,
           );
 
           const projectableNodes = facade.compileContents();

--- a/packages/upgrade/src/common/src/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/src/downgrade_component_adapter.ts
@@ -61,6 +61,7 @@ export class DowngradeComponentAdapter {
     private component: Type<any>,
     private wrapCallback: <T>(cb: () => T) => () => T,
     private readonly unsafelyOverwriteSignalInputs: boolean,
+    private readonly initializeInputsSynchronously: boolean,
   ) {
     this.componentScope = scope.$new();
   }
@@ -109,6 +110,44 @@ export class DowngradeComponentAdapter {
       projectableNodes,
       hostElement: this.element[0] as Element,
     });
+
+    // Required signal inputs throw an `NG0950` error if they are read before a value is
+    // available. Under certain conditions (such as when `propagateDigest` is set to false),
+    // Angular change detection runs synchronously during component creation. Setting the
+    // initial input values synchronously via `setInput` ensures that these required inputs
+    // are initialized before change detection runs, avoiding these crashes.
+    if (this.initializeInputsSynchronously) {
+      const inputs = reflectComponentType(this.component)?.inputs ?? [];
+      const attrs = this.attrs;
+      for (const input of inputs) {
+        const bindingDef = new PropertyBinding(input.propName, input.templateName);
+        let expr: string | null = null;
+        let value: any = undefined;
+        let hasValue = false;
+        if (attrs.hasOwnProperty(bindingDef.attr)) {
+          value = attrs[bindingDef.attr];
+          hasValue = true;
+        } else {
+          if (attrs.hasOwnProperty(bindingDef.bindAttr)) {
+            expr = attrs[bindingDef.bindAttr];
+          } else if (attrs.hasOwnProperty(bindingDef.bracketAttr)) {
+            expr = attrs[bindingDef.bracketAttr];
+          } else if (attrs.hasOwnProperty(bindingDef.bindonAttr)) {
+            expr = attrs[bindingDef.bindonAttr];
+          } else if (attrs.hasOwnProperty(bindingDef.bracketParenAttr)) {
+            expr = attrs[bindingDef.bracketParenAttr];
+          }
+          if (expr !== null) {
+            const parsedExpr = this.$parse(expr);
+            value = parsedExpr(this.scope, undefined);
+            hasValue = true;
+          }
+        }
+        if (hasValue) {
+          componentRef.setInput(input.templateName, value);
+        }
+      }
+    }
     const viewChangeDetector = componentRef.injector.get(ChangeDetectorRef);
     const changeDetector = componentRef.changeDetectorRef;
 

--- a/packages/upgrade/src/common/test/downgrade_component_adapter_spec.ts
+++ b/packages/upgrade/src/common/test/downgrade_component_adapter_spec.ts
@@ -5,7 +5,15 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Compiler, Component, Injector, NgModule, TestabilityRegistry} from '@angular/core';
+import {
+  Compiler,
+  Component,
+  Injector,
+  NgModule,
+  TestabilityRegistry,
+  input,
+  reflectComponentType,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import * as angular from '../src/angular1';
@@ -84,50 +92,50 @@ withEachNg1Version(() => {
       });
     });
 
+    class mockScope implements angular.IScope {
+      private destroyListeners: (() => void)[] = [];
+
+      $new() {
+        return this;
+      }
+      $watch(exp: angular.Ng1Expression, fn?: (a1?: any, a2?: any) => void) {
+        return () => {};
+      }
+      $on(event: string, fn?: (event?: any, ...args: any[]) => void) {
+        if (event === '$destroy' && fn) {
+          this.destroyListeners.push(fn);
+        }
+        return () => {};
+      }
+      $destroy() {
+        let listener: (() => void) | undefined;
+        while ((listener = this.destroyListeners.shift())) listener();
+      }
+      $apply(exp?: angular.Ng1Expression) {
+        return () => {};
+      }
+      $digest() {
+        return () => {};
+      }
+      $evalAsync(exp: angular.Ng1Expression, locals?: any) {
+        return () => {};
+      }
+      $$childTail!: angular.IScope;
+      $$childHead!: angular.IScope;
+      $$nextSibling!: angular.IScope;
+      [key: string]: any;
+      $id = 'mockScope';
+      $parent!: angular.IScope;
+      $root!: angular.IScope;
+      $$phase: any;
+    }
+
     describe('testability', () => {
       let adapter: DowngradeComponentAdapter;
       let content: string;
       let compiler: Compiler;
       let registry: TestabilityRegistry;
       let element: angular.IAugmentedJQuery;
-
-      class mockScope implements angular.IScope {
-        private destroyListeners: (() => void)[] = [];
-
-        $new() {
-          return this;
-        }
-        $watch(exp: angular.Ng1Expression, fn?: (a1?: any, a2?: any) => void) {
-          return () => {};
-        }
-        $on(event: string, fn?: (event?: any, ...args: any[]) => void) {
-          if (event === '$destroy' && fn) {
-            this.destroyListeners.push(fn);
-          }
-          return () => {};
-        }
-        $destroy() {
-          let listener: (() => void) | undefined;
-          while ((listener = this.destroyListeners.shift())) listener();
-        }
-        $apply(exp?: angular.Ng1Expression) {
-          return () => {};
-        }
-        $digest() {
-          return () => {};
-        }
-        $evalAsync(exp: angular.Ng1Expression, locals?: any) {
-          return () => {};
-        }
-        $$childTail!: angular.IScope;
-        $$childHead!: angular.IScope;
-        $$nextSibling!: angular.IScope;
-        [key: string]: any;
-        $id = 'mockScope';
-        $parent!: angular.IScope;
-        $root!: angular.IScope;
-        $$phase: any;
-      }
 
       function getAdaptor(): DowngradeComponentAdapter {
         let attrs = undefined as any;
@@ -176,6 +184,7 @@ withEachNg1Version(() => {
           NewComponent,
           wrapCallback,
           /* unsafelyOverwriteSignalInputs */ false,
+          /* initializeInputsSynchronously */ false,
         );
       }
 
@@ -204,6 +213,201 @@ withEachNg1Version(() => {
         expect(registry.getAllTestabilities().length).toEqual(1);
         element.remove!();
         expect(registry.getAllTestabilities().length).toEqual(0);
+      });
+    });
+
+    describe('initializeInputsSynchronously', () => {
+      let compiler: Compiler;
+
+      beforeEach(() => {
+        compiler = TestBed.inject(Compiler);
+      });
+
+      it('should initialize signal inputs synchronously when initializeInputsSynchronously is true', () => {
+        let attrs = {
+          '[val]': "'hello'",
+          $observe(attr: string, fn: Function) {
+            return () => {};
+          },
+          hasOwnProperty(attr: string) {
+            return attr === '[val]' || attr === '$observe';
+          },
+        } as any;
+        let scope = new mockScope();
+        let ngModel = undefined as any;
+        let parentInjector = TestBed.inject(Injector);
+        let $compile = undefined as any;
+        let $parse = (expr: string) => {
+          return (s: any) => {
+            if (expr.startsWith("'") && expr.endsWith("'")) {
+              return expr.slice(1, -1);
+            }
+            return s[expr] || expr;
+          };
+        };
+        let wrapCallback = (cb: any) => cb;
+
+        @Component({
+          selector: 'comp',
+          template: '',
+          standalone: false,
+        })
+        class TestComponent {
+          val = input.required<string>();
+        }
+
+        @NgModule({
+          declarations: [TestComponent],
+        })
+        class TestModule {}
+
+        const modFactory = compiler.compileModuleSync(TestModule);
+        const module = modFactory.create(parentInjector);
+
+        // Wire up JIT inputs
+        (TestComponent as any).ɵcmp.inputs = {val: ['val', 1 /* InputFlags.SignalBased */, null]};
+
+        const adapter = new DowngradeComponentAdapter(
+          angular.element('<div></div>'),
+          attrs,
+          scope,
+          ngModel,
+          module.injector,
+          parentInjector,
+          $compile,
+          $parse,
+          TestComponent,
+          wrapCallback,
+          /* unsafelyOverwriteSignalInputs */ false,
+          /* initializeInputsSynchronously */ true,
+        );
+
+        const ref = adapter.createComponentAndSetup([]);
+        // The required signal input is initialized synchronously immediately after creation,
+        // so calling val() must succeed.
+        expect(ref.instance.val()).toBe('hello');
+      });
+
+      it('should fail to initialize required signal inputs when initializeInputsSynchronously is false', () => {
+        let attrs = {
+          '[val]': "'hello'",
+          $observe(attr: string, fn: Function) {
+            return () => {};
+          },
+          hasOwnProperty(attr: string) {
+            return attr === '[val]' || attr === '$observe';
+          },
+        } as any;
+        let scope = new mockScope();
+        let ngModel = undefined as any;
+        let parentInjector = TestBed.inject(Injector);
+        let $compile = undefined as any;
+        let $parse = (expr: string) => {
+          return (s: any) => {
+            if (expr.startsWith("'") && expr.endsWith("'")) {
+              return expr.slice(1, -1);
+            }
+            return s[expr] || expr;
+          };
+        };
+        let wrapCallback = (cb: any) => cb;
+
+        @Component({
+          selector: 'comp',
+          template: '',
+          standalone: false,
+        })
+        class TestComponent {
+          val = input.required<string>();
+        }
+
+        @NgModule({
+          declarations: [TestComponent],
+        })
+        class TestModule {}
+
+        const modFactory = compiler.compileModuleSync(TestModule);
+        const module = modFactory.create(parentInjector);
+
+        // Wire up JIT inputs
+        (TestComponent as any).ɵcmp.inputs = {val: ['val', 1 /* InputFlags.SignalBased */, null]};
+
+        const adapter = new DowngradeComponentAdapter(
+          angular.element('<div></div>'),
+          attrs,
+          scope,
+          ngModel,
+          module.injector,
+          parentInjector,
+          $compile,
+          $parse,
+          TestComponent,
+          wrapCallback,
+          /* unsafelyOverwriteSignalInputs */ false,
+          /* initializeInputsSynchronously */ false,
+        );
+
+        const ref = adapter.createComponentAndSetup([]);
+        // The required signal input is not initialized synchronously, so calling val() must throw.
+        expect(() => ref.instance.val()).toThrowError(/NG0950/);
+      });
+
+      it('should fail to initialize required signal inputs when initializeInputsSynchronously is true but no binding is provided', () => {
+        let attrs = {
+          $observe(attr: string, fn: Function) {
+            return () => {};
+          },
+          hasOwnProperty(attr: string) {
+            return attr === '$observe';
+          },
+        } as any;
+        let scope = new mockScope();
+        let ngModel = undefined as any;
+        let parentInjector = TestBed.inject(Injector);
+        let $compile = undefined as any;
+        let $parse = (expr: string) => {
+          return (s: any) => s[expr] || expr;
+        };
+        let wrapCallback = (cb: any) => cb;
+
+        @Component({
+          selector: 'comp',
+          template: '',
+          standalone: false,
+        })
+        class TestComponent {
+          val = input.required<string>();
+        }
+
+        @NgModule({
+          declarations: [TestComponent],
+        })
+        class TestModule {}
+
+        const modFactory = compiler.compileModuleSync(TestModule);
+        const module = modFactory.create(parentInjector);
+
+        // Wire up JIT inputs
+        (TestComponent as any).ɵcmp.inputs = {val: ['val', 1 /* InputFlags.SignalBased */, null]};
+
+        const adapter = new DowngradeComponentAdapter(
+          angular.element('<div></div>'),
+          attrs,
+          scope,
+          ngModel,
+          module.injector,
+          parentInjector,
+          $compile,
+          $parse,
+          TestComponent,
+          wrapCallback,
+          /* unsafelyOverwriteSignalInputs */ false,
+          /* initializeInputsSynchronously */ true,
+        );
+
+        const ref = adapter.createComponentAndSetup([]);
+        // The required signal input has no binding value, so calling val() must still throw.
+        expect(() => ref.instance.val()).toThrowError(/NG0950/);
       });
     });
   });

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -1173,6 +1173,45 @@ withEachNg1Version(() => {
           ),
       );
     }));
+
+    it('should initialize signal inputs synchronously when `initializeInputsSynchronously` is true', waitForAsync(() => {
+      const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
+        $rootScope['val'] = 'hello';
+      });
+
+      @Component({
+        selector: 'ng2',
+        template: 'Value: {{val()}}',
+        changeDetection: ChangeDetectionStrategy.Eager,
+        standalone: false,
+      })
+      class Ng2Component {
+        val = input.required<string>();
+      }
+
+      @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
+
+      // Wire up the input() signal for JIT tests. AOT compilation handles this automatically.
+      (Ng2Component as any).ɵcmp.inputs = {val: ['val', 1 /* InputFlags.SignalBased */, null]};
+
+      ng1Module.directive(
+        'ng2',
+        downgradeComponent({
+          component: Ng2Component,
+          initializeInputsSynchronously: true,
+          propagateDigest: false,
+        }),
+      );
+
+      const element = html(`<div><ng2 [val]="val"></ng2></div>`);
+
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(multiTrim(document.body.textContent)).toEqual('Value: hello');
+      });
+    }));
   });
 
   describe('standalone', () => {


### PR DESCRIPTION
Add `initializeInputsSynchronously` option to `downgradeComponent` to allow initializing Angular component inputs synchronously during creation.

Previously, downgraded components evaluated input bindings asynchronously during the first AngularJS digest cycle. This caused issues for components using `input.required()` signal inputs, which threw `NG0950` errors if read during instantiation or initial rendering because the values were not yet available.

With this option enabled, the adapter uses `ComponentRef.setInput()` to apply bindings synchronously immediately after creation, ensuring required inputs are available before change detection runs.

Also fixes a bug in `@angular/core` where `writeToDirectiveInput` would crash when trying to read an undefined transform decorator on an input (common in JIT or manual mock inputs used in tests).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Downgraded Angular components evaluate their input bindings (`$watch` / `$observe` callbacks) asynchronously during the first AngularJS `$digest` cycle after component creation.

Because of this asynchronous initialization timing, if a downgraded component uses modern required signal inputs (`input.required()`), reading these signals during component instantiation or initial rendering/change detection throws error.

Issue Number: N/A

## What is the new behavior?

1. Adds a new configuration option `initializeInputsSynchronously?: boolean` (defaults to `false`) to `downgradeComponent()`.
2. When `initializeInputsSynchronously` is enabled (`true`), the downgraded component adapter evaluates the AngularJS input attributes/expressions and applies them synchronously using `ComponentRef.setInput()` immediately after component instantiation. This ensures that all inputs (including required signal inputs) are fully initialized before the initial change detection or rendering runs.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information
