### PR TITLE
fix(docs-infra): replace undefined --gray-50 in retro aria examples

### DIFF
--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.css
@@ -8,6 +8,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -28,6 +29,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 .select {
@@ -62,7 +67,7 @@
 .select:active {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 .select[aria-disabled='true'] {

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.css
@@ -8,6 +8,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -28,6 +29,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 .select {
@@ -62,7 +67,7 @@
 .select:active {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 .select[aria-disabled='true'] {

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.css
@@ -8,6 +8,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -28,6 +29,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 .select {
@@ -62,7 +67,7 @@
 .select:active {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 .select[aria-disabled='true'] {

--- a/adev/src/content/examples/aria/select/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/select/src/basic/retro/app/app.css
@@ -8,6 +8,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -28,6 +29,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 .select,
@@ -66,7 +71,7 @@
 .select:active {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 .select[aria-disabled='true'] {

--- a/adev/src/content/examples/aria/select/src/disabled/retro/app/app.css
+++ b/adev/src/content/examples/aria/select/src/disabled/retro/app/app.css
@@ -8,6 +8,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -28,6 +29,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 .select,
@@ -66,7 +71,7 @@
 .select:not([aria-disabled='true']):active {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 .select[aria-disabled='true'] {

--- a/adev/src/content/examples/aria/select/src/icons/retro/app/app.css
+++ b/adev/src/content/examples/aria/select/src/icons/retro/app/app.css
@@ -8,6 +8,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -28,6 +29,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 .select,
@@ -66,7 +71,7 @@
 .select:active {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 .select[aria-disabled='true'] {

--- a/adev/src/content/examples/aria/toolbar/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/toolbar/src/basic/retro/app/app.css
@@ -6,6 +6,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -26,6 +27,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 [ngToolbar] {
@@ -71,7 +76,7 @@
 [ngToolbarWidget][aria-checked='true'] {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 [ngToolbarWidget]:focus {

--- a/adev/src/content/examples/aria/toolbar/src/disabled/retro/app/app.css
+++ b/adev/src/content/examples/aria/toolbar/src/disabled/retro/app/app.css
@@ -6,6 +6,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -26,6 +27,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 [ngToolbar] {
@@ -71,7 +76,7 @@
 [ngToolbarWidget][aria-checked='true'] {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 [ngToolbarWidget]:focus {

--- a/adev/src/content/examples/aria/toolbar/src/rtl/retro/app/app.css
+++ b/adev/src/content/examples/aria/toolbar/src/rtl/retro/app/app.css
@@ -6,6 +6,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -26,6 +27,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 [ngToolbar] {
@@ -71,7 +76,7 @@
 [ngToolbarWidget][aria-checked='true'] {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 [ngToolbarWidget]:focus {

--- a/adev/src/content/examples/aria/toolbar/src/vertical/retro/app/app.css
+++ b/adev/src/content/examples/aria/toolbar/src/vertical/retro/app/app.css
@@ -6,6 +6,7 @@
 
   font-family: 'Press Start 2P';
   --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--page-background));
+  --retro-pressed-tint: #fbfbfb;
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
@@ -26,6 +27,10 @@
     inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
     0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
     0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+:host-context(.docs-dark-mode) {
+  --retro-pressed-tint: #151417;
 }
 
 [ngToolbar] {
@@ -73,7 +78,7 @@
 [ngToolbarWidget][aria-checked='true'] {
   transform: translate(4px, 4px);
   box-shadow: var(--retro-pressed-shadow);
-  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--retro-pressed-tint));
 }
 
 [ngToolbarWidget]:focus {


### PR DESCRIPTION
The retro variants of the toolbar, select, and multiselect aria examples tint the pressed button background with
color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50)), but --gray-50 is defined nowhere. Per the CSS spec, a var() with no fallback pointing at an undefined property invalidates the whole color-mix(), so the declaration is dropped and the pressed-state tint never applies.

Define a local `--retro-pressed-tint` token in each example's `:host` (`#fbfbfb` in light, `#151417` under `.docs-dark-mode`, the values `$gray-50`/`$gray-900` resolve to) and use it for the pressed-state mix. This keeps the example self-contained rather than depending on adev's global token scope, while staying theme-aware in both modes, following the same `:host-context(.docs-dark-mode)` token-flipping pattern used in `code-editor.component.scss`.

Before: 

<img width="879" height="409" alt="Screenshot 2026-07-25 at 20 18 42" src="https://github.com/user-attachments/assets/5f55c650-9fae-4bca-bbb1-18073a95aab8" />

After: 

<img width="853" height="408" alt="Screenshot 2026-07-25 at 20 18 19" src="https://github.com/user-attachments/assets/aff684da-31e9-48f3-89c9-978c62736754" />
