### PR TITLE
feat(compiler): support inline `@template` blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
@@ -275,6 +275,9 @@ export class CompletionEngine {
     // `context` template - they just need to be converted to `Completion`s.
     for (const node of this.data.boundTarget.getEntitiesInScope(context)) {
       if (node instanceof TmplAstReference) {
+        if (node.isSynthetic) {
+          continue;
+        }
         templateContext.set(node.name, {
           kind: CompletionKind.Reference,
           node,

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -7666,6 +7666,117 @@ suppress
       });
     });
 
+    describe('@template declarations', () => {
+      it('should type-check lexical expressions inside the template body', () => {
+        env.write(
+          'test.ts',
+          `
+            import {Component, input, TemplateRef} from '@angular/core';
+
+            @Component({
+              selector: 'template-consumer',
+              template: '',
+            })
+            export class TemplateConsumer {
+              template = input.required<TemplateRef<unknown>>();
+            }
+
+            @Component({
+              imports: [TemplateConsumer],
+              template: \`
+                <template-consumer [template]="item" />
+
+                @template item {
+                  {{title.missing}}
+                }
+              \`,
+            })
+            export class TestCmp {
+              title = 'Angular';
+            }
+          `,
+        );
+
+        const diagnostics = env
+          .driveDiagnostics()
+          .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, ''));
+
+        expect(diagnostics).toEqual([`Property 'missing' does not exist on type 'string'.`]);
+      });
+
+      it('should type-check lexical expressions inside an anonymous template body', () => {
+        env.write(
+          'test.ts',
+          `
+            import {Component, input, TemplateRef} from '@angular/core';
+
+            @Component({
+              selector: 'template-consumer',
+              template: '',
+            })
+            export class TemplateConsumer {
+              template = input.required<TemplateRef<unknown>>();
+            }
+
+            @Component({
+              imports: [TemplateConsumer],
+              template: \`
+                <template-consumer
+                  [template]="@template {
+                    {{title.missing}}
+                  }"
+                />
+              \`,
+            })
+            export class TestCmp {
+              title = 'Angular';
+            }
+          `,
+        );
+
+        const diagnostics = env
+          .driveDiagnostics()
+          .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, ''));
+
+        expect(diagnostics).toEqual([`Property 'missing' does not exist on type 'string'.`]);
+      });
+
+      it('should preserve ng-template context typing behavior for anonymous templates', () => {
+        env.write(
+          'test.ts',
+          `
+            import {Component, input, TemplateRef} from '@angular/core';
+
+            interface Item {
+              name: string;
+            }
+
+            @Component({
+              selector: 'template-consumer',
+              template: '',
+            })
+            export class TemplateConsumer {
+              template = input.required<TemplateRef<{$implicit: Item}>>();
+            }
+
+            @Component({
+              imports: [TemplateConsumer],
+              template: \`
+                <template-consumer
+                  [template]="@template(let item) {
+                    {{item.nonExistingProperty}}
+                  }"
+                />
+              \`,
+            })
+            export class TestCmp {}
+          `,
+        );
+
+        expect(env.driveDiagnostics()).toEqual([]);
+      });
+    });
+
     describe('@let declarations', () => {
       beforeEach(() =>
         env.tsconfig({

--- a/packages/compiler/src/combined_visitor.ts
+++ b/packages/compiler/src/combined_visitor.ts
@@ -23,6 +23,7 @@ export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements 
   }
 
   visitElement(element: t.Element): void {
+    this.visitAllTemplateNodes(element.inlineTemplates);
     this.visitAllTemplateNodes(element.attributes);
     this.visitAllTemplateNodes(element.inputs);
     this.visitAllTemplateNodes(element.outputs);
@@ -32,6 +33,7 @@ export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements 
   }
 
   visitTemplate(template: t.Template): void {
+    this.visitAllTemplateNodes(template.inlineTemplates);
     this.visitAllTemplateNodes(template.attributes);
     this.visitAllTemplateNodes(template.inputs);
     this.visitAllTemplateNodes(template.outputs);
@@ -135,6 +137,7 @@ export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements 
   }
 
   visitComponent(component: t.Component): void {
+    this.visitAllTemplateNodes(component.inlineTemplates);
     this.visitAllTemplateNodes(component.attributes);
     this.visitAllTemplateNodes(component.inputs);
     this.visitAllTemplateNodes(component.outputs);

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -25,6 +25,7 @@ export type Node =
   | Text
   | Block
   | BlockParameter
+  | InlineTemplate
   | Component
   | Directive
   | StartTagComment;
@@ -90,11 +91,29 @@ export class Attribute extends NodeWithI18n {
     public valueSpan: ParseSourceSpan | undefined,
     public valueTokens: InterpolatedAttributeToken[] | undefined,
     i18n: I18nMeta | undefined,
+    public inlineTemplate?: InlineTemplate,
   ) {
     super(sourceSpan, i18n);
   }
   override visit(visitor: Visitor, context: any): any {
     return visitor.visitAttribute(this, context);
+  }
+}
+
+export class InlineTemplate extends NodeWithI18n {
+  constructor(
+    public parameters: BlockParameter[],
+    public children: Node[],
+    sourceSpan: ParseSourceSpan,
+    public startSourceSpan: ParseSourceSpan,
+    public endSourceSpan: ParseSourceSpan,
+    i18n?: I18nMeta,
+  ) {
+    super(sourceSpan, i18n);
+  }
+
+  override visit(visitor: Visitor, context: unknown): unknown {
+    return visitor.visitInlineTemplate?.(this, context);
   }
 }
 
@@ -234,6 +253,7 @@ export interface Visitor {
   visitExpansionCase(expansionCase: ExpansionCase, context: any): any;
   visitBlock(block: Block, context: any): any;
   visitBlockParameter(parameter: BlockParameter, context: any): any;
+  visitInlineTemplate?(template: InlineTemplate, context: unknown): unknown;
   visitLetDeclaration(decl: LetDeclaration, context: any): any;
   visitComponent(component: Component, context: any): any;
   visitDirective(directive: Directive, context: any): any;
@@ -268,6 +288,13 @@ export class RecursiveVisitor implements Visitor {
   }
 
   visitAttribute(ast: Attribute, context: any): any {}
+  visitInlineTemplate(ast: InlineTemplate, context: unknown): unknown {
+    this.visitChildren(context, (visit) => {
+      visit(ast.parameters);
+      visit(ast.children);
+    });
+    return undefined;
+  }
   visitStartTagComment(ast: StartTagComment, context: any): any {}
   visitText(ast: Text, context: any): any {}
   visitComment(ast: Comment, context: any): any {}

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -12,6 +12,7 @@ import {ParseError, ParseLocation, ParseSourceFile, ParseSourceSpan} from '../pa
 import {NAMED_ENTITIES} from './entities';
 import {TagContentType, TagDefinition} from './tags';
 import {
+  AttributeNameToken,
   ComponentOpenStartToken,
   IncompleteComponentOpenToken,
   IncompleteTagOpenToken,
@@ -154,6 +155,7 @@ const SUPPORTED_BLOCKS = [
   '@loading',
   '@error',
   '@content',
+  '@template',
 ] as const;
 
 const INTERPOLATION = {start: '{{', end: '}}'} as const;
@@ -177,6 +179,8 @@ class _Tokenizer {
   private readonly _tokenizeBlocks: boolean;
   private readonly _tokenizeLet: boolean;
   private readonly _selectorlessEnabled: boolean;
+  private readonly _file: ParseSourceFile;
+  private readonly _options: TokenizeOptions;
   tokens: Token[] = [];
   errors: ParseError[] = [];
   nonNormalizedIcuExpressions: Token[] = [];
@@ -191,6 +195,8 @@ class _Tokenizer {
     private _getTagDefinition: (tagName: string) => TagDefinition,
     options: TokenizeOptions,
   ) {
+    this._file = _file;
+    this._options = options;
     this._tokenizeIcu = options.tokenizeExpansionForms || false;
     this._leadingTriviaCodePoints =
       options.leadingTriviaChars && options.leadingTriviaChars.map((c) => c.codePointAt(0) || 0);
@@ -363,11 +369,15 @@ class _Tokenizer {
     this._endToken([]);
   }
 
-  private _consumeBlockParameters() {
+  private _consumeBlockParameters(stopQuote?: number) {
     // Trim the whitespace until the first parameter.
     this._attemptCharCodeUntilFn(isBlockParameterChar);
 
-    while (this._cursor.peek() !== chars.$RPAREN && this._cursor.peek() !== chars.$EOF) {
+    while (
+      this._cursor.peek() !== chars.$RPAREN &&
+      this._cursor.peek() !== chars.$EOF &&
+      this._cursor.peek() !== stopQuote
+    ) {
       this._beginToken(TokenType.BLOCK_PARAMETER);
       const start = this._cursor.clone();
       let inQuote: number | null = null;
@@ -376,7 +386,9 @@ class _Tokenizer {
       // Consume the parameter until the next semicolon or brace.
       // Note that we skip over semicolons/braces inside of strings.
       while (
-        (this._cursor.peek() !== chars.$SEMICOLON && this._cursor.peek() !== chars.$EOF) ||
+        (this._cursor.peek() !== chars.$SEMICOLON &&
+          this._cursor.peek() !== chars.$EOF &&
+          this._cursor.peek() !== stopQuote) ||
         inQuote !== null
       ) {
         const char = this._cursor.peek();
@@ -676,18 +688,34 @@ class _Tokenizer {
   }
 
   private _peekStr(chars: string): boolean {
-    const len = chars.length;
-    if (this._cursor.charsLeft() < len) {
+    return this._cursorStartsWith(this._cursor, chars);
+  }
+
+  private _cursorStartsWith(cursor: CharacterCursor, value: string): boolean {
+    const len = value.length;
+    if (cursor.charsLeft() < len) {
       return false;
     }
-    const cursor = this._cursor.clone();
+    cursor = cursor.clone();
     for (let i = 0; i < len; i++) {
-      if (cursor.peek() !== chars.charCodeAt(i)) {
+      if (cursor.peek() !== value.charCodeAt(i)) {
         return false;
       }
       cursor.advance();
     }
     return true;
+  }
+
+  private _peekStrFollowedBy(value: string, predicate: (code: number) => boolean): boolean {
+    if (!this._peekStr(value)) {
+      return false;
+    }
+
+    const cursor = this._cursor.clone();
+    for (let i = 0; i < value.length; i++) {
+      cursor.advance();
+    }
+    return predicate(cursor.peek());
   }
 
   private _isBlockStart(): boolean {
@@ -1026,16 +1054,16 @@ class _Tokenizer {
   }
 
   private _consumeAttribute() {
-    this._consumeAttributeName();
+    const attributeName = this._consumeAttributeName();
     this._attemptCharCodeUntilFn(isNotWhitespace);
     if (this._attemptCharCode(chars.$EQ)) {
       this._attemptCharCodeUntilFn(isNotWhitespace);
-      this._consumeAttributeValue();
+      this._consumeAttributeValue(this._isPropertyBinding(attributeName));
     }
     this._attemptCharCodeUntilFn(isNotWhitespace);
   }
 
-  private _consumeAttributeName() {
+  private _consumeAttributeName(): AttributeNameToken {
     const attrNameStart = this._cursor.peek();
     if (attrNameStart === chars.$SQ || attrNameStart === chars.$DQ) {
       throw this._createError(_unexpectedCharacterErrorMsg(attrNameStart), this._cursor.getSpan());
@@ -1084,13 +1112,20 @@ class _Tokenizer {
     }
 
     const prefixAndName = this._consumePrefixAndName(nameEndPredicate);
-    this._endToken(prefixAndName);
+    return this._endToken(prefixAndName) as AttributeNameToken;
   }
 
-  private _consumeAttributeValue() {
+  private _consumeAttributeValue(allowInlineTemplate: boolean) {
     if (this._cursor.peek() === chars.$SQ || this._cursor.peek() === chars.$DQ) {
       const quoteChar = this._cursor.peek();
       this._consumeQuote(quoteChar);
+      if (allowInlineTemplate && this._consumeInlineTemplateAttributeValue(quoteChar)) {
+        this._consumeQuote(quoteChar);
+        return;
+      }
+      const misplacedTemplateStart = allowInlineTemplate
+        ? this._findMisplacedInlineTemplateStart(quoteChar)
+        : null;
       // In an attribute then end of the attribute value and the premature end to an interpolation
       // are both triggered by the `quoteChar`.
       const endPredicate = () => this._cursor.peek() === quoteChar;
@@ -1100,6 +1135,14 @@ class _Tokenizer {
         endPredicate,
         endPredicate,
       );
+      if (misplacedTemplateStart !== null) {
+        this.errors.push(
+          this._createError(
+            'Anonymous @template must be the complete value of a property binding.',
+            misplacedTemplateStart.getSpan(),
+          ),
+        );
+      }
       this._consumeQuote(quoteChar);
     } else {
       const endPredicate = () => isNameEnd(this._cursor.peek());
@@ -1110,6 +1153,180 @@ class _Tokenizer {
         endPredicate,
       );
     }
+  }
+
+  private _isPropertyBinding(attributeName: AttributeNameToken): boolean {
+    const name = attributeName.parts[1];
+    return (name.startsWith('[') && name.endsWith(']')) || name.startsWith('bind-');
+  }
+
+  private _findMisplacedInlineTemplateStart(quoteChar: number): CharacterCursor | null {
+    const cursor = this._cursor.clone();
+    let expressionQuote: number | null = null;
+
+    while (cursor.peek() !== quoteChar && cursor.peek() !== chars.$EOF) {
+      const code = cursor.peek();
+      if (code === chars.$BACKSLASH) {
+        cursor.advance();
+        if (cursor.peek() !== chars.$EOF) {
+          cursor.advance();
+        }
+        continue;
+      }
+      if (expressionQuote !== null) {
+        if (code === expressionQuote) {
+          expressionQuote = null;
+        }
+        cursor.advance();
+        continue;
+      }
+      if (chars.isQuote(code)) {
+        expressionQuote = code;
+        cursor.advance();
+        continue;
+      }
+
+      const startsTemplate =
+        this._cursorStartsWith(cursor, '@template') &&
+        this._cursorStartsWithTemplateBoundary(cursor, '@template');
+      if (startsTemplate) {
+        return cursor;
+      }
+      cursor.advance();
+    }
+    return null;
+  }
+
+  private _cursorStartsWithTemplateBoundary(cursor: CharacterCursor, value: string): boolean {
+    const boundaryCursor = cursor.clone();
+    for (let i = 0; i < value.length; i++) {
+      boundaryCursor.advance();
+    }
+    const code = boundaryCursor.peek();
+    return chars.isWhitespace(code) || code === chars.$LPAREN || code === chars.$LBRACE;
+  }
+
+  private _consumeInlineTemplateAttributeValue(quoteChar: number): boolean {
+    const initialCursor = this._cursor.clone();
+    this._attemptCharCodeUntilFn(isNotWhitespace);
+    const templateStart = this._cursor.clone();
+
+    const startsAnonymousTemplate = this._peekStrFollowedBy(
+      '@template',
+      (code) =>
+        chars.isWhitespace(code) ||
+        code === chars.$LPAREN ||
+        code === chars.$LBRACE ||
+        code === quoteChar,
+    );
+    if (!startsAnonymousTemplate) {
+      this._cursor = initialCursor;
+      return false;
+    }
+
+    this._beginToken(TokenType.INLINE_TEMPLATE_START, templateStart);
+    this._requireStr('@template');
+    this._endToken([]);
+    this._attemptCharCodeUntilFn(isNotWhitespace);
+
+    if (this._attemptCharCode(chars.$LPAREN)) {
+      this._consumeBlockParameters(quoteChar);
+      this._attemptCharCodeUntilFn(isNotWhitespace);
+      if (!this._attemptCharCode(chars.$RPAREN)) {
+        this.errors.push(
+          this._createError(
+            'Anonymous @template context parameters must end with ")".',
+            this._cursor.getSpan(templateStart),
+          ),
+        );
+        this._attemptCharCodeUntilFn((code) => code === quoteChar || code === chars.$EOF);
+        return true;
+      }
+      this._attemptCharCodeUntilFn(isNotWhitespace);
+    }
+
+    this._beginToken(TokenType.BLOCK_OPEN_END);
+    if (!this._attemptCharCode(chars.$LBRACE)) {
+      this.errors.push(
+        this._createError(
+          'Anonymous @template expression must have a template body.',
+          this._cursor.getSpan(templateStart),
+        ),
+      );
+      this._attemptCharCodeUntilFn((code) => code === quoteChar || code === chars.$EOF);
+      return true;
+    }
+    this._endToken([]);
+
+    const bodyStart = this._cursor.getSpan().start;
+    const bodyResult = tokenize(this._file.content, this._file.url, this._getTagDefinition, {
+      ...this._options,
+      range: {
+        startPos: bodyStart.offset,
+        startLine: bodyStart.line,
+        startCol: bodyStart.col,
+        endPos: this._file.content.length,
+      },
+    });
+
+    let blockDepth = 0;
+    let closingToken: Token | null = null;
+    for (const token of bodyResult.tokens) {
+      if (token.type === TokenType.BLOCK_OPEN_START) {
+        blockDepth++;
+      } else if (token.type === TokenType.BLOCK_CLOSE) {
+        if (blockDepth === 0) {
+          closingToken = token;
+          break;
+        }
+        blockDepth--;
+      }
+
+      if (token.type !== TokenType.EOF) {
+        this.tokens.push(token);
+      }
+    }
+
+    if (closingToken === null) {
+      throw this._createError(
+        'Unclosed anonymous @template expression.',
+        this._cursor.getSpan(templateStart),
+      );
+    }
+
+    this.errors.push(
+      ...bodyResult.errors.filter(
+        (error) => error.span.start.offset < closingToken.sourceSpan.start.offset,
+      ),
+    );
+    this.nonNormalizedIcuExpressions.push(
+      ...bodyResult.nonNormalizedIcuExpressions.filter(
+        (token) => token.sourceSpan.start.offset < closingToken.sourceSpan.start.offset,
+      ),
+    );
+
+    const closingOffset = closingToken.sourceSpan.end.offset;
+    while (this._cursor.getSpan().start.offset < closingOffset) {
+      this._cursor.advance();
+    }
+    this.tokens.push({
+      type: TokenType.INLINE_TEMPLATE_END,
+      parts: [],
+      sourceSpan: closingToken.sourceSpan,
+    });
+
+    this._attemptCharCodeUntilFn(isNotWhitespace);
+    if (this._cursor.peek() !== quoteChar) {
+      this.errors.push(
+        this._createError(
+          'Anonymous @template must be the complete value of a property binding.',
+          this._cursor.getSpan(),
+        ),
+      );
+      this._attemptCharCodeUntilFn((code) => code === quoteChar || code === chars.$EOF);
+    }
+
+    return true;
   }
 
   private _consumeQuote(quoteChar: number) {

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -32,6 +32,8 @@ import {
   IncompleteLetToken,
   IncompleteTagOpenToken,
   InElementCommentToken,
+  InlineTemplateEndToken,
+  InlineTemplateStartToken,
   InterpolatedAttributeToken,
   InterpolatedTextToken,
   LetEndToken,
@@ -652,12 +654,19 @@ class _TreeBuilder {
     const valueTokens: InterpolatedAttributeToken[] = [];
     let valueStartSpan: ParseSourceSpan | undefined = undefined;
     let valueEnd: ParseLocation | undefined = undefined;
+    let inlineTemplate: html.InlineTemplate | undefined;
     // NOTE: We need to use a new variable `nextTokenType` here to hide the actual type of
     // `_peek.type` from TS. Otherwise TS will narrow the type of `_peek.type` preventing it from
     // being able to consider `ATTR_VALUE_INTERPOLATION` as an option. This is because TS is not
     // able to see that `_advance()` will actually mutate `_peek`.
     const nextTokenType = this._peek.type as TokenType;
-    if (nextTokenType === TokenType.ATTR_VALUE_TEXT) {
+    if (nextTokenType === TokenType.INLINE_TEMPLATE_START) {
+      inlineTemplate = this._consumeInlineTemplate();
+      if (inlineTemplate !== undefined) {
+        valueStartSpan = inlineTemplate.sourceSpan;
+        valueEnd = attrEnd = inlineTemplate.sourceSpan.end;
+      }
+    } else if (nextTokenType === TokenType.ATTR_VALUE_TEXT) {
       valueStartSpan = this._peek.sourceSpan;
       valueEnd = this._peek.sourceSpan.end;
       while (
@@ -700,6 +709,65 @@ class _TreeBuilder {
       valueSpan,
       valueTokens.length > 0 ? valueTokens : undefined,
       undefined,
+      inlineTemplate,
+    );
+  }
+
+  private _consumeInlineTemplate(): html.InlineTemplate | undefined {
+    const startToken = this._advance<InlineTemplateStartToken>();
+    const parameters: html.BlockParameter[] = [];
+
+    while (this._peek.type === TokenType.BLOCK_PARAMETER) {
+      const parameter = this._advance<BlockParameterToken>();
+      parameters.push(new html.BlockParameter(parameter.parts[0], parameter.sourceSpan));
+    }
+
+    const openToken = this._advanceIf(TokenType.BLOCK_OPEN_END);
+    if (openToken === null) {
+      this.errors.push(
+        TreeError.create(
+          null,
+          startToken.sourceSpan,
+          'Anonymous @template expression must have a template body.',
+        ),
+      );
+      return undefined;
+    }
+
+    const bodyTokens: Token[] = [];
+    while (this._peek.type !== TokenType.INLINE_TEMPLATE_END && this._peek.type !== TokenType.EOF) {
+      bodyTokens.push(this._advance());
+    }
+
+    if (this._peek.type !== TokenType.INLINE_TEMPLATE_END) {
+      this.errors.push(
+        TreeError.create(null, startToken.sourceSpan, 'Unclosed anonymous @template expression.'),
+      );
+      return undefined;
+    }
+
+    const endToken = this._advance<InlineTemplateEndToken>();
+    bodyTokens.push({type: TokenType.EOF, parts: [], sourceSpan: endToken.sourceSpan});
+    const bodyParser = new _TreeBuilder(bodyTokens, this.tagDefinitionResolver);
+    bodyParser.build();
+    this.errors.push(...bodyParser.errors);
+
+    const startSourceSpan = new ParseSourceSpan(
+      startToken.sourceSpan.start,
+      openToken.sourceSpan.end,
+      startToken.sourceSpan.fullStart,
+    );
+    const sourceSpan = new ParseSourceSpan(
+      startToken.sourceSpan.start,
+      endToken.sourceSpan.end,
+      startToken.sourceSpan.fullStart,
+    );
+    return new html.InlineTemplate(
+      parameters,
+      bodyParser.rootNodes,
+      sourceSpan,
+      startSourceSpan,
+      endToken.sourceSpan,
     );
   }
 

--- a/packages/compiler/src/ml_parser/tokens.ts
+++ b/packages/compiler/src/ml_parser/tokens.ts
@@ -28,6 +28,8 @@ export const enum TokenType {
   ATTR_QUOTE,
   ATTR_VALUE_TEXT,
   ATTR_VALUE_INTERPOLATION,
+  INLINE_TEMPLATE_START,
+  INLINE_TEMPLATE_END,
   DOC_TYPE,
   EXPANSION_FORM_START,
   EXPANSION_CASE_VALUE,
@@ -73,6 +75,8 @@ export type Token =
   | AttributeQuoteToken
   | AttributeValueTextToken
   | AttributeValueInterpolationToken
+  | InlineTemplateStartToken
+  | InlineTemplateEndToken
   | DocTypeToken
   | ExpansionFormStartToken
   | ExpansionCaseValueToken
@@ -197,6 +201,16 @@ export interface AttributeValueInterpolationToken extends TokenBase {
   parts:
     | [startMarker: string, expression: string, endMarker: string]
     | [startMarker: string, expression: string];
+}
+
+export interface InlineTemplateStartToken extends TokenBase {
+  type: TokenType.INLINE_TEMPLATE_START;
+  parts: [];
+}
+
+export interface InlineTemplateEndToken extends TokenBase {
+  type: TokenType.INLINE_TEMPLATE_END;
+  parts: [];
 }
 
 export interface DocTypeToken extends TokenBase {

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -158,6 +158,8 @@ export class BoundEvent implements Node {
 }
 
 export class Element implements Node {
+  readonly inlineTemplates: Template[] = [];
+
   constructor(
     public name: string,
     public attributes: TextAttribute[],
@@ -607,6 +609,8 @@ export class LetDeclaration implements Node {
 }
 
 export class Component implements Node {
+  readonly inlineTemplates: Template[] = [];
+
   constructor(
     public componentName: string,
     public tagName: string | null,
@@ -646,6 +650,8 @@ export class Directive implements Node {
 }
 
 export class Template implements Node {
+  readonly inlineTemplates: Template[] = [];
+
   constructor(
     // tagName is the name of the container element, if applicable.
     // `null` is a special case for when there is a structural directive on an `ng-template` so
@@ -709,6 +715,8 @@ export class Reference implements Node {
     public sourceSpan: ParseSourceSpan,
     readonly keySpan: ParseSourceSpan,
     public valueSpan?: ParseSourceSpan,
+    readonly isSynthetic: boolean = false,
+    readonly isTemplateDeclaration: boolean = false,
   ) {}
   visit<Result>(visitor: Visitor<Result>): Result {
     return visitor.visitReference(this);
@@ -786,6 +794,7 @@ export interface Visitor<Result = any> {
 
 export class RecursiveVisitor implements Visitor<void> {
   visitElement(element: Element): void {
+    visitAll(this, element.inlineTemplates);
     visitAll(this, element.attributes);
     visitAll(this, element.inputs);
     visitAll(this, element.outputs);
@@ -794,6 +803,7 @@ export class RecursiveVisitor implements Visitor<void> {
     visitAll(this, element.references);
   }
   visitTemplate(template: Template): void {
+    visitAll(this, template.inlineTemplates);
     visitAll(this, template.attributes);
     visitAll(this, template.inputs);
     visitAll(this, template.outputs);
@@ -842,6 +852,7 @@ export class RecursiveVisitor implements Visitor<void> {
     visitAll(this, content.children);
   }
   visitComponent(component: Component): void {
+    visitAll(this, component.inlineTemplates);
     visitAll(this, component.attributes);
     visitAll(this, component.inputs);
     visitAll(this, component.outputs);

--- a/packages/compiler/src/render3/r3_template_blocks.ts
+++ b/packages/compiler/src/render3/r3_template_blocks.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as html from '../ml_parser/ast';
+import {ParseError, ParseSourceSpan} from '../parse_util';
+
+import * as t from './r3_ast';
+import {IDENTIFIER_PATTERN, LET_PATTERN} from './util';
+
+const TEMPLATE_BLOCK_PATTERN = /^template(?:\s+|$)/;
+
+/** Returns whether an HTML block represents a named `@template` declaration. */
+export function isTemplateBlock(name: string): boolean {
+  return TEMPLATE_BLOCK_PATTERN.test(name);
+}
+
+/** Returns the declared name of a named `@template` block. */
+export function getTemplateBlockName(ast: html.Block): string {
+  return ast.name.slice('template'.length).trim();
+}
+
+/** Creates an `ng-template` AST node from a named `@template` declaration. */
+export function createTemplateBlock(
+  ast: html.Block,
+  visitor: html.Visitor,
+): {node: t.Template | null; errors: ParseError[]} {
+  const errors: ParseError[] = [];
+  const name = getTemplateBlockName(ast);
+  const nameSpan = getNameSpan(ast, name);
+
+  if (name.length === 0) {
+    errors.push(new ParseError(ast.nameSpan, '@template declaration must have a name'));
+    return {node: null, errors};
+  }
+
+  if (!IDENTIFIER_PATTERN.test(name)) {
+    errors.push(new ParseError(nameSpan, '@template name must be a valid JavaScript identifier'));
+    return {node: null, errors};
+  }
+
+  const variables = parseTemplateVariables(ast.parameters, errors);
+  if (variables === null) {
+    return {node: null, errors};
+  }
+
+  return {
+    node: new t.Template(
+      'ng-template',
+      [],
+      [],
+      [],
+      [],
+      [],
+      html.visitAll(visitor, ast.children, ast.children),
+      [new t.Reference(name, '', nameSpan, nameSpan, undefined, false, true)],
+      variables,
+      false,
+      ast.sourceSpan,
+      ast.startSourceSpan,
+      ast.endSourceSpan,
+      ast.i18n,
+    ),
+    errors,
+  };
+}
+
+/** Creates an `ng-template` AST node for an anonymous inline template. */
+export function createInlineTemplate(
+  ast: html.InlineTemplate,
+  referenceName: string,
+  visitor: html.Visitor,
+): {node: t.Template | null; errors: ParseError[]} {
+  const errors: ParseError[] = [];
+  const variables = parseTemplateVariables(ast.parameters, errors);
+  if (variables === null) {
+    return {node: null, errors};
+  }
+
+  return {
+    node: new t.Template(
+      'ng-template',
+      [],
+      [],
+      [],
+      [],
+      [],
+      html.visitAll(visitor, ast.children, ast.children),
+      [
+        new t.Reference(
+          referenceName,
+          '',
+          ast.startSourceSpan,
+          ast.startSourceSpan,
+          undefined,
+          true,
+        ),
+      ],
+      variables,
+      false,
+      ast.sourceSpan,
+      ast.startSourceSpan,
+      ast.endSourceSpan,
+      ast.i18n,
+    ),
+    errors,
+  };
+}
+
+function parseTemplateVariables(
+  parameters: html.BlockParameter[],
+  errors: ParseError[],
+): t.Variable[] | null {
+  const variables: t.Variable[] = [];
+
+  for (const parameter of parameters) {
+    const expression = parameter.expression.trim();
+    const letMatch = expression.match(LET_PATTERN);
+
+    if (letMatch === null) {
+      errors.push(
+        new ParseError(
+          parameter.sourceSpan,
+          '@template context variables must start with "let", e.g. "let item"',
+        ),
+      );
+      continue;
+    }
+
+    const declaration = letMatch[1].trim();
+    const equalsIndex = declaration.indexOf('=');
+    const name = (equalsIndex === -1 ? declaration : declaration.slice(0, equalsIndex)).trim();
+    const value = (equalsIndex === -1 ? '' : declaration.slice(equalsIndex + 1)).trim();
+    const nameSpan = getParameterPartSpan(parameter, name);
+    const parameterEqualsIndex = parameter.expression.indexOf('=');
+    const valueSpan =
+      value.length === 0
+        ? undefined
+        : getParameterValueSpan(parameter, parameterEqualsIndex, value);
+
+    if (!IDENTIFIER_PATTERN.test(name)) {
+      errors.push(
+        new ParseError(
+          nameSpan,
+          `Context variable name "${name}" must be a valid JavaScript identifier`,
+        ),
+      );
+      continue;
+    }
+
+    if (equalsIndex !== -1 && !IDENTIFIER_PATTERN.test(value)) {
+      errors.push(
+        new ParseError(
+          valueSpan ?? parameter.sourceSpan,
+          `Context variable value "${value}" must be a valid JavaScript identifier`,
+        ),
+      );
+      continue;
+    }
+
+    if (variables.some((variable) => variable.name === name)) {
+      errors.push(
+        new ParseError(nameSpan, `Duplicate context variable "${name}" in @template declaration`),
+      );
+      continue;
+    }
+
+    variables.push(new t.Variable(name, value, parameter.sourceSpan, nameSpan, valueSpan));
+  }
+
+  return errors.length === 0 ? variables : null;
+}
+
+function getNameSpan(ast: html.Block, name: string): ParseSourceSpan {
+  const offset = ast.nameSpan.toString().lastIndexOf(name);
+  const start = ast.nameSpan.start.moveBy(Math.max(offset, 0));
+  return new ParseSourceSpan(start, start.moveBy(name.length));
+}
+
+function getParameterPartSpan(parameter: html.BlockParameter, part: string): ParseSourceSpan {
+  const offset = parameter.expression.indexOf(part);
+  const start = parameter.sourceSpan.start.moveBy(Math.max(offset, 0));
+  return new ParseSourceSpan(start, start.moveBy(part.length));
+}
+
+function getParameterValueSpan(
+  parameter: html.BlockParameter,
+  equalsIndex: number,
+  value: string,
+): ParseSourceSpan {
+  const valueOffset = equalsIndex + 1 + parameter.expression.slice(equalsIndex + 1).indexOf(value);
+  const start = parameter.sourceSpan.start.moveBy(valueOffset);
+  return new ParseSourceSpan(start, start.moveBy(value.length));
+}

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -34,6 +34,7 @@ import {
   isConnectedIfLoopBlock,
 } from './r3_control_flow';
 import {createDeferredBlock, isConnectedDeferLoopBlock} from './r3_deferred_blocks';
+import {createInlineTemplate, createTemplateBlock, isTemplateBlock} from './r3_template_blocks';
 import {I18N_ICU_VAR_PREFIX} from './view/i18n/util';
 
 const BIND_NAME_REGEXP = /^(?:(bind-)|(let-)|(ref-|#)|(on-)|(bindon-)|(@))(.*)$/;
@@ -94,11 +95,15 @@ export function htmlAstToRender3Ast(
   bindingParser: BindingParser,
   options: Render3ParseOptions,
 ): Render3ParseResult {
-  const transformer = new HtmlAstToIvyAst(bindingParser, options);
+  const source = htmlNodes[0]?.sourceSpan.start.file.content ?? '';
+  const transformer = new HtmlAstToIvyAst(bindingParser, options, source);
   const ivyNodes = html.visitAll(transformer, htmlNodes, htmlNodes);
 
   // Errors might originate in either the binding parser or the html to ivy transformer
-  const allErrors = bindingParser.errors.concat(transformer.errors);
+  const allErrors = bindingParser.errors.concat(
+    transformer.errors,
+    validateTemplateReferenceConflicts(ivyNodes),
+  );
 
   const result: Render3ParseResult = {
     nodes: ivyNodes,
@@ -111,6 +116,74 @@ export function htmlAstToRender3Ast(
     result.commentNodes = transformer.commentNodes;
   }
   return result;
+}
+
+function validateTemplateReferenceConflicts(nodes: t.Node[]): ParseError[] {
+  const errors: ParseError[] = [];
+
+  const validateReferences = (references: t.Reference[], scope: Map<string, t.Reference>) => {
+    for (const reference of references) {
+      if (reference.isSynthetic) {
+        continue;
+      }
+
+      const previous = scope.get(reference.name);
+      const conflictsWithTemplateDeclaration =
+        previous !== undefined &&
+        (previous.isTemplateDeclaration || reference.isTemplateDeclaration);
+      if (conflictsWithTemplateDeclaration) {
+        errors.push(
+          new ParseError(
+            reference.keySpan,
+            `Reference "#${reference.name}" is defined more than once`,
+          ),
+        );
+      } else if (previous === undefined) {
+        scope.set(reference.name, reference);
+      }
+    }
+  };
+
+  const validateNodes = (currentNodes: t.Node[], scope: Map<string, t.Reference>): void => {
+    for (const node of currentNodes) {
+      if (node instanceof t.Element || node instanceof t.Component) {
+        validateNodes(node.inlineTemplates, scope);
+        node.directives.forEach((directive) => validateReferences(directive.references, scope));
+        validateReferences(node.references, scope);
+        validateNodes(node.children, scope);
+      } else if (node instanceof t.Template) {
+        validateNodes(node.inlineTemplates, scope);
+        node.directives.forEach((directive) => validateReferences(directive.references, scope));
+        validateReferences(node.references, scope);
+        validateNodes(node.children, new Map());
+      } else if (node instanceof t.IfBlock) {
+        node.branches.forEach((branch) => validateNodes(branch.children, new Map()));
+      } else if (node instanceof t.ForLoopBlock) {
+        validateNodes(node.children, new Map());
+        if (node.empty !== null) {
+          validateNodes(node.empty.children, new Map());
+        }
+      } else if (node instanceof t.SwitchBlock) {
+        node.groups.forEach((group) => validateNodes(group.children, new Map()));
+      } else if (node instanceof t.DeferredBlock) {
+        validateNodes(node.children, new Map());
+        if (node.placeholder !== null) {
+          validateNodes(node.placeholder.children, new Map());
+        }
+        if (node.loading !== null) {
+          validateNodes(node.loading.children, new Map());
+        }
+        if (node.error !== null) {
+          validateNodes(node.error.children, new Map());
+        }
+      } else if (node instanceof t.Content || node instanceof t.ContentBlock) {
+        validateNodes(node.children, new Map());
+      }
+    }
+  };
+
+  validateNodes(nodes, new Map());
+  return errors;
 }
 
 class HtmlAstToIvyAst implements html.Visitor {
@@ -127,11 +200,21 @@ class HtmlAstToIvyAst implements html.Visitor {
    * These are typically blocks connected to other blocks or text nodes between connected blocks.
    */
   private processedNodes = new Set<html.Block | html.Text>();
+  private inlineTemplateIndex = 0;
 
   constructor(
     private bindingParser: BindingParser,
     private options: Render3ParseOptions,
+    private source: string,
   ) {}
+
+  private allocateInlineTemplateReferenceName(): string {
+    let referenceName = `_ngInlineTemplate${this.inlineTemplateIndex++}`;
+    while (this.source.includes(referenceName)) {
+      referenceName = `_ngInlineTemplate${this.inlineTemplateIndex++}`;
+    }
+    return referenceName;
+  }
 
   // HTML visitor
   visitElement(element: html.Element): t.Node | null {
@@ -170,6 +253,7 @@ class HtmlAstToIvyAst implements html.Visitor {
       references,
       variables,
       templateVariables,
+      inlineTemplates,
       elementHasInlineTemplate,
       parsedProperties,
       templateParsedProperties,
@@ -284,6 +368,9 @@ class HtmlAstToIvyAst implements html.Visitor {
     }
     if (isI18nRootElement) {
       this.inI18nBlock = false;
+    }
+    if (parsedElement instanceof t.Element || parsedElement instanceof t.Template) {
+      parsedElement.inlineTemplates.push(...inlineTemplates);
     }
     return parsedElement;
   }
@@ -402,6 +489,7 @@ class HtmlAstToIvyAst implements html.Visitor {
       boundEvents,
       references,
       templateVariables,
+      inlineTemplates,
       elementHasInlineTemplate,
       parsedProperties,
       templateParsedProperties,
@@ -464,6 +552,7 @@ class HtmlAstToIvyAst implements html.Visitor {
     if (isI18nRootElement) {
       this.inI18nBlock = false;
     }
+    node.inlineTemplates.push(...inlineTemplates);
     return node;
   }
 
@@ -487,6 +576,13 @@ class HtmlAstToIvyAst implements html.Visitor {
     // Connected blocks may have been processed as a part of the previous block.
     if (this.processedNodes.has(block)) {
       return null;
+    }
+
+    if (isTemplateBlock(block.name)) {
+      const result = createTemplateBlock(block, this);
+
+      this.errors.push(...result.errors);
+      return result.node;
     }
 
     let result: {node: t.Node | null; errors: ParseError[]} | null = null;
@@ -638,6 +734,7 @@ class HtmlAstToIvyAst implements html.Visitor {
     const i18nAttrsMeta: Record<string, i18n.I18nMeta> = {};
     const templateParsedProperties: ParsedProperty[] = [];
     const templateVariables: t.Variable[] = [];
+    const inlineTemplates: t.Template[] = [];
 
     // Whether the element has any *-attribute
     let elementHasInlineTemplate = false;
@@ -652,7 +749,32 @@ class HtmlAstToIvyAst implements html.Visitor {
         i18nAttrsMeta[attribute.name] = attribute.i18n;
       }
 
-      if (attribute.name.startsWith(TEMPLATE_ATTR_PREFIX)) {
+      if (attribute.inlineTemplate !== undefined) {
+        const referenceName = this.allocateInlineTemplateReferenceName();
+        const result = createInlineTemplate(attribute.inlineTemplate, referenceName, this);
+        this.errors.push(...result.errors);
+
+        if (result.node !== null) {
+          inlineTemplates.push(result.node);
+          hasBinding = this.parseAttribute(
+            isTemplateElement,
+            new html.Attribute(
+              attribute.name,
+              referenceName,
+              attribute.sourceSpan,
+              attribute.keySpan,
+              attribute.valueSpan,
+              undefined,
+              attribute.i18n,
+            ),
+            [],
+            parsedProperties,
+            boundEvents,
+            variables,
+            references,
+          );
+        }
+      } else if (attribute.name.startsWith(TEMPLATE_ATTR_PREFIX)) {
         // *-attributes
         if (elementHasInlineTemplate) {
           this.reportError(
@@ -713,6 +835,7 @@ class HtmlAstToIvyAst implements html.Visitor {
       references,
       variables,
       templateVariables,
+      inlineTemplates,
       elementHasInlineTemplate,
       parsedProperties,
       templateParsedProperties,

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -163,8 +163,7 @@ export function findMatchingDirectivesAndPipes(template: string, directiveSelect
 
 /** Object used to match template nodes to directives. */
 export type DirectiveMatcher<DirectiveT extends DirectiveMeta> =
-  | SelectorMatcher<DirectiveT[]>
-  | SelectorlessMatcher<DirectiveT>;
+  SelectorMatcher<DirectiveT[]> | SelectorlessMatcher<DirectiveT>;
 
 /**
  * Processes `Target`s with a given set of directives and performs a binding operation, which
@@ -369,6 +368,7 @@ class Scope implements Visitor {
   }
 
   visitTemplate(template: Template) {
+    template.inlineTemplates.forEach((node) => node.visit(this));
     template.directives.forEach((node) => node.visit(this));
 
     // References on a <ng-template> are defined in the outer scope, so capture them before
@@ -468,6 +468,7 @@ class Scope implements Visitor {
   visitUnknownBlock(block: UnknownBlock) {}
 
   private visitElementLike(node: Element | Component) {
+    node.inlineTemplates.forEach((current) => current.visit(this));
     node.directives.forEach((current) => current.visit(this));
     node.references.forEach((current) => this.visitReference(current));
     node.children.forEach((current) => current.visit(this));
@@ -662,6 +663,8 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
   }
 
   visitComponent(node: Component): void {
+    node.inlineTemplates.forEach((template) => template.visit(this));
+
     if (this.directiveMatcher instanceof SelectorlessMatcher) {
       const componentMatches = this.directiveMatcher.match(node.componentName);
 
@@ -689,6 +692,8 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
   }
 
   private visitElementOrTemplate(node: Element | Template): void {
+    node.inlineTemplates.forEach((template) => template.visit(this));
+
     const matchedDirectives: DirectiveT[] = [];
 
     if (this.directiveMatcher instanceof SelectorMatcher) {
@@ -1065,6 +1070,8 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
   }
 
   override visitTemplate(template: Template) {
+    template.inlineTemplates.forEach(this.visitNode);
+
     // First, visit inputs, outputs and template attributes of the template node.
     template.inputs.forEach(this.visitNode);
     template.outputs.forEach(this.visitNode);

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -280,6 +280,10 @@ function ingestNodes(unit: ViewCompilationUnit, template: t.Node[]): void {
  * Ingest an element AST from the template into the given `ViewCompilation`.
  */
 function ingestElement(unit: ViewCompilationUnit, element: t.Element): void {
+  for (const inlineTemplate of element.inlineTemplates) {
+    ingestTemplate(unit, inlineTemplate);
+  }
+
   if (
     element.i18n !== undefined &&
     !(element.i18n instanceof i18n.Message || element.i18n instanceof i18n.TagPlaceholder)
@@ -408,6 +412,10 @@ function ingestForeignComponent(
  * Ingest an `ng-template` node from the AST into the given `ViewCompilation`.
  */
 function ingestTemplate(unit: ViewCompilationUnit, tmpl: t.Template): void {
+  for (const inlineTemplate of tmpl.inlineTemplates) {
+    ingestTemplate(unit, inlineTemplate);
+  }
+
   if (
     tmpl.i18n !== undefined &&
     !(tmpl.i18n instanceof i18n.Message || tmpl.i18n instanceof i18n.TagPlaceholder)

--- a/packages/compiler/src/typecheck/ops/scope.ts
+++ b/packages/compiler/src/typecheck/ops/scope.ts
@@ -468,6 +468,9 @@ export class Scope {
 
   private appendNode(node: Node): void {
     if (node instanceof Element) {
+      for (const inlineTemplate of node.inlineTemplates) {
+        this.appendNode(inlineTemplate);
+      }
       const opIndex = this.opQueue.push(new TcbElementOp(this.tcb, this, node)) - 1;
       this.elementOpMap.set(node, opIndex);
       if (this.tcb.env.config.controlFlowPreventingContentProjection !== 'suppress') {
@@ -479,6 +482,9 @@ export class Scope {
       this.appendChildren(node);
       this.checkAndAppendReferencesOfNode(node);
     } else if (node instanceof Template) {
+      for (const inlineTemplate of node.inlineTemplates) {
+        this.appendNode(inlineTemplate);
+      }
       // Template children are rendered in a child scope.
       this.appendDirectivesAndInputsOfElementLikeNode(node);
       this.appendOutputsOfElementLikeNode(node, node.inputs, node.outputs);
@@ -492,6 +498,9 @@ export class Scope {
       }
       this.checkAndAppendReferencesOfNode(node);
     } else if (node instanceof Component) {
+      for (const inlineTemplate of node.inlineTemplates) {
+        this.appendNode(inlineTemplate);
+      }
       this.appendComponentNode(node);
     } else if (node instanceof DeferredBlock) {
       this.appendDeferredBlock(node);

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -302,6 +302,126 @@ describe('HtmlParser', () => {
     });
 
     describe('attributes', () => {
+      it('should parse an anonymous template in a property binding', () => {
+        const result = parser.parse(
+          '<cmp [content]="@template(let item; let index = index) {' +
+            '<div class="item">{{index}}: {{item}}</div>' +
+            '}" />',
+          'TestComp',
+        );
+
+        expect(humanizeErrors(result.errors)).toEqual([]);
+        const element = result.rootNodes[0] as html.Element;
+        const inlineTemplate = element.attrs[0].inlineTemplate;
+        expect(inlineTemplate).toBeInstanceOf(html.InlineTemplate);
+        expect(inlineTemplate?.parameters.map((parameter) => parameter.expression)).toEqual([
+          'let item',
+          'let index = index',
+        ]);
+        expect(inlineTemplate?.children[0]).toBeInstanceOf(html.Element);
+        expect((inlineTemplate?.children[0] as html.Element).attrs[0].value).toBe('item');
+      });
+
+      it('should allow regular template syntax and nested quotes in an anonymous template', () => {
+        const result = parser.parse(
+          `<cmp [content]='@template {
+            @if (visible()) {
+              <button (click)="select('primary')">{{title}}</button>
+              <app-card [data]="{name: title, enabled: true}" />
+            }
+          }' />`,
+          'TestComp',
+        );
+
+        expect(humanizeErrors(result.errors)).toEqual([]);
+        const element = result.rootNodes[0] as html.Element;
+        const inlineTemplate = element.attrs[0].inlineTemplate;
+        expect(inlineTemplate).toBeInstanceOf(html.InlineTemplate);
+        expect(inlineTemplate?.children.some((node) => node instanceof html.Block)).toBe(true);
+      });
+
+      it('should allow whitespace around an anonymous template', () => {
+        const result = parser.parse('<cmp [content]=" \n\t@template\t{Content}\n " />', 'TestComp');
+
+        expect(humanizeErrors(result.errors)).toEqual([]);
+        const element = result.rootNodes[0] as html.Element;
+        expect(element.attrs[0].inlineTemplate).toBeInstanceOf(html.InlineTemplate);
+      });
+
+      it('should require an anonymous template to be the complete binding value', () => {
+        for (const template of [
+          '<cmp [content]="@template {Content} || fallback" />',
+          '<cmp [content]="prefix + @template {Content}" />',
+        ]) {
+          const errors = humanizeErrors(parser.parse(template, 'TestComp').errors);
+          expect(
+            errors.some((error) =>
+              error.includes(
+                'Anonymous @template must be the complete value of a property binding.',
+              ),
+            ),
+          )
+            .withContext(JSON.stringify(errors))
+            .toBe(true);
+        }
+      });
+
+      it('should allow @template text in an ordinary string expression', () => {
+        const result = parser.parse('<cmp [content]="\'@template {Content}\'" />', 'TestComp');
+
+        expect(humanizeErrors(result.errors)).toEqual([]);
+        const element = result.rootNodes[0] as html.Element;
+        expect(element.attrs[0].inlineTemplate).toBeUndefined();
+      });
+
+      it('should not recognize an identifier that starts with @template', () => {
+        const result = parser.parse('<cmp [content]="@templateFactory" />', 'TestComp');
+
+        expect(humanizeErrors(result.errors)).toEqual([]);
+        const element = result.rootNodes[0] as html.Element;
+        expect(element.attrs[0].inlineTemplate).toBeUndefined();
+        expect(element.attrs[0].value).toBe('@templateFactory');
+      });
+
+      it('should report intentional diagnostics for incomplete anonymous templates', () => {
+        const cases = [
+          ['<cmp [content]="@template" />', 'must have a template body'],
+          ['<cmp [content]="@template()" />', 'must have a template body'],
+          ['<cmp [content]="@template(" />', 'context parameters must end with ")"'],
+          ['<cmp [content]="@template {" />', 'Unclosed anonymous @template expression'],
+        ];
+
+        for (const [template, expectedMessage] of cases) {
+          const errors = humanizeErrors(parser.parse(template, 'TestComp').errors);
+          expect(
+            errors.some((error) =>
+              error.some((part: unknown) => `${part}`.includes(expectedMessage)),
+            ),
+          )
+            .withContext(`${template}: ${JSON.stringify(errors)}`)
+            .toBe(true);
+        }
+      });
+
+      it('should diagnose invalid quotes inside a nested event binding', () => {
+        const result = parser.parse(
+          '<cmp [content]="@template {' +
+            '<button (click)="select("primary")">Select</button>' +
+            '}" />',
+          'TestComp',
+        );
+        const errors = humanizeErrors(result.errors);
+
+        expect(errors.length).toBeGreaterThan(0);
+        expect(
+          errors.some((error) =>
+            error.some((part: unknown) =>
+              `${part}`.includes('complete value of a property binding'),
+            ),
+          ),
+        ).toBe(false);
+      });
+
       it('should parse attributes on regular elements case sensitive', () => {
         expect(humanizeDom(parser.parse('<div kEy="v" key2=v2></div>', 'TestComp'))).toEqual([
           [html.Element, 'div', 0],

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -1743,6 +1743,34 @@ describe('HtmlLexer', () => {
   });
 
   describe('attributes', () => {
+    it('should tokenize an anonymous template as a property binding value', () => {
+      expect(
+        tokenizeAndHumanizeParts(
+          '<cmp [content]="@template {<div class="item">{{title}}</div>}" />',
+        ),
+      ).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'cmp'],
+        [TokenType.ATTR_NAME, '', '[content]'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.INLINE_TEMPLATE_START],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TAG_OPEN_START, '', 'div'],
+        [TokenType.ATTR_NAME, '', 'class'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, 'item'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', 'title', '}}'],
+        [TokenType.TEXT, ''],
+        [TokenType.TAG_CLOSE, '', 'div'],
+        [TokenType.INLINE_TEMPLATE_END],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END_VOID],
+        [TokenType.EOF],
+      ]);
+    });
+
     it('should parse attributes without prefix', () => {
       expect(tokenizeAndHumanizeParts('<t a>')).toEqual([
         [TokenType.TAG_OPEN_START, '', 't'],
@@ -3419,6 +3447,27 @@ describe('HtmlLexer', () => {
   });
 
   describe('blocks', () => {
+    it('should parse a named template declaration', () => {
+      expect(
+        tokenizeAndHumanizeParts(
+          '@template item(let value; let index = index) {<span>{{value}}</span>}',
+        ),
+      ).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'template item'],
+        [TokenType.BLOCK_PARAMETER, 'let value'],
+        [TokenType.BLOCK_PARAMETER, 'let index = index'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TAG_OPEN_START, '', 'span'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', 'value', '}}'],
+        [TokenType.TEXT, ''],
+        [TokenType.TAG_CLOSE, '', 'span'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
     it('should parse a block without parameters', () => {
       const expected = [
         [TokenType.BLOCK_OPEN_START, 'if'],

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -23,6 +23,7 @@ class R3AstHumanizer implements t.Visitor<void> {
       res.push('#selfClosing');
     }
     this.visitAll([
+      element.inlineTemplates,
       element.attributes,
       element.inputs,
       element.outputs,
@@ -39,6 +40,7 @@ class R3AstHumanizer implements t.Visitor<void> {
     }
     this.result.push(res);
     this.visitAll([
+      template.inlineTemplates,
       template.attributes,
       template.inputs,
       template.outputs,
@@ -517,6 +519,188 @@ describe('R3 template transform', () => {
         ['Template'],
         ['Variable', 'a', 'b'],
       ]);
+    });
+
+    describe('@template declarations', () => {
+      it('should parse a named template declaration', () => {
+        expectFromHtml('@template item {Hello {{name}}}').toEqual([
+          ['Template'],
+          ['Reference', 'item', ''],
+          ['BoundText', 'Hello {{ name }}'],
+        ]);
+      });
+
+      it('should parse template context variables', () => {
+        expectFromHtml(
+          '@template item(let value; let index = index) { {{value}}: {{index}} }',
+        ).toEqual([
+          ['Template'],
+          ['Reference', 'item', ''],
+          ['Variable', 'value', ''],
+          ['Variable', 'index', 'index'],
+          ['BoundText', ' {{ value }}: {{ index }} '],
+        ]);
+
+        const {nodes} = parse('@template item(let index = index) {}');
+        const template = nodes[0] as t.Template;
+        expect(template.variables[0].keySpan.toString()).toBe('index');
+        expect(template.variables[0].keySpan.start.offset).toBe(19);
+        expect(template.variables[0].valueSpan?.toString()).toBe('index');
+        expect(template.variables[0].valueSpan?.start.offset).toBe(27);
+      });
+
+      it('should allow whitespace other than spaces before the template name', () => {
+        expectFromHtml('@template\titem {Content}').toEqual([
+          ['Template'],
+          ['Reference', 'item', ''],
+          ['Text', 'Content'],
+        ]);
+      });
+
+      it('should support control flow inside a template declaration', () => {
+        expectFromHtml('@template item {@if (visible) {<span>Content</span>}}').toEqual([
+          ['Template'],
+          ['Reference', 'item', ''],
+          ['IfBlock'],
+          ['IfBlockBranch', 'visible'],
+          ['Element', 'span'],
+          ['Text', 'Content'],
+        ]);
+      });
+
+      it('should support template declarations inside control flow blocks', () => {
+        expectFromHtml('@if (visible) {@template item {Content}}').toEqual([
+          ['IfBlock'],
+          ['IfBlockBranch', 'visible'],
+          ['Template'],
+          ['Reference', 'item', ''],
+          ['Text', 'Content'],
+        ]);
+      });
+
+      it('should support nested template declarations', () => {
+        expectFromHtml('@template outer {@template inner {Content}}').toEqual([
+          ['Template'],
+          ['Reference', 'outer', ''],
+          ['Template'],
+          ['Reference', 'inner', ''],
+          ['Text', 'Content'],
+        ]);
+      });
+
+      it('should support multiple template declarations', () => {
+        expectFromHtml('@template first {One} @template second {Two}').toEqual([
+          ['Template'],
+          ['Reference', 'first', ''],
+          ['Text', 'One'],
+          ['Template'],
+          ['Reference', 'second', ''],
+          ['Text', 'Two'],
+        ]);
+      });
+
+      it('should report a missing template name', () => {
+        expect(() => parse('@template {Content}')).toThrowError(
+          /@template declaration must have a name/,
+        );
+      });
+
+      it('should report an invalid template name', () => {
+        expect(() => parse('@template 123item {Content}')).toThrowError(
+          /@template name must be a valid JavaScript identifier/,
+        );
+      });
+
+      it('should report an invalid context declaration', () => {
+        expect(() => parse('@template item(value) {Content}')).toThrowError(
+          /@template context variables must start with "let"/,
+        );
+      });
+
+      it('should report duplicate context declarations', () => {
+        expect(() => parse('@template item(let value; let value) {Content}')).toThrowError(
+          /Duplicate context variable "value" in @template declaration/,
+        );
+      });
+
+      it('should not treat an invalid declaration as a duplicate of a later valid one', () => {
+        const {nodes} = parse('@template item(invalid) {} @template item {Valid}', {
+          ignoreError: true,
+        });
+
+        expectFromR3Nodes(nodes).toEqual([
+          ['Template'],
+          ['Reference', 'item', ''],
+          ['Text', 'Valid'],
+        ]);
+      });
+
+      it('should report duplicate declarations after creating the Render3 AST', () => {
+        expect(() => parse('@template item {One} @template item {Two}')).toThrowError(
+          /Reference "#item" is defined more than once/,
+        );
+      });
+
+      it('should report conflicts with regular template references', () => {
+        expect(() => parse('<div #item></div> @template item {Content}')).toThrowError(
+          /Reference "#item" is defined more than once/,
+        );
+        expect(() => parse('@template item {Content} <ng-template #item />')).toThrowError(
+          /Reference "#item" is defined more than once/,
+        );
+      });
+
+      it('should allow the same declaration name in distinct embedded-view scopes', () => {
+        expectFromHtml('@if (visible) {@template item {Local}} @template item {Root}').toEqual([
+          ['IfBlock'],
+          ['IfBlockBranch', 'visible'],
+          ['Template'],
+          ['Reference', 'item', ''],
+          ['Text', 'Local'],
+          ['Template'],
+          ['Reference', 'item', ''],
+          ['Text', 'Root'],
+        ]);
+      });
+    });
+
+    describe('anonymous inline @template expressions', () => {
+      it('should lower an anonymous template to a template reference binding', () => {
+        expectFromHtml(
+          '<cmp [content]="@template(let item; let index = index) {' +
+            '<div class="item">{{index}}: {{item}}</div>' +
+            '}" />',
+        ).toEqual([
+          ['Element', 'cmp', '#selfClosing'],
+          ['Template'],
+          ['Reference', '_ngInlineTemplate0', ''],
+          ['Variable', 'item', ''],
+          ['Variable', 'index', 'index'],
+          ['Element', 'div'],
+          ['TextAttribute', 'class', 'item'],
+          ['BoundText', '{{ index }}: {{ item }}'],
+          ['BoundAttribute', BindingType.Property, 'content', '_ngInlineTemplate0'],
+        ]);
+      });
+
+      it('should allocate independent references and avoid user-defined names', () => {
+        expectFromHtml(
+          '<div #_ngInlineTemplate0></div>' +
+            '<cmp [header]="@template {Header}" [content]="@template {Content}" />',
+        ).toEqual([
+          ['Element', 'div'],
+          ['Reference', '_ngInlineTemplate0', ''],
+          ['Element', 'cmp', '#selfClosing'],
+          ['Template'],
+          ['Reference', '_ngInlineTemplate1', ''],
+          ['Text', 'Header'],
+          ['Template'],
+          ['Reference', '_ngInlineTemplate2', ''],
+          ['Text', 'Content'],
+          ['BoundAttribute', BindingType.Property, 'header', '_ngInlineTemplate1'],
+          ['BoundAttribute', BindingType.Property, 'content', '_ngInlineTemplate2'],
+        ]);
+      });
     });
 
     it('should parse attributes', () => {

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -14,10 +14,204 @@ import {
   ViewChild,
   ViewContainerRef,
   ChangeDetectionStrategy,
+  inject,
+  Input,
+  signal,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 
 describe('TemplateRef', () => {
+  describe('@template declarations', () => {
+    interface TemplateContext {
+      $implicit: string;
+      index: number;
+    }
+
+    const receivedTemplates: TemplateRef<TemplateContext>[] = [];
+
+    @Component({
+      selector: 'template-consumer',
+      template: '',
+      standalone: false,
+    })
+    class TemplateConsumer {
+      private readonly viewContainerRef = inject(ViewContainerRef);
+
+      @Input()
+      set first(template: TemplateRef<TemplateContext>) {
+        receivedTemplates.push(template);
+        this.viewContainerRef.createEmbeddedView(template, {$implicit: 'Frodo', index: 0});
+      }
+
+      @Input()
+      set second(template: TemplateRef<TemplateContext>) {
+        receivedTemplates.push(template);
+        this.viewContainerRef.createEmbeddedView(template, {$implicit: 'Bilbo', index: 1});
+      }
+    }
+
+    @Component({
+      template: `
+        <template-consumer [first]="item" [second]="item" />
+
+        @template item(let value; let index = index) {
+          {{prefix()}} {{index}}: {{value}};
+        }
+      `,
+      standalone: false,
+    })
+    class TemplateDeclarationApp {
+      readonly prefix = signal('Name');
+    }
+
+    @Component({
+      template: `
+        <template-consumer
+          [first]="@template(let value; let index = index) {
+            <span class="item">{{prefix()}} {{index}}: {{value}};</span>
+          }"
+          [second]="@template(let value; let index = index) {
+            <span class="item">{{prefix()}} {{index}}: {{value}};</span>
+          }"
+        />
+      `,
+      standalone: false,
+    })
+    class InlineTemplateApp {
+      readonly prefix = signal('Name');
+    }
+
+    const anonymousViews: ReturnType<ViewContainerRef['createEmbeddedView']>[] = [];
+    let createdItems = 0;
+    let destroyedItems = 0;
+
+    @Component({
+      selector: 'inline-template-item',
+      template: '{{label()}}',
+      standalone: false,
+    })
+    class InlineTemplateItem {
+      readonly label = signal('Item');
+
+      constructor() {
+        createdItems++;
+      }
+
+      ngOnDestroy(): void {
+        destroyedItems++;
+      }
+    }
+
+    @Component({
+      selector: 'inline-template-capture',
+      template: '',
+      standalone: false,
+    })
+    class InlineTemplateCapture {
+      private readonly viewContainerRef = inject(ViewContainerRef);
+
+      @Input()
+      set content(template: TemplateRef<unknown>) {
+        anonymousViews.push(
+          this.viewContainerRef.createEmbeddedView(template),
+          this.viewContainerRef.createEmbeddedView(template),
+        );
+      }
+    }
+
+    @Component({
+      template: `
+        <inline-template-capture
+          [content]="@template {
+            <inline-template-item />
+            <button (click)="select()">Select {{selectionCount()}}</button>
+          }"
+        />
+      `,
+      standalone: false,
+    })
+    class InlineTemplateLifecycleApp {
+      readonly selectionCount = signal(0);
+
+      select(): void {
+        this.selectionCount.update((count) => count + 1);
+      }
+    }
+
+    beforeEach(() => {
+      receivedTemplates.splice(0);
+      anonymousViews.splice(0);
+      createdItems = 0;
+      destroyedItems = 0;
+    });
+
+    it('should expose a stable TemplateRef that creates independent embedded views', async () => {
+      TestBed.configureTestingModule({declarations: [TemplateConsumer, TemplateDeclarationApp]});
+      const fixture = TestBed.createComponent(TemplateDeclarationApp);
+
+      await fixture.whenStable();
+
+      expect(receivedTemplates.length).toBe(2);
+      expect(receivedTemplates[0]).toBe(receivedTemplates[1]);
+      expect(fixture.nativeElement.textContent).toContain('Name 0: Frodo;');
+      expect(fixture.nativeElement.textContent).toContain('Name 1: Bilbo;');
+
+      fixture.componentInstance.prefix.set('Person');
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.textContent).toContain('Person 0: Frodo;');
+      expect(fixture.nativeElement.textContent).toContain('Person 1: Bilbo;');
+    });
+
+    it('should expose stable anonymous TemplateRefs with normal inner HTML quoting', async () => {
+      TestBed.configureTestingModule({declarations: [TemplateConsumer, InlineTemplateApp]});
+      const fixture = TestBed.createComponent(InlineTemplateApp);
+
+      await fixture.whenStable();
+
+      expect(receivedTemplates.length).toBe(2);
+      expect(receivedTemplates[0]).not.toBe(receivedTemplates[1]);
+      expect(fixture.nativeElement.textContent).toContain('Name 0: Frodo;');
+      expect(fixture.nativeElement.textContent).toContain('Name 1: Bilbo;');
+
+      fixture.componentInstance.prefix.set('Person');
+      await fixture.whenStable();
+
+      expect(receivedTemplates.length).toBe(2);
+      expect(fixture.nativeElement.textContent).toContain('Person 0: Frodo;');
+      expect(fixture.nativeElement.textContent).toContain('Person 1: Bilbo;');
+    });
+
+    it('should support events and independent view destruction', async () => {
+      TestBed.configureTestingModule({
+        declarations: [InlineTemplateCapture, InlineTemplateItem, InlineTemplateLifecycleApp],
+      });
+      const fixture = TestBed.createComponent(InlineTemplateLifecycleApp);
+
+      await fixture.whenStable();
+
+      expect(anonymousViews.length).toBe(2);
+      expect(createdItems).toBe(2);
+
+      fixture.nativeElement.querySelector('button').click();
+      await fixture.whenStable();
+      expect(fixture.nativeElement.textContent).toContain('Select 1');
+
+      anonymousViews[0].destroy();
+      await fixture.whenStable();
+      expect(destroyedItems).toBe(1);
+      expect(fixture.nativeElement.querySelectorAll('inline-template-item').length).toBe(1);
+
+      fixture.componentInstance.selectionCount.set(2);
+      await fixture.whenStable();
+      expect(fixture.nativeElement.textContent).toContain('Select 2');
+
+      anonymousViews[1].destroy();
+      await fixture.whenStable();
+      expect(destroyedItems).toBe(2);
+    });
+  });
+
   describe('rootNodes', () => {
     @Component({
       template: `<ng-template #templateRef></ng-template>`,

--- a/packages/language-service/src/document_symbols.ts
+++ b/packages/language-service/src/document_symbols.ts
@@ -538,9 +538,13 @@ class TemplateSymbolVisitor extends TmplAstRecursiveVisitor {
     this.addSymbol(symbol);
     this.pushChildren(symbol);
 
+    tmplAstVisitAll(this, element.inlineTemplates);
+
     // Add references as children
     for (const ref of element.references) {
-      ref.visit(this);
+      if (!ref.isSynthetic) {
+        ref.visit(this);
+      }
     }
 
     // Visit child elements
@@ -559,9 +563,13 @@ class TemplateSymbolVisitor extends TmplAstRecursiveVisitor {
     this.addSymbol(symbol);
     this.pushChildren(symbol);
 
+    tmplAstVisitAll(this, component.inlineTemplates);
+
     // Add references as children
     for (const ref of component.references) {
-      ref.visit(this);
+      if (!ref.isSynthetic) {
+        ref.visit(this);
+      }
     }
 
     // Visit child elements
@@ -600,9 +608,13 @@ class TemplateSymbolVisitor extends TmplAstRecursiveVisitor {
     this.addSymbol(symbol);
     this.pushChildren(symbol);
 
+    tmplAstVisitAll(this, template.inlineTemplates);
+
     // Add references and variables as children
     for (const ref of template.references) {
-      ref.visit(this);
+      if (!ref.isSynthetic) {
+        ref.visit(this);
+      }
     }
     for (const variable of template.variables) {
       this.addTemplateVariableSymbol(variable, structuralDirective !== null);

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -547,6 +547,9 @@ class TemplateTargetVisitor implements TmplAstVisitor {
   ) {
     const isTemplate = node instanceof TmplAstTemplate;
     const isDirective = node instanceof TmplAstDirective;
+    if (!isDirective) {
+      this.visitAll(node.inlineTemplates);
+    }
     this.visitAll(node.attributes);
     if (!isDirective) {
       this.visitAll(node.directives);
@@ -568,7 +571,7 @@ class TemplateTargetVisitor implements TmplAstVisitor {
     if (isTemplate) {
       this.visitAll(node.templateAttrs);
     }
-    this.visitAll(node.references);
+    this.visitAll(node.references.filter((reference) => !reference.isSynthetic));
     if (isTemplate) {
       this.visitAll(node.variables);
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message guidelines](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

Passing a short, one-off template to an input that accepts `TemplateRef` requires a separate named
`<ng-template>` declaration. Angular cannot parse template markup directly as the value of a
property binding.

Issue Number: #67953

## What is the new behavior?

Property bindings can use an anonymous `@template` block as their complete value:

```html
<cmp
  [content]="@template(let item; let index = index) {
    <div class="item">{{ index }}: {{ item }}</div>
  }"
/>
```

The HTML tokenizer enters a dedicated inline-template mode after recognizing `@template` at the start of a property-binding value. The body is tokenized and parsed as regular Angular template markup, so elements, bindings, interpolations, event handlers, object literals, components, and control-flow blocks retain their normal syntax and source spans.

The parser represents the construct with an explicit `InlineTemplate` AST node. Render3 lowering converts it to the existing `t.Template` model and binds the input to a compiler-generated local reference. The resulting value is a normal, stable `TemplateRef`; no HTML strings, runtime compilation, or new runtime abstraction are introduced.

Generated references avoid collisions with user declarations and are hidden from Language Service completions and document symbols. Inline template bodies participate in normal binding, ingest, code generation, and strict template type checking.

This change also hardens named `@template` declarations by:

- computing context-value source spans relative to the `=` token;
- recognizing valid whitespace between `template` and its name;
- checking duplicate declarations and conflicts with regular template references after creating the
  Render3 AST;
- preventing an invalid declaration from poisoning a later valid declaration.

Anonymous templates are currently restricted to the complete value of a quoted property binding. Composed expressions such as `prefix + @template {Content}` produce an intentional diagnostic. Context-variable typing matches ordinary `<ng-template let-item>` behavior; the receiving `TemplateRef<Context>` input does not provide contextual type inference by itself.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Product documentation is not included in this change and can be added after the syntax and naming are accepted.