### PR TITLE
fix(docs-infra): define missing win95 variables in aria autocomplete examples

### DIFF
--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.css
@@ -2,6 +2,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
 
 :host {
+  --win95-gray: #c0c0c0;
+  --win95-dark-gray: #808080;
+  --win95-light: #ffffff;
+  --win95-shadow: #000000;
+
   display: flex;
   justify-content: center;
   font-size: 0.6rem;

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.css
@@ -2,6 +2,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
 
 :host {
+  --win95-gray: #c0c0c0;
+  --win95-dark-gray: #808080;
+  --win95-light: #ffffff;
+  --win95-shadow: #000000;
+
   display: flex;
   justify-content: center;
   font-size: 0.6rem;

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.css
@@ -2,6 +2,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
 
 :host {
+  --win95-gray: #c0c0c0;
+  --win95-dark-gray: #808080;
+  --win95-light: #ffffff;
+  --win95-shadow: #000000;
+
   display: flex;
   justify-content: center;
   font-size: 0.6rem;


### PR DESCRIPTION
Superseeds #69428 

The retro-themed aria autocomplete examples style the clear button with var(--win95-gray), var(--win95-dark-gray), var(--win95-light), and var(--win95-shadow), but none of the three example stylesheets defines those custom properties. The variables resolve to nothing, so the button falls back to inherited theme colors — color: var(--win95-shadow) becomes the light-theme text color in dark mode, leaving the button unreadable.

Define the four variables in :host of each example, matching the values already used by the sibling aria tree examples, so the clear button keeps its Windows 95 look in both light and dark themes.

Before:

<img width="836" height="318" alt="image" src="https://github.com/user-attachments/assets/f69b4093-2886-4a87-9ce8-96683c6b7657" />

<img width="847" height="328" alt="image" src="https://github.com/user-attachments/assets/cae10647-e507-48c1-bae5-0151c8874057" />

After:

<img width="833" height="320" alt="image" src="https://github.com/user-attachments/assets/715b2ff8-c3be-4d76-8ecb-b620e817888a" />

<img width="844" height="334" alt="image" src="https://github.com/user-attachments/assets/b5b5da5f-a84f-436a-b50c-79c941c6ba2f" />

