### PR TITLE
fix(core): initialize hydration triggers after late runtime activation

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -97,6 +97,7 @@ export {
 } from './hydration/api';
 export {CACHE_ACTIVE as ɵCACHE_ACTIVE} from './hydration/cache';
 export {withEventReplay as ɵwithEventReplay} from './hydration/event_replay';
+export {resetIncrementalHydrationRuntimeForTests as ɵresetIncrementalHydrationRuntimeForTests} from './hydration/incremental_runtime';
 export {
   EVENT_REPLAY_QUEUE as ɵEVENT_REPLAY_QUEUE,
   IS_ENABLED_BLOCKING_INITIAL_NAVIGATION as ɵIS_ENABLED_BLOCKING_INITIAL_NAVIGATION,

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -44,6 +44,7 @@ import {
 } from './i18n';
 import {
   createDehydratedBlockRegistry,
+  INCREMENTAL_HYDRATION_BOOTSTRAP,
   runIncrementalHydrationBootstrap,
 } from './incremental_runtime';
 import {
@@ -353,21 +354,31 @@ export function withIncrementalHydration(): Provider[] {
   ];
 
   if (typeof ngServerMode === 'undefined' || !ngServerMode) {
-    providers.push({
-      provide: APP_BOOTSTRAP_LISTENER,
-      useFactory: () => {
-        const injector = inject(Injector);
-        const doc = inject(DOCUMENT);
-
-        return () => {
-          // No-op when the incremental-hydration runtime has not been
-          // activated. When activated, performs defer-block scanning,
-          // trigger initialization, and jsaction wiring.
-          runIncrementalHydrationBootstrap(injector, doc);
-        };
+    providers.push(
+      {
+        provide: INCREMENTAL_HYDRATION_BOOTSTRAP,
+        useFactory: () => ({
+          requested: false,
+          activated: false,
+          injector: inject(Injector),
+          document: inject(DOCUMENT),
+        }),
       },
-      multi: true,
-    });
+      {
+        provide: APP_BOOTSTRAP_LISTENER,
+        useFactory: () => {
+          const state = inject(INCREMENTAL_HYDRATION_BOOTSTRAP);
+
+          return () => {
+            if (!state.requested) {
+              state.requested = true;
+              runIncrementalHydrationBootstrap(state);
+            }
+          };
+        },
+        multi: true,
+      },
+    );
   }
 
   return providers;

--- a/packages/core/src/hydration/incremental_runtime.ts
+++ b/packages/core/src/hydration/incremental_runtime.ts
@@ -6,9 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {Injector} from '../di';
 import {DehydratedBlockRegistry} from '../defer/registry';
 import {processAndInitTriggers} from '../defer/triggering';
+import type {Injector} from '../di';
+import {InjectionToken} from '../di/injection_token';
+import {INJECTOR} from '../render3/interfaces/view';
+import {getLView} from '../render3/state';
 import {performanceMarkFeature} from '../util/performance';
 import {gatherDeferBlocksCommentNodes} from './node_lookup_utils';
 import {
@@ -34,6 +37,18 @@ let _runIncrementalHydrationBootstrap: (injector: Injector, doc: Document) => vo
  */
 let isIncrementalHydrationRuntimeActive = false;
 
+interface IncrementalHydrationBootstrapState {
+  requested: boolean;
+  activated: boolean;
+  injector: Injector;
+  document: Document;
+}
+
+export const INCREMENTAL_HYDRATION_BOOTSTRAP =
+  new InjectionToken<IncrementalHydrationBootstrapState>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'INCREMENTAL_HYDRATION_BOOTSTRAP' : '',
+  );
+
 /**
  * Returns the `DehydratedBlockRegistry` used by incremental hydration, or
  * `null` if the runtime has not been activated.
@@ -43,39 +58,60 @@ export function createDehydratedBlockRegistry(): DehydratedBlockRegistry | null 
 }
 
 /**
- * Runs the incremental-hydration bootstrap routine (defer-block scanning,
- * trigger initialization, jsaction wiring). Called from `APP_BOOTSTRAP_LISTENER`.
- * No-op until the runtime is activated.
+ * Runs incremental hydration bootstrap once application bootstrap and the
+ * compiler-generated runtime activation have both occurred.
  */
-export function runIncrementalHydrationBootstrap(injector: Injector, doc: Document): void {
-  _runIncrementalHydrationBootstrap(injector, doc);
+export function runIncrementalHydrationBootstrap(state: IncrementalHydrationBootstrapState): void {
+  if (state.requested && state.activated) {
+    _runIncrementalHydrationBootstrap(state.injector, state.document);
+  }
 }
 
 /**
  * Activates the incremental-hydration runtime.
  *
- * Emitted by the Angular compiler at the top level of every component file
- * whose template contains a `@defer (hydrate ...)` trigger. The first call
- * swaps in real implementations; subsequent calls are no-ops.
+ * Emitted by the Angular compiler before the first hydrating `@defer` block in
+ * a creation block. The first call swaps in the real implementations. Every
+ * client call also notifies the current application that the runtime is
+ * available.
  *
  * @codeGenApi
  */
 export function ɵɵenableIncrementalHydrationRuntime(): void {
-  if (isIncrementalHydrationRuntimeActive) {
-    return;
+  if (!isIncrementalHydrationRuntimeActive) {
+    isIncrementalHydrationRuntimeActive = true;
+
+    enableRetrieveDeferBlockDataImpl();
+
+    performanceMarkFeature('NgIncrementalHydration');
+
+    _dehydratedBlockRegistryFactory = () => new DehydratedBlockRegistry();
+
+    _runIncrementalHydrationBootstrap = (injector, doc) => {
+      const deferBlockData = processBlockData(injector);
+      const commentsByBlockId = gatherDeferBlocksCommentNodes(doc, doc.body);
+      processAndInitTriggers(injector, deferBlockData, commentsByBlockId);
+      appendDeferBlocksToJSActionMap(doc, injector);
+    };
   }
-  isIncrementalHydrationRuntimeActive = true;
 
-  enableRetrieveDeferBlockDataImpl();
+  if (typeof ngServerMode === 'undefined' || !ngServerMode) {
+    const injector = getLView()[INJECTOR];
+    const state = injector.get(INCREMENTAL_HYDRATION_BOOTSTRAP, null, {optional: true});
+    if (state !== null && !state.activated) {
+      state.activated = true;
+      runIncrementalHydrationBootstrap(state);
+    }
+  }
+}
 
-  performanceMarkFeature('NgIncrementalHydration');
-
-  _dehydratedBlockRegistryFactory = () => new DehydratedBlockRegistry();
-
-  _runIncrementalHydrationBootstrap = (injector, doc) => {
-    const deferBlockData = processBlockData(injector);
-    const commentsByBlockId = gatherDeferBlocksCommentNodes(doc, doc.body);
-    processAndInitTriggers(injector, deferBlockData, commentsByBlockId);
-    appendDeferBlocksToJSActionMap(doc, injector);
-  };
+/**
+ * Resets module-level runtime activation for tests that run SSR and client hydration in the same
+ * process. This is not a full hydration reset and should only be used when cold client activation
+ * is part of the behavior under test.
+ */
+export function resetIncrementalHydrationRuntimeForTests(): void {
+  isIncrementalHydrationRuntimeActive = false;
+  _dehydratedBlockRegistryFactory = () => null;
+  _runIncrementalHydrationBootstrap = () => {};
 }

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -138,6 +138,7 @@
       "HttpResponseBase",
       "HydrationFeatureKind",
       "ID",
+      "INCREMENTAL_HYDRATION_BOOTSTRAP",
       "INJECTOR",
       "INJECTOR",
       "INJECTOR_DEF_TYPES",

--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -21,6 +21,7 @@ import {
   PLATFORM_ID,
   Provider,
   QueryList,
+  ɵresetIncrementalHydrationRuntimeForTests as resetIncrementalHydrationRuntimeForTests,
   ɵresetIncrementalHydrationEnabledWarnedForTests as resetIncrementalHydrationEnabledWarnedForTests,
   signal,
   ɵTimerScheduler as TimerScheduler,
@@ -1304,6 +1305,65 @@ describe('platform-server partial hydration integration', () => {
 
           // Internal cleanup before we do server->client transition in this test.
           resetTViewsFor(SimpleComponent);
+
+          ////////////////////////////////
+          const doc = getDocument();
+          const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+            envProviders: [...providers, {provide: PLATFORM_ID, useValue: 'browser'}],
+            hydrationFeatures,
+          });
+          appRef.tick();
+          await appRef.whenStable();
+
+          expect(activeObservers.length).toBe(1);
+          expect(activeObservers[0].options).toEqual({rootMargin: '123px', threshold: 0.5});
+        });
+
+        it('should create an IntersectionObserver for a nested routed viewport block', async () => {
+          @Component({
+            selector: 'routed',
+            template: `
+              @defer (hydrate on interaction) {
+                <main>
+                  @defer (hydrate on viewport({rootMargin: '123px', threshold: 0.5})) {
+                    <article>defer block rendered!</article>
+                  } @placeholder {
+                    <span>Inner block placeholder</span>
+                  }
+                </main>
+              } @placeholder {
+                <span>Outer block placeholder</span>
+              }
+            `,
+          })
+          class RoutedComponent {}
+
+          @Component({
+            selector: 'app',
+            imports: [RouterOutlet],
+            template: '<router-outlet />',
+          })
+          class SimpleComponent {}
+
+          const providers = [
+            {provide: APP_ID, useValue: 'custom-app-id'},
+            {provide: PlatformLocation, useClass: MockPlatformLocation},
+            provideRouter([{path: '', component: RoutedComponent}]),
+          ] as unknown as Provider[];
+          const hydrationFeatures = () => [withIncrementalHydration()];
+
+          const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain(
+            '"__nghDeferData__":{"d0":{"r":1,"s":2},"d1":{"r":1,"s":2,"t":[{"trigger":2,"intersectionObserverOptions":{"rootMargin":"123px","threshold":0.5}}],"p":"d0"}}',
+          );
+
+          // Internal cleanup before we do server->client transition in this test.
+          resetTViewsFor(SimpleComponent, RoutedComponent);
+          // The root view has no hydration triggers, so verify that the routed view activates a
+          // cold client runtime.
+          resetIncrementalHydrationRuntimeForTests();
 
           ////////////////////////////////
           const doc = getDocument();
@@ -3068,6 +3128,9 @@ describe('platform-server partial hydration integration', () => {
       expect(ssrContents).toContain(`<p id="hydrated">nope</p>`);
 
       resetTViewsFor(SimpleComponent, LazyCmp);
+      // The immediate trigger is nested in a lazy route, so verify that it is discovered with a
+      // cold client runtime.
+      resetIncrementalHydrationRuntimeForTests();
 
       const doc = getDocument();
       const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {


### PR DESCRIPTION
After incremental hydration became tree-shakable, application bootstrap could finish before a routed component activated the runtime. The one-time trigger scan was then skipped, leaving routed and nested hydration triggers uninitialized.

Coordinate application bootstrap with runtime activation and initialize once both have occurred.

Fixes #69908
 