### PR TITLE
docs: fix self-referential link in defer block description

### DIFF
--- a/tools/manual_api_docs/blocks/defer.md
+++ b/tools/manual_api_docs/blocks/defer.md
@@ -1,4 +1,4 @@
-A type of [block](api/core/@defer) that can be used to defer load the JavaScript for components,
+The `@defer` block can be used to lazy load components,
 directives and pipes used inside a component template.
 
 ## Syntax

--- a/tools/manual_api_docs/blocks/let.md
+++ b/tools/manual_api_docs/blocks/let.md
@@ -2,6 +2,7 @@
 
 ## Syntax
 
+<!-- prettier-ignore -->
 ```angular-html
 @let name = user.name;
 @let data = data$ | async;
@@ -10,7 +11,7 @@
 ## Description
 
 `@let` declarations are similar to [JavaScript's `let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) and
-their values can be any valid Angular expression. The expressions will be re-evaluated everytime the template is executed.
+their values can be any valid Angular expression. The expressions will be re-evaluated every time the template is executed.
 
 Similarly to JavaScript variables, variables declared with `@let`, can be used:
 
@@ -21,12 +22,12 @@ Similarly to JavaScript variables, variables declared with `@let`, can be used:
 @let user = user$ | async;
 
 @if (user) {
-  <h1>Hello, {{user.name}}</h1>
-  <user-avatar [photo]="user.photo"/>
+  <h1>Hello, {{ user.name }}</h1>
+  <user-avatar [photo]="user.photo" />
 
   <ul>
     @for (snack of user.favoriteSnacks; track snack.id) {
-      <li>{{snack.name}}</li>
+      <li>{{ snack.name }}</li>
     }
   </ul>
 


### PR DESCRIPTION
Replace broken `[block](api/core/@defer)` link with inline code formatting. The link was pointing to the page itself, as no dedicated block concept page exists at that URL.
