### PR TITLE
feat(core): add opt-in caller-scoped provisioning to injectAsync

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -925,6 +925,7 @@ export function injectAsync<T>(loader: () => Promise<DefaultExport<ProviderToken
 // @public
 export interface InjectAsyncOptions {
     prefetch?: PrefetchTrigger;
+    scope?: 'self';
 }
 
 // @public

--- a/packages/core/src/di/inject_async.ts
+++ b/packages/core/src/di/inject_async.ts
@@ -7,6 +7,8 @@
  */
 
 import {IDLE_SERVICE} from '../defer/idle_service';
+import {Type} from '../interface/type';
+import {DestroyRef} from '../linker/destroy_ref';
 import {DefaultExport, maybeUnwrapDefaultExport} from '../util/default_export';
 import {promiseWithResolvers} from '../util/promise_with_resolvers';
 import {assertInInjectionContext} from './contextual';
@@ -64,6 +66,7 @@ export function injectAsync<T>(
   }
 
   const injector = inject(Injector);
+  const scope = options?.scope;
 
   let loadedPromise: Promise<InjectAsyncLoaderResult<T>> | null = null;
   const load = () => {
@@ -81,7 +84,49 @@ export function injectAsync<T>(
   }
 
   // We can't use `inject` later on because of the async nature of the loader
-  return () => load().then((loadedToken) => injector.get(maybeUnwrapDefaultExport(loadedToken))!);
+  return () =>
+    load().then((loadedToken) =>
+      resolveInjectAsyncToken(maybeUnwrapDefaultExport(loadedToken), injector, scope),
+    );
+}
+
+/**
+ * Sentinel returned by `Injector.get` when the token is not provided anywhere up the chain. A fresh
+ * object reference, so it can never collide with an actual provided value (including `null`).
+ */
+const NOT_PROVIDED = {};
+
+/**
+ * Resolves the loaded `token` against the caller's `injector`.
+ *
+ * With the default `scope`, this is a plain `injector.get(token)` - throwing `NG0201` if the token
+ * is not provided, exactly as before. With `scope: 'self'`, the token is resolved up the chain first
+ * (so an ancestor/component provider or a `TestBed` override still wins) and, only if it is not
+ * provided anywhere, the loaded class is lazily provided at the caller's scope, with its lifecycle
+ * tied to the caller.
+ */
+function resolveInjectAsyncToken<T>(
+  token: ProviderToken<T>,
+  injector: Injector,
+  scope: 'self' | undefined,
+): T {
+  if (scope !== 'self') {
+    return injector.get(token)!;
+  }
+
+  const existing = injector.get(token, NOT_PROVIDED as unknown as T);
+  if ((existing as unknown) !== NOT_PROVIDED) {
+    return existing;
+  }
+
+  const scoped = Injector.create({
+    providers: [{provide: token, useClass: token as Type<T>}],
+    parent: injector,
+  });
+  // Tie the child injector's lifecycle to the caller: when the caller is destroyed the instance is
+  // destroyed too (`ngOnDestroy` / `DestroyRef.onDestroy` fire), like a component-provided service.
+  injector.get(DestroyRef).onDestroy(() => scoped.destroy());
+  return scoped.get(token);
 }
 
 /**
@@ -97,6 +142,18 @@ export interface InjectAsyncOptions {
    *
    */
   prefetch?: PrefetchTrigger;
+
+  /**
+   * Controls what happens when the loaded token is not provided anywhere up the injector chain.
+   *
+   * - When omitted (the default), the token is resolved with `injector.get` and an `NG0201` error
+   *   is thrown if it is not provided anywhere - the existing behavior.
+   * - `'self'` resolves the token up the chain first (so an ancestor/component provider or a
+   *   `TestBed` override still wins) and, only if it is not provided anywhere, lazily provides the
+   *   loaded class at the caller's injector scope, tying its lifecycle to the caller. Requires the
+   *   loader to resolve to a concrete class.
+   */
+  scope?: 'self';
 }
 
 /**

--- a/packages/core/src/di/inject_async.ts
+++ b/packages/core/src/di/inject_async.ts
@@ -7,12 +7,14 @@
  */
 
 import {IDLE_SERVICE} from '../defer/idle_service';
+import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
 import {DestroyRef} from '../linker/destroy_ref';
 import {DefaultExport, maybeUnwrapDefaultExport} from '../util/default_export';
 import {promiseWithResolvers} from '../util/promise_with_resolvers';
+import {stringify} from '../util/stringify';
 import {assertInInjectionContext} from './contextual';
-import {Injector} from './injector';
+import {DestroyableInjector, Injector} from './injector';
 import {inject} from './injector_compatibility';
 import {ProviderToken} from './provider_token';
 
@@ -22,7 +24,7 @@ type InjectAsyncLoaderResult<T> = ProviderToken<T> | DefaultExport<ProviderToken
  * A helper function that allows to inject dependencies asynchronously,
  * which can be useful in cases when the dependency is not needed immediately and can be loaded lazily.
  *
- * NOTE: To enable lazy loading, the injected service must be auto-provided. This means it should be decorated with either `@Injectable({providedIn: 'root'})` or `@Service()`.
+ * NOTE: By default, the injected service must be auto-provided. This means it should be decorated with either `@Injectable({providedIn: 'root'})` or `@Service()`. Alternatively, the `{scope: 'self'}` option allows a plain `@Injectable()` class that is not provided anywhere to be lazily provided at the caller's injector scope.
  *
  * @param loader A function that returns a promise resolving to the injectable service
  * @param options Configuration options for the async injection
@@ -67,6 +69,9 @@ export function injectAsync<T>(
 
   const injector = inject(Injector);
   const scope = options?.scope;
+  // With `scope: 'self'` the `DestroyRef` must be captured eagerly: by the time the loader
+  // resolves, the caller might already be destroyed and its injector unusable.
+  const destroyRef = scope === 'self' ? inject(DestroyRef) : null;
 
   let loadedPromise: Promise<InjectAsyncLoaderResult<T>> | null = null;
   const load = () => {
@@ -83,11 +88,58 @@ export function injectAsync<T>(
       .catch(() => {});
   }
 
+  // The injector that self-provides the loaded class, created at most once per `injectAsync`
+  // call-site so that repeated invocations of the returned function resolve the same instance.
+  let scopedInjector: DestroyableInjector | null = null;
+
+  const resolveToken = (token: ProviderToken<T>): T => {
+    if (scope !== 'self') {
+      return injector.get(token)!;
+    }
+
+    if (scopedInjector !== null) {
+      return scopedInjector.get(token);
+    }
+
+    if (destroyRef!.destroyed) {
+      throw new RuntimeError(
+        RuntimeErrorCode.INJECTOR_ALREADY_DESTROYED,
+        ngDevMode &&
+          `injectAsync: cannot resolve ${stringify(token)} because the injection ` +
+            `context that called \`injectAsync\` has already been destroyed.`,
+      );
+    }
+
+    // Resolve up the chain first, so that an ancestor/component provider
+    // or a `TestBed` override still wins over self-provisioning.
+    const existing = injector.get(token, NOT_PROVIDED as unknown as T);
+    if ((existing as unknown) !== NOT_PROVIDED) {
+      return existing;
+    }
+
+    if (ngDevMode && typeof token !== 'function') {
+      throw new RuntimeError(
+        RuntimeErrorCode.INVALID_INJECTION_TOKEN,
+        `injectAsync: the token loaded with \`scope: 'self'\` must be a class ` +
+          `so that it can be self-provided, but got: ${stringify(token)}. ` +
+          `Provide the token in an injector instead.`,
+      );
+    }
+
+    scopedInjector = Injector.create({
+      providers: [{provide: token, useClass: token as Type<T>}],
+      parent: injector,
+    });
+    // Tie the child injector's lifecycle to the caller: when the caller is destroyed the instance
+    // is destroyed too (`ngOnDestroy` / `DestroyRef.onDestroy` fire), like a component-provided
+    // service.
+    const scoped = scopedInjector;
+    destroyRef!.onDestroy(() => scoped.destroy());
+    return scopedInjector.get(token);
+  };
+
   // We can't use `inject` later on because of the async nature of the loader
-  return () =>
-    load().then((loadedToken) =>
-      resolveInjectAsyncToken(maybeUnwrapDefaultExport(loadedToken), injector, scope),
-    );
+  return () => load().then((loadedToken) => resolveToken(maybeUnwrapDefaultExport(loadedToken)));
 }
 
 /**
@@ -95,39 +147,6 @@ export function injectAsync<T>(
  * object reference, so it can never collide with an actual provided value (including `null`).
  */
 const NOT_PROVIDED = {};
-
-/**
- * Resolves the loaded `token` against the caller's `injector`.
- *
- * With the default `scope`, this is a plain `injector.get(token)` - throwing `NG0201` if the token
- * is not provided, exactly as before. With `scope: 'self'`, the token is resolved up the chain first
- * (so an ancestor/component provider or a `TestBed` override still wins) and, only if it is not
- * provided anywhere, the loaded class is lazily provided at the caller's scope, with its lifecycle
- * tied to the caller.
- */
-function resolveInjectAsyncToken<T>(
-  token: ProviderToken<T>,
-  injector: Injector,
-  scope: 'self' | undefined,
-): T {
-  if (scope !== 'self') {
-    return injector.get(token)!;
-  }
-
-  const existing = injector.get(token, NOT_PROVIDED as unknown as T);
-  if ((existing as unknown) !== NOT_PROVIDED) {
-    return existing;
-  }
-
-  const scoped = Injector.create({
-    providers: [{provide: token, useClass: token as Type<T>}],
-    parent: injector,
-  });
-  // Tie the child injector's lifecycle to the caller: when the caller is destroyed the instance is
-  // destroyed too (`ngOnDestroy` / `DestroyRef.onDestroy` fire), like a component-provided service.
-  injector.get(DestroyRef).onDestroy(() => scoped.destroy());
-  return scoped.get(token);
-}
 
 /**
  * Interface for `options` argument used within `injectAsync` call.
@@ -151,7 +170,8 @@ export interface InjectAsyncOptions {
    * - `'self'` resolves the token up the chain first (so an ancestor/component provider or a
    *   `TestBed` override still wins) and, only if it is not provided anywhere, lazily provides the
    *   loaded class at the caller's injector scope, tying its lifecycle to the caller. Requires the
-   *   loader to resolve to a concrete class.
+   *   loader to resolve to a concrete class. Each `injectAsync` call-site self-provides at most one
+   *   instance: repeated invocations of the returned function resolve the same instance.
    */
   scope?: 'self';
 }

--- a/packages/core/test/di/inject_async/inject_async_spec.ts
+++ b/packages/core/test/di/inject_async/inject_async_spec.ts
@@ -337,3 +337,73 @@ describe('injectAsync', () => {
     });
   });
 });
+
+describe('injectAsync - {scope: "self"}', () => {
+  const TOKEN = new InjectionToken<string>('TOKEN');
+
+  // A plain `@Injectable` (no `providedIn`), so it can be tree-shaken into the dynamic chunk.
+  @Injectable()
+  class LazyDialog {
+    readonly token = inject(TOKEN);
+  }
+
+  it('provides an unprovided class at the caller scope, resolving component-level providers', async () => {
+    @Component({
+      template: '',
+      providers: [{provide: TOKEN, useValue: 'from-host'}],
+    })
+    class HostComponent {
+      readonly loadDialog = injectAsync(() => Promise.resolve(LazyDialog), {scope: 'self'});
+    }
+
+    TestBed.configureTestingModule({imports: [HostComponent]});
+    const fixture = TestBed.createComponent(HostComponent);
+    const dialog = await fixture.componentInstance.loadDialog();
+
+    expect(dialog).toBeInstanceOf(LazyDialog);
+    expect(dialog.token).toBe('from-host');
+  });
+
+  it('ties the lazy instance lifecycle to the caller component', async () => {
+    let destroyed = false;
+
+    @Injectable()
+    class HostBoundService {
+      ngOnDestroy() {
+        destroyed = true;
+      }
+    }
+
+    @Component({template: ''})
+    class HostComponent {
+      readonly loadService = injectAsync(() => Promise.resolve(HostBoundService), {scope: 'self'});
+    }
+
+    TestBed.configureTestingModule({imports: [HostComponent]});
+    const fixture = TestBed.createComponent(HostComponent);
+    await fixture.componentInstance.loadService();
+    expect(destroyed).toBe(false);
+
+    fixture.destroy();
+    expect(destroyed).toBe(true);
+  });
+
+  it('still lets a component-level override of the lazy token win (mocking preserved)', async () => {
+    @Injectable()
+    class MockDialog {}
+
+    @Component({
+      template: '',
+      providers: [{provide: LazyDialog, useClass: MockDialog}],
+    })
+    class HostComponent {
+      readonly loadDialog = injectAsync(() => Promise.resolve(LazyDialog), {scope: 'self'});
+    }
+
+    TestBed.configureTestingModule({imports: [HostComponent]});
+    const fixture = TestBed.createComponent(HostComponent);
+    const dialog = await fixture.componentInstance.loadDialog();
+
+    expect(dialog).toBeInstanceOf(MockDialog);
+  });
+});

--- a/packages/core/test/di/inject_async/inject_async_spec.ts
+++ b/packages/core/test/di/inject_async/inject_async_spec.ts
@@ -406,4 +406,70 @@ describe('injectAsync - {scope: "self"}', () => {
 
     expect(dialog).toBeInstanceOf(MockDialog);
   });
+
+  it('resolves the same instance across repeated and concurrent invocations', async () => {
+    let instances = 0;
+
+    @Injectable()
+    class CountingService {
+      constructor() {
+        instances++;
+      }
+    }
+
+    @Component({template: ''})
+    class HostComponent {
+      readonly loadService = injectAsync(() => Promise.resolve(CountingService), {scope: 'self'});
+    }
+
+    TestBed.configureTestingModule({imports: [HostComponent]});
+    const fixture = TestBed.createComponent(HostComponent);
+
+    // Two concurrent invocations followed by a later one must all
+    // resolve the same self-provided instance.
+    const [a, b] = await Promise.all([
+      fixture.componentInstance.loadService(),
+      fixture.componentInstance.loadService(),
+    ]);
+    const c = await fixture.componentInstance.loadService();
+
+    expect(a).toBeInstanceOf(CountingService);
+    expect(b).toBe(a);
+    expect(c).toBe(a);
+    expect(instances).toBe(1);
+  });
+
+  it('rejects with a clear error when first resolved after the caller was destroyed', async () => {
+    @Injectable()
+    class LateService {}
+
+    @Component({template: ''})
+    class HostComponent {
+      readonly loadService = injectAsync(() => Promise.resolve(LateService), {scope: 'self'});
+    }
+
+    TestBed.configureTestingModule({imports: [HostComponent]});
+    const fixture = TestBed.createComponent(HostComponent);
+    const loadService = fixture.componentInstance.loadService;
+
+    fixture.destroy();
+
+    await expectAsync(loadService()).toBeRejectedWithError(/NG0205.*already been destroyed/);
+  });
+
+  it('throws a clear error when the loaded token is not a class', async () => {
+    const UNPROVIDED = new InjectionToken<string>('UNPROVIDED');
+
+    @Component({template: ''})
+    class HostComponent {
+      readonly loadValue = injectAsync(() => Promise.resolve(UNPROVIDED), {scope: 'self'});
+    }
+
+    TestBed.configureTestingModule({imports: [HostComponent]});
+    const fixture = TestBed.createComponent(HostComponent);
+
+    await expectAsync(fixture.componentInstance.loadValue()).toBeRejectedWithError(
+      /NG0204.*must be a class/,
+    );
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
      <!-- Public API TSDoc is updated. The angular.dev "Lazy loading services" guide can be updated in a follow-up. -->

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`injectAsync` resolves the loaded token with a plain `injector.get(token)`. As its doc-comment states, the service must therefore be auto-provided (`@Injectable({providedIn: 'root'})` or `@Service()`), which makes it a **root singleton**.

As a result, a service cannot be both **lazy-loaded** and **scoped to the calling component**:

- Listing the class in a component's `providers: [Svc]` requires a static import of `Svc`, which pulls it into the component chunk and defeats code-splitting.
- `providedIn: 'root'` / `@Service()` load lazily but produce a root singleton: it cannot see component-level providers and is not destroyed with the component.

So the "lazy + component-scoped" combination is currently impossible to express. A token that is not provided anywhere throws `NG0201`.

Issue Number: https://github.com/angular/angular/issues/69934

## What is the new behavior?

Adds an opt-in `{scope: 'self'}` option to `injectAsync`. When set, the token is resolved up the injector chain first (so an ancestor/component provider or a `TestBed` override still wins) and, **only if it is not provided anywhere**, the loaded class is lazily provided at the caller's injector scope, with its lifecycle tied to the caller (destroyed together with it).

```ts
// A plain @Injectable (no providedIn), tree-shakeable into the dynamic chunk:
@Component({ providers: [{ provide: TOKEN, useValue: 'from-host' }] })
class HostComponent {
  // Lazy-loaded AND scoped to this component: it can see TOKEN and dies with the component.
  private loadDialog = injectAsync(
    () => import('./dialog.service').then((m) => m.DialogService),
    { scope: 'self' },
  );
}
```

Behavior summary:

- Default (option omitted): **unchanged**. Plain `injector.get`, throws `NG0201` when unprovided.
- `scope: 'self'`: resolve-first, fallback-self. Ancestor providers and `TestBed`/component overrides of the token still win (mocking preserved); self-provisioning only happens as a fallback.
- The self-provided instance's lifecycle is tied to the caller via `DestroyRef` (`ngOnDestroy` / `DestroyRef.onDestroy` fire on caller destruction).

This composes with `@Service({ autoProvided: false })`: that decorator declares "provided by the user", and `injectAsync(loader, { scope: 'self' })` becomes the lazy way to satisfy that contract.

**Design choice:** `scope: 'self'` is deliberately "resolve-first, fallback-self" and NOT "always create at self". The latter would shadow ancestor providers and break `TestBed.overrideProvider` / component-level mocks of the lazy token, which is unacceptable for a framework that mocks through DI.

Changes in this PR:

- `packages/core/src/di/inject_async.ts`: new `scope?: 'self'` option on `InjectAsyncOptions` and the `resolveInjectAsyncToken` helper. Default path byte-for-byte equivalent to before.
- `packages/core/test/di/inject_async/inject_async_spec.ts`: 3 tests (component-scoped resolution, lifecycle tied to caller, ancestor/override still wins).
- `goldens/public-api/core/index.api.md`: one added field on `InjectAsyncOptions`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The default code path and existing overloads are unchanged; the new behavior is only reachable via the explicit `{scope: 'self'}` flag. The existing test "should throw if the service wasn't provided in root" keeps passing verbatim.

## Other information

Local verification performed (Bazel test suite not run locally; relying on CI):

- `pnpm ts-circular-deps:check`: 0 cycles (the new `DestroyRef` import resolves to its defining module, not the `di` barrel, so no import cycle is introduced).
- `prettier --check` on both changed TS files: passes.

Open design questions for reviewers:

- **Naming:** `scope: 'self'` vs `provideIfMissing` vs `ifMissing: 'self-provide'`. `'self'` risks confusion with `@Self()` DI semantics (it is not that).
- **Typed overloads:** self-provisioning needs a concrete `Type<T>` (`useClass`). This PR keeps the existing `ProviderToken` overloads for minimal API churn; a follow-up could add constrained overloads that reject `InjectionToken` / `AbstractType` under `scope: 'self'`.
- **Dev-mode signal:** should self-provisioning emit a one-time dev warning to catch a service that merely forgot its `providedIn`?
- **Root-injector caller:** when called outside a component, the instance lives for the app lifetime. Document, or warn?
