### PR TITLE
fix(common): skip zero-height warning for detached fill-mode images

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -1244,9 +1244,17 @@ function assertNonZeroRenderedHeight(
   renderer: Renderer2,
   destroyRef: DestroyRef,
 ) {
-  const callback = () => {
-    removeLoadListenerFn();
-    removeErrorListenerFn();
+  const check = () => {
+    if (destroyRef.destroyed) {
+      return;
+    }
+    // A memory-cached image can fire `load` before its view is attached to the
+    // document, and a detached element always reports a zero height. Defer the
+    // check until the element is connected and participates in layout.
+    if (!img.isConnected) {
+      requestAnimationFrame(check);
+      return;
+    }
     const renderedHeight = img.clientHeight;
     if (dir.fill && renderedHeight === 0) {
       console.warn(
@@ -1260,6 +1268,12 @@ function assertNonZeroRenderedHeight(
         ),
       );
     }
+  };
+
+  const callback = () => {
+    removeLoadListenerFn();
+    removeErrorListenerFn();
+    check();
   };
 
   const removeLoadListenerFn = renderer.listen(img, 'load', callback);

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1059,6 +1059,11 @@ describe('Image directive', () => {
   });
 
   describe('fill mode', () => {
+    // Resolves after the deferred zero-height recheck had a chance to run.
+    function nextRecheck(): Promise<void> {
+      return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    }
+
     it('should allow unsized images in fill mode', () => {
       setupTestingModule();
 
@@ -1067,6 +1072,90 @@ describe('Image directive', () => {
         const fixture = createTestComponent(template);
         fixture.detectChanges();
       }).not.toThrow();
+    });
+    it('should warn when a connected fill-mode image renders with a zero height', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const img = fixture.nativeElement.querySelector('img')!;
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      expect(img.isConnected).toBe(true);
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+
+      expect(consoleWarnSpy.calls.count()).toBe(1);
+      expect(consoleWarnSpy.calls.argsFor(0)[0]).toMatch(
+        /NG02952.*the height of the fill-mode image is zero/,
+      );
+    });
+    it('should defer the zero-height check for an image that loads while detached and not warn once it attaches with a height', async () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const img = fixture.nativeElement.querySelector('img')!;
+      // A memory-cached image can fire `load` before its view is attached to
+      // the document, and a detached element always reports a zero height.
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      Object.defineProperty(img, 'isConnected', {value: false, configurable: true});
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      // The view attaches and the image lays out normally.
+      Object.defineProperty(img, 'isConnected', {value: true, configurable: true});
+      Object.defineProperty(img, 'clientHeight', {value: 350, configurable: true});
+      await nextRecheck();
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should still warn when an image that loaded while detached attaches with a zero height', async () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const img = fixture.nativeElement.querySelector('img')!;
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      Object.defineProperty(img, 'isConnected', {value: false, configurable: true});
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      // The view attaches, but the containing element is genuinely zero-height.
+      Object.defineProperty(img, 'isConnected', {value: true, configurable: true});
+      await nextRecheck();
+
+      expect(consoleWarnSpy.calls.count()).toBe(1);
+      expect(consoleWarnSpy.calls.argsFor(0)[0]).toMatch(
+        /NG02952.*the height of the fill-mode image is zero/,
+      );
+    });
+
+    it('should stop the deferred zero-height check when the view is destroyed', async () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const img = fixture.nativeElement.querySelector('img')!;
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      Object.defineProperty(img, 'isConnected', {value: false, configurable: true});
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+
+      fixture.destroy();
+      await nextRecheck();
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
     it('should throw if width is provided for fill mode image', () => {
       setupTestingModule();

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1016,12 +1016,101 @@ describe('Image directive', () => {
   });
 
   describe('fill mode', () => {
+    // Resolves after the deferred zero-height recheck had a chance to run.
+    function nextRecheck(): Promise<void> {
+      return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    }
+
     it('should allow unsized images in fill mode', async () => {
       setupTestingModule();
 
       const template = '<img ngSrc="path/img.png" fill>';
       const fixture = createTestComponent(template);
       await expectAsync(fixture.whenStable()).toBeResolved();
+    });
+    it('should warn when a connected fill-mode image renders with a zero height', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const img = fixture.nativeElement.querySelector('img')!;
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      expect(img.isConnected).toBe(true);
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+
+      expect(consoleWarnSpy.calls.count()).toBe(1);
+      expect(consoleWarnSpy.calls.argsFor(0)[0]).toMatch(
+        /NG02952.*the height of the fill-mode image is zero/,
+      );
+    });
+    it('should defer the zero-height check for an image that loads while detached and not warn once it attaches with a height', async () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const img = fixture.nativeElement.querySelector('img')!;
+      // A memory-cached image can fire `load` before its view is attached to
+      // the document, and a detached element always reports a zero height.
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      Object.defineProperty(img, 'isConnected', {value: false, configurable: true});
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      // The view attaches and the image lays out normally.
+      Object.defineProperty(img, 'isConnected', {value: true, configurable: true});
+      Object.defineProperty(img, 'clientHeight', {value: 350, configurable: true});
+      await nextRecheck();
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should still warn when an image that loaded while detached attaches with a zero height', async () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const img = fixture.nativeElement.querySelector('img')!;
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      Object.defineProperty(img, 'isConnected', {value: false, configurable: true});
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      // The view attaches, but the containing element is genuinely zero-height.
+      Object.defineProperty(img, 'isConnected', {value: true, configurable: true});
+      await nextRecheck();
+
+      expect(consoleWarnSpy.calls.count()).toBe(1);
+      expect(consoleWarnSpy.calls.argsFor(0)[0]).toMatch(
+        /NG02952.*the height of the fill-mode image is zero/,
+      );
+    });
+
+    it('should stop the deferred zero-height check when the view is destroyed', async () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const img = fixture.nativeElement.querySelector('img')!;
+      Object.defineProperty(img, 'clientHeight', {value: 0, configurable: true});
+      Object.defineProperty(img, 'isConnected', {value: false, configurable: true});
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      img.dispatchEvent(new Event('load'));
+
+      fixture.destroy();
+      await nextRecheck();
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
     it('should throw if width is provided for fill mode image', async () => {
       setupTestingModule();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`assertNonZeroRenderedHeight` emits NG02952 ("the height of the fill-mode image is zero") whenever a fill-mode image fires `load` with `clientHeight === 0`. A memory-cached image can fire `load` before its embedded view is attached to the document — for example when the same `ngSrc` appears in more than one `@defer` block and later instances are served from memory cache — and a detached element always reports a zero height. The warning then fires in bursts and points developers at container CSS that is not broken (the issue includes document-level capture-phase evidence that every warned image was detached at dispatch time and laid out correctly one tick later).

Issue Number: #69636

## What is the new behavior?

The zero-height check only warns when `img.isConnected` is true, where a zero `clientHeight` is meaningful. Two tests pin both directions: a **connected** fill-mode image with zero rendered height still warns, and a detached one no longer does. The new detached-image test fails on `main`.

One design note for review: this skips the check for detached-at-load images rather than deferring it until the element connects, so an image that loads detached and later attaches into a genuinely zero-height container will not warn. If the team prefers re-checking on attachment, I'm happy to rework in that direction. Prior attempt #69809 proposed the same guard but was closed the same day (CLA); this implementation and its tests were written independently, and the positive-direction test is new.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Dev-mode-only diagnostic; no production behavior change. `pnpm test packages/common/test:test` passes with the fix and fails on `main` with the new test.
