### PR TITLE
feat(core): add `loaded` callback parameter to `@defer` blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -1576,4 +1576,40 @@ class TestComponent {
       );
     });
   });
+
+  describe('defer loaded callback', () => {
+    it('should report an error when loaded callback method does not exist', () => {
+      const messages = diagnose(
+        `
+          @defer (on timer(500ms); loaded nonExistentMethod()) {
+            <div></div>
+          }
+        `,
+        `
+          export class TestComponent {
+          }
+        `,
+      );
+
+      expect(messages.length).toBe(1);
+      expect(messages[0]).toContain(`Property 'nonExistentMethod' does not exist on type 'TestComponent'`);
+    });
+
+    it('should not report an error when loaded callback method exists', () => {
+      const messages = diagnose(
+        `
+          @defer (on timer(500ms); loaded onDeferredLoaded()) {
+            <div></div>
+          }
+        `,
+        `
+          export class TestComponent {
+            onDeferredLoaded(): void {}
+          }
+        `,
+      );
+
+      expect(messages).toEqual([]);
+    });
+  });
 });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1960,6 +1960,32 @@ describe('type check blocks', () => {
         'new IntersectionObserver(null!, ({ "rootMargin": "123px" })); "" + ((this).main()); "" + ((this).placeholder());',
       );
     });
+
+    it('should generate `loaded` callback expression', () => {
+      const TEMPLATE = `
+        @defer (on timer(500ms); loaded onDeferredLoaded()) {
+          {{main()}}
+        }
+      `;
+
+      expect(tcb(TEMPLATE)).toContain('(this).onDeferredLoaded()');
+    });
+
+    it('should produce a diagnostic when loaded method does not exist on the component', () => {
+      const TEMPLATE = `
+        @defer (on timer(500ms); loaded onNonExistentMethod()) {
+          {{main()}}
+        }
+      `;
+      const SOURCE = `
+        export class TestComponent {
+          main(): string { return ''; }
+        }
+      `;
+      expect(diagnose(TEMPLATE, SOURCE)).toEqual([
+        jasmine.stringContaining(`Property 'onNonExistentMethod' does not exist on type 'TestComponent'`),
+      ]);
+    });
   });
 
   describe('conditional blocks', () => {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -423,6 +423,22 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should generate a defer block with a `loaded` callback",
+      "inputFiles": ["deferred_with_loaded_callback.ts"],
+      "compilationModeFilter": ["full compile"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "deferred_with_loaded_callback_template.js",
+              "generated": "deferred_with_loaded_callback.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loaded_callback.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loaded_callback.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+@Component({
+    template: `
+    @defer (on timer(500ms); loaded onDeferredLoaded()) {Deferred content} @placeholder {Placeholder}
+  `,
+    standalone: false
+})
+export class MyApp {
+  onDeferredLoaded() {}
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loaded_callback_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loaded_callback_template.js
@@ -1,0 +1,26 @@
+function MyApp_Defer_0_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, "Deferred content");
+  }
+}
+function MyApp_DeferPlaceholder_1_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, "Placeholder");
+  }
+}
+…
+export class MyApp {
+  …
+  static ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
+  …
+  template: function MyApp_Template(rf, ctx) {
+    if (rf & 1) {
+      $r3$.ɵɵdomTemplate(0, MyApp_Defer_0_Template, 1, 0)(1, MyApp_DeferPlaceholder_1_Template, 1, 0);
+      $r3$.ɵɵdefer(2, 0, null, null, 1);
+      $r3$.ɵɵdeferOnTimer(500);
+      $r3$.ɵɵdeferOnLoaded(() => ctx.onDeferredLoaded());
+    }
+  },
+  …
+});
+…

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -385,6 +385,7 @@ export class DeferredBlock extends BlockNode implements Node {
     public placeholder: DeferredBlockPlaceholder | null,
     public loading: DeferredBlockLoading | null,
     public error: DeferredBlockError | null,
+    public loaded: AST | null,
     nameSpan: ParseSourceSpan,
     sourceSpan: ParseSourceSpan,
     public mainBlockSpan: ParseSourceSpan,

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -386,6 +386,7 @@ export class DeferredBlock extends BlockNode implements Node {
     public loading: DeferredBlockLoading | null,
     public error: DeferredBlockError | null,
     public loaded: AST | null,
+    public loadedSourceSpan: ParseSourceSpan | null,
     nameSpan: ParseSourceSpan,
     sourceSpan: ParseSourceSpan,
     public mainBlockSpan: ParseSourceSpan,

--- a/packages/compiler/src/render3/r3_deferred_blocks.ts
+++ b/packages/compiler/src/render3/r3_deferred_blocks.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ASTWithSource} from '../expression_parser/ast';
 import * as html from '../ml_parser/ast';
 import {ParseError, ParseSourceSpan} from '../parse_util';
 import {BindingParser} from '../template_parser/binding_parser';
@@ -46,6 +47,9 @@ const WHEN_PARAMETER_PATTERN = /^when\s/;
 /** Pattern to identify a `on` parameter in a block. */
 const ON_PARAMETER_PATTERN = /^on\s/;
 
+/** Pattern to identify a `loaded` parameter in a block. */
+const LOADED_PARAMETER_PATTERN = /^loaded\s/;
+
 /**
  * Predicate function that determines if a block with
  * a specific name cam be connected to a `defer` block.
@@ -63,7 +67,7 @@ export function createDeferredBlock(
 ): {node: t.DeferredBlock; errors: ParseError[]} {
   const errors: ParseError[] = [];
   const {placeholder, loading, error} = parseConnectedBlocks(connectedBlocks, errors, visitor);
-  const {triggers, prefetchTriggers, hydrateTriggers} = parsePrimaryTriggers(
+  const {triggers, prefetchTriggers, hydrateTriggers, loadedExpression} = parsePrimaryTriggers(
     ast,
     bindingParser,
     errors,
@@ -92,6 +96,7 @@ export function createDeferredBlock(
     placeholder,
     loading,
     error,
+    loadedExpression,
     ast.nameSpan,
     sourceSpanWithConnectedBlocks,
     ast.sourceSpan,
@@ -272,6 +277,7 @@ function parsePrimaryTriggers(
   const triggers: t.DeferredBlockTriggers = {};
   const prefetchTriggers: t.DeferredBlockTriggers = {};
   const hydrateTriggers: t.DeferredBlockTriggers = {};
+  let loadedExpression: ASTWithSource | null = null;
 
   for (const param of ast.parameters) {
     // The lexer ignores the leading spaces so we can assume
@@ -290,6 +296,32 @@ function parsePrimaryTriggers(
       parseOnTrigger(param, bindingParser, hydrateTriggers, errors, placeholder);
     } else if (HYDRATE_NEVER_PATTERN.test(param.expression)) {
       parseNeverTrigger(param, hydrateTriggers, errors);
+    } else if (LOADED_PARAMETER_PATTERN.test(param.expression)) {
+      if (loadedExpression !== null) {
+        errors.push(
+          new ParseError(
+            param.sourceSpan,
+            '@defer block can only have one "loaded" parameter',
+          ),
+        );
+      } else {
+        const start = getTriggerParametersStart(param.expression, 'loaded'.length);
+        if (start === -1) {
+          errors.push(
+            new ParseError(
+              param.sourceSpan,
+              'Expected an expression after "loaded" keyword',
+            ),
+          );
+        } else {
+          loadedExpression = bindingParser.parseBinding(
+            param.expression.slice(start),
+            false,
+            param.sourceSpan,
+            param.sourceSpan.start.offset + start,
+          );
+        }
+      }
     } else {
       errors.push(new ParseError(param.sourceSpan, 'Unrecognized trigger'));
     }
@@ -304,5 +336,5 @@ function parsePrimaryTriggers(
     );
   }
 
-  return {triggers, prefetchTriggers, hydrateTriggers};
+  return {triggers, prefetchTriggers, hydrateTriggers, loadedExpression};
 }

--- a/packages/compiler/src/render3/r3_deferred_blocks.ts
+++ b/packages/compiler/src/render3/r3_deferred_blocks.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ASTWithSource} from '../expression_parser/ast';
+import {AST, ASTWithSource, BindingPipe, RecursiveAstVisitor} from '../expression_parser/ast';
 import * as html from '../ml_parser/ast';
 import {ParseError, ParseSourceSpan} from '../parse_util';
 import {BindingParser} from '../template_parser/binding_parser';
@@ -48,7 +48,7 @@ const WHEN_PARAMETER_PATTERN = /^when\s/;
 const ON_PARAMETER_PATTERN = /^on\s/;
 
 /** Pattern to identify a `loaded` parameter in a block. */
-const LOADED_PARAMETER_PATTERN = /^loaded\s/;
+const LOADED_PARAMETER_PATTERN = /^loaded(\s|$)/;
 
 /**
  * Predicate function that determines if a block with
@@ -67,12 +67,8 @@ export function createDeferredBlock(
 ): {node: t.DeferredBlock; errors: ParseError[]} {
   const errors: ParseError[] = [];
   const {placeholder, loading, error} = parseConnectedBlocks(connectedBlocks, errors, visitor);
-  const {triggers, prefetchTriggers, hydrateTriggers, loadedExpression} = parsePrimaryTriggers(
-    ast,
-    bindingParser,
-    errors,
-    placeholder,
-  );
+  const {triggers, prefetchTriggers, hydrateTriggers, loadedExpression, loadedSourceSpan} =
+    parsePrimaryTriggers(ast, bindingParser, errors, placeholder);
 
   // The `defer` block has a main span encompassing all of the connected branches as well.
   let lastEndSourceSpan = ast.endSourceSpan;
@@ -97,6 +93,7 @@ export function createDeferredBlock(
     loading,
     error,
     loadedExpression,
+    loadedSourceSpan,
     ast.nameSpan,
     sourceSpanWithConnectedBlocks,
     ast.sourceSpan,
@@ -278,6 +275,7 @@ function parsePrimaryTriggers(
   const prefetchTriggers: t.DeferredBlockTriggers = {};
   const hydrateTriggers: t.DeferredBlockTriggers = {};
   let loadedExpression: ASTWithSource | null = null;
+  let loadedSourceSpan: ParseSourceSpan | null = null;
 
   for (const param of ast.parameters) {
     // The lexer ignores the leading spaces so we can assume
@@ -314,12 +312,26 @@ function parsePrimaryTriggers(
             ),
           );
         } else {
-          loadedExpression = bindingParser.parseBinding(
+          const parsed = bindingParser.parseBinding(
             param.expression.slice(start),
             false,
             param.sourceSpan,
             param.sourceSpan.start.offset + start,
           );
+          if (PipeDetector.containsPipe(parsed)) {
+            errors.push(
+              new ParseError(
+                param.sourceSpan,
+                'Pipes are not allowed in the "loaded" callback of a @defer block',
+              ),
+            );
+          } else {
+            loadedExpression = parsed;
+            loadedSourceSpan = new ParseSourceSpan(
+              param.sourceSpan.start.moveBy(start),
+              param.sourceSpan.end,
+            );
+          }
         }
       }
     } else {
@@ -336,5 +348,21 @@ function parsePrimaryTriggers(
     );
   }
 
-  return {triggers, prefetchTriggers, hydrateTriggers, loadedExpression};
+  return {triggers, prefetchTriggers, hydrateTriggers, loadedExpression, loadedSourceSpan};
+}
+
+/** Visitor that determines whether an expression contains a pipe. */
+class PipeDetector extends RecursiveAstVisitor {
+  hasPipe = false;
+
+  static containsPipe(ast: AST): boolean {
+    const visitor = new PipeDetector();
+    visitor.visit(ast);
+    return visitor.hasPipe;
+  }
+
+  override visitPipe(ast: BindingPipe, context: any): void {
+    this.hasPipe = true;
+    super.visitPipe(ast, context);
+  }
 }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -191,6 +191,7 @@ export class Identifiers {
     name: 'ɵɵdeferEnableTimerScheduling',
     moduleName: CORE,
   };
+  static deferOnLoaded: o.ExternalReference = {name: 'ɵɵdeferOnLoaded', moduleName: CORE};
   static enableIncrementalHydrationRuntime: o.ExternalReference = {
     name: 'ɵɵenableIncrementalHydrationRuntime',
     moduleName: CORE,

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -1096,6 +1096,7 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
     deferred.prefetchTriggers.when?.value.visit(this);
     deferred.hydrateTriggers.when?.value.visit(this);
     deferred.hydrateTriggers.never?.visit(this);
+    deferred.loaded?.visit(this);
     deferred.placeholder && this.visitNode(deferred.placeholder);
     deferred.loading && this.visitNode(deferred.loading);
     deferred.error && this.visitNode(deferred.error);

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -176,6 +176,11 @@ export enum OpKind {
   DeferWhen,
 
   /**
+   * An operation that registers a callback to be invoked when a `@defer` block completes loading.
+   */
+  DeferOnLoaded,
+
+  /**
    * An i18n message that has been extracted for inclusion in the consts array.
    */
   I18nMessage,

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1304,6 +1304,9 @@ export function transformExpressionsInOp(
     case OpKind.DeferWhen:
       op.expr = transformExpressionsInExpression(op.expr, transform, flags);
       break;
+    case OpKind.DeferOnLoaded:
+      op.loadedExpr = transformExpressionsInExpression(op.loadedExpr, transform, flags);
+      break;
     case OpKind.StoreLet:
       op.value = transformExpressionsInExpression(op.value, transform, flags);
       break;

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -64,6 +64,7 @@ export type CreateOp =
   | ExtractedAttributeOp
   | DeferOp
   | DeferOnOp
+  | DeferOnLoadedOp
   | ConditionalCreateOp
   | ConditionalBranchCreateOp
   | RepeaterCreateOp
@@ -1569,6 +1570,49 @@ export function createDeferOnOp(
     defer,
     trigger,
     modifier,
+    sourceSpan,
+    ...NEW_OP,
+  };
+}
+
+/**
+ * Represents an operation that registers a callback to be invoked when a `@defer` block
+ * transitions to the Complete state.
+ */
+export interface DeferOnLoadedOp extends Op<CreateOp> {
+  kind: OpKind.DeferOnLoaded;
+
+  /**
+   * The xref of the defer block this loaded callback belongs to.
+   */
+  deferXref: XrefId;
+
+  /**
+   * The function expression wrapping the loaded callback. Filled during reification.
+   */
+  loadedFn: o.Expression | null;
+
+  /**
+   * The parsed method call expression (e.g. `ctx.onDeferredLoaded()`).
+   */
+  loadedExpr: o.Expression;
+
+  sourceSpan: ParseSourceSpan;
+}
+
+/**
+ * Create a `DeferOnLoadedOp`.
+ */
+export function createDeferOnLoadedOp(
+  deferXref: XrefId,
+  loadedExpr: o.Expression,
+  sourceSpan: ParseSourceSpan,
+): DeferOnLoadedOp {
+  return {
+    kind: OpKind.DeferOnLoaded,
+    deferXref,
+    loadedFn: null,
+    loadedExpr,
     sourceSpan,
     ...NEW_OP,
   };

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -841,6 +841,17 @@ function ingestDeferBlock(unit: ViewCompilationUnit, deferBlock: t.DeferredBlock
 
   unit.create.push(deferOnOps);
   unit.update.push(deferWhenOps);
+
+  // Ingest the `loaded` callback expression if present.
+  if (deferBlock.loaded !== null) {
+    const loadedExpr = convertAst(
+      deferBlock.loaded,
+      unit.job,
+      convertSourceSpan(deferBlock.loaded.span, deferBlock.sourceSpan),
+    );
+    const loadedOp = ir.createDeferOnLoadedOp(deferXref, loadedExpr, deferBlock.sourceSpan);
+    unit.create.push(loadedOp);
+  }
 }
 
 function calcDeferBlockFlags(deferBlockDetails: t.DeferredBlock): ir.TDeferDetailsFlags | null {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -844,12 +844,9 @@ function ingestDeferBlock(unit: ViewCompilationUnit, deferBlock: t.DeferredBlock
 
   // Ingest the `loaded` callback expression if present.
   if (deferBlock.loaded !== null) {
-    const loadedExpr = convertAst(
-      deferBlock.loaded,
-      unit.job,
-      convertSourceSpan(deferBlock.loaded.span, deferBlock.sourceSpan),
-    );
-    const loadedOp = ir.createDeferOnLoadedOp(deferXref, loadedExpr, deferBlock.sourceSpan);
+    const loadedSourceSpan = deferBlock.loadedSourceSpan ?? deferBlock.sourceSpan;
+    const loadedExpr = convertAst(deferBlock.loaded, unit.job, loadedSourceSpan);
+    const loadedOp = ir.createDeferOnLoadedOp(deferXref, loadedExpr, loadedSourceSpan);
     unit.create.push(loadedOp);
   }
 }

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -413,6 +413,13 @@ export function deferOn(
   return call(instructionToCall, args, sourceSpan);
 }
 
+export function deferOnLoaded(
+  fn: o.Expression,
+  sourceSpan: ParseSourceSpan | null,
+): ir.CreateOp {
+  return call(Identifiers.deferOnLoaded, [fn], sourceSpan);
+}
+
 export function projectionDef(def: o.Expression | null): ir.CreateOp {
   return call(Identifiers.projectionDef, def ? [def] : [], null);
 }

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -459,6 +459,10 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
         }
         ir.OpList.replace(op, ng.deferOn(op.trigger.kind, args, op.modifier, op.sourceSpan));
         break;
+      case ir.OpKind.DeferOnLoaded:
+        const loadedFn = o.arrowFn([], op.loadedExpr);
+        ir.OpList.replace(op, ng.deferOnLoaded(loadedFn, op.sourceSpan));
+        break;
       case ir.OpKind.ProjectionDef:
         ir.OpList.replace<ir.CreateOp>(op, ng.projectionDef(op.def));
         break;

--- a/packages/compiler/src/typecheck/ops/scope.ts
+++ b/packages/compiler/src/typecheck/ops/scope.ts
@@ -933,6 +933,11 @@ export class Scope {
       this.opQueue.push(new TcbConditionOp(this.tcb, this, block.hydrateTriggers.when.value));
     }
 
+    // Type-check the `loaded` callback expression to validate the method exists and is callable.
+    if (block.loaded !== null) {
+      this.opQueue.push(new TcbExpressionOp(this.tcb, this, block.loaded));
+    }
+
     this.appendChildren(block);
 
     if (block.placeholder !== null) {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -97,7 +97,11 @@ class R3AstHumanizer implements t.Visitor<void> {
   }
 
   visitDeferredBlock(deferred: t.DeferredBlock): void {
-    this.result.push(['DeferredBlock']);
+    const result: (string | null)[] = ['DeferredBlock'];
+    if (deferred.loaded !== null) {
+      result.push(`loaded ${unparse(deferred.loaded)}`);
+    }
+    this.result.push(result);
     deferred.visitAll(this);
   }
 
@@ -1405,6 +1409,32 @@ describe('R3 template transform', () => {
       ]);
     });
 
+    it('should parse a deferred block with a `loaded` parameter', () => {
+      expectFromHtml('@defer (on idle; loaded onDeferredLoaded()){hello}').toEqual([
+        ['DeferredBlock', 'loaded onDeferredLoaded()'],
+        ['IdleDeferredTrigger'],
+        ['Text', 'hello'],
+      ]);
+    });
+
+    it('should parse a deferred block with `loaded` and `when` triggers', () => {
+      expectFromHtml(
+        '@defer (when isVisible(); on timer(100ms); loaded onLoaded()){hello}',
+      ).toEqual([
+        ['DeferredBlock', 'loaded onLoaded()'],
+        ['BoundDeferredTrigger', 'isVisible()'],
+        ['TimerDeferredTrigger', 100],
+        ['Text', 'hello'],
+      ]);
+    });
+
+    it('should parse a deferred block with `loaded` as the only parameter', () => {
+      expectFromHtml('@defer (loaded onLoaded()){hello}').toEqual([
+        ['DeferredBlock', 'loaded onLoaded()'],
+        ['Text', 'hello'],
+      ]);
+    });
+
     describe('block validations', () => {
       it('should report syntax error in `when` trigger', () => {
         expect(() => parse('@defer (when isVisible#){hello}')).toThrowError(
@@ -1715,6 +1745,18 @@ describe('R3 template transform', () => {
         ).toThrowError(
           /Cannot specify additional `hydrate` triggers if `hydrate never` is present/,
         );
+      });
+
+      it('should report an error when `loaded` has no expression', () => {
+        expect(() => parse('@defer (loaded){hello}')).toThrowError(
+          /Expected an expression after "loaded" keyword/,
+        );
+      });
+
+      it('should report multiple `loaded` parameters', () => {
+        expect(() =>
+          parse('@defer (loaded onLoaded(); loaded onOtherLoaded()) {hello}'),
+        ).toThrowError(/@defer block can only have one "loaded" parameter/);
       });
     });
   });

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1758,6 +1758,12 @@ describe('R3 template transform', () => {
           parse('@defer (loaded onLoaded(); loaded onOtherLoaded()) {hello}'),
         ).toThrowError(/@defer block can only have one "loaded" parameter/);
       });
+
+      it('should report a pipe in a `loaded` expression', () => {
+        expect(() => parse('@defer (loaded onLoaded(value | somePipe)){hello}')).toThrowError(
+          /Pipes are not allowed in the "loaded" callback of a @defer block/,
+        );
+      });
     });
   });
 

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -122,6 +122,7 @@ export {
   ɵɵdeferOnIdle,
   ɵɵdeferOnImmediate,
   ɵɵdeferOnInteraction,
+  ɵɵdeferOnLoaded,
   ɵɵdeferOnTimer,
   ɵɵdeferOnViewport,
   ɵɵdeferPrefetchOnHover,

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -890,11 +890,16 @@ export function ɵɵdeferHydrateOnViewport(options?: IntersectionObserverInit) {
 /**
  * Registers a callback to be invoked when the defer block
  * transitions to the Complete state.
+ *
+ * The callback is invoked synchronously right after the deferred content is
+ * created and inserted into the DOM, but before that content has been change
+ * detected for the first time. It is not invoked on the server and it does not
+ * fire when the block transitions to the Error state.
  * @codeGenApi
  */
 export function ɵɵdeferOnLoaded(fn: () => void) {
   const lView = getLView();
-  const tNode = getSelectedTNode();
+  const tNode = getCurrentTNode()!;
   const lDetails = getLDeferBlockDetails(lView, tNode);
 
   if (!Array.isArray(lDetails[ON_LOADED_FNS])) {

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -38,6 +38,7 @@ import {
   DependencyResolverFn,
   DeferBlockTrigger,
   LDeferBlockDetails,
+  ON_LOADED_FNS,
   TDeferBlockDetails,
   TriggerType,
   SSR_UNIQUE_ID,
@@ -199,6 +200,7 @@ export function ɵɵdefer(
     ssrBlockState, // SSR_BLOCK_STATE
     null, // ON_COMPLETE_FNS
     null, // HYDRATE_TRIGGER_CLEANUP_FNS
+    null, // ON_LOADED_FNS
   ];
   setLDeferBlockDetails(lView, adjustedIndex, lDetails);
 
@@ -883,4 +885,21 @@ export function ɵɵdeferHydrateOnViewport(options?: IntersectionObserverInit) {
   }
   // The actual triggering of hydration on viewport happens in triggering.ts,
   // since these instructions won't exist for dehydrated content.
+}
+
+/**
+ * Registers a callback to be invoked when the defer block
+ * transitions to the Complete state.
+ * @codeGenApi
+ */
+export function ɵɵdeferOnLoaded(fn: () => void) {
+  const lView = getLView();
+  const tNode = getSelectedTNode();
+  const lDetails = getLDeferBlockDetails(lView, tNode);
+
+  if (!Array.isArray(lDetails[ON_LOADED_FNS])) {
+    lDetails[ON_LOADED_FNS] = [];
+  }
+
+  lDetails[ON_LOADED_FNS].push(fn);
 }

--- a/packages/core/src/defer/interfaces.ts
+++ b/packages/core/src/defer/interfaces.ts
@@ -243,6 +243,7 @@ export const SSR_UNIQUE_ID = 6;
 export const SSR_BLOCK_STATE = 7;
 export const ON_COMPLETE_FNS = 8;
 export const HYDRATE_TRIGGER_CLEANUP_FNS = 9;
+export const ON_LOADED_FNS = 10;
 
 /**
  * Describes instance-specific defer block data.
@@ -304,6 +305,13 @@ export interface LDeferBlockDetails extends Array<unknown> {
    * List of cleanup functions for hydrate triggers.
    */
   [HYDRATE_TRIGGER_CLEANUP_FNS]: VoidFunction[] | null;
+
+  /**
+   * A set of callbacks registered via the `loaded` parameter, to be invoked
+   * only when the block successfully transitions to the `Complete` state
+   * (not on `Error`, unlike `ON_COMPLETE_FNS`).
+   */
+  [ON_LOADED_FNS]: VoidFunction[] | null;
 }
 
 /**

--- a/packages/core/src/defer/rendering.ts
+++ b/packages/core/src/defer/rendering.ts
@@ -315,9 +315,21 @@ function applyDeferBlockState(
 
     // Invoke user-registered `loaded` callbacks only on a successful `Complete`
     // transition (not on `Error`), matching the `loaded` template semantics.
-    if (newState === DeferBlockState.Complete && Array.isArray(lDetails[ON_LOADED_FNS])) {
+    // The callbacks are skipped on the server: the block would also complete
+    // during client-side hydration and the callbacks would fire twice otherwise.
+    if (
+      (typeof ngServerMode === 'undefined' || !ngServerMode) &&
+      newState === DeferBlockState.Complete &&
+      Array.isArray(lDetails[ON_LOADED_FNS])
+    ) {
       for (const callback of lDetails[ON_LOADED_FNS]) {
-        callback();
+        // A callback might throw: route the error through the `ErrorHandler`
+        // (as event listeners do) rather than aborting the rendering process.
+        try {
+          callback();
+        } catch (error) {
+          handleUncaughtError(hostLView, error);
+        }
       }
       lDetails[ON_LOADED_FNS] = null;
     }

--- a/packages/core/src/defer/rendering.ts
+++ b/packages/core/src/defer/rendering.ts
@@ -37,6 +37,7 @@ import {
   LOADING_AFTER_CLEANUP_FN,
   NEXT_DEFER_BLOCK_STATE,
   ON_COMPLETE_FNS,
+  ON_LOADED_FNS,
   SSR_BLOCK_STATE,
   STATE_IS_FROZEN_UNTIL,
   TDeferBlockDetails,
@@ -310,6 +311,15 @@ function applyDeferBlockState(
         callback();
       }
       lDetails[ON_COMPLETE_FNS] = null;
+    }
+
+    // Invoke user-registered `loaded` callbacks only on a successful `Complete`
+    // transition (not on `Error`), matching the `loaded` template semantics.
+    if (newState === DeferBlockState.Complete && Array.isArray(lDetails[ON_LOADED_FNS])) {
+      for (const callback of lDetails[ON_LOADED_FNS]) {
+        callback();
+      }
+      lDetails[ON_LOADED_FNS] = null;
     }
   }
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -127,6 +127,7 @@ export {
   ɵɵdeferOnTimer,
   ɵɵdeferOnHover,
   ɵɵdeferOnInteraction,
+  ɵɵdeferOnLoaded,
   ɵɵdeferOnViewport,
   ɵɵdeferPrefetchWhen,
   ɵɵdeferPrefetchOnIdle,

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -121,6 +121,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵdeferOnTimer': r3.ɵɵdeferOnTimer,
   'ɵɵdeferOnHover': r3.ɵɵdeferOnHover,
   'ɵɵdeferOnInteraction': r3.ɵɵdeferOnInteraction,
+  'ɵɵdeferOnLoaded': r3.ɵɵdeferOnLoaded,
   'ɵɵdeferOnViewport': r3.ɵɵdeferOnViewport,
   'ɵɵdeferPrefetchWhen': r3.ɵɵdeferPrefetchWhen,
   'ɵɵdeferPrefetchOnIdle': r3.ɵɵdeferPrefetchOnIdle,

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -5185,6 +5185,417 @@ describe('@defer', () => {
       expect(app.nativeElement.innerHTML).toContain('another child: b | token: nested');
     });
   });
+
+  describe('`loaded` callback', () => {
+    it('should invoke the loaded callback after defer block renders', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Deferred content',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {}
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (on immediate; loaded onDeferredLoaded()) {
+            <nested-cmp />
+          } @placeholder {
+            Placeholder
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        loadedCallCount = 0;
+        onDeferredLoaded() {
+          this.loadedCallCount++;
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [dynamicImportOf(NestedCmp)];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(0);
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(1);
+      expect(fixture.nativeElement.textContent).toContain('Deferred content');
+    });
+
+    it('should NOT invoke the loaded callback if block is destroyed before completion', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Deferred content',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {}
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @if (show) {
+            @defer (on immediate; loaded onDeferredLoaded()) {
+              <nested-cmp />
+            } @placeholder {
+              Placeholder
+            }
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        show = true;
+        loadedCallCount = 0;
+        onDeferredLoaded() {
+          this.loadedCallCount++;
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [dynamicImportOf(NestedCmp, 100)];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(0);
+
+      // Destroy the block before it completes loading
+      fixture.componentInstance.show = false;
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(0);
+    });
+
+    it('should work with `on timer` trigger', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Timer deferred',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {}
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (on timer(500ms); loaded onDeferredLoaded()) {
+            <nested-cmp />
+          } @placeholder {
+            Placeholder
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        loadedCallCount = 0;
+        onDeferredLoaded() {
+          this.loadedCallCount++;
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [dynamicImportOf(NestedCmp)];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+          {provide: TimerScheduler, useClass: FakeTimerScheduler},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fakeScheduler = TestBed.inject(TimerScheduler) as unknown as FakeTimerScheduler;
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(0);
+
+      fakeScheduler.invoke();
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(1);
+      expect(fixture.nativeElement.textContent).toContain('Timer deferred');
+    });
+
+    it('should work with `when` trigger', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'When deferred',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {}
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (when shouldLoad; loaded onDeferredLoaded()) {
+            <nested-cmp />
+          } @placeholder {
+            Placeholder
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        shouldLoad = false;
+        loadedCallCount = 0;
+        onDeferredLoaded() {
+          this.loadedCallCount++;
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [dynamicImportOf(NestedCmp)];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(0);
+
+      // Trigger the when condition
+      fixture.componentInstance.shouldLoad = true;
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(1);
+      expect(fixture.nativeElement.textContent).toContain('When deferred');
+    });
+
+    it('should fire callbacks independently for multiple defer blocks', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Deferred {{ id }}',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {
+        @Input() id!: string;
+      }
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (on immediate; loaded onFirstLoaded()) {
+            <nested-cmp id="first" />
+          } @placeholder {
+            Placeholder 1
+          }
+          @defer (on immediate; loaded onSecondLoaded()) {
+            <nested-cmp id="second" />
+          } @placeholder {
+            Placeholder 2
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        firstCallCount = 0;
+        secondCallCount = 0;
+        onFirstLoaded() {
+          this.firstCallCount++;
+        }
+        onSecondLoaded() {
+          this.secondCallCount++;
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [dynamicImportOf(NestedCmp)];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.firstCallCount).toBe(1);
+      expect(fixture.componentInstance.secondCallCount).toBe(1);
+    });
+
+    it('should fire the loaded callback only once (one-shot behavior)', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Deferred content',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {}
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (on immediate; loaded onDeferredLoaded()) {
+            <nested-cmp />
+          } @placeholder {
+            Placeholder
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        loadedCallCount = 0;
+        onDeferredLoaded() {
+          this.loadedCallCount++;
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [dynamicImportOf(NestedCmp)];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(1);
+
+      // Trigger additional change detection cycles — callback should not fire again
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(1);
+    });
+
+    it('should NOT invoke the loaded callback when loading fails (Error state)', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Deferred content',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {}
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (on immediate; loaded onDeferredLoaded()) {
+            <nested-cmp />
+          } @placeholder {
+            Placeholder
+          } @error {
+            Failed to load dependencies :(
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        loadedCallCount = 0;
+        onDeferredLoaded() {
+          this.loadedCallCount++;
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [failedDynamicImport()];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        rethrowApplicationErrors: false,
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(0);
+
+      // Wait for the (failing) dependencies to settle and render the `@error` block.
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // The `loaded` callback must NOT fire on the Error transition.
+      expect(fixture.componentInstance.loadedCallCount).toBe(0);
+      expect(fixture.nativeElement.textContent).toContain('Failed to load dependencies');
+    });
+  });
 });
 
 describe('IdleScheduler', () => {

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -5301,6 +5301,181 @@ describe('@defer', () => {
       expect(fixture.componentInstance.loadedCallCount).toBe(0);
     });
 
+    it('should invoke the loaded callback when the defer block is nested in an `@if`', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Deferred content',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {}
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @if (show) {
+            @defer (on immediate; loaded onDeferredLoaded()) {
+              <nested-cmp />
+            } @placeholder {
+              Placeholder
+            }
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        show = true;
+        loadedCallCount = 0;
+        onDeferredLoaded() {
+          this.loadedCallCount++;
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [dynamicImportOf(NestedCmp)];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(0);
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedCallCount).toBe(1);
+      expect(fixture.nativeElement.textContent).toContain('Deferred content');
+    });
+
+    it('should pass `@for` loop context variables to the loaded callback', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Deferred content',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {}
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @for (item of items; track item) {
+            @defer (on immediate; loaded onDeferredLoaded(item)) {
+              <nested-cmp />
+            } @placeholder {
+              Placeholder
+            }
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        items = ['a', 'b'];
+        loadedItems: string[] = [];
+        onDeferredLoaded(item: string) {
+          this.loadedItems.push(item);
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [dynamicImportOf(NestedCmp)];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedItems).toEqual([]);
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.loadedItems).toEqual(['a', 'b']);
+    });
+
+    it('should invoke other loaded callbacks when one of them throws', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Deferred content',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class NestedCmp {}
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (on immediate; loaded onFirstLoaded()) {
+            <nested-cmp />
+          } @placeholder {
+            Placeholder 1
+          }
+          @defer (on immediate; loaded onSecondLoaded()) {
+            <nested-cmp />
+          } @placeholder {
+            Placeholder 2
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class RootCmp {
+        secondCallCount = 0;
+        onFirstLoaded() {
+          throw new Error('loaded callback error');
+        }
+        onSecondLoaded() {
+          this.secondCallCount++;
+        }
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => [dynamicImportOf(NestedCmp)];
+        },
+      };
+
+      TestBed.configureTestingModule({
+        rethrowApplicationErrors: false,
+        providers: [
+          ...COMMON_PROVIDERS,
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // The throwing callback must not prevent rendering or the other block's callback.
+      expect(fixture.componentInstance.secondCallCount).toBe(1);
+      expect(fixture.nativeElement.textContent).toContain('Deferred content');
+    });
+
     it('should work with `on timer` trigger', async () => {
       @Component({
         selector: 'nested-cmp',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
      <!-- The angular.dev `@defer` guide can be updated in a follow-up. -->

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`@defer` blocks expose no hook to run component logic when the block finishes loading and renders its main content. Consumers who need to react to a defer block becoming visible (analytics, focus management, kicking off follow-up work) have to resort to lifecycle hooks on the deferred component itself or to `afterNextRender`, neither of which maps cleanly to "this specific `@defer` block completed".

Issue Number: https://github.com/angular/angular/issues/69727

## What is the new behavior?

Adds an opt-in `loaded` parameter to `@defer` that calls a component method once the block successfully transitions to the `Complete` state:

```html
@defer (on timer(500ms); loaded onDeferredLoaded()) {
  <my-cmp />
} @placeholder {
  Loading...
}
