### PR TITLE
refactor(forms): modernize signal forms tests to rely on `whenStable`

### DIFF
--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -1393,7 +1393,7 @@ describe('FieldNode', () => {
 
       const fixture = TestBed.createComponent(TestCmp);
       const cmp = fixture.componentInstance;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(cmp.f().errorSummary()).toEqual([
         jasmine.objectContaining({kind: 'error-b'}),
@@ -1401,7 +1401,7 @@ describe('FieldNode', () => {
       ]);
     });
 
-    it('should sort bound errors before unbound errors', () => {
+    it('should sort bound errors before unbound errors', async () => {
       @Component({
         template: ` <input [formField]="f.a" /> `,
         imports: [FormField],
@@ -1415,7 +1415,7 @@ describe('FieldNode', () => {
 
       const fixture = TestBed.createComponent(TestCmp);
       const cmp = fixture.componentInstance;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(cmp.f().errorSummary()).toEqual([
         jasmine.objectContaining({kind: 'error-a'}),
@@ -1423,7 +1423,7 @@ describe('FieldNode', () => {
       ]);
     });
 
-    it('should sort errors from nested fields by DOM position', () => {
+    it('should sort errors from nested fields by DOM position', async () => {
       @Component({
         template: `
           <input [formField]="f.group.child" />
@@ -1440,7 +1440,7 @@ describe('FieldNode', () => {
 
       const fixture = TestBed.createComponent(TestCmp);
       const cmp = fixture.componentInstance;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(cmp.f().errorSummary()).toEqual([
         jasmine.objectContaining({kind: 'child'}),

--- a/packages/forms/signals/test/web/debounce_async_validation_bug.spec.ts
+++ b/packages/forms/signals/test/web/debounce_async_validation_bug.spec.ts
@@ -47,7 +47,6 @@ describe('debounced inside validateAsync bug', () => {
     }
 
     const fixture = TestBed.createComponent(DebounceBug);
-    fixture.detectChanges();
     await fixture.whenStable();
 
     // In a "zoneless and async-first" testing environment, just need to change something and wait

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -469,7 +469,7 @@ describe('ControlValueAccessor', () => {
     expect(fixture.componentInstance.f().value()).toBe('typing');
   });
 
-  it('should not throw if the ControlValueAccessor implementation uses signals', () => {
+  it('should not throw if the ControlValueAccessor implementation uses signals', async () => {
     @Component({
       selector: 'signal-custom-control',
       template: `<input [value]="value()" [disabled]="disabled()" />`,
@@ -521,7 +521,7 @@ describe('ControlValueAccessor', () => {
     }
 
     const fixture = TestBed.createComponent(App);
-    expect(() => fixture.detectChanges()).not.toThrowError(/NG0600/);
+    await expectAsync(fixture.whenStable()).not.toBeRejectedWithError(/NG0600/);
 
     expect(() => fixture.componentInstance.disabled.set(true)).not.toThrowError(/NG0600/);
   });


### PR DESCRIPTION
Rely on zoneless test scheduling instead of manually triggering change detection. Keep Signals Forms tests aligned with the async-first testing pattern.
 