### PR TITLE
fix(compiler): correctly handle selector prefixes with :host-context

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -487,6 +487,10 @@ export class ShadowCss {
     yield text.slice(prev);
   }
 
+  private _hasBothHostAndHostContext(part: string): boolean {
+    return part.includes(_polyfillHost) && part.includes(_polyfillHostContext);
+  }
+
   /*
    * convert a rule like :host-context(.foo) > .bar { }
    *
@@ -503,91 +507,202 @@ export class ShadowCss {
    * .foo<scopeName> .bar { ... }
    */
   private _convertColonHostContext(cssText: string): string {
-    // Splits up the selectors on their top-level commas, processes the :host-context in them
-    // individually and stitches them back together. This ensures that individual selectors don't
-    // affect each other.
-    const results: string[] = [];
-    for (const part of this._splitOnTopLevelCommas(cssText, false)) {
-      results.push(this._convertColonHostContextInSelectorPart(part));
-    }
-    return results.join(',');
+    return processRules(cssText, (rule) => {
+      if (rule.selector.startsWith('@')) {
+        if (scopedAtRuleIdentifiers.some((atRule) => rule.selector.startsWith(atRule))) {
+          rule.content = this._convertColonHostContext(rule.content);
+        }
+        return rule;
+      }
+      const results: string[] = [];
+      for (const part of this._splitOnTopLevelCommas(rule.selector, false)) {
+        if (this._hasBothHostAndHostContext(part)) {
+          results.push(this._convertColonHostContextLegacy(part));
+        } else {
+          results.push(this._convertColonHostContextModern(part));
+        }
+      }
+      rule.selector = results.join(',');
+      return rule;
+    });
   }
 
-  private _convertColonHostContextInSelectorPart(cssText: string): string {
-    return cssText.replace(_cssColonHostContextReGlobal, (selectorText, pseudoPrefix) => {
-      // We have captured a selector that contains a `:host-context` rule.
+  /**
+   * Converts `:host-context` selectors using the legacy path to preserve backwards compatibility.
+   * This is used when a selector contains both `:host` and `:host-context`, leaving preceding
+   * selectors outside the second permuted block.
+   */
+  private _convertColonHostContextLegacy(cssText: string): string {
+    return cssText.replace(_cssColonHostContextReGlobal, (selectorText) => {
+      const {contextSelectorGroups, remainingSelectorText, pseudoPrefix} =
+        this._parseHostContext(selectorText);
 
-      // For backward compatibility `:host-context` may contain a comma separated list of selectors.
-      // Each context selector group will contain a list of host-context selectors that must match
-      // an ancestor of the host.
-      // (Normally `contextSelectorGroups` will only contain a single array of context selectors.)
-      const contextSelectorGroups: string[][] = [[]];
-
-      // There may be more than `:host-context` in this selector so `selectorText` could look like:
-      // `:host-context(.one):host-context(.two)`.
-      // Loop until every :host-context in the compound selector has been processed.
-      let startIndex = selectorText.indexOf(_polyfillHostContext);
-      while (startIndex !== -1) {
-        const afterPrefix = selectorText.substring(startIndex + _polyfillHostContext.length);
-
-        if (!afterPrefix || afterPrefix[0] !== '(') {
-          // Edge case of :host-context with no parens (e.g. `:host-context .inner`)
-          selectorText = afterPrefix;
-          startIndex = selectorText.indexOf(_polyfillHostContext);
-          continue;
-        }
-
-        // Extract comma-separated selectors between the parentheses
-        const newContextSelectors: string[] = [];
-        let endIndex = 0; // Index of the closing paren of the :host-context()
-        for (const selector of this._splitOnTopLevelCommas(afterPrefix.substring(1), true)) {
-          endIndex = endIndex + selector.length + 1;
-          const trimmed = selector.trim();
-          if (trimmed) {
-            newContextSelectors.push(trimmed);
-          }
-        }
-
-        // We must duplicate the current selector group for each of these new selectors.
-        // For example if the current groups are:
-        // ```
-        // [
-        //   ['a', 'b', 'c'],
-        //   ['x', 'y', 'z'],
-        // ]
-        // ```
-        // And we have a new set of comma separated selectors: `:host-context(m,n)` then the new
-        // groups are:
-        // ```
-        // [
-        //   ['a', 'b', 'c', 'm'],
-        //   ['x', 'y', 'z', 'm'],
-        //   ['a', 'b', 'c', 'n'],
-        //   ['x', 'y', 'z', 'n'],
-        // ]
-        // ```
-        const contextSelectorGroupsLength = contextSelectorGroups.length;
-        repeatGroups(contextSelectorGroups, newContextSelectors.length);
-        for (let i = 0; i < newContextSelectors.length; i++) {
-          for (let j = 0; j < contextSelectorGroupsLength; j++) {
-            contextSelectorGroups[j + i * contextSelectorGroupsLength].push(newContextSelectors[i]);
-          }
-        }
-
-        // Update the `selectorText` and see repeat to see if there are more `:host-context`s.
-        selectorText = afterPrefix.substring(endIndex + 1);
-        startIndex = selectorText.indexOf(_polyfillHostContext);
-      }
-
-      // The context selectors now must be combined with each other to capture all the possible
-      // selectors that `:host-context` can match. See `_combineHostContextSelectors()` for more
-      // info about how this is done.
       return contextSelectorGroups
         .map((contextSelectors) =>
-          _combineHostContextSelectors(contextSelectors, selectorText, pseudoPrefix),
+          _combineHostContextSelectors(contextSelectors, remainingSelectorText, pseudoPrefix),
         )
         .join(', ');
     });
+  }
+
+  /**
+   * Converts `:host-context` selectors using the modern path to resolve scoping issues.
+   * This path dynamically prepends and distributes any preceding context selectors (e.g. `.foo`)
+   * to all generated permutations of the `:host-context` selector.
+   *
+   * @param cssText The input CSS stylesheet or selector text.
+   * @returns The transformed CSS text with modern `:host-context` scoping applied.
+   */
+  private _convertColonHostContextModern(cssText: string): string {
+    return cssText.replace(
+      _cssColonHostContextReGlobal,
+      (...args: (string | number | undefined)[]) => {
+        const match = args[0] as string;
+        const offset = args[args.length - 2] as number;
+        const prefix = cssText.slice(0, offset);
+        const hasHostOrHostContextPlaceholder = _hostOrContextPlaceholderRe.test(prefix);
+        const {contextSelectorGroups, remainingSelectorText, pseudoPrefix} =
+          this._parseHostContext(match);
+
+        const allPermutations: string[] = [];
+        for (const contextSelectors of contextSelectorGroups) {
+          const combined = _combineHostContextSelectors(
+            contextSelectors,
+            remainingSelectorText,
+            pseudoPrefix,
+          );
+          for (const part of this._splitOnTopLevelCommas(combined, false)) {
+            const trimmed = part.trimStart();
+            if (trimmed) {
+              allPermutations.push(trimmed);
+            }
+          }
+        }
+
+        if (!prefix || hasHostOrHostContextPlaceholder) {
+          return allPermutations.join(', ');
+        }
+
+        return allPermutations
+          .map((part, index) => (index === 0 ? part : prefix + part))
+          .join(', ');
+      },
+    );
+  }
+
+  /**
+   * Parses `:host-context` selector text into constituent context selector groups,
+   * remaining selector text, and optional pseudo prefix (e.g., `:where(` or `:is(`).
+   *
+   * @param selectorText The selector string containing `:host-context`.
+   * @returns The parsed result containing selector groups and remaining text.
+   */
+  private _parseHostContext(selectorText: string): HostContextParseResult {
+    let pseudoPrefix = '';
+    const unwrapped = _unwrapPseudoWrapper(selectorText);
+    if (unwrapped) {
+      pseudoPrefix = unwrapped.prefix;
+      selectorText = unwrapped.inner;
+    }
+
+    const units: HostContextUnit[] = [];
+    let remainingSelectorText = '';
+
+    let startIndex = selectorText.indexOf(_polyfillHostContext);
+    while (startIndex !== -1) {
+      const prefixBefore = selectorText.substring(0, startIndex);
+      const pseudoUnitMatch = prefixBefore.match(_whereOrIsSuffixRe);
+      const unitPseudoPrefix = pseudoUnitMatch ? pseudoUnitMatch[0] : '';
+
+      const afterPrefixIndex = startIndex + _polyfillHostContext.length;
+      if (afterPrefixIndex >= selectorText.length || selectorText[afterPrefixIndex] !== '(') {
+        selectorText = selectorText.substring(afterPrefixIndex);
+        startIndex = selectorText.indexOf(_polyfillHostContext);
+        continue;
+      }
+
+      const closeParenIndex = _findMatchingParen(selectorText, afterPrefixIndex);
+      if (closeParenIndex === -1) {
+        break;
+      }
+
+      const innerArgs = selectorText.substring(afterPrefixIndex + 1, closeParenIndex);
+      let endUnitIndex = closeParenIndex;
+      let effectiveUnitPrefix = '';
+      if (unitPseudoPrefix && selectorText[closeParenIndex + 1] === ')') {
+        endUnitIndex = closeParenIndex + 1;
+        effectiveUnitPrefix = unitPseudoPrefix;
+      }
+
+      units.push({
+        innerArgs: innerArgs.trim(),
+        unitPseudoPrefix: effectiveUnitPrefix,
+      });
+
+      const nextIndex = endUnitIndex + 1;
+      remainingSelectorText = selectorText.substring(nextIndex);
+      selectorText = selectorText.substring(nextIndex);
+
+      startIndex = selectorText.indexOf(_polyfillHostContext);
+    }
+
+    const allUnitsShareSamePseudoPrefix =
+      !pseudoPrefix &&
+      units.length > 0 &&
+      units.every(
+        (unit) =>
+          unit.unitPseudoPrefix !== '' && unit.unitPseudoPrefix === units[0].unitPseudoPrefix,
+      );
+
+    if (allUnitsShareSamePseudoPrefix) {
+      pseudoPrefix = units[0].unitPseudoPrefix;
+    }
+
+    const contextSelectorGroups: string[][] = [[]];
+    for (const unit of units) {
+      let formattedUnit = '';
+      if (!pseudoPrefix && unit.unitPseudoPrefix) {
+        formattedUnit = `${unit.unitPseudoPrefix}${unit.innerArgs})`;
+      } else {
+        formattedUnit = unit.innerArgs;
+      }
+
+      const newContextSelectors: string[] = [];
+      for (const selector of this._splitOnTopLevelCommas(formattedUnit, false)) {
+        const trimmed = selector.trim();
+        if (trimmed) {
+          newContextSelectors.push(trimmed);
+        }
+      }
+
+      // We must duplicate the current selector group for each of these new selectors.
+      // For example if the current groups are:
+      // ```
+      // [
+      //   ['a', 'b', 'c'],
+      //   ['x', 'y', 'z'],
+      // ]
+      // ```
+      // And we have a new set of comma separated selectors: `:host-context(m,n)` then the new
+      // groups are:
+      // ```
+      // [
+      //   ['a', 'b', 'c', 'm'],
+      //   ['x', 'y', 'z', 'm'],
+      //   ['a', 'b', 'c', 'n'],
+      //   ['x', 'y', 'z', 'n'],
+      // ]
+      // ```
+      const contextSelectorGroupsLength = contextSelectorGroups.length;
+      repeatGroups(contextSelectorGroups, newContextSelectors.length);
+      for (let i = 0; i < newContextSelectors.length; i++) {
+        for (let j = 0; j < contextSelectorGroupsLength; j++) {
+          contextSelectorGroups[j + i * contextSelectorGroupsLength].push(newContextSelectors[i]);
+        }
+      }
+    }
+
+    return {contextSelectorGroups, remainingSelectorText, pseudoPrefix};
   }
 
   // change a selector like 'div' to 'name div'
@@ -976,10 +1091,23 @@ class SafeSelector {
   }
 }
 
+interface HostContextParseResult {
+  readonly contextSelectorGroups: readonly string[][];
+  readonly remainingSelectorText: string;
+  readonly pseudoPrefix: string;
+}
+
+interface HostContextUnit {
+  readonly innerArgs: string;
+  readonly unitPseudoPrefix: string;
+}
+
 const _cssScopedPseudoFunctionPrefix = '(:(where|is)\\()?';
 const _cssPrefixWithPseudoSelectorFunction = /:(where|is)\(/gi;
+const _whereOrIsPrefixRe = /^:(where|is)\(/i;
+const _whereOrIsSuffixRe = /:(where|is)\($/i;
+const _hostOrContextPlaceholderRe = /-shadowcss|:host/;
 const _polyfillHost = '-shadowcsshost';
-// note: :host-context pre-processed to -shadowcsshostcontext.
 const _polyfillHostContext = '-shadowcsscontext';
 // Matches text content with no parentheses, e.g., "foo"
 const _noParens = '[^)(]*';
@@ -1254,8 +1382,32 @@ function unescapeQuotes(str: string, isQuoted: boolean): string {
 }
 
 /**
- * Combine the `contextSelectors` with the `hostMarker` and the `otherSelectors`
- * to create a selector that matches the same as `:host-context()`.
+ * Unwraps an outer pseudo-class wrapper such as `:where(...)` or `:is(...)` if present.
+ *
+ * @param selector The selector string to inspect.
+ * @returns The prefix and inner content if unwrapped, or null if not wrapped.
+ */
+function _unwrapPseudoWrapper(selector: string): {prefix: string; inner: string} | null {
+  const match = selector.match(_whereOrIsPrefixRe);
+  if (!match || !selector.endsWith(')')) {
+    return null;
+  }
+
+  const openParenIndex = match[0].length - 1;
+  const closeParenIndex = _findMatchingParen(selector, openParenIndex);
+  if (closeParenIndex !== selector.length - 1) {
+    return null;
+  }
+
+  return {
+    prefix: match[0],
+    inner: selector.slice(openParenIndex + 1, closeParenIndex),
+  };
+}
+
+/**
+ * Combines context selectors with the host marker and remaining selectors
+ * to generate host-context target selectors.
  *
  * Given a single context selector `A` we need to output selectors that match on the host and as an
  * ancestor of the host:
@@ -1274,27 +1426,30 @@ function unescapeQuotes(str: string, isQuoted: boolean): string {
  *
  * And so on...
  *
- * @param contextSelectors an array of context selectors that will be combined.
- * @param otherSelectors the rest of the selectors that are not context selectors.
+ * @param contextSelectors The list of context selectors to combine.
+ * @param otherSelectors The remaining portion of the selector.
+ * @param pseudoPrefix Optional pseudo-class prefix (e.g. ':where(' or ':is(').
+ * @returns The combined CSS selector string.
  */
 function _combineHostContextSelectors(
-  contextSelectors: string[],
+  contextSelectors: readonly string[],
   otherSelectors: string,
   pseudoPrefix = '',
 ): string {
   const hostMarker = _polyfillHostNoCombinator;
-  _polyfillHostRe.lastIndex = 0; // reset the regex to ensure we get an accurate test
-  const otherSelectorsHasHost = _polyfillHostRe.test(otherSelectors);
+  const otherSelectorsHasHost = otherSelectors.includes(_polyfillHost);
+  const pseudoSuffix = pseudoPrefix ? ')' : '';
 
   // If there are no context selectors then just output a host marker
   if (contextSelectors.length === 0) {
     return hostMarker + otherSelectors;
   }
 
-  const combined: string[] = [contextSelectors.pop() || ''];
-  while (contextSelectors.length > 0) {
+  const selectors = [...contextSelectors];
+  const combined: string[] = [selectors.pop() || ''];
+  while (selectors.length > 0) {
     const length = combined.length;
-    const contextSelector = contextSelectors.pop();
+    const contextSelector = selectors.pop();
     for (let i = 0; i < length; i++) {
       const previousSelectors = combined[i];
       // Add the new selector as a descendant of the previous selectors
@@ -1308,12 +1463,53 @@ function _combineHostContextSelectors(
   // Finally connect the selector to the `hostMarker`s: either acting directly on the host
   // (A<hostMarker>) or as an ancestor (A <hostMarker>).
   return combined
-    .map((s) =>
-      otherSelectorsHasHost
-        ? `${pseudoPrefix}${s}${otherSelectors}`
-        : `${pseudoPrefix}${s}${hostMarker}${otherSelectors}, ${pseudoPrefix}${s} ${hostMarker}${otherSelectors}`,
-    )
+    .map((selector) => {
+      if (otherSelectorsHasHost) {
+        return `${pseudoPrefix}${selector}${pseudoSuffix}${otherSelectors}`;
+      }
+      const direct = `${selector}${hostMarker}`;
+      const ancestor = `${selector} ${hostMarker}`;
+      return `${pseudoPrefix}${direct}${pseudoSuffix}${otherSelectors}, ${pseudoPrefix}${ancestor}${pseudoSuffix}${otherSelectors}`;
+    })
     .join(',');
+}
+
+/**
+ * Finds the index of the matching closing parenthesis for an opening parenthesis at openIndex.
+ *
+ * @param text The text string to search within.
+ * @param openIndex The index of the opening parenthesis.
+ * @returns The index of the matching closing parenthesis, or -1 if not found.
+ */
+function _findMatchingParen(text: string, openIndex: number): number {
+  let depth = 0;
+  let inQuote: string | null = null;
+  for (let i = openIndex; i < text.length; i++) {
+    const char = text[i];
+    if (char === '\\') {
+      i++;
+      continue;
+    }
+    if (inQuote !== null) {
+      if (char === inQuote) {
+        inQuote = null;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      inQuote = char;
+      continue;
+    }
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+  return -1;
 }
 
 /**

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -187,6 +187,67 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
+    it('should handle combinations of double :host-context and :where', () => {
+      // 1. :where on the outside containing two :host-context selectors chained
+      expect(
+        shim(':where(:host-context(.one):host-context(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one.two[a-host]), :where(.one.two [a-host]), :where(.one .two[a-host]), ' +
+          ':where(.one .two [a-host]), :where(.two .one[a-host]), :where(.two .one [a-host]) {}',
+      );
+
+      // 2. :where on the outside containing two :host-context selectors as descendants
+      expect(
+        shim(':where(:host-context(.one) :host-context(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one.two[a-host]), :where(.one.two [a-host]), :where(.one .two[a-host]), ' +
+          ':where(.one .two [a-host]), :where(.two .one[a-host]), :where(.two .one [a-host]) {}',
+      );
+
+      // 3. Mix: first :host-context inside :where, second :host-context outside
+      expect(
+        shim(':where(:host-context(.one)) :host-context(.two) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one).two[a-host], :where(.one).two [a-host], :where(.one) .two[a-host], ' +
+          ':where(.one) .two [a-host], .two :where(.one)[a-host], .two :where(.one) [a-host] {}',
+      );
+
+      // 4. Mix: first :host-context outside, second :host-context inside :where
+      expect(
+        shim(':host-context(.one) :where(:host-context(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        '.one:where(.two)[a-host], .one:where(.two) [a-host], .one :where(.two)[a-host], ' +
+          '.one :where(.two) [a-host], :where(.two) .one[a-host], :where(.two) .one [a-host] {}',
+      );
+
+      // 5. Two :host-context selectors with :where inside
+      expect(
+        shim(':host-context(:where(.one)) :host-context(:where(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one):where(.two)[a-host], :where(.one):where(.two) [a-host], ' +
+          ':where(.one) :where(.two)[a-host], :where(.one) :where(.two) [a-host], ' +
+          ':where(.two) :where(.one)[a-host], :where(.two) :where(.one) [a-host] {}',
+      );
+
+      // 6. Mix: one :host-context inside :where, one :host-context with :where inside
+      expect(
+        shim(':where(:host-context(.one)) :host-context(:where(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one):where(.two)[a-host], :where(.one):where(.two) [a-host], ' +
+          ':where(.one) :where(.two)[a-host], :where(.one) :where(.two) [a-host], ' +
+          ':where(.two) :where(.one)[a-host], :where(.two) :where(.one) [a-host] {}',
+      );
+
+      // 7. Mix: one :host-context with :where inside, one :host-context inside :where
+      expect(
+        shim(':host-context(:where(.one)) :where(:host-context(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one):where(.two)[a-host], :where(.one):where(.two) [a-host], ' +
+          ':where(.one) :where(.two)[a-host], :where(.one) :where(.two) [a-host], ' +
+          ':where(.two) :where(.one)[a-host], :where(.two) :where(.one) [a-host] {}',
+      );
+    });
+
     it('should handle tag selector', () => {
       expect(shim(':host-context(div) {}', 'contenta', 'a-host')).toEqualCss(
         'div[a-host], div [a-host] {}',
@@ -212,6 +273,12 @@ describe('ShadowCss, :host and :host-context', () => {
       );
       expect(shim(':host-context([a=b]) {}', 'contenta', 'a-host')).toEqualCss(
         '[a=b][a-host], [a=b] [a-host] {}',
+      );
+      expect(
+        shim(':host-context([data-theme="dark,compact"]) .button {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        '[data-theme="dark,compact"][a-host] .button[contenta], ' +
+          '[data-theme="dark,compact"] [a-host] .button[contenta] {}',
       );
     });
 
@@ -278,6 +345,13 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
+    it('should distribute preceding prefix across all permutations of multi-argument :host-context', () => {
+      expect(shim('div :host-context(.foo, .bar) span {}', 'contenta', 'a-host')).toEqualCss(
+        'div .foo[a-host] span[contenta], div .foo [a-host] span[contenta], ' +
+          'div .bar[a-host] span[contenta], div .bar [a-host] span[contenta] {}',
+      );
+    });
+
     it('should handle :host-context with comma-separated child selector', () => {
       expect(shim(':host-context(.foo) a:not(.a, .b) {}', 'contenta', 'a-host')).toEqualCss(
         '.foo[a-host] a[contenta]:not(.a, .b), .foo [a-host] a[contenta]:not(.a, .b) {}',
@@ -325,6 +399,23 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
+    it('should handle selectors on different elements (prefixed :host-context)', () => {
+      expect(shim('.foo :host-context(div) :host(.x) > .y {}', 'contenta', 'a-host')).toEqualCss(
+        '.foo div .x[a-host] > .y[contenta] {}',
+      );
+
+      expect(
+        shim(
+          'body[data-cm-color-scheme=dark] :host-context(.cm-gm2) .cfc-message-warning {}',
+          'contenta',
+          'a-host',
+        ),
+      ).toEqualCss(
+        'body[data-cm-color-scheme=dark] .cm-gm2[a-host] .cfc-message-warning[contenta], ' +
+          'body[data-cm-color-scheme=dark] .cm-gm2 [a-host] .cfc-message-warning[contenta] {}',
+      );
+    });
+
     it('should parse multiple rules containing :host-context and :host', () => {
       const input = `
             :host-context(outer1) :host(bar) {}
@@ -332,6 +423,36 @@ describe('ShadowCss, :host and :host-context', () => {
         `;
       expect(shim(input, 'contenta', 'a-host')).toEqualCss(
         'outer1 bar[a-host] {} ' + 'outer2 foo[a-host] {}',
+      );
+    });
+
+    it('should maintain prefixed context on all host-context permutations in multi-rule stylesheets containing :host', () => {
+      const input = `
+        body[data-cm-color-scheme="dark"] :host-context(.cm-gm2) .foo {}
+        :host {}
+      `;
+      expect(shim(input, 'contenta', 'a-host')).toEqualCss(
+        'body[data-cm-color-scheme="dark"] .cm-gm2[a-host] .foo[contenta], ' +
+          'body[data-cm-color-scheme="dark"] .cm-gm2 [a-host] .foo[contenta] {} ' +
+          '[a-host] {}',
+      );
+    });
+
+    it('should handle preceding tag before :host-context', () => {
+      expect(shim('div:host-context(.bar) .zot { color: red; }', 'contenta', 'a-host')).toEqualCss(
+        'div.bar[a-host] .zot[contenta], div.bar [a-host] .zot[contenta] { color: red; }',
+      );
+    });
+
+    it('should handle preceding component selector before :host-context', () => {
+      expect(shim('app-card:host-context(.dark-theme) {}', 'contenta', 'a-host')).toEqualCss(
+        'app-card.dark-theme[a-host], app-card.dark-theme [a-host] {}',
+      );
+    });
+
+    it('should handle preceding class selector before :host-context', () => {
+      expect(shim('.foo :host-context(.bar) {}', 'contenta', 'a-host')).toEqualCss(
+        '.foo .bar[a-host], .foo .bar [a-host] {}',
       );
     });
   });

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -187,6 +187,75 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
+    it('should handle combinations of double :host-context and :where', () => {
+      // 1. :where on the outside containing two :host-context selectors chained
+      expect(
+        shim(':where(:host-context(.one):host-context(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one.two[a-host]), :where(.one.two [a-host]), :where(.one .two[a-host]), ' +
+          ':where(.one .two [a-host]), :where(.two .one[a-host]), :where(.two .one [a-host]) {}',
+      );
+
+      // 2. :where on the outside containing two :host-context selectors as descendants
+      expect(
+        shim(':where(:host-context(.one) :host-context(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one.two[a-host]), :where(.one.two [a-host]), :where(.one .two[a-host]), ' +
+          ':where(.one .two [a-host]), :where(.two .one[a-host]), :where(.two .one [a-host]) {}',
+      );
+
+      // 3. Mix: first :host-context inside :where, second :host-context outside
+      expect(
+        shim(':where(:host-context(.one)) :host-context(.two) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one).two[a-host], :where(.one).two [a-host], :where(.one) .two[a-host], ' +
+          ':where(.one) .two [a-host], .two :where(.one)[a-host], .two :where(.one) [a-host] {}',
+      );
+
+      // 4. Mix: first :host-context outside, second :host-context inside :where
+      expect(
+        shim(':host-context(.one) :where(:host-context(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        '.one:where(.two)[a-host], .one:where(.two) [a-host], .one :where(.two)[a-host], ' +
+          '.one :where(.two) [a-host], :where(.two) .one[a-host], :where(.two) .one [a-host] {}',
+      );
+
+      // 5. Two :host-context selectors with :where inside
+      expect(
+        shim(':host-context(:where(.one)) :host-context(:where(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one):where(.two)[a-host], :where(.one):where(.two) [a-host], ' +
+          ':where(.one) :where(.two)[a-host], :where(.one) :where(.two) [a-host], ' +
+          ':where(.two) :where(.one)[a-host], :where(.two) :where(.one) [a-host] {}',
+      );
+
+      // 6. Mix: one :host-context inside :where, one :host-context with :where inside
+      expect(
+        shim(':where(:host-context(.one)) :host-context(:where(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one):where(.two)[a-host], :where(.one):where(.two) [a-host], ' +
+          ':where(.one) :where(.two)[a-host], :where(.one) :where(.two) [a-host], ' +
+          ':where(.two) :where(.one)[a-host], :where(.two) :where(.one) [a-host] {}',
+      );
+
+      // 7. Mix: one :host-context with :where inside, one :host-context inside :where
+      expect(
+        shim(':host-context(:where(.one)) :where(:host-context(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one):where(.two)[a-host], :where(.one):where(.two) [a-host], ' +
+          ':where(.one) :where(.two)[a-host], :where(.one) :where(.two) [a-host], ' +
+          ':where(.two) :where(.one)[a-host], :where(.two) :where(.one) [a-host] {}',
+      );
+    });
+
+    it('should handle :where containing :host-context followed by descendant selectors', () => {
+      expect(
+        shim(':where(:host-context(.dark)) .button {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.dark[a-host]) .button[contenta], :where(.dark [a-host]) .button[contenta] {}',
+      );
+    });
+
     it('should handle tag selector', () => {
       expect(shim(':host-context(div) {}', 'contenta', 'a-host')).toEqualCss(
         'div[a-host], div [a-host] {}',
@@ -212,6 +281,12 @@ describe('ShadowCss, :host and :host-context', () => {
       );
       expect(shim(':host-context([a=b]) {}', 'contenta', 'a-host')).toEqualCss(
         '[a=b][a-host], [a=b] [a-host] {}',
+      );
+      expect(
+        shim(':host-context([data-theme="dark,compact"]) .button {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        '[data-theme="dark,compact"][a-host] .button[contenta], ' +
+          '[data-theme="dark,compact"] [a-host] .button[contenta] {}',
       );
     });
 
@@ -278,6 +353,13 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
+    it('should distribute preceding prefix across all permutations of multi-argument :host-context', () => {
+      expect(shim('div :host-context(.foo, .bar) span {}', 'contenta', 'a-host')).toEqualCss(
+        'div .foo[a-host] span[contenta], div .foo [a-host] span[contenta], ' +
+          'div .bar[a-host] span[contenta], div .bar [a-host] span[contenta] {}',
+      );
+    });
+
     it('should handle :host-context with comma-separated child selector', () => {
       expect(shim(':host-context(.foo) a:not(.a, .b) {}', 'contenta', 'a-host')).toEqualCss(
         '.foo[a-host] a[contenta]:not(.a, .b), .foo [a-host] a[contenta]:not(.a, .b) {}',
@@ -325,6 +407,23 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
+    it('should handle selectors on different elements (prefixed :host-context)', () => {
+      expect(shim('.foo :host-context(div) :host(.x) > .y {}', 'contenta', 'a-host')).toEqualCss(
+        '.foo div .x[a-host] > .y[contenta] {}',
+      );
+
+      expect(
+        shim(
+          'body[data-cm-color-scheme=dark] :host-context(.cm-gm2) .cfc-message-warning {}',
+          'contenta',
+          'a-host',
+        ),
+      ).toEqualCss(
+        'body[data-cm-color-scheme=dark] .cm-gm2[a-host] .cfc-message-warning[contenta], ' +
+          'body[data-cm-color-scheme=dark] .cm-gm2 [a-host] .cfc-message-warning[contenta] {}',
+      );
+    });
+
     it('should parse multiple rules containing :host-context and :host', () => {
       const input = `
             :host-context(outer1) :host(bar) {}
@@ -332,6 +431,30 @@ describe('ShadowCss, :host and :host-context', () => {
         `;
       expect(shim(input, 'contenta', 'a-host')).toEqualCss(
         'outer1 bar[a-host] {} ' + 'outer2 foo[a-host] {}',
+      );
+    });
+
+    it('should maintain prefixed context on all host-context permutations in multi-rule stylesheets containing :host', () => {
+      const input = `
+        body[data-cm-color-scheme="dark"] :host-context(.cm-gm2) .foo {}
+        :host {}
+      `;
+      expect(shim(input, 'contenta', 'a-host')).toEqualCss(
+        'body[data-cm-color-scheme="dark"] .cm-gm2[a-host] .foo[contenta], ' +
+          'body[data-cm-color-scheme="dark"] .cm-gm2 [a-host] .foo[contenta] {} ' +
+          '[a-host] {}',
+      );
+    });
+
+    it('should handle preceding tag before :host-context', () => {
+      expect(shim('div:host-context(.bar) .zot { color: red; }', 'contenta', 'a-host')).toEqualCss(
+        'div.bar[a-host] .zot[contenta], div.bar [a-host] .zot[contenta] { color: red; }',
+      );
+    });
+
+    it('should handle preceding class selector before :host-context', () => {
+      expect(shim('.foo :host-context(.bar) {}', 'contenta', 'a-host')).toEqualCss(
+        '.foo .bar[a-host], .foo .bar [a-host] {}',
       );
     });
   });


### PR DESCRIPTION
When `:host-context` selectors are preceded by outer element/component selectors or combined with pseudo-class wrappers like `:where()`, ShadowCss previously failed to properly distribute the prefix across all generated host-context permutations.

This update unwraps pseudo wrappers when inserting host markers and ensures preceding selector prefixes (excluding prefixes containing `:host`) are preserved across all host-context permutations.

Issue  #58345

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58345 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This change alters how certain selector are being processed. See other information below.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
To start, this change include prefixes with `:host` (i.e. `:host :host-context(.foo) .bar`). Such selectors don't really make sense and the change has extra branching to preserve this behavior just because there are many cases where styles are written like that in Google Cloud. 

New tests are added, below I provide the output from the test outputs for some of the newly added tests before the change, to see the improvements. All previously created tests are intact and pass with the new parsing changes.

1.
```
Input: body[data-cm-color-scheme="dark"] :host-context(.cm-gm2) .foo {}
Output: body[data-cm-color-scheme="dark"] .cm-gm2[a-host] .foo[contenta], .cm-gm2 [a-host] .foo[contenta] {}
```
2.
```
Input: div:host-context(.bar) .zot { color: red; }
Output: div.bar[a-host] .zot[contenta], .bar [a-host] .zot[contenta] { color:red;}
```
3.
```
Input: app-card:host-context(.dark-theme) {}
Output: app-card.dark-theme[a-host], .dark-theme [a-host] {}
```
4.
```
Input: .foo :host-context(.bar) {}
Output: .foo .bar[a-host], .bar [a-host] {}
```
5.
```
Input: body[data-cm-color-scheme=dark] :host-context(.cm-gm2) .cfc-message-warning {}
Output: body[data-cm-color-scheme=dark] .cm-gm2[a-host] .cfc-message-warning[contenta], .cm-gm2 [a-host] .cfc-message-warning[contenta] {}
```
6.
```
Input: div :host-context(.foo, .bar) span {}
Output: div .foo[a-host] span[contenta], .foo [a-host] span[contenta], .bar[a-host] span[contenta], .bar [a-host] span[contenta] {}
```
7.
```
Input: :where(:host-context(.one)) :host-context(.two) {}
Output: :where(.one.two-shadowcsshost-no-combinato), :where(.one.tw) [a-host], :where(.on) .two[a-host], :where(.on) .two [a-host], :where(.tw) .one[a-host], :where(.tw) .one [a-host] {}
```
8.
```
Input: :host-context(.one) :where(:host-context(.two)) {}
Output: .one.two[a-host]) , .one.two [a-host]) ,.one .two[a-host]) , .one .two [a-host]) ,.two .one[a-host]) , .two .one [a-host])[contenta] {}
```
9.
```
Input: :host-context([data-theme="dark,compact"]) .button {}
Output: [data-theme="dark[a-host] .button[contenta] ,[contenta] [data-theme="dark[contenta] [a-host] .button[contenta], compact"][a-host] .button[contenta] ,[contenta] compact"][contenta] [a-host] .button[contenta] {}
```