### PR TITLE
refactor(common): remove duplicate helper function

### DIFF
--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AsyncPipe} from '../../index';
 import {
   ChangeDetectorRef,
   Component,
@@ -16,8 +15,9 @@ import {
   signal,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {useAutoTick} from '@angular/private/testing';
 import {Observable, of, Subscribable, Unsubscribable} from 'rxjs';
-import {useAutoTick} from './util';
+import {AsyncPipe} from '../../index';
 
 describe('AsyncPipe', () => {
   let pipe: AsyncPipe;

--- a/packages/common/test/pipes/util.ts
+++ b/packages/common/test/pipes/util.ts
@@ -11,13 +11,3 @@ export async function timeout(ms?: number): Promise<void> {
     setTimeout(resolve, ms);
   });
 }
-
-export function useAutoTick() {
-  beforeEach(() => {
-    jasmine.clock().install();
-    jasmine.clock().autoTick();
-  });
-  afterEach(() => {
-    jasmine.clock().uninstall();
-  });
-}


### PR DESCRIPTION
We have `useAutoTick` in our private shared utils.
