### PR TITLE
fix(compiler): strip ::ng-deep from nested selectors

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -602,6 +602,10 @@ export class ShadowCss {
           hostSelector,
           isParentSelector: true,
         });
+
+        // TODO(crisbeto): this is temporary to help us land #69885.
+        // Strip ::ng-deep from nested content.
+        content = rule.content.replace(_shadowDeepSelectors, ' ');
       } else if (scopedAtRuleIdentifiers.some((atRule) => rule.selector.startsWith(atRule))) {
         content = this._scopeSelectors(rule.content, scopeSelector, hostSelector);
       } else if (rule.selector.startsWith('@font-face') || rule.selector.startsWith('@page')) {

--- a/packages/compiler/test/shadow_css/ng_deep_spec.ts
+++ b/packages/compiler/test/shadow_css/ng_deep_spec.ts
@@ -31,4 +31,70 @@ describe('ShadowCss, ng-deep', () => {
     css = ':host > ::ng-deep > .x {}';
     expect(shim(css, 'contenta', 'h')).toEqualCss('[h] > > .x {}');
   });
+
+  // TODO(crisbeto): this is temporary until we land #69885.
+  it('should strip ::ng-deep from nested selectors', () => {
+    const css = `
+      .parent {
+        ::ng-deep .child {
+          color: red;
+        }
+
+        .wrapper {
+          &::ng-deep .inner {
+            color: blue;
+          }
+
+          &:hover ::ng-deep .inner-hover {
+            color: green;
+          }
+
+          .deep {
+            ::ng-deep .deepest {
+              color: yellow;
+            }
+          }
+        }
+      }
+
+      @media screen and (max-width: 600px) {
+        .media-parent {
+          ::ng-deep .media-child {
+            color: purple;
+          }
+        }
+      }
+    `;
+    expect(shim(css, 'contenta')).toEqualCss(`
+      .parent[contenta] {
+        .child {
+          color: red;
+        }
+
+        .wrapper {
+          & .inner {
+            color: blue;
+          }
+
+          &:hover .inner-hover {
+            color: green;
+          }
+
+          .deep {
+            .deepest {
+              color: yellow;
+            }
+          }
+        }
+      }
+
+      @media screen and (max-width: 600px) {
+        .media-parent[contenta] {
+          .media-child {
+            color: purple;
+          }
+        }
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Adds some temporary logic to strip `::ng-deep` from nested selectors which will help us land #69885.
