### PR TITLE
test(compiler-cli): add compliance case for @HostListener on a property

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
@@ -461,6 +461,38 @@ export declare class MyComponent {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: host_listener_property.js
+ ****************************************************************************************************/
+import { Directive, HostListener } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+    handleClick = ($event) => { };
+    handleBeforeUnload = ($event) => { };
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+    static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, host: { listeners: { "click": "handleClick($event)", "window:beforeunload": "handleBeforeUnload($event)" } }, ngImport: i0 });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Directive
+        }], propDecorators: { handleClick: [{
+                type: HostListener,
+                args: ['click', ['$event']]
+            }], handleBeforeUnload: [{
+                type: HostListener,
+                args: ['window:beforeunload', ['$event']]
+            }] } });
+
+/****************************************************************************************************
+ * PARTIAL FILE: host_listener_property.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    handleClick: ($event: any) => void;
+    private handleBeforeUnload;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MyComponent, never, never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: event_arg_listener_implicit_meaning.js
  ****************************************************************************************************/
 import { Component } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
@@ -161,6 +161,21 @@
       ]
     },
     {
+      "description": "should generate host listeners for a decorator on a property holding a function",
+      "inputFiles": ["host_listener_property.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "host_listener_property_host_bindings.js",
+              "generated": "host_listener_property.js"
+            }
+          ],
+          "failureMessage": "Incorrect event listener"
+        }
+      ]
+    },
+    {
       "description": "should assume $event is referring to the event variable in a listener by default",
       "inputFiles": ["event_arg_listener_implicit_meaning.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/host_listener_property.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/host_listener_property.ts
@@ -1,0 +1,10 @@
+import {Directive, HostListener} from '@angular/core';
+
+@Directive()
+export class MyComponent {
+  @HostListener('click', ['$event'])
+  handleClick = ($event: any) => {};
+
+  @HostListener('window:beforeunload', ['$event'])
+  private handleBeforeUnload = ($event: any) => {};
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/host_listener_property_host_bindings.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/host_listener_property_host_bindings.js
@@ -1,0 +1,10 @@
+…
+hostBindings: function MyComponent_HostBindings(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵlistener("click", function MyComponent_click_HostBindingHandler($event) {
+        return ctx.handleClick($event);
+    })("beforeunload", function MyComponent_beforeunload_HostBindingHandler($event) {
+        return ctx.handleBeforeUnload($event);
+    }, i0.ɵɵresolveWindow);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/host_listener_property_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/host_listener_property_isolated.golden.d.ts
@@ -1,0 +1,7 @@
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    handleClick: ($event: any) => void;
+    private handleBeforeUnload;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MyComponent, never, never, {}, {}, never, never, true, never>;
+}


### PR DESCRIPTION
Adds a compliance test for `@HostListener` on a property, which we seem to have not had before.