### PR TITLE
docs: remove semicolon text node

### DIFF
--- a/tools/manual_api_docs/blocks/switch.md
+++ b/tools/manual_api_docs/blocks/switch.md
@@ -67,7 +67,7 @@ When the switched expression is nested within a union, you must explicitly speci
   template: `
     @switch (state.mode) {
       @case ('show') {
-        {{ state.menu }};
+        {{ state.menu }}
       }
       @case ('hide') {}
       @default never;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

In one of the example a semicolon is used in a switch-case as if it's part of the syntax, but it will just render as a text node

Issue Number: N/A

## What is the new behavior?

Removed semicolon

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
