### PR TITLE
docs: invoke signal inputs in adev examples and tutorials

### DIFF
--- a/adev/src/content/examples/animations/src/app/open-close.1.ts
+++ b/adev/src/content/examples/animations/src/app/open-close.1.ts
@@ -57,7 +57,7 @@ export class OpenCloseKeyframeComponent {
 
   logging = input(false);
   onAnimationEvent(event: AnimationEvent) {
-    if (!this.logging) {
+    if (!this.logging()) {
       return;
     }
   }

--- a/adev/src/content/examples/animations/src/app/open-close.3.ts
+++ b/adev/src/content/examples/animations/src/app/open-close.3.ts
@@ -33,7 +33,7 @@ export class OpenCloseBooleanComponent {
 
   logging = input(false);
   onAnimationEvent(event: AnimationEvent) {
-    if (!this.logging) {
+    if (!this.logging()) {
       return;
     }
   }

--- a/adev/src/content/examples/animations/src/app/open-close.ts
+++ b/adev/src/content/examples/animations/src/app/open-close.ts
@@ -70,7 +70,7 @@ export class OpenClose {
   // #docregion events1, events
   onAnimationEvent(event: AnimationEvent) {
     // #enddocregion events1, events
-    if (!this.logging) {
+    if (!this.logging()) {
       return;
     }
     // #docregion events

--- a/adev/src/content/examples/form-validation/src/app/shared/forbidden-name.directive.ts
+++ b/adev/src/content/examples/form-validation/src/app/shared/forbidden-name.directive.ts
@@ -34,7 +34,7 @@ export class ForbiddenValidatorDirective implements Validator {
   readonly forbiddenName = input<string>('', {alias: 'appForbiddenName'});
 
   validate(control: AbstractControl): ValidationErrors | null {
-    return this.forbiddenName
+    return this.forbiddenName()
       ? forbiddenNameValidator(new RegExp(this.forbiddenName(), 'i'))(control)
       : null;
   }

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing-location/housing-location.ts
@@ -9,7 +9,7 @@ import {RouterLink} from '@angular/router';
     <section class="listing">
       <img
         class="listing-photo"
-        [src]="housingLocation.photo"
+        [src]="housingLocation().photo"
         alt="Exterior photo of {{ housingLocation().name }}"
         crossorigin
       />

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing-location/housing-location.ts
@@ -9,7 +9,7 @@ import {RouterLink} from '@angular/router';
     <section class="listing">
       <img
         class="listing-photo"
-        [src]="housingLocation.photo"
+        [src]="housingLocation().photo"
         alt="Exterior photo of {{ housingLocation().name }}"
         crossorigin
       />


### PR DESCRIPTION
Several adev example and tutorial files read a signal input as a bare reference (this.foo) instead of invoking it (this.foo()). Because an InputSignal is a function object, the bare reference is always truthy and never yields the underlying value, so the surrounding guard or binding silently did the wrong thing:

- animations open-close(.1/.3): the `!this.logging` guard in onAnimationEvent was always false, so the early return never fired.
- form-validation forbidden-name.directive: the `this.forbiddenName` ternary condition was always truthy, so validation ran even when no forbidden name was configured.
- first-app steps 12 and 14 housing-location: `housingLocation.photo` read `.photo` off the signal function (undefined), leaving the listing image src empty.

Invoke the signals so the examples reflect correct signal-input usage.