### PR TITLE
fix(docs-infra): fix malformed --webgl-page-background declaration

### DIFF
--- a/adev/shared-docs/styles/_colors.scss
+++ b/adev/shared-docs/styles/_colors.scss
@@ -232,7 +232,8 @@ $gray-50: oklch(98.81% 0 0); // #fbfbfb
   // for the "unfilled" portion of the word that hasn't
   // been highlighted by the gradient
   --gray-unfilled: #{$gray-400};
-  --webgl-page-background: var(var(--page-background)) --webgl-gray-unfilled: #{$gray-400};
+  --webgl-page-background: var(--page-background);
+  --webgl-gray-unfilled: #{$gray-400};
 }
 
 @mixin dark-mode-definitions() {


### PR DESCRIPTION
In the light theme block of _colors.scss, --webgl-page-background and --webgl-gray-unfilled were written on a single line without a separating semicolon, and --webgl-page-background wrapped --page-background in an invalid nested var(). As a result --webgl-page-background got a garbage value and --webgl-gray-unfilled was never defined in the light theme.

Split them into two well-formed declarations and drop the nested var(), matching the structure already used in the dark theme block.