### PR TITLE
fix(docs-infra): fix undefined CSS custom properties in shared-docs styles

### DIFF
--- a/adev/shared-docs/styles/_colors.scss
+++ b/adev/shared-docs/styles/_colors.scss
@@ -131,7 +131,7 @@ $gray-50: oklch(98.81% 0 0); // #fbfbfb
   --light-pink-to-light-purple-horizontal-gradient: linear-gradient(
     90deg,
     var(--light-pink) 0%,
-    var(--light-purple) 100%
+    var(--light-violet) 100%
   );
 
   --light-vivid-pink-to-light-electric-violet-horizontal-gradient: linear-gradient(

--- a/adev/shared-docs/styles/_kbd.scss
+++ b/adev/shared-docs/styles/_kbd.scss
@@ -2,7 +2,7 @@
   // We only target non-nested kbd elements
   kbd:not(:has(kbd)) {
     position: relative;
-    color: var(---tertiary-contrast);
+    color: var(--tertiary-contrast);
     border: 1px solid var(--quinary-contrast);
     box-shadow:
       0 1px 0 rgba(0, 0, 0, 0.2),


### PR DESCRIPTION
Two custom properties in the shared-docs styles reference tokens that are defined nowhere, so the declarations are invalid at computed-value time.

_kbd.scss sets the `<kbd>` text color with var(---tertiary-contrast); the extra leading dash points at an undefined property with no fallback, so the color resolves to the inherited value instead of the intended --tertiary-contrast.

_colors.scss builds --light-pink-to-light-purple-horizontal-gradient from var(--light-purple), which is not defined anywhere (the sibling token is --light-violet, defined in the same file), invalidating the gradient. The gradient is not currently referenced, so this corrects a latent malformed declaration rather than a visible bug.

Point both at the defined tokens: --tertiary-contrast and --light-violet.