### PR TITLE
[Backport 21.2.X]  fix(platform-server): update domino to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "d3": "^7.0.0",
     "dagre-d3-es": "^7.0.14",
     "diff": "^8.0.0",
-    "domino": "https://github.com/angular/domino.git#f74cccd496283b6141fbdbeb25b168f4b1c9836a",
+    "domino": "https://github.com/angular/domino.git#f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56",
     "esbuild": "0.27.2",
     "esbuild-plugin-umd-wrapper": "^3.0.0",
     "http-server": "^14.0.0",

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^24.3.0",
     "@types/systemjs": "6.15.4",
     "bluebird": "3.7.2",
-    "domino": "https://github.com/angular/domino.git#f74cccd496283b6141fbdbeb25b168f4b1c9836a",
+    "domino": "https://github.com/angular/domino.git#f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56",
     "esbuild-plugin-umd-wrapper": "3.0.0",
     "jest-environment-jsdom": "30.2.0",
     "jest-environment-node": "30.2.0",

--- a/packages/zone.js/test/typings/package.json
+++ b/packages/zone.js/test/typings/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "domino": "https://github.com/angular/domino.git#f74cccd496283b6141fbdbeb25b168f4b1c9836a",
+    "domino": "https://github.com/angular/domino.git#f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56",
     "zone.js": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.3
       domino:
-        specifier: https://github.com/angular/domino.git#f74cccd496283b6141fbdbeb25b168f4b1c9836a
-        version: '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f74cccd496283b6141fbdbeb25b168f4b1c9836a'
+        specifier: https://github.com/angular/domino.git#f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56
+        version: '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56'
       esbuild:
         specifier: 0.27.2
         version: 0.27.2
@@ -1304,8 +1304,8 @@ importers:
         specifier: 3.7.2
         version: 3.7.2
       domino:
-        specifier: https://github.com/angular/domino.git#f74cccd496283b6141fbdbeb25b168f4b1c9836a
-        version: '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f74cccd496283b6141fbdbeb25b168f4b1c9836a'
+        specifier: https://github.com/angular/domino.git#f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56
+        version: '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56'
       esbuild-plugin-umd-wrapper:
         specifier: 3.0.0
         version: 3.0.0
@@ -1352,8 +1352,8 @@ importers:
   packages/zone.js/test/typings:
     dependencies:
       domino:
-        specifier: https://github.com/angular/domino.git#f74cccd496283b6141fbdbeb25b168f4b1c9836a
-        version: '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f74cccd496283b6141fbdbeb25b168f4b1c9836a'
+        specifier: https://github.com/angular/domino.git#f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56
+        version: '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56'
       zone.js:
         specifier: workspace:*
         version: link:../..
@@ -1780,10 +1780,9 @@ packages:
       '@angular/compiler':
         optional: true
 
-  '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f74cccd496283b6141fbdbeb25b168f4b1c9836a':
-    resolution: {tarball: https://codeload.github.com/angular/domino/tar.gz/f74cccd496283b6141fbdbeb25b168f4b1c9836a}
+  '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56':
+    resolution: {tarball: https://codeload.github.com/angular/domino/tar.gz/f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56}
     version: 2.1.6
-    engines: {npm: Please use pnpm instead of NPM to install dependencies, pnpm: 10.31.0, yarn: Please use pnpm instead of Yarn to install dependencies}
 
   '@angular/material@21.2.9':
     resolution: {integrity: sha512-uU5Sy0rSd4Y4WjqTcrqs3MpfY/Uy5tmDPSAAvwD0y5y4QVOLoV8uhTQDI/nNg2Lh9NoJKvykZE1ITRMvjfRALQ==}
@@ -14357,7 +14356,7 @@ snapshots:
     optionalDependencies:
       '@angular/compiler': link:packages/compiler
 
-  '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f74cccd496283b6141fbdbeb25b168f4b1c9836a': {}
+  '@angular/domino@https://codeload.github.com/angular/domino/tar.gz/f88e5aa49cf2804d7c2df22ef1640eb4ec43dd56': {}
 
   '@angular/material@21.2.9(@angular/cdk@21.2.9(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2))(@angular/common@packages+common)(@angular/core@packages+core)(@angular/forms@packages+forms)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2)':
     dependencies:


### PR DESCRIPTION
Updates the domino dependency to the latest version as used in the main branch.

This update contains fixes for https://github.com/angular/domino/pull/32.

Note : We could consider this a similar case to https://github.com/angular/angular/security/advisories/GHSA-gxx4-3xcv-f8qx
