### PR TITLE
feat(core): update component styles in-place during hmr

### DIFF
--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -40,6 +40,8 @@ import {RendererFactory} from './interfaces/renderer';
 import {NgZone} from '../zone';
 import {ViewEncapsulation} from '../metadata/view';
 import {NG_COMP_DEF} from './fields';
+import {SHARED_STYLES_HOST, SharedStylesHost} from './interfaces/shared_styles_host';
+import {APP_ID} from '../application/application_tokens';
 import {
   createLView,
   getInitialLViewFlagsFromDef,
@@ -106,15 +108,166 @@ export function ɵɵreplaceMetadata(
   // If a `tView` hasn't been created yet, it means that this component hasn't been instantianted
   // before. In this case there's nothing left for us to do aside from patching it in.
   if (oldDef.tView) {
-    const trackedViews = getTrackedLViews().values();
-    for (const root of trackedViews) {
-      // Note: we have the additional check, because `IsRoot` can also indicate
-      // a component created through something like `createComponent`.
-      if (isRootView(root) && root[PARENT] === null) {
-        recreateMatchingLViews(importMeta, id, newDef, oldDef, root);
+    const oldStyles = oldDef.styles ?? [];
+    const newStyles = newDef.styles ?? [];
+    const oldUrls = oldDef.getExternalStyles?.(oldDef.id) ?? oldDef.getExternalStyles?.() ?? [];
+    const newUrls = newDef.getExternalStyles?.(newDef.id) ?? newDef.getExternalStyles?.() ?? [];
+
+    const isStyleUpdate = isPureStyleUpdate(oldDef, newDef, oldStyles, newStyles, oldUrls, newUrls);
+
+    const trackedViews = getTrackedLViews();
+    let styleReplaced = false;
+
+    if (isStyleUpdate) {
+      const processedHosts = new Set<SharedStylesHost>();
+      for (const root of trackedViews.values()) {
+        if (isRootView(root) && root[PARENT] === null) {
+          try {
+            const sharedStylesHost = root[INJECTOR].get(SHARED_STYLES_HOST, null, {optional: true});
+            if (sharedStylesHost?.replaceStyles && !processedHosts.has(sharedStylesHost)) {
+              processedHosts.add(sharedStylesHost);
+              const appId = root[INJECTOR].get(APP_ID, 'ng');
+              const compId = `${appId}-${oldDef.id}`;
+              const isEmulated = oldDef.encapsulation === ViewEncapsulation.Emulated;
+              const shimmedOld = isEmulated ? shimStyles(compId, oldStyles) : oldStyles;
+              const shimmedNew = isEmulated ? shimStyles(compId, newStyles) : newStyles;
+
+              sharedStylesHost.replaceStyles(
+                shimmedOld,
+                shimmedNew,
+                oldUrls,
+                newUrls,
+                oldDef.encapsulation !== ViewEncapsulation.None,
+              );
+              styleReplaced = true;
+            }
+          } catch {
+            // Injector may be destroyed in test environments
+          }
+        }
+      }
+    }
+
+    if (!styleReplaced) {
+      for (const root of trackedViews.values()) {
+        if (isRootView(root) && root[PARENT] === null) {
+          recreateMatchingLViews(importMeta, id, newDef, oldDef, root);
+        }
       }
     }
   }
+}
+
+/**
+ * Normalizes hostAttrs array by filtering out compiler-generated `_nghost-` encapsulation attributes.
+ */
+function normalizeHostAttrs(attrs: unknown): unknown[] {
+  if (!Array.isArray(attrs)) return [];
+  return attrs.filter((attr) => typeof attr !== 'string' || !attr.startsWith('_nghost-'));
+}
+
+/**
+ * Determines whether a metadata update is strictly a style modification
+ * (inline or external URLs) without any structural, binding, or scope changes.
+ */
+function isPureStyleUpdate(
+  oldDef: ComponentDef<unknown>,
+  newDef: ComponentDef<unknown>,
+  oldStyles: string[],
+  newStyles: string[],
+  oldUrls: string[],
+  newUrls: string[],
+): boolean {
+  if (
+    oldDef.encapsulation !== newDef.encapsulation ||
+    oldDef.encapsulation === ViewEncapsulation.ShadowDom ||
+    oldDef.encapsulation === ViewEncapsulation.ExperimentalIsolatedShadowDom ||
+    oldDef.onPush !== newDef.onPush
+  ) {
+    return false;
+  }
+
+  const stylesChanged =
+    oldStyles.length !== newStyles.length ||
+    oldStyles.some((s, i) => s !== newStyles[i]) ||
+    oldUrls.length !== newUrls.length ||
+    oldUrls.some((u, i) => u !== newUrls[i]);
+
+  if (!stylesChanged) {
+    return false;
+  }
+
+  return (
+    isSameFunctionOrNull(oldDef.template, newDef.template) &&
+    isSameFunctionOrNull(oldDef.hostBindings, newDef.hostBindings) &&
+    isSameObjectOrNull(
+      normalizeHostAttrs(oldDef.hostAttrs),
+      normalizeHostAttrs(newDef.hostAttrs),
+    ) &&
+    isSameFunctionOrNull(oldDef.providersResolver, newDef.providersResolver) &&
+    isSameFunctionOrNull(oldDef.viewProvidersResolver, newDef.viewProvidersResolver) &&
+    isSameObjectOrNull(oldDef.inputs, newDef.inputs) &&
+    isSameObjectOrNull(oldDef.outputs, newDef.outputs) &&
+    isSameFunctionOrNull(oldDef.contentQueries, newDef.contentQueries) &&
+    isSameFunctionOrNull(oldDef.viewQuery, newDef.viewQuery) &&
+    isSameObjectOrNull(oldDef.selectors, newDef.selectors) &&
+    isSameObjectOrNull(oldDef.hostDirectives, newDef.hostDirectives) &&
+    isSameObjectOrNull(oldDef.exportAs, newDef.exportAs)
+  );
+}
+
+/**
+ * Replaces `%COMP%` placeholders in component styles with the component's unique encapsulation ID.
+ * NOTE: Keep implementation in sync with `shimStylesContent` in `packages/platform-browser/src/dom/dom_renderer.ts`.
+ */
+function shimStyles(compId: string, styles: string[]): string[] {
+  return styles.map((s) => s.replace(/%COMP%/g, compId));
+}
+
+/**
+ * Compares two optional function references or function implementations for equivalence.
+ * Returns true if both references are equal or have identical stringified code bodies.
+ */
+function isSameFunctionOrNull(
+  fn1: Function | null | undefined,
+  fn2: Function | null | undefined,
+): boolean {
+  if (!fn1 && !fn2) return true;
+  return (
+    fn1 === fn2 ||
+    (typeof fn1 === 'function' && typeof fn2 === 'function' && fn1.toString() === fn2.toString())
+  );
+}
+
+/**
+ * Compares two optional object literals, arrays, functions, or records for structural equivalence.
+ */
+function isSameObjectOrNull(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (!a && !b) return true;
+  if (typeof a === 'function' && typeof b === 'function') {
+    return a.toString() === b.toString();
+  }
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') return false;
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((val, i) => isSameObjectOrNull(val, b[i]))
+    );
+  }
+
+  const keysA = Object.keys(a as object);
+  const keysB = Object.keys(b as object);
+  if (keysA.length !== keysB.length) return false;
+
+  return keysA.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(b, key) &&
+      isSameObjectOrNull((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key]),
+  );
 }
 
 /**

--- a/packages/core/src/render3/interfaces/shared_styles_host.ts
+++ b/packages/core/src/render3/interfaces/shared_styles_host.ts
@@ -30,6 +30,22 @@ export interface SharedStylesHost {
   removeStyles(styles: string[], urls?: string[]): void;
 
   /**
+   * Replaces existing styles in the DOM by mutating their element content or href in-place.
+   * @param oldStyles An array of existing style content strings.
+   * @param newStyles An array of new style content strings.
+   * @param oldUrls An array of existing external style URLs.
+   * @param newUrls An array of new external style URLs.
+   * @param isScoped Whether the styles are scoped to a specific component class. Defaults to `true`.
+   */
+  replaceStyles?(
+    oldStyles: string[],
+    newStyles: string[],
+    oldUrls?: string[],
+    newUrls?: string[],
+    isScoped?: boolean,
+  ): void;
+
+  /**
    * Adds a host node to contain styles added to the DOM and adds all existing style usage to
    * the newly added host node.
    *

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -333,6 +333,189 @@ describe('hot module replacement', () => {
     );
   });
 
+  it('should update styles in-place during HMR when styles are modified', () => {
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      template: '<span>Test</span>',
+      styles: ['span { color: red; }'],
+      changeDetection: ChangeDetectionStrategy.Eager,
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {}
+
+    @Component({
+      imports: [ChildCmp],
+      template: '<child-cmp/>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
+    class RootCmp {}
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+
+    markNodesAsCreatedInitially(fixture.nativeElement);
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      styles: ['span { color: blue; }'],
+    });
+    fixture.detectChanges();
+
+    verifyNodesRemainUntouched(fixture.nativeElement);
+    expectHTML(fixture.nativeElement, '<child-cmp><span>Test</span></child-cmp>');
+  });
+
+  it('should update styles in-place during HMR when multiple instances of component are rendered', () => {
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      template: '<span>Test</span>',
+      styles: ['span { color: red; }'],
+      changeDetection: ChangeDetectionStrategy.Eager,
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {}
+
+    @Component({
+      imports: [ChildCmp],
+      template: '<child-cmp/><child-cmp/>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
+    class RootCmp {}
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+
+    markNodesAsCreatedInitially(fixture.nativeElement);
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      styles: ['span { color: blue; }'],
+    });
+    fixture.detectChanges();
+
+    verifyNodesRemainUntouched(fixture.nativeElement);
+    expectHTML(
+      fixture.nativeElement,
+      '<child-cmp><span>Test</span></child-cmp><child-cmp><span>Test</span></child-cmp>',
+    );
+  });
+
+  it('should update styles for ShadowDom encapsulated component during HMR', () => {
+    // Domino doesn't support shadow DOM.
+    if (isNode) {
+      return;
+    }
+
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      template: '<span>Test</span>',
+      styles: ['span { color: red; }'],
+      encapsulation: ViewEncapsulation.ShadowDom,
+      changeDetection: ChangeDetectionStrategy.Eager,
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {}
+
+    @Component({
+      imports: [ChildCmp],
+      template: '<child-cmp/>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
+    class RootCmp {}
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+
+    const childHost = fixture.nativeElement.querySelector('child-cmp');
+    expectHTML(childHost.shadowRoot, `<style>span { color: red; }</style><span>Test</span>`);
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      styles: ['span { color: blue; }'],
+    });
+    fixture.detectChanges();
+
+    const newChildHost = fixture.nativeElement.querySelector('child-cmp');
+    // ShadowDom encapsulation components trigger view recreation because styles are scoped within shadow roots
+    expect(newChildHost).not.toBe(childHost);
+    expectHTML(newChildHost.shadowRoot, `<style>span { color: blue; }</style><span>Test</span>`);
+  });
+
+  it('should recreate component when metadata other than styles is modified during HMR', () => {
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      template: '<span>Test</span>',
+      styles: ['span { color: red; }'],
+      changeDetection: ChangeDetectionStrategy.Eager,
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {}
+
+    @Component({
+      imports: [ChildCmp],
+      template: '<child-cmp/>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
+    class RootCmp {}
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+
+    const spanBefore = fixture.nativeElement.querySelector('span');
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      template: '<span>Modified Template</span>',
+      styles: ['span { color: blue; }'],
+    });
+    fixture.detectChanges();
+
+    const spanAfter = fixture.nativeElement.querySelector('span');
+    expect(spanAfter).not.toBe(spanBefore);
+    expectHTML(fixture.nativeElement, '<child-cmp><span>Modified Template</span></child-cmp>');
+  });
+
+  it('should recreate component when host attributes are modified alongside styles during HMR', () => {
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      template: '<span>Test</span>',
+      styles: ['span { color: red; }'],
+      host: {'class': 'initial-class'},
+      changeDetection: ChangeDetectionStrategy.Eager,
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {}
+
+    @Component({
+      imports: [ChildCmp],
+      template: '<child-cmp/>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
+    class RootCmp {}
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+
+    const childHostBefore = fixture.nativeElement.querySelector('child-cmp');
+    const spanBefore = fixture.nativeElement.querySelector('span');
+    expect(childHostBefore.classList.contains('initial-class')).toBeTrue();
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      styles: ['span { color: blue; }'],
+      host: {'class': 'updated-class'},
+    });
+    fixture.detectChanges();
+
+    const spanAfter = fixture.nativeElement.querySelector('span');
+    expect(spanAfter).not.toBe(spanBefore);
+  });
+
   it('should continue binding inputs to a component that is replaced', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -156,6 +156,53 @@ export class SharedStylesHost implements ɵSharedStylesHost, OnDestroy {
     urls?.forEach((value) => this.removeUsage(value, this.external));
   }
 
+  /**
+   * Replaces existing styles in the DOM by mutating element content or href in-place.
+   * If a style element cannot be replaced in-place, it is removed and the new style added.
+   * @param oldStyles An array of existing style content strings.
+   * @param newStyles An array of new style content strings.
+   * @param oldUrls An array of existing external style URLs.
+   * @param newUrls An array of new external style URLs.
+   * @param isScoped Whether the styles are scoped to a specific component class. Defaults to `true`.
+   */
+  replaceStyles(
+    oldStyles: string[],
+    newStyles: string[],
+    oldUrls?: string[],
+    newUrls?: string[],
+    isScoped: boolean = true,
+  ): void {
+    // In dev mode, perform in-place DOM element updates for HMR.
+    // In production builds (ngDevMode === false), the bundler dead-code eliminates
+    // the HMR code block and tree-shakes the standalone replaceStyleEntries function.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      replaceStyleEntries(
+        oldStyles,
+        newStyles,
+        this.inline,
+        isScoped,
+        (el, val) => (el.textContent = val),
+        (val) => this.removeUsage(val, this.inline),
+        (val) => this.addUsage(val, this.inline, createStyleElement),
+      );
+
+      if (oldUrls || newUrls) {
+        replaceStyleEntries(
+          oldUrls ?? [],
+          newUrls ?? [],
+          this.external,
+          isScoped,
+          (el, val) => el.setAttribute('href', val),
+          (val) => this.removeUsage(val, this.external),
+          (val) => this.addUsage(val, this.external, createLinkElement),
+        );
+      }
+    } else {
+      this.removeStyles(oldStyles, oldUrls);
+      this.addStyles(newStyles, newUrls);
+    }
+  }
+
   protected addUsage<T extends HTMLElement>(
     value: string,
     usages: Map<string, UsageRecord<T>>,
@@ -249,5 +296,59 @@ export class SharedStylesHost implements ɵSharedStylesHost, OnDestroy {
 
     // Insert the element into the DOM with the host node as parent
     return host.appendChild(element);
+  }
+}
+
+/**
+ * Helper function for in-place style replacement during HMR in dev mode.
+ * Placed at module level so bundlers can tree-shake it when ngDevMode is false.
+ */
+function replaceStyleEntries<T extends HTMLElement>(
+  oldValues: string[],
+  newValues: string[],
+  usages: Map<string, UsageRecord<T>>,
+  isScoped: boolean,
+  updater: (element: T, value: string) => void,
+  remover: (value: string) => void,
+  adder: (value: string) => void,
+): void {
+  const oldRecords = oldValues.map((val) => usages.get(val));
+  const maxLen = Math.max(oldValues.length, newValues.length);
+
+  for (let i = 0; i < maxLen; i++) {
+    const oldVal = oldValues[i];
+    const newVal = newValues[i];
+
+    if (oldVal !== undefined && newVal !== undefined) {
+      if (oldVal === newVal) {
+        continue;
+      }
+
+      const record = oldRecords[i];
+      if (record && (record.usage === 1 || isScoped)) {
+        usages.delete(oldVal);
+
+        const existingNewRecord = usages.get(newVal);
+        const isTargetInLaterOld = oldValues.slice(i + 1).includes(newVal);
+
+        if (existingNewRecord && !isTargetInLaterOld) {
+          existingNewRecord.usage += record.usage;
+          removeElements(record.elements);
+        } else {
+          for (const element of record.elements) {
+            updater(element, newVal);
+          }
+          usages.set(newVal, record);
+        }
+        continue;
+      }
+    }
+
+    if (oldVal !== undefined) {
+      remover(oldVal);
+    }
+    if (newVal !== undefined) {
+      adder(newVal);
+    }
   }
 }

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -233,4 +233,155 @@ describe('SharedStylesHost', () => {
       expect(someHost.innerHTML).toEqual('');
     });
   });
+
+  describe('replaceStyles', () => {
+    it('should mutate inline style node textContent in-place', () => {
+      ssh.addStyles(['a { color: red; }']);
+      ssh.addHost(someHost);
+      const originalStyleNode = someHost.querySelector('style');
+      expect(someHost.innerHTML).toEqual('<style>a { color: red; }</style>');
+
+      ssh.replaceStyles(['a { color: red; }'], ['a { color: blue; }']);
+
+      const updatedStyleNode = someHost.querySelector('style');
+      expect(someHost.innerHTML).toEqual('<style>a { color: blue; }</style>');
+      expect(updatedStyleNode).toBe(originalStyleNode);
+    });
+
+    it('should mutate external link href in-place', () => {
+      ssh.addStyles([], ['component-1.css?v=1']);
+      ssh.addHost(someHost);
+      const originalLinkNode = someHost.querySelector('link');
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css?v=1">');
+
+      ssh.replaceStyles([], [], ['component-1.css?v=1'], ['component-1.css?v=2']);
+
+      const updatedLinkNode = someHost.querySelector('link');
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css?v=2">');
+      expect(updatedLinkNode).toBe(originalLinkNode);
+    });
+
+    it('should mutate style nodes across multiple host nodes in-place', () => {
+      const secondHost = getDOM().createElement('div');
+      ssh.addStyles(['a { color: red; }']);
+      ssh.addHost(someHost);
+      ssh.addHost(secondHost);
+
+      const style1 = someHost.querySelector('style');
+      const style2 = secondHost.querySelector('style');
+
+      ssh.replaceStyles(['a { color: red; }'], ['a { color: green; }']);
+
+      expect(someHost.innerHTML).toEqual('<style>a { color: green; }</style>');
+      expect(secondHost.innerHTML).toEqual('<style>a { color: green; }</style>');
+      expect(someHost.querySelector('style')).toBe(style1);
+      expect(secondHost.querySelector('style')).toBe(style2);
+    });
+
+    it('should merge usage and remove duplicate element when replacing with an existing style', () => {
+      ssh.addStyles(['a { color: blue; }']);
+      ssh.addStyles(['a { color: red; }']);
+      ssh.addHost(someHost);
+      expect(someHost.children.length).toBe(2);
+
+      ssh.replaceStyles(['a { color: red; }'], ['a { color: blue; }']);
+
+      expect(someHost.children.length).toBe(1);
+      expect(someHost.innerHTML).toEqual('<style>a { color: blue; }</style>');
+
+      ssh.removeStyles(['a { color: blue; }']);
+      expect(someHost.children.length).toBe(1);
+
+      ssh.removeStyles(['a { color: blue; }']);
+      expect(someHost.children.length).toBe(0);
+    });
+
+    it('should merge usage and remove duplicate link when replacing with an existing URL', () => {
+      ssh.addStyles([], ['a.css']);
+      ssh.addStyles([], ['b.css']);
+      ssh.addHost(someHost);
+      expect(someHost.children.length).toBe(2);
+
+      ssh.replaceStyles([], [], ['b.css'], ['a.css']);
+
+      expect(someHost.children.length).toBe(1);
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="a.css">');
+    });
+
+    it('should handle arrays of different lengths by adding or removing styles', () => {
+      ssh.addStyles(['a { color: red; }', 'b { color: red; }']);
+      ssh.addHost(someHost);
+      expect(someHost.children.length).toBe(2);
+
+      ssh.replaceStyles(['a { color: red; }', 'b { color: red; }'], ['a { color: blue; }']);
+
+      expect(someHost.children.length).toBe(1);
+      expect(someHost.innerHTML).toEqual('<style>a { color: blue; }</style>');
+    });
+
+    it('should mutate style in-place and preserve usage count for multiple instances of an emulated component', () => {
+      const emulatedStyleRed = 'a[_ngcontent-c1] { color: red; }';
+      const emulatedStyleBlue = 'a[_ngcontent-c1] { color: blue; }';
+
+      ssh.addStyles([emulatedStyleRed]); // Instance 1
+      ssh.addStyles([emulatedStyleRed]); // Instance 2
+      ssh.addHost(someHost);
+
+      const originalStyleNode = someHost.querySelector('style');
+      expect(someHost.innerHTML).toEqual(`<style>${emulatedStyleRed}</style>`);
+
+      ssh.replaceStyles([emulatedStyleRed], [emulatedStyleBlue]);
+
+      // Style node is mutated in-place and shared across active instances
+      expect(someHost.innerHTML).toEqual(`<style>${emulatedStyleBlue}</style>`);
+      expect(someHost.querySelector('style')).toBe(originalStyleNode);
+
+      // Unmounting Instance 1 should NOT remove the style node
+      ssh.removeStyles([emulatedStyleBlue]);
+      expect(someHost.innerHTML).toEqual(`<style>${emulatedStyleBlue}</style>`);
+
+      // Unmounting Instance 2 removes the style node
+      ssh.removeStyles([emulatedStyleBlue]);
+      expect(someHost.innerHTML).toEqual('');
+    });
+
+    it('should not mutate style in-place when un-encapsulated style has usage > 1 to protect other components', () => {
+      // Simulate Component A and Component B sharing the same initial un-encapsulated style
+      ssh.addStyles(['a { color: red; }']); // Comp A
+      ssh.addStyles(['a { color: red; }']); // Comp B
+      ssh.addHost(someHost);
+
+      expect(someHost.innerHTML).toEqual('<style>a { color: red; }</style>');
+
+      // Comp A (ViewEncapsulation.None) changes style to blue
+      ssh.replaceStyles(
+        ['a { color: red; }'],
+        ['a { color: blue; }'],
+        [],
+        [],
+        /* isScoped */ false,
+      );
+
+      // Comp B must retain its red style while Comp A receives its new blue style
+      expect(someHost.children.length).toBe(2);
+      expect(someHost.innerHTML).toEqual(
+        '<style>a { color: red; }</style><style>a { color: blue; }</style>',
+      );
+    });
+    it('should not lose styles when style arrays overlap or shift positions', () => {
+      ssh.addStyles(['a { color: red; }', 'b { color: red; }']);
+      ssh.addHost(someHost);
+      expect(someHost.children.length).toBe(2);
+
+      ssh.replaceStyles(
+        ['a { color: red; }', 'b { color: red; }'],
+        ['b { color: red; }', 'c { color: red; }'],
+      );
+
+      expect(someHost.children.length).toBe(2);
+      expect(someHost.innerHTML).toEqual(
+        '<style>b { color: red; }</style><style>c { color: red; }</style>',
+      );
+    });
+  });
 });


### PR DESCRIPTION
During hot module replacement (HMR), updating component inline styles
(`<style>`) or external stylesheet URLs (`<link rel="stylesheet">`) previously
triggered a complete destruction and recreation of matching component view
trees (`LView`). This caused loss of live application state (such as input
values, scroll positions, component signal state, and iframe instances) whenever
a CSS or SCSS file was edited.

This change introduces `replaceStyles` on `SharedStylesHost`, allowing HMR to
mutate inline style `textContent` or link `href` attributes in-place. The method
accepts an `isScoped` flag (`oldDef.encapsulation !== ViewEncapsulation.None`)
to distinguish component-scoped styles from un-encapsulated styles:
- For scoped styles (`isScoped === true`), in-place mutation and tracking
  record re-keying runs regardless of `record.usage`, preserving active instance
  usage counts so that multi-instance components unmount cleanly without premature
  style removal.
- For unscoped styles (`isScoped === false`), if `record.usage > 1`, it falls
  back to `removeUsage` + `addUsage` to protect other component classes sharing
  identical un-encapsulated initial CSS.

If non-style metadata (such as `template`, `inputs`, `outputs`, `providers`,
`hostBindings`, `selectors`, or `hostDirectives`) or encapsulation (`ShadowDom`)
changes alongside styles, HMR safely falls back to view tree recreation.