### PR TITLE
fix(devtools): avoid initializing profiler in production mode

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/profiling/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/profiling/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ts_project")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -20,4 +20,17 @@ ts_project(
         "//devtools/projects/ng-devtools-backend/src/lib/shared/utils:general",
         "//devtools/projects/protocol",
     ],
+)
+
+ts_test_library(
+    name = "performance_track_test_lib",
+    srcs = ["performance-track.spec.ts"],
+    deps = [
+        ":profiling",
+    ],
+)
+
+zoneless_web_test_suite(
+    name = "performance_track_test",
+    deps = [":performance_track_test_lib"],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/profiling/performance-track.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/profiling/performance-track.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+describe('performance track', () => {
+  const globalWithAngularDebugApi = window as unknown as {ng?: unknown};
+  let angularDebugApi: unknown;
+
+  beforeEach(() => {
+    angularDebugApi = globalWithAngularDebugApi.ng;
+    globalWithAngularDebugApi.ng = {};
+  });
+
+  afterEach(() => {
+    if (angularDebugApi === undefined) {
+      delete globalWithAngularDebugApi.ng;
+    } else {
+      globalWithAngularDebugApi.ng = angularDebugApi;
+    }
+  });
+
+  it('does not throw an error when initialized in development mode', async () => {
+    const performanceTrack = await import('./performance-track');
+
+    expect(() => performanceTrack.enablePerformanceTrack()).not.toThrow();
+  });
+});

--- a/devtools/projects/ng-devtools-backend/src/lib/profiling/performance-track.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/profiling/performance-track.ts
@@ -16,9 +16,6 @@ type Method = keyof LifecycleProfile | 'changeDetection' | string;
 // Performance track global flag.
 let chromeDevToolsPerformanceTrackEnabled = false;
 
-/** Enable Angular's performance track in the Chrome DevTools profiler. */
-export const enablePerformanceTrack = () => (chromeDevToolsPerformanceTrackEnabled = true);
-
 /** Disable Angular's performance track in the Chrome DevTools profiler. */
 export const disablePerformanceTrack = () => (chromeDevToolsPerformanceTrackEnabled = false);
 
@@ -64,7 +61,7 @@ const endMark = (nodeName: string, method: Method) => {
   }
 };
 
-getProfiler().subscribe({
+const timingHooks = {
   onChangeDetectionStart(component: ComponentInstance): void {
     if (!performanceTrackEnabled()) {
       return;
@@ -101,4 +98,21 @@ getProfiler().subscribe({
     }
     endMark(getDirectiveName(component), output);
   },
-});
+};
+
+let performanceTrackInitialized = false;
+
+function initializePerformanceTrack(): void {
+  if (performanceTrackInitialized) {
+    return;
+  }
+
+  getProfiler().subscribe(timingHooks);
+  performanceTrackInitialized = true;
+}
+
+/** Enable Angular's performance track in the Chrome DevTools profiler. */
+export function enablePerformanceTrack(): void {
+  initializePerformanceTrack();
+  chromeDevToolsPerformanceTrackEnabled = true;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs are not required for this internal behavior change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Opening Chrome DevTools on a production Angular application causes the Angular DevTools backend to throw while loading:

```text
Angular DevTools: Angular debugging APIs are not available. Ensure that your
Angular app is in development mode and does not invoke `enableProdMode()`.
```

The extension correctly detects that the application is running in production mode, but the exception is still added to the inspected page's console and the backend handshake cannot complete.

This is a regression introduced by #69396 (`ff115925e773d4d97fe0b6ce127ece95887e4172`).

Before that refactor, the timing API subscribed to profiler hooks as part of the lazy `DirectiveForestHooks` initialization. The refactor separated the profiler and timing API, moving `getProfiler().subscribe(...)` to the top-level evaluation of `timing-api.ts`.

As a result, importing the backend initializes the profiler unconditionally, including on production applications where the development-only `window.ng` debugging APIs are expected to be unavailable.

Issue Number: #69944

## What is the new behavior?

Profiler hook subscription is initialized lazily when `enableTimingAPI()` is called instead of when the timing API module is loaded.

Production Angular applications can therefore be detected without accessing development-only debugging APIs or adding an uncaught exception to the page's console.

The timing API behavior is preserved: enabling it initializes the profiler and subscribes to the timing hooks once.

A regression test verifies that:

- loading the timing API without `window.ng` does not initialize the profiler;
- enabling the timing API still initializes the profiler successfully.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified with:

```text
//devtools/projects/ng-devtools-backend/src/lib/profiling:timing_api_test_chromium
//devtools/projects/ng-devtools-backend/src/lib/profiling:timing_api_test_firefox
//devtools/projects/ng-devtools-backend/src/lib:client_event_subscribers_test_chromium
//devtools/projects/ng-devtools-backend/src/lib:client_event_subscribers_test_firefox
```

All targeted tests pass in Chromium and Firefox.

The Chrome Angular DevTools release bundle also builds successfully:

```text
//devtools/projects/shell-browser/src:prodapp
```
