### PR TITLE
fix(core): throw NG0500 instead of a raw TypeError on element hydration mismatch

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {
   invalidSkipHydrationHost,
   validateMatchingNode,
@@ -359,26 +360,44 @@ function locateOrCreateElementNodeImpl(
     setSegmentHead(hydrationInfo, index, native.nextSibling);
   }
 
-  // Checks if the skip hydration attribute is present during hydration so we know to
-  // skip attempting to hydrate this block. We check both TNode and RElement for an
-  // attribute: the RElement case is needed for i18n cases, when we add it to host
-  // elements during the annotation phase (after all internal data structures are setup).
-  if (
-    hydrationInfo &&
-    (hasSkipHydrationAttrOnTNode(tNode) || hasSkipHydrationAttrOnRElement(native))
-  ) {
-    if (isComponentHost(tNode)) {
-      enterSkipHydrationBlock(tNode);
+  if (hydrationInfo) {
+    // `hasSkipHydrationAttrOnRElement` below calls `.hasAttribute`, which needs `native` to be
+    // an Element. `validateMatchingNode` above would normally catch a wrong node type, but it's
+    // dev-mode only. Guard against it here too, cheaply, so production throws a coded
+    // RuntimeError instead of a raw TypeError. In production, skip the full sentence and just
+    // include the mismatched node's `nodeName`/`textContent` so the error stays cheap to build.
+    if ((native as unknown as Node).nodeType !== Node.ELEMENT_NODE) {
+      const node = native as unknown as Node;
+      // Truncate so a large text node can't blow up the error message, same as
+      // `shorten()` in `hydration/error_handling.ts`.
+      const textContent = node.textContent && node.textContent.slice(0, 50);
+      const description = textContent ? `${node.nodeName} ("${textContent}")` : node.nodeName;
+      throw new RuntimeError(
+        RuntimeErrorCode.HYDRATION_NODE_MISMATCH,
+        ngDevMode
+          ? `During hydration Angular expected an element at this location, but found a ${description} node instead.`
+          : description,
+      );
+    }
 
-      // Since this isn't hydratable, we need to empty the node
-      // so there's no duplicate content after render
-      clearElementContents(native);
+    // Checks if the skip hydration attribute is present during hydration so we know to
+    // skip attempting to hydrate this block. We check both TNode and RElement for an
+    // attribute: the RElement case is needed for i18n cases, when we add it to host
+    // elements during the annotation phase (after all internal data structures are setup).
+    if (hasSkipHydrationAttrOnTNode(tNode) || hasSkipHydrationAttrOnRElement(native)) {
+      if (isComponentHost(tNode)) {
+        enterSkipHydrationBlock(tNode);
 
-      ngDevMode && markRNodeAsSkippedByHydration(native);
-    } else if (ngDevMode) {
-      // If this is not a component host, throw an error.
-      // Hydration can be skipped on per-component basis only.
-      throw invalidSkipHydrationHost(native);
+        // Since this isn't hydratable, we need to empty the node
+        // so there's no duplicate content after render
+        clearElementContents(native);
+
+        ngDevMode && markRNodeAsSkippedByHydration(native);
+      } else if (ngDevMode) {
+        // If this is not a component host, throw an error.
+        // Hydration can be skipped on per-component basis only.
+        throw invalidSkipHydrationHost(native);
+      }
     }
   }
   return native;

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -6252,6 +6252,80 @@ describe('platform-server full application hydration integration', () => {
         });
       });
 
+      it(
+        'should throw a coded RuntimeError, not a raw TypeError, when an element ' +
+          'instruction locates a Text node in production mode (ngDevMode off)',
+        async () => {
+          // Regression test. `locateOrCreateElementNodeImpl` always calls
+          // `hasSkipHydrationAttrOnRElement(native)`, which calls
+          // `native.hasAttribute(...)`. The `validateMatchingNode` check that would
+          // normally catch a "found a Text node instead of an <b> element" mismatch
+          // only runs in dev mode, so it's removed from production builds. Without
+          // the extra `nodeType` guard added for this fix, if hydration finds a Text
+          // node here instead of an Element (because the server-rendered DOM didn't
+          // match what the client's compiled template expected), production would
+          // hit `native.hasAttribute`, which doesn't exist on a Text node, and throw
+          // a raw TypeError instead of a coded RuntimeError.
+          @Component({
+            selector: 'app',
+            template: `
+              <div id="abc">
+                <p>This is an original content</p>
+                <b>Bold text</b>
+                <i>Italic text</i>
+              </div>
+            `,
+          })
+          class SimpleComponent {
+            private doc = inject(DOCUMENT);
+            private isServer = isPlatformServer(inject(PLATFORM_ID));
+            ngAfterViewInit() {
+              // Only change the DOM on the server, right before it gets serialized.
+              // The client's compiled template still expects a `<b>` element here,
+              // but the serialized (and later hydrated) DOM will have a plain Text
+              // node instead.
+              if (this.isServer) {
+                const b = this.doc.querySelector('b');
+                const text = this.doc.createTextNode('Not an element anymore!');
+                b?.parentNode?.replaceChild(text, b);
+              }
+            }
+          }
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain('<app ngh');
+
+          resetTViewsFor(SimpleComponent);
+
+          // Simulate a production build. `locateOrCreateElementNodeImpl` only calls
+          // `validateMatchingNode` when `ngDevMode` is truthy, so turning it off
+          // here means the full mismatch check is skipped, and only the new
+          // `nodeType` guard runs.
+          const previousNgDevMode = (globalThis as any).ngDevMode;
+          (globalThis as any).ngDevMode = false;
+          try {
+            await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+              envProviders: [withNoopErrorHandler()],
+            });
+            fail('Expected the hydration process to throw.');
+          } catch (e: unknown) {
+            const error = e as Error;
+            // This is the fixed behavior: a coded NG0500 RuntimeError, not a raw
+            // TypeError. Unlike other production RuntimeErrors, this one keeps a
+            // minimal message (the mismatched node's `nodeName` and `textContent`)
+            // rather than an empty one, since it's cheap (no DOM-printing machinery)
+            // and helps debugging a hydration mismatch that's otherwise invisible in prod.
+            expect(error instanceof TypeError).toBe(false);
+            expect(error.message).toBe('NG0500: #text ("Not an element anymore!")');
+            expect(error.message).not.toContain('hasAttribute is not a function');
+          } finally {
+            (globalThis as any).ngDevMode = previousNgDevMode;
+          }
+        },
+      );
+
       it('should if there are any third-party scripts that manipulate the DOM', async () => {
         @Component({
           selector: 'app',

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -6232,6 +6232,80 @@ describe('platform-server full application hydration integration', () => {
         });
       });
 
+      it(
+        'should throw a coded RuntimeError, not a raw TypeError, when an element ' +
+          'instruction locates a Text node in production mode (ngDevMode off)',
+        async () => {
+          // Regression test. `locateOrCreateElementNodeImpl` always calls
+          // `hasSkipHydrationAttrOnRElement(native)`, which calls
+          // `native.hasAttribute(...)`. The `validateMatchingNode` check that would
+          // normally catch a "found a Text node instead of an <b> element" mismatch
+          // only runs in dev mode, so it's removed from production builds. Without
+          // the extra `nodeType` guard added for this fix, if hydration finds a Text
+          // node here instead of an Element (because the server-rendered DOM didn't
+          // match what the client's compiled template expected), production would
+          // hit `native.hasAttribute`, which doesn't exist on a Text node, and throw
+          // a raw TypeError instead of a coded RuntimeError.
+          @Component({
+            selector: 'app',
+            template: `
+              <div id="abc">
+                <p>This is an original content</p>
+                <b>Bold text</b>
+                <i>Italic text</i>
+              </div>
+            `,
+          })
+          class SimpleComponent {
+            private doc = inject(DOCUMENT);
+            private isServer = isPlatformServer(inject(PLATFORM_ID));
+            ngAfterViewInit() {
+              // Only change the DOM on the server, right before it gets serialized.
+              // The client's compiled template still expects a `<b>` element here,
+              // but the serialized (and later hydrated) DOM will have a plain Text
+              // node instead.
+              if (this.isServer) {
+                const b = this.doc.querySelector('b');
+                const text = this.doc.createTextNode('Not an element anymore!');
+                b?.parentNode?.replaceChild(text, b);
+              }
+            }
+          }
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain('<app ngh');
+
+          resetTViewsFor(SimpleComponent);
+
+          // Simulate a production build. `locateOrCreateElementNodeImpl` only calls
+          // `validateMatchingNode` when `ngDevMode` is truthy, so turning it off
+          // here means the full mismatch check is skipped, and only the new
+          // `nodeType` guard runs.
+          const previousNgDevMode = (globalThis as any).ngDevMode;
+          (globalThis as any).ngDevMode = false;
+          try {
+            await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+              envProviders: [withNoopErrorHandler()],
+            });
+            fail('Expected the hydration process to throw.');
+          } catch (e: unknown) {
+            const error = e as Error;
+            // This is the fixed behavior: a coded NG0500 RuntimeError, not a raw
+            // TypeError. Unlike other production RuntimeErrors, this one keeps a
+            // minimal message (the mismatched node's `nodeName` and `textContent`)
+            // rather than an empty one, since it's cheap (no DOM-printing machinery)
+            // and helps debugging a hydration mismatch that's otherwise invisible in prod.
+            expect(error instanceof TypeError).toBe(false);
+            expect(error.message).toBe('NG0500: #text ("Not an element anymore!")');
+            expect(error.message).not.toContain('hasAttribute is not a function');
+          } finally {
+            (globalThis as any).ngDevMode = previousNgDevMode;
+          }
+        },
+      );
+
       it('should if there are any third-party scripts that manipulate the DOM', async () => {
         @Component({
           selector: 'app',


### PR DESCRIPTION
When hydration locates the DOM node for an ɵɵelementStart/ɵɵdomElementStart instruction, locateOrCreateElementNodeImpl assumed the located node was always an Element and called hasSkipHydrationAttrOnRElement(native), which does native.hasAttribute(...). The check that would normally catch this class of mismatch, validateMatchingNode, is gated behind `ngDevMode &&` and is compiled out of production builds. So when a real SSR/hydration structural mismatch located a Text or Comment node instead of the expected Element, production builds hit .hasAttribute on a node type that doesn't have it and crashed with a raw, uncoded TypeError instead of a coded hydration-mismatch RuntimeError.

Add a cheap, always-on nodeType check ahead of that call. On mismatch it throws RuntimeError(HYDRATION_NODE_MISMATCH, ngDevMode && '...'), the same pattern used elsewhere in the codebase, so the descriptive message is only built in dev mode and production keeps throwing just the bare NG0500 code without pulling validateMatchingNode's DOM-printing machinery into the production bundle (verified via the bundling/hydration golden-symbols test, which is unchanged).