### PR TITLE
fix(devtools): invoke selectedNode signal in directive tree keyboard …

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
@@ -280,7 +280,7 @@ export class DirectiveForestComponent {
   }
 
   isEditingDirectiveState(event: Event): boolean {
-    return (event.target as Element).tagName === 'INPUT' || !this.selectedNode;
+    return (event.target as Element).tagName === 'INPUT' || !this.selectedNode();
   }
 
   handleFilter(filterFn: FilterFn): void {


### PR DESCRIPTION
`isEditingDirectiveState` used `!this.selectedNode` (a bare signal reference, always truthy) instead of `!this.selectedNode()`, so the guard was dead and ArrowDown with no selection threw a TypeError.