### PR TITLE
refactor(core): modernize unit tests to rely on `whenStable`

### DIFF
--- a/packages/core/test/acceptance/after_render_effect_spec.ts
+++ b/packages/core/test/acceptance/after_render_effect_spec.ts
@@ -75,7 +75,7 @@ describe('afterRenderEffect', () => {
     expect(log.length).toBe(0);
   });
 
-  it('should run when made dirty via signal', () => {
+  it('should run when made dirty via signal', async () => {
     const log: string[] = [];
     const appRef = TestBed.inject(ApplicationRef);
     const counter = signal(0);
@@ -93,12 +93,12 @@ describe('afterRenderEffect', () => {
     log.length = 0;
 
     counter.set(1);
-    appRef.tick();
+    await appRef.whenStable();
 
     expect(log).toEqual(['earlyRead: 1']);
   });
 
-  it('should not run when not actually dirty from signals', () => {
+  it('should not run when not actually dirty from signals', async () => {
     const log: string[] = [];
     const appRef = TestBed.inject(ApplicationRef);
     const counter = signal(0);
@@ -114,13 +114,13 @@ describe('afterRenderEffect', () => {
     log.length = 0;
 
     counter.set(2);
-    appRef.tick();
+    await appRef.whenStable();
 
     // Should not have run since `isEven()` didn't actually change despite becoming dirty.
     expect(log.length).toBe(0);
   });
 
-  it('should pass data from one phase to the next via signal', () => {
+  it('should pass data from one phase to the next via signal', async () => {
     const log: string[] = [];
     const appRef = TestBed.inject(ApplicationRef);
     const counter = signal(0);
@@ -138,20 +138,20 @@ describe('afterRenderEffect', () => {
 
     // isEven: false
     counter.set(1);
-    appRef.tick();
+    await appRef.whenStable();
 
     // isEven: true
     counter.set(2);
-    appRef.tick();
+    await appRef.whenStable();
 
     // No change (no log).
     counter.set(4);
-    appRef.tick();
+    await appRef.whenStable();
 
     expect(log).toEqual(['isEven: false', 'isEven: true']);
   });
 
-  it('should run cleanup functions before re-running phase effects', () => {
+  it('should run cleanup functions before re-running phase effects', async () => {
     const log: string[] = [];
     const appRef = TestBed.inject(ApplicationRef);
     const counter = signal(0);
@@ -179,19 +179,19 @@ describe('afterRenderEffect', () => {
 
     // A counter of 1 will clean up and rerun both effects.
     counter.set(1);
-    appRef.tick();
+    await appRef.whenStable();
     expect(log).toEqual(['cleanup earlyRead', 'earlyRead: 1', 'cleanup write', 'write: false']);
     log.length = 0;
 
     // A counter of 3 will clean up and rerun the earlyRead phase only.
     counter.set(3);
-    appRef.tick();
+    await appRef.whenStable();
     expect(log).toEqual(['cleanup earlyRead', 'earlyRead: 3']);
     log.length = 0;
 
     // A counter of 4 will then clean up and rerun both effects.
     counter.set(4);
-    appRef.tick();
+    await appRef.whenStable();
     expect(log).toEqual(['cleanup earlyRead', 'earlyRead: 4', 'cleanup write', 'write: true']);
   });
 
@@ -281,7 +281,7 @@ describe('afterRenderEffect', () => {
     expect(log).toEqual(['earlyRead: 0', 'earlyRead: 1']);
   });
 
-  it('should cause a re-run for hooks that re-dirty themselves', () => {
+  it('should cause a re-run for hooks that re-dirty themselves', async () => {
     const log: string[] = [];
     const appRef = TestBed.inject(ApplicationRef);
     const counter = signal(0);
@@ -300,15 +300,15 @@ describe('afterRenderEffect', () => {
       {injector: appRef.injector},
     );
 
-    appRef.tick();
+    await appRef.whenStable();
     log.length = 0;
 
     counter.set(1);
-    appRef.tick();
+    await appRef.whenStable();
     expect(log).toEqual(['counter: 1', 'counter: 0']);
   });
 
-  it('should cause a re-run for hooks that re-dirty earlier hooks', () => {
+  it('should cause a re-run for hooks that re-dirty earlier hooks', async () => {
     const log: string[] = [];
     const appRef = TestBed.inject(ApplicationRef);
     const counter = signal(0);
@@ -330,15 +330,15 @@ describe('afterRenderEffect', () => {
       {injector: appRef.injector},
     );
 
-    appRef.tick();
+    await appRef.whenStable();
     log.length = 0;
 
     counter.set(1);
-    appRef.tick();
+    await appRef.whenStable();
     expect(log).toEqual(['earlyRead: 1', 'write: 1', 'earlyRead: 0', 'write: 0']);
   });
 
-  it('should not run later hooks when an earlier hook is re-dirtied', () => {
+  it('should not run later hooks when an earlier hook is re-dirtied', async () => {
     const log: string[] = [];
     const appRef = TestBed.inject(ApplicationRef);
     const counter = signal(0);
@@ -358,11 +358,11 @@ describe('afterRenderEffect', () => {
       {injector: appRef.injector},
     );
 
-    appRef.tick();
+    await appRef.whenStable();
     log.length = 0;
 
     counter.set(1);
-    appRef.tick();
+    await appRef.whenStable();
     expect(log).toEqual(['earlyRead: 1', 'earlyRead: 0', 'write: 0']);
   });
 });

--- a/packages/core/test/acceptance/authoring/model_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/model_inputs_spec.ts
@@ -24,7 +24,7 @@ import {SIGNAL} from '../../../primitives/signals';
 import {TestBed} from '../../../testing';
 
 describe('model inputs', () => {
-  it('should support two-way binding to a signal', () => {
+  it('should support two-way binding to a signal', async () => {
     @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
@@ -54,7 +54,7 @@ describe('model inputs', () => {
 
     // Changing the value from the outside.
     host.value.set(3);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(3);
     expect(host.dir.value()).toBe(3);
   });
@@ -94,7 +94,7 @@ describe('model inputs', () => {
     expect(host.dir.value()).toBe(3);
   });
 
-  it('should support two-way binding a signal to a non-model input/output pair', () => {
+  it('should support two-way binding a signal to a non-model input/output pair', async () => {
     @Directive({selector: '[dir]'})
     class Dir {
       @Input() value = 0;
@@ -127,12 +127,12 @@ describe('model inputs', () => {
 
     // Changing the value from the outside.
     host.value.set(3);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(3);
     expect(host.dir.value).toBe(3);
   });
 
-  it('should support a one-way property binding to a model', () => {
+  it('should support a one-way property binding to a model', async () => {
     @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
@@ -158,19 +158,19 @@ describe('model inputs', () => {
 
     // Changing the value from within the directive.
     host.dir.value.set(2);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value).toBe(1);
     expect(host.dir.value()).toBe(2);
 
     // Changing the value from the outside.
     host.value = 3;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value).toBe(3);
     expect(host.dir.value()).toBe(3);
   });
 
-  it('should emit to the change output when the model changes', () => {
+  it('should emit to the change output when the model changes', async () => {
     const emittedValues: number[] = [];
 
     @Directive({selector: '[dir]'})
@@ -197,20 +197,20 @@ describe('model inputs', () => {
     expect(emittedValues).toEqual([]);
 
     host.dir.value.set(1);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(emittedValues).toEqual([1]);
 
     // Same value should not emit.
     host.dir.value.set(1);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(emittedValues).toEqual([1]);
 
     host.dir.value.update((value) => value * 5);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(emittedValues).toEqual([1, 5]);
   });
 
-  it('should not emit to the change event when then property binding changes', () => {
+  it('should not emit to the change event when then property binding changes', async () => {
     const emittedValues: number[] = [];
 
     @Directive({selector: '[dir]'})
@@ -237,11 +237,11 @@ describe('model inputs', () => {
     expect(emittedValues).toEqual([]);
 
     host.value.set(2);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(emittedValues).toEqual([]);
   });
 
-  it('should support binding to the model input and output separately', () => {
+  it('should support binding to the model input and output separately', async () => {
     const emittedValues: number[] = [];
 
     @Directive({selector: '[dir]'})
@@ -271,19 +271,19 @@ describe('model inputs', () => {
     expect(emittedValues).toEqual([]);
 
     host.dir.value.set(2);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(1);
     expect(host.dir.value()).toBe(2);
     expect(emittedValues).toEqual([2]);
 
     host.value.set(3);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(3);
     expect(host.dir.value()).toBe(3);
     expect(emittedValues).toEqual([2]);
   });
 
-  it('should support two-way binding to a model with an alias', () => {
+  it('should support two-way binding to a model with an alias', async () => {
     @Directive({selector: '[dir]'})
     class Dir {
       value = model(0, {alias: 'alias'});
@@ -308,18 +308,18 @@ describe('model inputs', () => {
 
     // Changing the value from within the directive.
     host.dir.value.set(2);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(2);
     expect(host.dir.value()).toBe(2);
 
     // Changing the value from the outside.
     host.value.set(3);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(3);
     expect(host.dir.value()).toBe(3);
   });
 
-  it('should support binding to an aliased model input and output separately', () => {
+  it('should support binding to an aliased model input and output separately', async () => {
     const emittedValues: number[] = [];
 
     @Directive({selector: '[dir]'})
@@ -349,13 +349,13 @@ describe('model inputs', () => {
     expect(emittedValues).toEqual([]);
 
     host.dir.value.set(2);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(1);
     expect(host.dir.value()).toBe(2);
     expect(emittedValues).toEqual([2]);
 
     host.value.set(3);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(3);
     expect(host.dir.value()).toBe(3);
     expect(emittedValues).toEqual([2]);
@@ -384,7 +384,7 @@ describe('model inputs', () => {
     );
   });
 
-  it('should stop emitting to the output on destroy', () => {
+  it('should stop emitting to the output on destroy', async () => {
     let emittedEvents = 0;
 
     @Directive({selector: '[dir]'})
@@ -411,7 +411,7 @@ describe('model inputs', () => {
     expect(emittedEvents).toBe(0);
 
     modelRef.set(1);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(emittedEvents).toBe(1);
 
     fixture.destroy();
@@ -421,7 +421,7 @@ describe('model inputs', () => {
     expect(emittedEvents).toBe(1);
   });
 
-  it('should support inherited model inputs', () => {
+  it('should support inherited model inputs', async () => {
     @Directive()
     abstract class BaseDir {
       value = model(0);
@@ -449,18 +449,18 @@ describe('model inputs', () => {
 
     // Changing the value from within the directive.
     host.dir.value.set(2);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(2);
     expect(host.dir.value()).toBe(2);
 
     // Changing the value from the outside.
     host.value.set(3);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value()).toBe(3);
     expect(host.dir.value()).toBe(3);
   });
 
-  it('should reflect changes to a two-way-bound signal in the DOM', () => {
+  it('should reflect changes to a two-way-bound signal in the DOM', async () => {
     @Directive({
       selector: '[dir]',
       host: {
@@ -484,7 +484,7 @@ describe('model inputs', () => {
     }
 
     const fixture = TestBed.createComponent(App);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement.textContent).toContain('Current value: 1');
 
     fixture.nativeElement.querySelector('button').click();
@@ -496,7 +496,7 @@ describe('model inputs', () => {
     expect(fixture.nativeElement.textContent).toContain('Current value: 3');
   });
 
-  it('should support ngOnChanges for two-way model bindings', () => {
+  it('should support ngOnChanges for two-way model bindings', async () => {
     const changes: SimpleChange[] = [];
 
     @Directive({selector: '[dir]'})
@@ -531,7 +531,7 @@ describe('model inputs', () => {
     ]);
 
     fixture.componentInstance.value.set(2);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(changes).toEqual([
       jasmine.objectContaining({
@@ -571,7 +571,7 @@ describe('model inputs', () => {
     expect(() => fixture.destroy()).not.toThrow();
   });
 
-  it('should support two-way binding to a signal @for loop variable', () => {
+  it('should support two-way binding to a signal @for loop variable', async () => {
     @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
@@ -605,7 +605,7 @@ describe('model inputs', () => {
 
     // Changing the value from the outside.
     host.values[0].set(3);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.values[0]()).toBe(3);
     expect(host.dir.value()).toBe(3);
   });

--- a/packages/core/test/acceptance/authoring/output_function_spec.ts
+++ b/packages/core/test/acceptance/authoring/output_function_spec.ts
@@ -153,7 +153,7 @@ describe('output() function', () => {
     );
   });
 
-  it('should run listeners outside of `emit` reactive context', () => {
+  it('should run listeners outside of `emit` reactive context', async () => {
     @Directive({
       selector: '[dir]',
     })
@@ -189,7 +189,7 @@ describe('output() function', () => {
 
     expect(dir.effectCount).toEqual(1);
     fixture.componentInstance.signalUnrelatedToDir.update((v) => v + 1);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(dir.effectCount).toEqual(1);
   });

--- a/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
@@ -41,7 +41,7 @@ describe('signal inputs', () => {
     }),
   );
 
-  it('should be possible to bind to an input', () => {
+  it('should be possible to bind to an input', async () => {
     @Component({
       selector: 'input-comp',
       template: 'input:{{input()}}',
@@ -66,12 +66,12 @@ describe('signal inputs', () => {
 
     fixture.componentInstance.value = 2;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('input:2');
   });
 
-  it('should be possible to use an input in a computed expression', () => {
+  it('should be possible to use an input in a computed expression', async () => {
     @Component({
       selector: 'input-comp',
       template: 'changed:{{changed()}}',
@@ -97,12 +97,12 @@ describe('signal inputs', () => {
 
     fixture.componentInstance.value = 2;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('changed:computed-2');
   });
 
-  it('should be possible to use an input in an effect', () => {
+  it('should be possible to use an input in an effect', async () => {
     let effectLog: unknown[] = [];
 
     @Component({
@@ -137,7 +137,7 @@ describe('signal inputs', () => {
 
     fixture.componentInstance.value = 2;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(effectLog).toEqual([1, 2]);
   });
@@ -194,7 +194,7 @@ describe('signal inputs', () => {
     expect(transformRunCount).toBe(1);
   });
 
-  it('should be possible to bind to an inherited input', () => {
+  it('should be possible to bind to an inherited input', async () => {
     @Directive()
     class BaseDir {
       input = input<number>();
@@ -222,12 +222,12 @@ describe('signal inputs', () => {
 
     fixture.componentInstance.value = 2;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('input:2');
   });
 
-  it('should support two-way binding to signal input and @Output decorated member', () => {
+  it('should support two-way binding to signal input and @Output decorated member', async () => {
     @Directive({selector: '[dir]'})
     class Dir {
       value = input(0);
@@ -255,14 +255,14 @@ describe('signal inputs', () => {
     // Changing the value from within the directive.
     host.dir.valueChange.emit(2);
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value).toBe(2);
     expect(host.dir.value()).toBe(2);
 
     // Changing the value from the outside.
     host.value = 3;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(host.value).toBe(3);
     expect(host.dir.value()).toBe(3);
   });
@@ -634,7 +634,7 @@ describe('signal inputs', () => {
 
       TestBed.configureTestingModule({animationsEnabled: true});
       const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const notification = fixture.nativeElement.querySelector('notification');
 

--- a/packages/core/test/acceptance/authoring/signal_queries_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_queries_spec.ts
@@ -85,7 +85,7 @@ describe('queries as signals', () => {
       expect(fixture.componentInstance.foundEl()).toBeTrue();
     });
 
-    it('should query for multiple elements in a template', () => {
+    it('should query for multiple elements in a template', async () => {
       @Component({
         template: `
           <div #el></div>
@@ -113,12 +113,12 @@ describe('queries as signals', () => {
 
       fixture.componentInstance.show = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.foundEl()).toBe(2);
 
       fixture.componentInstance.show = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.foundEl()).toBe(1);
     });
 
@@ -159,7 +159,7 @@ describe('queries as signals', () => {
       expect(result2).toBe(result1);
     });
 
-    it('should not mark signal as dirty when a child query result does not change', () => {
+    it('should not mark signal as dirty when a child query result does not change', async () => {
       let computeCount = 0;
 
       @Component({
@@ -185,12 +185,12 @@ describe('queries as signals', () => {
       // computed re-evaluation
       fixture.componentInstance.show = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.divEl()).toBe(divEl);
       expect(fixture.componentInstance.isThere()).toBe(1);
     });
 
-    it('should return the same array instance when there were no changes in results after view manipulation', () => {
+    it('should return the same array instance when there were no changes in results after view manipulation', async () => {
       @Component({
         template: `
           <div #el></div>
@@ -212,7 +212,7 @@ describe('queries as signals', () => {
 
       fixture.componentInstance.show = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       // subsequent reads should return the same result instance since the query results didn't
       // change
       const result2 = fixture.componentInstance.divEls();
@@ -273,7 +273,7 @@ describe('queries as signals', () => {
   });
 
   describe('content queries', () => {
-    it('should run content queries defined on components', () => {
+    it('should run content queries defined on components', async () => {
       @Component({
         selector: 'query-cmp',
         template: `{{ noOfEls() }}`,
@@ -313,16 +313,16 @@ describe('queries as signals', () => {
 
       fixture.componentInstance.show = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toBe('4');
 
       fixture.componentInstance.show = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toBe('3');
     });
 
-    it('should run content queries defined on directives', () => {
+    it('should run content queries defined on directives', async () => {
       @Directive({
         selector: '[query]',
         host: {'[textContent]': `noOfEls()`},
@@ -362,12 +362,12 @@ describe('queries as signals', () => {
 
       fixture.componentInstance.show = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toBe('4');
 
       fixture.componentInstance.show = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toBe('3');
     });
 
@@ -477,7 +477,7 @@ describe('queries as signals', () => {
   });
 
   describe('reactivity and performance', () => {
-    it('should not dirty a children query when a list of matches does not change - a view with matches', () => {
+    it('should not dirty a children query when a list of matches does not change - a view with matches', async () => {
       let recomputeCount = 0;
 
       @Component({
@@ -505,16 +505,16 @@ describe('queries as signals', () => {
       // trigger view manipulation that should dirty queries but not change the results
       fixture.componentInstance.show = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       fixture.componentInstance.show = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(fixture.componentInstance.foundElCount()).toBe(1);
       expect(recomputeCount).toBe(1);
     });
 
-    it('should not dirty a children query when a list of matches does not change - a view with another container', () => {
+    it('should not dirty a children query when a list of matches does not change - a view with another container', async () => {
       let recomputeCount = 0;
 
       @Component({
@@ -543,10 +543,10 @@ describe('queries as signals', () => {
       // trigger view manipulation that should dirty queries but not change the results
       fixture.componentInstance.show = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       fixture.componentInstance.show = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(fixture.componentInstance.foundElCount()).toBe(1);
       expect(recomputeCount).toBe(1);
@@ -586,7 +586,7 @@ describe('queries as signals', () => {
   });
 
   describe('mix of signal and decorator queries', () => {
-    it('should allow specifying both types of queries in one component', () => {
+    it('should allow specifying both types of queries in one component', async () => {
       @Component({
         template: `
           <div #el></div>
@@ -611,18 +611,18 @@ describe('queries as signals', () => {
 
       fixture.componentInstance.show = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.divElsSignal().length).toBe(2);
       expect(fixture.componentInstance.divElsDecorator.length).toBe(2);
 
       fixture.componentInstance.show = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.divElsSignal().length).toBe(1);
       expect(fixture.componentInstance.divElsDecorator.length).toBe(1);
     });
 
-    it('should allow combination via inheritance of both types of queries in one component', () => {
+    it('should allow combination via inheritance of both types of queries in one component', async () => {
       @Component({
         template: `
           <div #el></div>
@@ -657,13 +657,13 @@ describe('queries as signals', () => {
 
       fixture.componentInstance.show = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.divElsSignal().length).toBe(2);
       expect(fixture.componentInstance.divElsDecorator.length).toBe(2);
 
       fixture.componentInstance.show = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.divElsSignal().length).toBe(1);
       expect(fixture.componentInstance.divElsDecorator.length).toBe(1);
     });

--- a/packages/core/test/acceptance/exports_spec.ts
+++ b/packages/core/test/acceptance/exports_spec.ts
@@ -200,7 +200,7 @@ describe('exports', () => {
       );
     });
 
-    it('should support local refs in nested dynamic views', () => {
+    it('should support local refs in nested dynamic views', async () => {
       const fixture = initWithTemplate(
         AppComp,
         `
@@ -218,7 +218,7 @@ describe('exports', () => {
       fixture.componentInstance.outer = true;
       fixture.componentInstance.inner = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // result should be <input value="one"><div>one <input value="two"><div>one - two</div></div>
       // but contains bindings comments for ngIf

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -27,6 +27,7 @@ import {
   provideZoneChangeDetection,
   QueryList,
   signal,
+  provideZonelessChangeDetection,
   TemplateRef,
   ViewChild,
   ViewChildren,
@@ -90,54 +91,54 @@ describe('acceptance integration tests', () => {
       );
     });
 
-    it('should add and remove DOM nodes when ng-container is a child of a regular element', () => {
+    it('should add and remove DOM nodes when ng-container is a child of a regular element', async () => {
       @Component({
         template:
-          '<ng-template [ngIf]="render"><div><ng-container>content</ng-container></div></ng-template>',
+          '<ng-template [ngIf]="render()"><div><ng-container>content</ng-container></div></ng-template>',
         standalone: false,
 
         changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
-        render = false;
+        render = signal(false);
       }
 
-      TestBed.configureTestingModule({declarations: [App], imports: [CommonModule]});
+      TestBed.configureTestingModule({declarations: [App], imports: [CommonModule], providers: [provideZonelessChangeDetection()]});
       const fixture = TestBed.createComponent(App);
 
       expect(stripHtmlComments(fixture.nativeElement.innerHTML)).toEqual('');
 
-      fixture.componentInstance.render = true;
-      fixture.detectChanges();
+      fixture.componentInstance.render.set(true);
+      await fixture.whenStable();
       expect(stripHtmlComments(fixture.nativeElement.innerHTML)).toEqual('<div>content</div>');
 
-      fixture.componentInstance.render = false;
-      fixture.detectChanges();
+      fixture.componentInstance.render.set(false);
+      await fixture.whenStable();
       expect(stripHtmlComments(fixture.nativeElement.innerHTML)).toEqual('');
     });
 
-    it('should add and remove DOM nodes when ng-container is a child of an embedded view', () => {
+    it('should add and remove DOM nodes when ng-container is a child of an embedded view', async () => {
       @Component({
-        template: '<ng-container *ngIf="render">content</ng-container>',
+        template: '<ng-container *ngIf="render()">content</ng-container>',
         standalone: false,
 
         changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
-        render = false;
+        render = signal(false);
       }
 
-      TestBed.configureTestingModule({declarations: [App], imports: [CommonModule]});
+      TestBed.configureTestingModule({declarations: [App], imports: [CommonModule], providers: [provideZonelessChangeDetection()]});
       const fixture = TestBed.createComponent(App);
 
       expect(stripHtmlComments(fixture.nativeElement.innerHTML)).toEqual('');
 
-      fixture.componentInstance.render = true;
-      fixture.detectChanges();
+      fixture.componentInstance.render.set(true);
+      await fixture.whenStable();
       expect(stripHtmlComments(fixture.nativeElement.innerHTML)).toEqual('content');
 
-      fixture.componentInstance.render = false;
-      fixture.detectChanges();
+      fixture.componentInstance.render.set(false);
+      await fixture.whenStable();
       expect(stripHtmlComments(fixture.nativeElement.innerHTML)).toEqual('');
     });
 
@@ -427,48 +428,50 @@ describe('acceptance integration tests', () => {
   });
 
   describe('text bindings', () => {
-    it('should render "undefined" as ""', () => {
+    it('should render "undefined" as ""', async () => {
       @Component({
-        template: '{{name}}',
+        template: '{{name()}}',
         standalone: false,
-
-        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
-        name: string | undefined = 'benoit';
+        name = signal<string | undefined>('benoit');
       }
 
-      TestBed.configureTestingModule({declarations: [App]});
+      TestBed.configureTestingModule({
+        declarations: [App],
+        providers: [provideZonelessChangeDetection()],
+      });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
 
       expect(fixture.nativeElement.innerHTML).toEqual('benoit');
 
-      fixture.componentInstance.name = undefined;
-      fixture.detectChanges();
+      fixture.componentInstance.name.set(undefined);
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('');
     });
 
-    it('should render "null" as ""', () => {
+    it('should render "null" as ""', async () => {
       @Component({
-        template: '{{name}}',
+        template: '{{name()}}',
         standalone: false,
-
-        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
-        name: string | null = 'benoit';
+        name = signal<string | null>('benoit');
       }
 
-      TestBed.configureTestingModule({declarations: [App]});
+      TestBed.configureTestingModule({
+        declarations: [App],
+        providers: [provideZonelessChangeDetection()],
+      });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
 
       expect(fixture.nativeElement.innerHTML).toEqual('benoit');
 
-      fixture.componentInstance.name = null;
-      fixture.detectChanges();
+      fixture.componentInstance.name.set(null);
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('');
     });
@@ -597,129 +600,139 @@ describe('acceptance integration tests', () => {
   });
 
   describe('Siblings update', () => {
-    it('should handle a flat list of static/bound text nodes', () => {
+    it('should handle a flat list of static/bound text nodes', async () => {
       @Component({
-        template: 'Hello {{name}}!',
+        template: 'Hello {{name()}}!',
         standalone: false,
-
-        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
-        name = '';
+        name = signal('');
       }
 
-      TestBed.configureTestingModule({declarations: [App]});
+      TestBed.configureTestingModule({
+        declarations: [App],
+        providers: [provideZonelessChangeDetection()],
+      });
       const fixture = TestBed.createComponent(App);
-
-      fixture.componentInstance.name = 'world';
       fixture.detectChanges();
+
+      fixture.componentInstance.name.set('world');
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('Hello world!');
 
-      fixture.componentInstance.name = 'monde';
-      fixture.detectChanges();
+      fixture.componentInstance.name.set('monde');
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('Hello monde!');
     });
 
-    it('should handle a list of static/bound text nodes as element children', () => {
+    it('should handle a list of static/bound text nodes as element children', async () => {
       @Component({
-        template: '<b>Hello {{name}}!</b>',
+        template: '<b>Hello {{name()}}!</b>',
         standalone: false,
-
-        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
-        name = '';
+        name = signal('');
       }
 
-      TestBed.configureTestingModule({declarations: [App]});
+      TestBed.configureTestingModule({
+        declarations: [App],
+        providers: [provideZonelessChangeDetection()],
+      });
       const fixture = TestBed.createComponent(App);
+      fixture.detectChanges(); // initial bootstrap
 
-      fixture.componentInstance.name = 'world';
-      fixture.detectChanges();
+      fixture.componentInstance.name.set('world');
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('<b>Hello world!</b>');
 
-      fixture.componentInstance.name = 'mundo';
-      fixture.detectChanges();
+      fixture.componentInstance.name.set('mundo');
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('<b>Hello mundo!</b>');
     });
 
-    it('should render/update text node as a child of a deep list of elements', () => {
+    it('should render/update text node as a child of a deep list of elements', async () => {
       @Component({
-        template: '<b><b><b><b>Hello {{name}}!</b></b></b></b>',
+        template: '<b><b><b><b>Hello {{name()}}!</b></b></b></b>',
         standalone: false,
-
-        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
-        name = '';
+        name = signal('');
       }
 
-      TestBed.configureTestingModule({declarations: [App]});
+      TestBed.configureTestingModule({
+        declarations: [App],
+        providers: [provideZonelessChangeDetection()],
+      });
       const fixture = TestBed.createComponent(App);
-
-      fixture.componentInstance.name = 'world';
       fixture.detectChanges();
+
+      fixture.componentInstance.name.set('world');
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('<b><b><b><b>Hello world!</b></b></b></b>');
 
-      fixture.componentInstance.name = 'mundo';
-      fixture.detectChanges();
+      fixture.componentInstance.name.set('mundo');
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('<b><b><b><b>Hello mundo!</b></b></b></b>');
     });
 
-    it('should update 2 sibling elements', () => {
+    it('should update 2 sibling elements', async () => {
       @Component({
-        template: '<b><span></span><span class="foo" [id]="id"></span></b>',
+        template: '<b><span></span><span class="foo" [id]="id()"></span></b>',
         standalone: false,
-
-        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
-        id = '';
+        id = signal('');
       }
 
-      TestBed.configureTestingModule({declarations: [App]});
+      TestBed.configureTestingModule({
+        declarations: [App],
+        providers: [provideZonelessChangeDetection()],
+      });
       const fixture = TestBed.createComponent(App);
-
-      fixture.componentInstance.id = 'foo';
       fixture.detectChanges();
+
+      fixture.componentInstance.id.set('foo');
+      await fixture.whenStable();
       expect(fixture.nativeElement.innerHTML).toEqual(
         '<b><span></span><span class="foo" id="foo"></span></b>',
       );
 
-      fixture.componentInstance.id = 'bar';
-      fixture.detectChanges();
+      fixture.componentInstance.id.set('bar');
+      await fixture.whenStable();
       expect(fixture.nativeElement.innerHTML).toEqual(
         '<b><span></span><span class="foo" id="bar"></span></b>',
       );
     });
 
-    it('should handle sibling text node after element with child text node', () => {
+    it('should handle sibling text node after element with child text node', async () => {
       @Component({
-        template: '<p>hello</p>{{name}}',
+        template: '<p>hello</p>{{name()}}',
         standalone: false,
-
-        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
-        name = '';
+        name = signal('');
       }
 
-      TestBed.configureTestingModule({declarations: [App]});
+      TestBed.configureTestingModule({
+        declarations: [App],
+        providers: [provideZonelessChangeDetection()],
+      });
       const fixture = TestBed.createComponent(App);
-
-      fixture.componentInstance.name = 'world';
       fixture.detectChanges();
+
+      fixture.componentInstance.name.set('world');
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('<p>hello</p>world');
 
-      fixture.componentInstance.name = 'mundo';
-      fixture.detectChanges();
+      fixture.componentInstance.name.set('mundo');
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.innerHTML).toEqual('<p>hello</p>mundo');
     });
@@ -905,54 +918,60 @@ describe('acceptance integration tests', () => {
 
   describe('element bindings', () => {
     describe('elementAttribute', () => {
-      it('should support attribute bindings', () => {
+      it('should support attribute bindings', async () => {
         @Component({
-          template: '<button [attr.title]="title"></button>',
+          template: '<button [attr.title]="title()"></button>',
           standalone: false,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
-          title: string | null = '';
+          title = signal<string | null>('');
         }
 
-        TestBed.configureTestingModule({declarations: [App]});
+        TestBed.configureTestingModule({
+          declarations: [App],
+          providers: [provideZonelessChangeDetection()],
+        });
         const fixture = TestBed.createComponent(App);
-        fixture.componentInstance.title = 'Hello';
         fixture.detectChanges();
+
+        fixture.componentInstance.title.set('Hello');
+        await fixture.whenStable();
         // initial binding
         expect(fixture.nativeElement.innerHTML).toEqual('<button title="Hello"></button>');
 
         // update binding
-        fixture.componentInstance.title = 'Hi!';
-        fixture.detectChanges();
+        fixture.componentInstance.title.set('Hi!');
+        await fixture.whenStable();
         expect(fixture.nativeElement.innerHTML).toEqual('<button title="Hi!"></button>');
 
         // remove attribute
-        fixture.componentInstance.title = null;
-        fixture.detectChanges();
+        fixture.componentInstance.title.set(null);
+        await fixture.whenStable();
         expect(fixture.nativeElement.innerHTML).toEqual('<button></button>');
       });
 
-      it('should stringify values used attribute bindings', () => {
+      it('should stringify values used attribute bindings', async () => {
         @Component({
-          template: '<button [attr.title]="title"></button>',
+          template: '<button [attr.title]="title()"></button>',
           standalone: false,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
-          title: any;
+          title = signal<any>(undefined);
         }
 
-        TestBed.configureTestingModule({declarations: [App]});
+        TestBed.configureTestingModule({
+          declarations: [App],
+          providers: [provideZonelessChangeDetection()],
+        });
         const fixture = TestBed.createComponent(App);
-        fixture.componentInstance.title = NaN;
         fixture.detectChanges();
+
+        fixture.componentInstance.title.set(NaN);
+        await fixture.whenStable();
         expect(fixture.nativeElement.innerHTML).toEqual('<button title="NaN"></button>');
 
-        fixture.componentInstance.title = {toString: () => 'Custom toString'};
-        fixture.detectChanges();
+        fixture.componentInstance.title.set({toString: () => 'Custom toString'});
+        await fixture.whenStable();
         expect(fixture.nativeElement.innerHTML).toEqual(
           '<button title="Custom toString"></button>',
         );
@@ -1116,163 +1135,172 @@ describe('acceptance integration tests', () => {
     });
 
     describe('elementStyle', () => {
-      it('should support binding to styles', () => {
+      it('should support binding to styles', async () => {
         @Component({
-          template: '<span [style.font-size]="size"></span>',
+          template: '<span [style.font-size]="size()"></span>',
           standalone: false,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
-          size: string | null = '';
+          size = signal<string | null>('');
         }
 
-        TestBed.configureTestingModule({declarations: [App]});
+        TestBed.configureTestingModule({
+          declarations: [App],
+          providers: [provideZonelessChangeDetection()],
+        });
         const fixture = TestBed.createComponent(App);
-        fixture.componentInstance.size = '10px';
         fixture.detectChanges();
+
+        fixture.componentInstance.size.set('10px');
+        await fixture.whenStable();
         const span: HTMLElement = fixture.nativeElement.querySelector('span');
 
         expect(span.style.fontSize).toBe('10px');
 
-        fixture.componentInstance.size = '16px';
-        fixture.detectChanges();
+        fixture.componentInstance.size.set('16px');
+        await fixture.whenStable();
         expect(span.style.fontSize).toBe('16px');
 
-        fixture.componentInstance.size = null;
-        fixture.detectChanges();
+        fixture.componentInstance.size.set(null);
+        await fixture.whenStable();
         expect(span.style.fontSize).toBeFalsy();
       });
 
-      it('should support binding to styles with suffix', () => {
+      it('should support binding to styles with suffix', async () => {
         @Component({
-          template: '<span [style.font-size.px]="size"></span>',
+          template: '<span [style.font-size.px]="size()"></span>',
           standalone: false,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
-          size: string | number | null = '';
+          size = signal<string | number | null>('');
         }
 
-        TestBed.configureTestingModule({declarations: [App]});
+        TestBed.configureTestingModule({
+          declarations: [App],
+          providers: [provideZonelessChangeDetection()],
+        });
         const fixture = TestBed.createComponent(App);
-        fixture.componentInstance.size = '100';
         fixture.detectChanges();
+
+        fixture.componentInstance.size.set('100');
+        await fixture.whenStable();
         const span: HTMLElement = fixture.nativeElement.querySelector('span');
 
         expect(span.style.fontSize).toEqual('100px');
 
-        fixture.componentInstance.size = 200;
-        fixture.detectChanges();
+        fixture.componentInstance.size.set(200);
+        await fixture.whenStable();
         expect(span.style.fontSize).toEqual('200px');
 
-        fixture.componentInstance.size = 0;
-        fixture.detectChanges();
+        fixture.componentInstance.size.set(0);
+        await fixture.whenStable();
         expect(span.style.fontSize).toEqual('0px');
 
-        fixture.componentInstance.size = null;
-        fixture.detectChanges();
+        fixture.componentInstance.size.set(null);
+        await fixture.whenStable();
         expect(span.style.fontSize).toBeFalsy();
       });
     });
 
     describe('class-based styling', () => {
-      it('should support CSS class toggle', () => {
+      it('should support CSS class toggle', async () => {
         @Component({
-          template: '<span [class.active]="value"></span>',
+          template: '<span [class.active]="value()"></span>',
           standalone: false,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
-          value: any;
+          value = signal<any>(undefined);
         }
 
-        TestBed.configureTestingModule({declarations: [App]});
+        TestBed.configureTestingModule({
+          declarations: [App],
+          providers: [provideZonelessChangeDetection()],
+        });
         const fixture = TestBed.createComponent(App);
-        fixture.componentInstance.value = true;
         fixture.detectChanges();
+
+        fixture.componentInstance.value.set(true);
+        await fixture.whenStable();
         const span = fixture.nativeElement.querySelector('span');
 
         expect(span.getAttribute('class')).toEqual('active');
 
-        fixture.componentInstance.value = false;
-        fixture.detectChanges();
+        fixture.componentInstance.value.set(false);
+        await fixture.whenStable();
         expect(span.getAttribute('class')).toBeFalsy();
 
         // truthy values
-        fixture.componentInstance.value = 'a_string';
-        fixture.detectChanges();
-        expect(span.getAttribute('class')).toEqual('active');
-
-        fixture.componentInstance.value = 10;
-        fixture.detectChanges();
+        fixture.componentInstance.value.set(10);
+        await fixture.whenStable();
         expect(span.getAttribute('class')).toEqual('active');
 
         // falsy values
-        fixture.componentInstance.value = '';
-        fixture.detectChanges();
+        fixture.componentInstance.value.set('');
+        await fixture.whenStable();
         expect(span.getAttribute('class')).toBeFalsy();
 
-        fixture.componentInstance.value = 0;
-        fixture.detectChanges();
+        fixture.componentInstance.value.set(0);
+        await fixture.whenStable();
         expect(span.getAttribute('class')).toBeFalsy();
       });
 
-      it('should work correctly with existing static classes', () => {
+      it('should work correctly with existing static classes', async () => {
         @Component({
-          template: '<span class="existing" [class.active]="value"></span>',
+          template: '<span class="existing" [class.active]="value()"></span>',
           standalone: false,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
-          value: any;
+          value = signal<any>(undefined);
         }
 
-        TestBed.configureTestingModule({declarations: [App]});
+        TestBed.configureTestingModule({
+          declarations: [App],
+          providers: [provideZonelessChangeDetection()],
+        });
         const fixture = TestBed.createComponent(App);
-        fixture.componentInstance.value = true;
         fixture.detectChanges();
+
+        fixture.componentInstance.value.set(true);
+        await fixture.whenStable();
         expect(fixture.nativeElement.innerHTML).toEqual('<span class="existing active"></span>');
 
-        fixture.componentInstance.value = false;
-        fixture.detectChanges();
+        fixture.componentInstance.value.set(false);
+        await fixture.whenStable();
         expect(fixture.nativeElement.innerHTML).toEqual('<span class="existing"></span>');
       });
 
-      it('should apply classes properly when nodes are components', () => {
+      it('should apply classes properly when nodes are components', async () => {
         @Component({
           selector: 'my-comp',
           template: 'Comp Content',
           standalone: false,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {}
 
         @Component({
-          template: '<my-comp [class.active]="value"></my-comp>',
+          template: '<my-comp [class.active]="value()"></my-comp>',
           standalone: false,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
-          value: any;
+          value = signal<any>(undefined);
         }
 
-        TestBed.configureTestingModule({declarations: [App, MyComp]});
+        TestBed.configureTestingModule({
+          declarations: [App, MyComp],
+          providers: [provideZonelessChangeDetection()],
+        });
         const fixture = TestBed.createComponent(App);
-        fixture.componentInstance.value = true;
         fixture.detectChanges();
+
+        fixture.componentInstance.value.set(true);
+        await fixture.whenStable();
         const compElement = fixture.nativeElement.querySelector('my-comp');
 
         expect(fixture.nativeElement.textContent).toContain('Comp Content');
         expect(compElement.getAttribute('class')).toBe('active');
 
-        fixture.componentInstance.value = false;
-        fixture.detectChanges();
+        fixture.componentInstance.value.set(false);
+        await fixture.whenStable();
         expect(compElement.getAttribute('class')).toBeFalsy();
       });
 

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -4938,7 +4938,7 @@ describe('hook order', () => {
 });
 
 describe('non-regression', () => {
-  it('should call lifecycle hooks for directives active on <ng-template>', () => {
+  it('should call lifecycle hooks for directives active on <ng-template>', async () => {
     let destroyed = false;
 
     @Directive({
@@ -4973,7 +4973,7 @@ describe('non-regression', () => {
 
     fixture.componentInstance.show = false;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(destroyed).toBeTruthy();
   });

--- a/packages/core/test/acceptance/outputs_spec.ts
+++ b/packages/core/test/acceptance/outputs_spec.ts
@@ -322,7 +322,7 @@ describe('outputs', () => {
     expect(counter).toBe(2);
   });
 
-  it('should work with an input and output of the same name', () => {
+  it('should work with an input and output of the same name', async () => {
     let counter = 0;
 
     @Directive({
@@ -358,7 +358,7 @@ describe('outputs', () => {
 
     fixture.componentInstance.change = false;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(otherDir.change).toBe(false);
 

--- a/packages/core/test/acceptance/pipe_spec.ts
+++ b/packages/core/test/acceptance/pipe_spec.ts
@@ -319,7 +319,7 @@ describe('pipe', () => {
     expect(fixture.nativeElement.textContent).toEqual('bob from duplicate 2');
   });
 
-  it('should support pipe in context of ternary operator', () => {
+  it('should support pipe in context of ternary operator', async () => {
     @Pipe({
       name: 'pipe',
       standalone: false,
@@ -348,7 +348,7 @@ describe('pipe', () => {
 
     fixture.componentInstance.condition = true;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('a');
   });
 
@@ -405,7 +405,7 @@ describe('pipe', () => {
   });
 
   describe('pure', () => {
-    it('should call pure pipes only if the arguments change', () => {
+    it('should call pure pipes only if the arguments change', async () => {
       @Component({
         template: '{{person.name | countingPipe}}',
         standalone: false,
@@ -423,30 +423,30 @@ describe('pipe', () => {
       // change from undefined -> null
       fixture.componentInstance.person.name = null;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toEqual('null state:0');
 
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toEqual('null state:0');
 
       // change from null -> some value
       fixture.componentInstance.person.name = 'bob';
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toEqual('bob state:1');
 
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toEqual('bob state:1');
 
       // change from some value -> some other value
       fixture.componentInstance.person.name = 'bart';
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toEqual('bart state:2');
 
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.nativeElement.textContent).toEqual('bart state:2');
     });
   });
@@ -670,7 +670,7 @@ describe('pipe', () => {
       expect(fixture.nativeElement.textContent).toBe('MyComponent Title - Service Title');
     });
 
-    it('should inject the ChangeDetectorRef of the containing view when using pipe inside a component input', () => {
+    it('should inject the ChangeDetectorRef of the containing view when using pipe inside a component input', async () => {
       let pipeChangeDetectorRef: ChangeDetectorRef | undefined;
 
       @Component({
@@ -720,13 +720,13 @@ describe('pipe', () => {
       fixture.componentInstance.displayValue = 1;
       fixture.componentInstance.comp.displayValue = 1;
       pipeChangeDetectorRef!.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.textContent).toContain('Outer value: "1"');
       expect(fixture.nativeElement.textContent).toContain('Inner value: "0"');
     });
 
-    it('should inject the ChangeDetectorRef of the containing view when using pipe inside a component input which has child nodes', () => {
+    it('should inject the ChangeDetectorRef of the containing view when using pipe inside a component input which has child nodes', async () => {
       let pipeChangeDetectorRef: ChangeDetectorRef | undefined;
 
       @Component({
@@ -778,7 +778,7 @@ describe('pipe', () => {
       fixture.componentInstance.displayValue = 1;
       fixture.componentInstance.comp.displayValue = 1;
       pipeChangeDetectorRef!.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.textContent).toContain('Outer value: "1"');
       expect(fixture.nativeElement.textContent).toContain('Inner value: "0"');

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -533,7 +533,7 @@ describe('providers', () => {
       });
     });
 
-    it('should call ngOnDestroy if host component is destroyed', () => {
+    it('should call ngOnDestroy if host component is destroyed', async () => {
       const logs: string[] = [];
 
       @Injectable()
@@ -574,7 +574,7 @@ describe('providers', () => {
 
       fixture.componentInstance.condition = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(logs).toEqual(['OnDestroy Token']);
     });

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -294,7 +294,7 @@ describe('TemplateRef', () => {
       @ViewChild('containerRef', {read: ViewContainerRef}) containerRef!: ViewContainerRef;
     }
 
-    it('should update if the context of a view ref is mutated', () => {
+    it('should update if the context of a view ref is mutated', async () => {
       TestBed.configureTestingModule({declarations: [App]});
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
@@ -307,12 +307,12 @@ describe('TemplateRef', () => {
 
       context.name = 'Bilbo';
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.textContent).toBe('Bilbo');
     });
 
-    it('should update if the context of a view ref is replaced', () => {
+    it('should update if the context of a view ref is replaced', async () => {
       TestBed.configureTestingModule({declarations: [App]});
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
@@ -324,12 +324,12 @@ describe('TemplateRef', () => {
 
       viewRef.context = {name: 'Bilbo'};
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.textContent).toBe('Bilbo');
     });
 
-    it('should use the latest context information inside template listeners', () => {
+    it('should use the latest context information inside template listeners', async () => {
       const events: string[] = [];
 
       @Component({
@@ -365,12 +365,12 @@ describe('TemplateRef', () => {
 
       viewRef.context = {name: 'Bilbo'};
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       button.click();
       expect(events).toEqual(['Frodo', 'Bilbo']);
     });
 
-    it('should warn if the context of an embedded view ref is replaced', () => {
+    it('should warn if the context of an embedded view ref is replaced', async () => {
       TestBed.configureTestingModule({declarations: [App]});
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
@@ -383,7 +383,7 @@ describe('TemplateRef', () => {
 
       viewRef.context = {name: 'Bilbo'};
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(console.warn).toHaveBeenCalledTimes(1);
       expect(console.warn).toHaveBeenCalledWith(

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -277,7 +277,7 @@ describe('TemplateRef', () => {
       @ViewChild('containerRef', {read: ViewContainerRef}) containerRef!: ViewContainerRef;
     }
 
-    it('should update if the context of a view ref is mutated', () => {
+    it('should update if the context of a view ref is mutated', async () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
       const context = {name: 'Frodo'};
@@ -294,7 +294,7 @@ describe('TemplateRef', () => {
       expect(fixture.nativeElement.textContent).toBe('Bilbo');
     });
 
-    it('should update if the context of a view ref is replaced', () => {
+    it('should update if the context of a view ref is replaced', async () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
       const viewRef = fixture.componentInstance.templateRef.createEmbeddedView({name: 'Frodo'});
@@ -347,7 +347,7 @@ describe('TemplateRef', () => {
       expect(events).toEqual(['Frodo', 'Bilbo']);
     });
 
-    it('should warn if the context of an embedded view ref is replaced', () => {
+    it('should warn if the context of an embedded view ref is replaced', async () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
       const viewRef = fixture.componentInstance.templateRef.createEmbeddedView({name: 'Frodo'});

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -289,7 +289,7 @@ describe('TemplateRef', () => {
 
       context.name = 'Bilbo';
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.textContent).toBe('Bilbo');
     });
@@ -305,12 +305,12 @@ describe('TemplateRef', () => {
 
       viewRef.context = {name: 'Bilbo'};
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(fixture.nativeElement.textContent).toBe('Bilbo');
     });
 
-    it('should use the latest context information inside template listeners', () => {
+    it('should use the latest context information inside template listeners', async () => {
       const events: string[] = [];
 
       @Component({
@@ -342,7 +342,7 @@ describe('TemplateRef', () => {
 
       viewRef.context = {name: 'Bilbo'};
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       button.click();
       expect(events).toEqual(['Frodo', 'Bilbo']);
     });
@@ -359,7 +359,7 @@ describe('TemplateRef', () => {
 
       viewRef.context = {name: 'Bilbo'};
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(console.warn).toHaveBeenCalledTimes(1);
       expect(console.warn).toHaveBeenCalledWith(


### PR DESCRIPTION

This is to prevent existing tests to polute the context with outdated practices. 