### PR TITLE
fix(platform-browser): omit null, undefined, or NaN property attributes during SSR

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -454,6 +454,15 @@ class DefaultDomRenderer2 implements Renderer2 {
     (typeof ngDevMode === 'undefined' || ngDevMode) &&
       this.throwOnSyntheticProps &&
       checkNoSyntheticProp(name, 'property');
+
+    if (
+      typeof ngServerMode !== 'undefined' &&
+      ngServerMode &&
+      (value == null || Number.isNaN(value))
+    ) {
+      return el.removeAttribute?.(name);
+    }
+
     el[name] = value;
   }
 

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -211,6 +211,47 @@ describe('platform-server full application hydration integration', () => {
         expect(ssrContents).not.toContain(extraChildNodes);
         expect(ssrContents).toContain('<app ngh="0"><div>Some content</div></app>');
       });
+
+      it('should not serialize null, undefined, or NaN property values into attributes during SSR (fixes #69785)', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            <input id="input-null" [value]="nullValue" />
+            <input id="input-undefined" [value]="undefinedValue" />
+            <input id="input-nan" [value]="nanValue" />
+            <input id="input-zero" [value]="zeroValue" />
+            <input id="input-empty" [value]="emptyValue" />
+            <input id="input-str" [value]="strValue" />
+            <img id="img-null" [src]="nullValue" />
+            <a id="a-null" [href]="nullValue"></a>
+            <div id="div-null" [hidden]="nullValue"></div>
+          `,
+        })
+        class AppComponent {
+          nullValue: string | null = null;
+          undefinedValue: string | undefined = undefined;
+          nanValue: number = NaN;
+          zeroValue: number = 0;
+          emptyValue: string = '';
+          strValue: string = 'hello';
+        }
+
+        const html = await ssr(AppComponent);
+        const ssrContents = getAppContents(html);
+
+        // Disallowed string representations
+        expect(ssrContents).not.toContain('value="null"');
+        expect(ssrContents).not.toContain('value="undefined"');
+        expect(ssrContents).not.toContain('value="NaN"');
+        expect(ssrContents).not.toContain('src="null"');
+        expect(ssrContents).not.toContain('href="null"');
+        expect(ssrContents).not.toContain('hidden="null"');
+
+        // Valid values should be preserved
+        expect(ssrContents).toContain('id="input-zero" value="0"');
+        expect(ssrContents).toContain('id="input-empty" value=""');
+        expect(ssrContents).toContain('id="input-str" value="hello"');
+      });
     });
 
     describe('hydration', () => {


### PR DESCRIPTION
Fixes #69785

### Problem
On the server (SSR with Domino), setting DOM properties to `null`, `undefined`, or `NaN` causes Domino's serializer to render string attributes like `value="null"`, `src="null"`, or `value="NaN"`. This causes a visible hydration flicker when the client renders the page.

### Solution
When running server-side (`ngServerMode`), call `removeAttribute(name)` instead so Domino omits the attribute entirely from the serialized HTML output.

### Scope
Includes changes to:
- `packages/platform-browser/src/dom/dom_renderer.ts`
- `packages/platform-server/test/full_app_hydration_spec.ts`