### PR TITLE
docs: document overlay stacking change in v21 update guide

### DIFF
--- a/adev/src/app/features/update/recommendations.ts
+++ b/adev/src/app/features/update/recommendations.ts
@@ -2784,6 +2784,15 @@ export const RECOMMENDATIONS: Step[] = [
   {
     possibleIn: 2100,
     necessaryAsOf: 2100,
+    level: ApplicationComplexity.Medium,
+    material: true,
+    step: '21.0.0-cdk-overlay-top-layer-stacking',
+    action:
+      "CDK overlays can now render in the browser's native top layer, causing elements that previously appeared above Material overlays via `z-index` to render beneath them. You can restore the previous behavior by providing `OVERLAY_DEFAULT_CONFIG` from `@angular/cdk/overlay` with the value `{usePopover: false}`.",
+  },
+  {
+    possibleIn: 2100,
+    necessaryAsOf: 2100,
     level: ApplicationComplexity.Advanced,
     step: '21.0.0-update-signal-input-access-in-custom-elements',
     action:


### PR DESCRIPTION
The v20 to v21 update guide doesn't mention that CDK/Material overlays can now render in the browser's native top layer. Add a checklist item so upgrades that rely on the old stacking behavior don't get caught out.

fixes #69971

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The Angular update guide doesn't flag that in v21 the CDK overlay can use the browser's native top layer (popover). Application elements that previously relied on a higher `z-index` to sit above a Material overlay can now be painted underneath it, and raising their `z-index` doesn't help because top-layer elements sit above the document's normal stacking contexts. These regressions only show up in specific UI flows, so they're easy to miss when upgrading.

Issue Number: #69971

## What is the new behavior?

The v21 update checklist now includes a Material step describing the top-layer stacking change and pointing users at the `{provide: OVERLAY_DEFAULT_CONFIG, useValue: {usePopover: false}}` provider from `@angular/cdk/overlay` as a way to keep the previous behavior while they migrate.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
