### PR TITLE
[Backport 21.2.X] Cherry-pick compiler and http bug fixes (#68821, #68571, #69306)

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -374,17 +374,17 @@ function getFilteredHeaders(
 }
 
 function sortAndConcatParams(params: HttpParams | URLSearchParams): string {
-  return [...params.keys()]
-    .sort()
-    .map((k) => `${k}=${params.getAll(k)}`)
-    .join('&');
+  const searchParams = new URLSearchParams(
+    params instanceof URLSearchParams ? params : params.toString(),
+  );
+  searchParams.sort();
+  return searchParams.toString();
 }
 
 function makeCacheKey(
   request: HttpRequest<any>,
   mappedRequestUrl: string,
 ): StateKey<TransferHttpResponse> {
-  // make the params encoded same as a url so it's easy to identify
   const {params, method, responseType} = request;
   const encodedParams = sortAndConcatParams(params);
 

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -19,7 +19,14 @@ import {TestBed} from '@angular/core/testing';
 import {useAutoTick, timeout, withBody} from '@angular/private/testing';
 import {BehaviorSubject, Observable, of} from 'rxjs';
 
-import {HttpClient, HttpHeaders, HttpRequest, HttpResponse, provideHttpClient} from '../public_api';
+import {
+  HttpClient,
+  HttpHeaders,
+  HttpParams,
+  HttpRequest,
+  HttpResponse,
+  provideHttpClient,
+} from '../public_api';
 import {
   BODY,
   CACHE_OPTIONS,
@@ -456,6 +463,38 @@ describe('TransferCache', () => {
       await expectAsync(TestBed.inject(HttpClient).get('/test-1?foo=1').toPromise()).toBeResolvedTo(
         'foo',
       );
+    });
+
+    it('should differentiate repeated parameters from scalar comma parameters', () => {
+      let scalarResponse!: string;
+      TestBed.inject(HttpClient)
+        .get('/test-params', {params: new HttpParams().set('role', 'user,admin')})
+        .subscribe((response) => (scalarResponse = response as string));
+      TestBed.inject(HttpTestingController)
+        .expectOne('/test-params?role=user,admin')
+        .flush('scalar');
+
+      let repeatedResponse!: string;
+      TestBed.inject(HttpClient)
+        .get('/test-params', {
+          params: new HttpParams().append('role', 'user').append('role', 'admin'),
+        })
+        .subscribe((response) => (repeatedResponse = response as string));
+      TestBed.inject(HttpTestingController)
+        .expectOne('/test-params?role=user&role=admin')
+        .flush('repeated');
+
+      let repeatedCachedResponse!: string;
+      TestBed.inject(HttpClient)
+        .get('/test-params', {
+          params: new HttpParams().append('role', 'user').append('role', 'admin'),
+        })
+        .subscribe((response) => (repeatedCachedResponse = response as string));
+      TestBed.inject(HttpTestingController).expectNone('/test-params?role=user&role=admin');
+
+      expect(scalarResponse).toBe('scalar');
+      expect(repeatedResponse).toBe('repeated');
+      expect(repeatedCachedResponse).toBe('repeated');
     });
 
     it('should skip cache when specified', () => {

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -208,7 +208,7 @@ export class I18nMetaVisitor implements html.Visitor {
             isTrustedType = isTrustedTypesSink(node.name, name);
           }
 
-          if (isTrustedType) {
+          if (isTrustedType || name.toLowerCase().startsWith('on')) {
             this._reportError(
               attr,
               `Translating attribute '${name}' is disallowed for security reasons.`,

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -208,7 +208,7 @@ export class I18nMetaVisitor implements html.Visitor {
             isTrustedType = isTrustedTypesSink(node.name, name);
           }
 
-          if (isTrustedType || name.toLowerCase().startsWith('on')) {
+          if (isTrustedType || isPossibleEventHandler(name)) {
             this._reportError(
               attr,
               `Translating attribute '${name}' is disallowed for security reasons.`,
@@ -349,4 +349,15 @@ export function i18nMetaToJSDoc(meta: I18nMeta): o.JSDocComment {
     tags.push({tagName: o.JSDocTagName.Meaning, text: meta.meaning});
   }
   return o.jsDocComment(tags);
+}
+
+/**
+ * Check if the propertyName is a potential event handler.
+ * We consider a property to be a potential event handler if its name is longer than 2 characters and starts with 'on' (e.g. 'onclick', 'onload', etc.).
+ * @param propertyName The name of the property to check.
+ * @returns True if the property is a potential event handler, false otherwise.
+ */
+function isPossibleEventHandler(propertyName: string): boolean {
+  const name = propertyName.toLowerCase();
+  return name.length > 2 && name !== 'only' && name.startsWith('on');
 }

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -368,6 +368,15 @@ describe('security integration tests', function () {
       expect(link.getAttribute('href')).toEqual('unsafe:javascript:alert(1)');
     });
 
+    it('should throw error on translated event attributes', () => {
+      const template = `<img src="/missing-image.png" onerror="void 0" i18n-onerror>`;
+      TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+      expect(() => TestBed.createComponent(SecuredComponent)).toThrowError(
+        /Translating attribute 'onerror' is disallowed for security reasons./,
+      );
+    });
+
     it('should throw error on security-sensitive attributes with constant values', () => {
       const template = `<iframe srcdoc="foo" i18n-srcdoc></iframe>`;
       TestBed.overrideComponent(SecuredComponent, {set: {template}});

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -377,6 +377,13 @@ describe('security integration tests', function () {
       );
     });
 
+    it('should not throw error on translating "on" attribute', () => {
+      const template = `<div on="some-value" i18n-on></div>`;
+      TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+      expect(() => TestBed.createComponent(SecuredComponent)).not.toThrow();
+    });
+
     it('should throw error on security-sensitive attributes with constant values', () => {
       const template = `<iframe srcdoc="foo" i18n-srcdoc></iframe>`;
       TestBed.overrideComponent(SecuredComponent, {set: {template}});


### PR DESCRIPTION
This PR backports the following bug fixes to the `21.2.x` branch:

- #68821 - fix(compiler): disallow i18n event attributes (commit 6c41f5ca01c0ae045fc7d929b72853a11eb55865)
- #68571 - fix(http): distinguish repeated transfer cache params (commit a6c7fc5c13e6e494a4c9bd8e773b8d4b2a99b20c)
- #69306 - fix(compiler): restrict possible event handler check to property names longer than 2 characters (commit 417a4071a776464d549509ed3aec121dbd2fda5e)
