### PR TITLE
test(platform-server): add SSR integration test for null and normal input values

### DIFF
--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -211,6 +211,26 @@ describe('platform-server full application hydration integration', () => {
         expect(ssrContents).not.toContain(extraChildNodes);
         expect(ssrContents).toContain('<app ngh="0"><div>Some content</div></app>');
       });
+
+      it('should serialize input values correctly for both null and normal non-empty values during SSR', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            <input id="input-null" [value]="nullValue" />
+            <input id="input-normal" [value]="normalValue" />
+          `,
+        })
+        class AppComponent {
+          nullValue: string | null = null;
+          normalValue = 'hello';
+        }
+
+        const html = await ssr(AppComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).not.toContain('value="null"');
+        expect(ssrContents).toContain('id="input-normal" value="hello"');
+      });
     });
 
     describe('hydration', () => {


### PR DESCRIPTION
test(platform-server): add SSR integration test for null and normal input values

Fixes #69785

Add an Angular SSR integration test in platform-server verifying that null input values do not render string attributes like value="null" during server-side rendering, while normal non-empty string values like value="hello" are properly preserved.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [x] Other... Please describe: Integration Test

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #69785

During Angular Server-Side Rendering (SSR), binding `null` properties such as `<input [value]="null">` serializes string attributes like `<input value="null">`, which causes a hydration flicker when the client app hydrates.

## What is the new behavior?

Adds an Angular SSR integration test in `platform-server` (`full_app_hydration_spec.ts`) verifying that:
1. `null` input values omit string attributes like `value="null"`.
2. Normal non-empty string values such as `value="hello"` are properly preserved.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This PR is kept as pending merge of Domino PR [angular/domino#34](https://github.com/angular/domino/pull/34) and a subsequent Domino version bump in `package.json`.

<img width="571" height="471" alt="image" src="https://github.com/user-attachments/assets/30056e80-7e84-4923-8611-49c8fba1c7e2" />