### PR TITLE
refactor(forms): modernize reactive forms tests to rely on `whenStable`

### DIFF
--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -1667,7 +1667,7 @@ import {asyncValidator} from './util';
 
       it('should NOT track signals read inside CVA.writeValue when setValue is called inside an effect', async () => {
         const fixture = TestBed.createComponent(HostComponent);
-        fixture.detectChanges(); // wires up FormControlDirective + CVA
+        await fixture.whenStable(); // wires up FormControlDirective + CVA
 
         const driver = signal('A');
         let runs = 0;
@@ -1698,7 +1698,7 @@ import {asyncValidator} from './util';
 
       it('should NOT track signals read inside CVA.writeValue when patchValue is called inside an effect', async () => {
         const fixture = TestBed.createComponent(HostComponent);
-        fixture.detectChanges(); // wires up FormControlDirective + CVA
+        await fixture.whenStable(); // wires up FormControlDirective + CVA
 
         const driver = signal('A');
         let runs = 0;
@@ -1729,7 +1729,7 @@ import {asyncValidator} from './util';
 
       it('should NOT track signals read inside CVA.writeValue when reset is called inside an effect', async () => {
         const fixture = TestBed.createComponent(HostComponent);
-        fixture.detectChanges(); // wires up FormControlDirective + CVA
+        await fixture.whenStable(); // wires up FormControlDirective + CVA
 
         const driver = signal('A');
         let runs = 0;

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -265,7 +265,7 @@ import {useAutoTick, timeout} from '@angular/private/testing';
       expect(a.errors).toEqual({'sync1': true, 'sync2': true});
     });
 
-    it('should be injectable', () => {
+    it('should be injectable', async () => {
       @Component({
         template: '...',
       })
@@ -276,7 +276,7 @@ import {useAutoTick, timeout} from '@angular/private/testing';
       TestBed.configureTestingModule({imports: [ReactiveFormsModule]});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.fb).toBeInstanceOf(FormBuilder);
 
       const fc = fixture.componentInstance.fb.control('foo');
@@ -291,7 +291,7 @@ import {useAutoTick, timeout} from '@angular/private/testing';
       expect(fc.value).toEqual(null);
     });
 
-    it('should be injectable as NonNullableFormBuilder', () => {
+    it('should be injectable as NonNullableFormBuilder', async () => {
       @Component({
         template: '...',
       })
@@ -302,7 +302,7 @@ import {useAutoTick, timeout} from '@angular/private/testing';
       TestBed.configureTestingModule({imports: [ReactiveFormsModule]});
 
       const fixture = TestBed.createComponent(MyComp);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.fb).toBeInstanceOf(FormBuilder);
 
       const fc = fixture.componentInstance.fb.control('foo');

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -1708,7 +1708,7 @@ import {asyncValidator, asyncValidatorReturningObservable} from './util';
 
       it('should NOT track signals read inside CVA.writeValue when setValue is called inside an effect', async () => {
         const fixture = TestBed.createComponent(HostComponent);
-        fixture.detectChanges(); // wires up FormControlDirective + CVA
+        await fixture.whenStable(); // wires up FormControlDirective + CVA
 
         const driver = signal('A');
         let runs = 0;
@@ -1740,7 +1740,7 @@ import {asyncValidator, asyncValidatorReturningObservable} from './util';
 
       it('should NOT track signals read inside CVA.writeValue when patchValue is called inside an effect', async () => {
         const fixture = TestBed.createComponent(HostComponent);
-        fixture.detectChanges(); // wires up FormControlDirective + CVA
+        await fixture.whenStable(); // wires up FormControlDirective + CVA
 
         const driver = signal('A');
         let runs = 0;
@@ -1771,7 +1771,7 @@ import {asyncValidator, asyncValidatorReturningObservable} from './util';
 
       it('should NOT track signals read inside CVA.writeValue when reset is called inside an effect', async () => {
         const fixture = TestBed.createComponent(HostComponent);
-        fixture.detectChanges(); // wires up FormControlDirective + CVA
+        await fixture.whenStable(); // wires up FormControlDirective + CVA
 
         const driver = signal('A');
         let runs = 0;

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -2819,7 +2819,7 @@ import {
 
       it('should NOT track signals read inside CVA.writeValue when setValue is called inside an effect', async () => {
         const fixture = TestBed.createComponent(HostComponent);
-        fixture.detectChanges(); // wires up FormControlDirective + CVA
+        await fixture.whenStable(); // wires up FormControlDirective + CVA
 
         const driver = signal('A');
         let runs = 0;
@@ -2850,7 +2850,7 @@ import {
 
       it('should NOT track signals read inside CVA.writeValue when patchValue is called inside an effect', async () => {
         const fixture = TestBed.createComponent(HostComponent);
-        fixture.detectChanges(); // wires up FormControlDirective + CVA
+        await fixture.whenStable(); // wires up FormControlDirective + CVA
 
         const driver = signal('A');
         let runs = 0;
@@ -2881,7 +2881,7 @@ import {
 
       it('should NOT track signals read inside CVA.writeValue when reset is called inside an effect', async () => {
         const fixture = TestBed.createComponent(HostComponent);
-        fixture.detectChanges(); // wires up FormControlDirective + CVA
+        await fixture.whenStable(); // wires up FormControlDirective + CVA
 
         const driver = signal('A');
         let runs = 0;

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -173,11 +173,11 @@ describe('reactive forms integration tests', () => {
   }
 
   describe('basic functionality', () => {
-    it('should work with single controls', () => {
+    it('should work with single controls', async () => {
       const fixture = initTest(FormControlComp);
       const control = new FormControl('old value');
       fixture.componentInstance.control = control;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // model -> view
       const input = fixture.debugElement.query(By.css('input'));
@@ -190,29 +190,29 @@ describe('reactive forms integration tests', () => {
       expect(control.value).toEqual('updated value');
     });
 
-    it('should work with formGroups (model -> view)', () => {
+    it('should work with formGroups (model -> view)', async () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input'));
       expect(input.nativeElement.value).toEqual('loginValue');
     });
 
-    it('should add novalidate by default to form', () => {
+    it('should add novalidate by default to form', async () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const form = fixture.debugElement.query(By.css('form'));
       expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
     });
 
-    it('work with formGroups (view -> model)', () => {
+    it('work with formGroups (view -> model)', async () => {
       const fixture = initTest(FormGroupComp);
       const form = new FormGroup({'login': new FormControl('oldValue')});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input'));
       input.nativeElement.value = 'updatedValue';
@@ -223,47 +223,47 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('re-bound form groups', () => {
-    it('should update DOM elements initially', () => {
+    it('should update DOM elements initially', async () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({'login': new FormControl('oldValue')});
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       fixture.componentInstance.form = new FormGroup({'login': new FormControl('newValue')});
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input'));
       expect(input.nativeElement.value).toEqual('newValue');
     });
 
-    it('should update model when UI changes', () => {
+    it('should update model when UI changes', async () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({'login': new FormControl('oldValue')});
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const newForm = new FormGroup({'login': new FormControl('newValue')});
       fixture.componentInstance.form = newForm;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input'));
       input.nativeElement.value = 'Nancy';
       dispatchEvent(input.nativeElement, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(newForm.value).toEqual({login: 'Nancy'});
 
       newForm.setValue({login: 'Carson'});
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(input.nativeElement.value).toEqual('Carson');
     });
 
-    it('should update nested form group model when UI changes', () => {
+    it('should update nested form group model when UI changes', async () => {
       const fixture = initTest(NestedFormGroupNameComp);
       fixture.componentInstance.form = new FormGroup({
         'signin': new FormGroup({'login': new FormControl(), 'password': new FormControl()}),
       });
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const newForm = new FormGroup({
         'signin': new FormGroup({
@@ -273,7 +273,7 @@ describe('reactive forms integration tests', () => {
       });
       fixture.componentInstance.form = newForm;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const inputs = fixture.debugElement.queryAll(By.css('input'));
       expect(inputs[0].nativeElement.value).toEqual('Nancy');
@@ -281,16 +281,16 @@ describe('reactive forms integration tests', () => {
 
       inputs[0].nativeElement.value = 'Carson';
       dispatchEvent(inputs[0].nativeElement, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(newForm.value).toEqual({signin: {login: 'Carson', password: 'secret'}});
 
       newForm.setValue({signin: {login: 'Bess', password: 'otherpass'}});
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(inputs[0].nativeElement.value).toEqual('Bess');
     });
 
-    it('should pick up dir validators from form controls', () => {
+    it('should pick up dir validators from form controls', async () => {
       const fixture = initTest(LoginIsEmptyWrapper, LoginIsEmptyValidator);
       const form = new FormGroup({
         'login': new FormControl(''),
@@ -299,7 +299,7 @@ describe('reactive forms integration tests', () => {
         'pattern': new FormControl(''),
       });
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(form.get('login')!.errors).toEqual({required: true});
 
       const newForm = new FormGroup({
@@ -310,18 +310,18 @@ describe('reactive forms integration tests', () => {
       });
       fixture.componentInstance.form = newForm;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(newForm.get('login')!.errors).toEqual({required: true});
     });
 
-    it('should pick up dir validators from nested form groups', () => {
+    it('should pick up dir validators from nested form groups', async () => {
       const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
       const form = new FormGroup({
         'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')}),
       });
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(form.get('signin')!.valid).toBe(false);
 
       const newForm = new FormGroup({
@@ -329,22 +329,22 @@ describe('reactive forms integration tests', () => {
       });
       fixture.componentInstance.form = newForm;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(form.get('signin')!.valid).toBe(false);
     });
 
-    it('should strip named controls that are not found', () => {
+    it('should strip named controls that are not found', async () => {
       const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
       const form: FormGroup = new FormGroup({
         'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')}),
       });
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       form.addControl('email', new FormControl('email'));
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       let emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
       expect(emailInput.nativeElement.value).toEqual('email');
@@ -354,25 +354,25 @@ describe('reactive forms integration tests', () => {
       });
       fixture.componentInstance.form = newForm;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
       expect(emailInput as any).toBe(null); // TODO: remove `any` after #22449 is closed.
     });
 
-    it('should strip array controls that are not found', () => {
+    it('should strip array controls that are not found', async () => {
       const fixture = initTest(FormArrayComp);
       const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
       const form = new FormGroup({cities: cityArray});
       fixture.componentInstance.form = form;
       fixture.componentInstance.cityArray = cityArray;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       let inputs = fixture.debugElement.queryAll(By.css('input'));
       expect(inputs[2]).not.toBeDefined();
       cityArray.push(new FormControl('LA'));
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       inputs = fixture.debugElement.queryAll(By.css('input'));
       expect(inputs[2]).toBeDefined();
@@ -382,13 +382,13 @@ describe('reactive forms integration tests', () => {
       fixture.componentInstance.form = newForm;
       fixture.componentInstance.cityArray = newArr;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       inputs = fixture.debugElement.queryAll(By.css('input'));
       expect(inputs[2]).not.toBeDefined();
     });
 
-    it('should sync the disabled state if it changes right after a group is re-bound', () => {
+    it('should sync the disabled state if it changes right after a group is re-bound', async () => {
       @Component({
         template: `
           <form [formGroup]="form">
@@ -416,43 +416,43 @@ describe('reactive forms integration tests', () => {
       }
 
       const fixture = initTest(App);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.nativeElement.querySelector('input');
       expect(input.disabled).toBe(false);
 
       fixture.componentInstance.recreateAndDisable();
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(input.disabled).toBe(true);
     });
 
     describe('nested control rebinding', () => {
-      it('should attach dir to control when leaf control changes', () => {
+      it('should attach dir to control when leaf control changes', async () => {
         const form: FormGroup = new FormGroup({'login': new FormControl('oldValue')});
         const fixture = initTest(FormGroupComp);
         fixture.componentInstance.form = form;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         form.removeControl('login');
         form.addControl('login', new FormControl('newValue'));
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input'));
         expect(input.nativeElement.value).toEqual('newValue');
 
         input.nativeElement.value = 'user input';
         dispatchEvent(input.nativeElement, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(form.value).toEqual({login: 'user input'});
 
         form.setValue({login: 'Carson'});
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(input.nativeElement.value).toEqual('Carson');
       });
 
-      it('should attach dirs to all child controls when group control changes', () => {
+      it('should attach dirs to all child controls when group control changes', async () => {
         const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
         const form: FormGroup = new FormGroup({
           signin: new FormGroup({
@@ -461,7 +461,7 @@ describe('reactive forms integration tests', () => {
           }),
         });
         fixture.componentInstance.form = form;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         form.removeControl('signin');
         form.addControl(
@@ -471,7 +471,7 @@ describe('reactive forms integration tests', () => {
             password: new FormControl('newPassword'),
           }),
         );
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[0].nativeElement.value).toEqual('newLogin');
@@ -479,43 +479,43 @@ describe('reactive forms integration tests', () => {
 
         inputs[0].nativeElement.value = 'user input';
         dispatchEvent(inputs[0].nativeElement, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(form.value).toEqual({signin: {login: 'user input', password: 'newPassword'}});
 
         form.setValue({signin: {login: 'Carson', password: 'Drew'}});
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(inputs[0].nativeElement.value).toEqual('Carson');
         expect(inputs[1].nativeElement.value).toEqual('Drew');
       });
 
-      it('should attach dirs to all present child controls when array control changes', () => {
+      it('should attach dirs to all present child controls when array control changes', async () => {
         const fixture = initTest(FormArrayComp);
         const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
         const form: FormGroup = new FormGroup({cities: cityArray});
         fixture.componentInstance.form = form;
         fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         form.removeControl('cities');
         form.addControl('cities', new FormArray([new FormControl('LA')]));
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input'));
         expect(input.nativeElement.value).toEqual('LA');
 
         input.nativeElement.value = 'MTV';
         dispatchEvent(input.nativeElement, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(form.value).toEqual({cities: ['MTV']});
 
         form.setValue({cities: ['LA']});
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(input.nativeElement.value).toEqual('LA');
       });
 
-      it('should remove controls correctly after re-binding a form array', () => {
+      it('should remove controls correctly after re-binding a form array', async () => {
         const fixture = initTest(FormArrayComp);
         const cityArray = new FormArray([
           new FormControl('SF'),
@@ -525,7 +525,7 @@ describe('reactive forms integration tests', () => {
         const form = new FormGroup({cities: cityArray});
         fixture.componentInstance.form = form;
         fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const newArr = new FormArray([
           new FormControl('SF'),
@@ -535,11 +535,11 @@ describe('reactive forms integration tests', () => {
         fixture.componentInstance.cityArray = newArr;
         form.setControl('cities', newArr);
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         newArr.removeAt(0);
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         let inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[0].nativeElement.value).toEqual('NY');
@@ -548,29 +548,29 @@ describe('reactive forms integration tests', () => {
         let firstInput = inputs[0].nativeElement;
         firstInput.value = 'new value';
         dispatchEvent(firstInput, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(newArr.value).toEqual(['new value', 'LA']);
 
         newArr.removeAt(0);
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
         firstInput.value = 'last one';
         dispatchEvent(firstInput, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(newArr.value).toEqual(['last one']);
 
         newArr.get([0])!.setValue('set value');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
         expect(firstInput.value).toEqual('set value');
       });
 
-      it('should submit properly after removing controls on a re-bound array', () => {
+      it('should submit properly after removing controls on a re-bound array', async () => {
         const fixture = initTest(FormArrayComp);
         const cityArray = new FormArray([
           new FormControl('SF'),
@@ -580,7 +580,7 @@ describe('reactive forms integration tests', () => {
         const form = new FormGroup({cities: cityArray});
         fixture.componentInstance.form = form;
         fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const newArr = new FormArray([
           new FormControl('SF'),
@@ -590,33 +590,33 @@ describe('reactive forms integration tests', () => {
         fixture.componentInstance.cityArray = newArr;
         form.setControl('cities', newArr);
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         newArr.removeAt(0);
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const formEl = fixture.debugElement.query(By.css('form'));
         expect(() => dispatchEvent(formEl.nativeElement, 'submit')).not.toThrowError();
       });
 
-      it('should insert controls properly on a re-bound array', () => {
+      it('should insert controls properly on a re-bound array', async () => {
         const fixture = initTest(FormArrayComp);
         const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
         const form = new FormGroup({cities: cityArray});
         fixture.componentInstance.form = form;
         fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const newArr = new FormArray([new FormControl('SF'), new FormControl('NY')]);
         fixture.componentInstance.cityArray = newArr;
         form.setControl('cities', newArr);
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         newArr.insert(1, new FormControl('LA'));
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         let inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[0].nativeElement.value).toEqual('SF');
@@ -626,12 +626,12 @@ describe('reactive forms integration tests', () => {
         const lastInput = inputs[2].nativeElement;
         lastInput.value = 'Tulsa';
         dispatchEvent(lastInput, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(newArr.value).toEqual(['SF', 'LA', 'Tulsa']);
 
         newArr.get([2])!.setValue('NY');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(lastInput.value).toEqual('NY');
       });
@@ -639,7 +639,7 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('template pipeline integration', () => {
-    it('should not crash when a control directive is applied to an element inside an @if block', () => {
+    it('should not crash when a control directive is applied to an element inside an @if block', async () => {
       @Component({
         selector: 'my-app',
         template: `
@@ -656,7 +656,7 @@ describe('reactive forms integration tests', () => {
       }
 
       const fixture = initTest(App);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input'));
       expect(input.nativeElement.value).toEqual('Angular');
@@ -664,13 +664,13 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('form arrays', () => {
-    it('should support form arrays', () => {
+    it('should support form arrays', async () => {
       const fixture = initTest(FormArrayComp);
       const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
       const form = new FormGroup({cities: cityArray});
       fixture.componentInstance.form = form;
       fixture.componentInstance.cityArray = cityArray;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const inputs = fixture.debugElement.queryAll(By.css('input'));
 
@@ -681,30 +681,30 @@ describe('reactive forms integration tests', () => {
 
       inputs[0].nativeElement.value = 'LA';
       dispatchEvent(inputs[0].nativeElement, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       //  view -> model
       expect(form.value).toEqual({cities: ['LA', 'NY']});
     });
 
-    it('should support pushing new controls to form arrays', () => {
+    it('should support pushing new controls to form arrays', async () => {
       const fixture = initTest(FormArrayComp);
       const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
       const form = new FormGroup({cities: cityArray});
       fixture.componentInstance.form = form;
       fixture.componentInstance.cityArray = cityArray;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       cityArray.push(new FormControl('LA'));
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const inputs = fixture.debugElement.queryAll(By.css('input'));
       expect(inputs[2].nativeElement.value).toEqual('LA');
       expect(form.value).toEqual({cities: ['SF', 'NY', 'LA']});
     });
 
-    it('should support form groups nested in form arrays', () => {
+    it('should support form groups nested in form arrays', async () => {
       const fixture = initTest(FormArrayNestedGroup);
       const cityArray = new FormArray([
         new FormGroup({town: new FormControl('SF'), state: new FormControl('CA')}),
@@ -713,7 +713,7 @@ describe('reactive forms integration tests', () => {
       const form = new FormGroup({cities: cityArray});
       fixture.componentInstance.form = form;
       fixture.componentInstance.cityArray = cityArray;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const inputs = fixture.debugElement.queryAll(By.css('input'));
       expect(inputs[0].nativeElement.value).toEqual('SF');
@@ -729,7 +729,7 @@ describe('reactive forms integration tests', () => {
 
       inputs[0].nativeElement.value = 'LA';
       dispatchEvent(inputs[0].nativeElement, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(form.value).toEqual({
         cities: [
@@ -741,92 +741,92 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('programmatic changes', () => {
-    it('should update the value in the DOM when setValue() is called', () => {
+    it('should update the value in the DOM when setValue() is called', async () => {
       const fixture = initTest(FormGroupComp);
       const login = new FormControl('oldValue');
       const form = new FormGroup({'login': login});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       login.setValue('newValue');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input'));
       expect(input.nativeElement.value).toEqual('newValue');
     });
 
     describe('disabled controls', () => {
-      it('should add disabled attribute to an individual control when instantiated as disabled', () => {
+      it('should add disabled attribute to an individual control when instantiated as disabled', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl({value: 'some value', disabled: true});
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input'));
         expect(input.nativeElement.disabled).toBe(true);
 
         control.enable();
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(input.nativeElement.disabled).toBe(false);
       });
 
-      it('should add disabled attribute to formControlName when instantiated as disabled', () => {
+      it('should add disabled attribute to formControlName when instantiated as disabled', async () => {
         const fixture = initTest(FormGroupComp);
         const control = new FormControl({value: 'some value', disabled: true});
         fixture.componentInstance.form = new FormGroup({login: control});
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input'));
         expect(input.nativeElement.disabled).toBe(true);
 
         control.enable();
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(input.nativeElement.disabled).toBe(false);
       });
 
-      it('should add disabled attribute to an individual control when disable() is called', () => {
+      it('should add disabled attribute to an individual control when disable() is called', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('some value');
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         control.disable();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input'));
         expect(input.nativeElement.disabled).toBe(true);
 
         control.enable();
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(input.nativeElement.disabled).toBe(false);
       });
 
-      it('should add disabled attribute to child controls when disable() is called on group', () => {
+      it('should add disabled attribute to child controls when disable() is called on group', async () => {
         const fixture = initTest(FormGroupComp);
         const form = new FormGroup({'login': new FormControl('login')});
         fixture.componentInstance.form = form;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         form.disable();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[0].nativeElement.disabled).toBe(true);
 
         form.enable();
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(inputs[0].nativeElement.disabled).toBe(false);
       });
 
-      it('should not add disabled attribute to custom controls when disable() is called', () => {
+      it('should not add disabled attribute to custom controls when disable() is called', async () => {
         const fixture = initTest(MyInputForm, MyInput);
         const control = new FormControl('some value');
         fixture.componentInstance.form = new FormGroup({login: control});
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         control.disable();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('my-input'));
         expect(input.nativeElement.getAttribute('disabled')).toBe(null);
@@ -834,7 +834,7 @@ describe('reactive forms integration tests', () => {
     });
 
     describe('dynamic change of FormGroup and FormArray shapes', () => {
-      it('should handle FormControl and FormGroup swap', () => {
+      it('should handle FormControl and FormGroup swap', async () => {
         @Component({
           template: `
             <form [formGroup]="form">
@@ -872,7 +872,7 @@ describe('reactive forms integration tests', () => {
         const fixture = initTest(App);
         fixture.componentInstance.useStandaloneControl();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         let input = fixture.nativeElement.querySelector('input');
         expect(input.id).toBe('standalone-id');
@@ -882,7 +882,7 @@ describe('reactive forms integration tests', () => {
         // in data model and trigger change detection.
         fixture.componentInstance.useControlInsideGroup();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         input = fixture.nativeElement.querySelector('input');
         expect(input.id).toBe('inside-group-id');
@@ -892,14 +892,14 @@ describe('reactive forms integration tests', () => {
         // in data model and trigger change detection.
         fixture.componentInstance.useStandaloneControl();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         input = fixture.nativeElement.querySelector('input');
         expect(input.id).toBe('standalone-id');
         expect(input.value).toBe('standalone');
       });
 
-      it('should handle FormControl and FormArray swap', () => {
+      it('should handle FormControl and FormArray swap', async () => {
         @Component({
           template: `
             <form [formGroup]="form">
@@ -937,7 +937,7 @@ describe('reactive forms integration tests', () => {
         const fixture = initTest(App);
         fixture.componentInstance.useStandaloneControl();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         let input = fixture.nativeElement.querySelector('input');
         expect(input.id).toBe('standalone-id');
@@ -947,7 +947,7 @@ describe('reactive forms integration tests', () => {
         // in data model and trigger change detection.
         fixture.componentInstance.useControlInsideArray();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         input = fixture.nativeElement.querySelector('input');
         expect(input.id).toBe('inside-array-id');
@@ -957,14 +957,14 @@ describe('reactive forms integration tests', () => {
         // in data model and trigger change detection.
         fixture.componentInstance.useStandaloneControl();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         input = fixture.nativeElement.querySelector('input');
         expect(input.id).toBe('standalone-id');
         expect(input.value).toBe('standalone');
       });
 
-      it('should handle FormGroup and FormArray swap', () => {
+      it('should handle FormGroup and FormArray swap', async () => {
         @Component({
           template: `
             <form [formGroup]="form">
@@ -1006,7 +1006,7 @@ describe('reactive forms integration tests', () => {
         const fixture = initTest(App);
         fixture.componentInstance.useControlInsideGroup();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         let input = fixture.nativeElement.querySelector('input');
         expect(input.id).toBe('inside-group-id');
@@ -1016,7 +1016,7 @@ describe('reactive forms integration tests', () => {
         // in data model and trigger change detection.
         fixture.componentInstance.useControlInsideArray();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         input = fixture.nativeElement.querySelector('input');
         expect(input.id).toBe('inside-array-id');
@@ -1026,7 +1026,7 @@ describe('reactive forms integration tests', () => {
         // in data model and trigger change detection.
         fixture.componentInstance.useControlInsideGroup();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         input = fixture.nativeElement.querySelector('input');
         expect(input.id).toBe('inside-group-id');
@@ -1036,12 +1036,12 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('user input', () => {
-    it('should mark controls as touched after interacting with the DOM control', () => {
+    it('should mark controls as touched after interacting with the DOM control', async () => {
       const fixture = initTest(FormGroupComp);
       const login = new FormControl('oldValue');
       const form = new FormGroup({'login': login});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const loginEl = fixture.debugElement.query(By.css('input'));
       expect(login.touched).toBe(false);
@@ -1053,23 +1053,23 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('submit and reset events', () => {
-    it('should emit ngSubmit event with the original submit event on submit', () => {
+    it('should emit ngSubmit event with the original submit event on submit', async () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
       fixture.componentInstance.event = null!;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
       dispatchEvent(formEl, 'submit');
 
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(fixture.componentInstance.event.type).toEqual('submit');
     });
 
-    it('should mark formGroup as submitted on submit event', () => {
+    it('should mark formGroup as submitted on submit event', async () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
       expect(formGroupDir.submitted).toBe(false);
@@ -1077,16 +1077,16 @@ describe('reactive forms integration tests', () => {
       const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
       dispatchEvent(formEl, 'submit');
 
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(formGroupDir.submitted).toEqual(true);
     });
 
-    it('should set value in UI when form resets to that value programmatically', () => {
+    it('should set value in UI when form resets to that value programmatically', async () => {
       const fixture = initTest(FormGroupComp);
       const login = new FormControl('some value');
       const form = new FormGroup({'login': login});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
       expect(loginEl.value).toBe('some value');
@@ -1095,12 +1095,12 @@ describe('reactive forms integration tests', () => {
       expect(loginEl.value).toBe('reset value');
     });
 
-    it('should clear value in UI when form resets programmatically', () => {
+    it('should clear value in UI when form resets programmatically', async () => {
       const fixture = initTest(FormGroupComp);
       const login = new FormControl('some value');
       const form = new FormGroup({'login': login});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
       expect(loginEl.value).toBe('some value');
@@ -1111,11 +1111,11 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('value changes and status changes', () => {
-    it('should mark controls as dirty before emitting a value change event', () => {
+    it('should mark controls as dirty before emitting a value change event', async () => {
       const fixture = initTest(FormGroupComp);
       const login = new FormControl('oldValue');
       fixture.componentInstance.form = new FormGroup({'login': login});
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       login.valueChanges.subscribe(() => {
         expect(login.dirty).toBe(true);
@@ -1127,12 +1127,12 @@ describe('reactive forms integration tests', () => {
       dispatchEvent(loginEl, 'input');
     });
 
-    it('should mark control as pristine before emitting a value change event when resetting ', () => {
+    it('should mark control as pristine before emitting a value change event when resetting ', async () => {
       const fixture = initTest(FormGroupComp);
       const login = new FormControl('oldValue');
       const form = new FormGroup({'login': login});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
       loginEl.value = 'newValue';
@@ -1471,11 +1471,11 @@ describe('reactive forms integration tests', () => {
       expect(fcEvents.length).toBe(0);
     });
 
-    it('formControl should emit an event when resetting a form', () => {
+    it('formControl should emit an event when resetting a form', async () => {
       const fixture = initTest(FormGroupComp);
       const form = new FormGroup({'login': new FormControl('', Validators.required)});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
 
@@ -1493,11 +1493,11 @@ describe('reactive forms integration tests', () => {
       expect(events[3].source).toBe(form);
     });
 
-    it('formControl should not emit an event when resetting a form with emit:false', () => {
+    it('formControl should not emit an event when resetting a form with emit:false', async () => {
       const fixture = initTest(FormGroupComp);
       const form = new FormGroup({'login': new FormControl('', Validators.required)});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
 
@@ -1510,12 +1510,12 @@ describe('reactive forms integration tests', () => {
       expect(events[0]).toBeInstanceOf(TouchedChangeEvent);
     });
 
-    it('formControl should only update self', () => {
+    it('formControl should only update self', async () => {
       const fixture = initTest(FormGroupComp);
       const form = new FormGroup({'login': new FormControl('', Validators.required)});
       const parentForm = new FormGroup({form});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
 
@@ -1546,11 +1546,11 @@ describe('reactive forms integration tests', () => {
       expect(parentEvents[2]).toBeInstanceOf(StatusChangeEvent);
     });
 
-    it('formControl should emit an event when submitting a form', () => {
+    it('formControl should emit an event when submitting a form', async () => {
       const fixture = initTest(FormGroupComp);
       const form = new FormGroup({'login': new FormControl('', Validators.required)});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
 
@@ -1563,7 +1563,7 @@ describe('reactive forms integration tests', () => {
       expect(events[0].source).toBe(form);
     });
 
-    it('formArray should emit an event when resetting a form', () => {
+    it('formArray should emit an event when resetting a form', async () => {
       @Component({
         selector: 'form-array-comp',
         template: ` <form #formElement [formArray]="form" (ngSubmit)="event = $event">
@@ -1583,7 +1583,7 @@ describe('reactive forms integration tests', () => {
       }
 
       const fixture = initTest(FormArrayComp);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const formArrayDir = fixture.debugElement.children[0].injector.get(FormArrayDirective);
 
@@ -1691,7 +1691,7 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('setting status classes', () => {
-    it('should not assign status on standalone <form> element', () => {
+    it('should not assign status on standalone <form> element', async () => {
       @Component({
         selector: 'form-comp',
         template: ` <form></form> `,
@@ -1701,7 +1701,7 @@ describe('reactive forms integration tests', () => {
       class FormComp {}
 
       const fixture = initReactiveFormsTest(FormComp);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const form = fixture.debugElement.query(By.css('form')).nativeElement;
       // Expect no classes added to the <form> element since it has no
@@ -1709,7 +1709,7 @@ describe('reactive forms integration tests', () => {
       expect(sortedClassList(form)).toEqual([]);
     });
 
-    it('should not assign status on standalone <form> element with form control inside', () => {
+    it('should not assign status on standalone <form> element with form control inside', async () => {
       @Component({
         selector: 'form-comp',
         template: `
@@ -1724,7 +1724,7 @@ describe('reactive forms integration tests', () => {
         control = new FormControl('abc');
       }
       const fixture = initReactiveFormsTest(FormComp);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const form = fixture.debugElement.query(By.css('form')).nativeElement;
       // Expect no classes added to the <form> element since it has no
@@ -1735,23 +1735,23 @@ describe('reactive forms integration tests', () => {
       expect(sortedClassList(input)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
     });
 
-    it('should work with single fields', () => {
+    it('should work with single fields', async () => {
       const fixture = initTest(FormControlComp);
       const control = new FormControl('', Validators.required);
       fixture.componentInstance.control = control;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
       dispatchEvent(input, 'blur');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
 
       input.value = 'updatedValue';
       dispatchEvent(input, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
     });
@@ -1781,39 +1781,39 @@ describe('reactive forms integration tests', () => {
       const fixture = initTest(FormControlComp);
       const control = new FormControl('', Validators.required, uniqLoginAsyncValidator('good'));
       fixture.debugElement.componentInstance.control = control;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
       dispatchEvent(input, 'blur');
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
 
       input.value = 'bad';
       dispatchEvent(input, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-pending', 'ng-touched']);
 
       await timeout();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-invalid', 'ng-touched']);
 
       input.value = 'good';
       dispatchEvent(input, 'input');
       await timeout();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
     });
 
-    it('should work with single fields in parent forms', () => {
+    it('should work with single fields in parent forms', async () => {
       const fixture = initTest(FormGroupComp);
       const form = new FormGroup({'login': new FormControl('', Validators.required)});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
@@ -1821,35 +1821,35 @@ describe('reactive forms integration tests', () => {
       expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
       dispatchEvent(input, 'blur');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
 
       input.value = 'updatedValue';
       dispatchEvent(input, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
       expect(sortedClassList(formEl)).not.toContain('ng-submitted');
 
       dispatchEvent(formEl, 'submit');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).not.toContain('ng-submitted');
       expect(sortedClassList(formEl)).toContain('ng-submitted');
 
       dispatchEvent(formEl, 'reset');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).not.toContain('ng-submitted');
       expect(sortedClassList(formEl)).not.toContain('ng-submitted');
     });
 
-    it('should work with formGroup', () => {
+    it('should work with formGroup', async () => {
       const fixture = initTest(FormGroupComp);
       const form = new FormGroup({'login': new FormControl('', Validators.required)});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
@@ -1857,29 +1857,29 @@ describe('reactive forms integration tests', () => {
       expect(sortedClassList(formEl)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
       dispatchEvent(input, 'blur');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(formEl)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
 
       input.value = 'updatedValue';
       dispatchEvent(input, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(formEl)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
 
       dispatchEvent(formEl, 'submit');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(formEl)).toContain('ng-submitted');
 
       dispatchEvent(formEl, 'reset');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).not.toContain('ng-submitted');
       expect(sortedClassList(formEl)).not.toContain('ng-submitted');
     });
 
-    it('should not assign `ng-submitted` class to elements with `formArrayName`', () => {
+    it('should not assign `ng-submitted` class to elements with `formArrayName`', async () => {
       // Since element with the `formArrayName` can not represent top-level forms (can only be
       // inside other elements), this test verifies that these elements never receive
       // `ng-submitted` CSS class even when they are located inside submitted form.
@@ -1888,7 +1888,7 @@ describe('reactive forms integration tests', () => {
       const form = new FormGroup({cities: cityArray});
       fixture.componentInstance.form = form;
       fixture.componentInstance.cityArray = cityArray;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const [loginInput, passwordInput] = fixture.debugElement
         .queryAll(By.css('input'))
@@ -1902,27 +1902,27 @@ describe('reactive forms integration tests', () => {
       expect(sortedClassList(formEl)).not.toContain('ng-submitted');
 
       dispatchEvent(formEl, 'submit');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
       expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
       expect(sortedClassList(formEl)).toContain('ng-submitted');
 
       dispatchEvent(formEl, 'reset');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
       expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
       expect(sortedClassList(formEl)).not.toContain('ng-submitted');
     });
 
-    it('should apply submitted status with nested formArrayName', () => {
+    it('should apply submitted status with nested formArrayName', async () => {
       const fixture = initTest(NestedFormArrayNameComp);
       const ic = new FormControl('foo');
       const arr = new FormArray([ic]);
       const form = new FormGroup({arr});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const arrEl = fixture.debugElement.query(By.css('div')).nativeElement;
@@ -1933,21 +1933,21 @@ describe('reactive forms integration tests', () => {
       expect(sortedClassList(formEl)).not.toContain('ng-submitted');
 
       dispatchEvent(formEl, 'submit');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).not.toContain('ng-submitted');
       expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
       expect(sortedClassList(formEl)).toContain('ng-submitted');
 
       dispatchEvent(formEl, 'reset');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(input)).not.toContain('ng-submitted');
       expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
       expect(sortedClassList(formEl)).not.toContain('ng-submitted');
     });
 
-    it('should apply submitted status with nested formGroupName', () => {
+    it('should apply submitted status with nested formGroupName', async () => {
       const fixture = initTest(NestedFormGroupNameComp);
       const loginControl = new FormControl('', {
         validators: Validators.required,
@@ -1959,7 +1959,7 @@ describe('reactive forms integration tests', () => {
         {updateOn: 'blur'},
       );
       fixture.componentInstance.form = formGroup;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const [loginInput, passwordInput] = fixture.debugElement
         .queryAll(By.css('input'))
@@ -1972,21 +1972,21 @@ describe('reactive forms integration tests', () => {
       // dirtied.
       dispatchEvent(loginInput, 'input');
       dispatchEvent(loginInput, 'blur');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
       expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
       expect(sortedClassList(formEl)).not.toContain('ng-submitted');
 
       dispatchEvent(formEl, 'submit');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
       expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
       expect(sortedClassList(formEl)).toContain('ng-submitted');
 
       dispatchEvent(formEl, 'reset');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
       expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
@@ -1996,16 +1996,16 @@ describe('reactive forms integration tests', () => {
 
   describe('updateOn options', () => {
     describe('on blur', () => {
-      it('should not update value or validity based on user input until blur', () => {
+      it('should not update value or validity based on user input until blur', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to remain unchanged until blur.')
@@ -2015,7 +2015,7 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to change once control is blurred.')
@@ -2025,18 +2025,18 @@ describe('reactive forms integration tests', () => {
           .toBe(true);
       });
 
-      it('should not update parent group value/validity from child until blur', () => {
+      it('should not update parent group value/validity from child until blur', async () => {
         const fixture = initTest(FormGroupComp);
         const form = new FormGroup({
           login: new FormControl('', {validators: Validators.required, updateOn: 'blur'}),
         });
         fixture.componentInstance.form = form;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(form.value)
           .withContext('Expected group value to remain unchanged until blur.')
@@ -2046,7 +2046,7 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(form.value)
           .withContext('Expected group value to change once input blurred.')
@@ -2054,14 +2054,14 @@ describe('reactive forms integration tests', () => {
         expect(form.valid).withContext('Expected validation to run once input blurred.').toBe(true);
       });
 
-      it('should not wait for blur event to update if value is set programmatically', () => {
+      it('should not wait for blur event to update if value is set programmatically', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         control.setValue('Nancy');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         expect(input.value)
@@ -2073,65 +2073,65 @@ describe('reactive forms integration tests', () => {
         expect(control.valid).withContext('Expected validation to run immediately.').toBe(true);
       });
 
-      it('should not update dirty state until control is blurred', () => {
+      it('should not update dirty state until control is blurred', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('', {updateOn: 'blur'});
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.dirty).withContext('Expected control to start out pristine.').toBe(false);
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.dirty)
           .withContext('Expected control to stay pristine until blurred.')
           .toBe(false);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.dirty)
           .withContext('Expected control to update dirty state when blurred.')
           .toBe(true);
       });
 
-      it('should update touched when control is blurred', () => {
+      it('should update touched when control is blurred', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('', {updateOn: 'blur'});
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.touched).withContext('Expected control to start out untouched.').toBe(false);
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.touched)
           .withContext('Expected control to update touched state when blurred.')
           .toBe(true);
       });
 
-      it('should continue waiting for blur to update if previously blurred', () => {
+      it('should continue waiting for blur to update if previously blurred', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('Nancy', {
           validators: Validators.required,
           updateOn: 'blur',
         });
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         dispatchEvent(input, 'focus');
         input.value = '';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to remain unchanged until second blur.')
@@ -2141,7 +2141,7 @@ describe('reactive forms integration tests', () => {
           .toBe(true);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to update when blur occurs again.')
@@ -2151,36 +2151,36 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
       });
 
-      it('should not use stale pending value if value set programmatically', () => {
+      it('should not use stale pending value if value set programmatically', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'aa';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         control.setValue('Nancy');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(input.value)
           .withContext('Expected programmatic value to stick after blur.')
           .toEqual('Nancy');
       });
 
-      it('should set initial value and validity on init', () => {
+      it('should set initial value and validity on init', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('Nancy', {
           validators: Validators.maxLength(3),
           updateOn: 'blur',
         });
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
 
@@ -2193,32 +2193,32 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
       });
 
-      it('should reset properly', () => {
+      it('should reset properly', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'aa';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(control.dirty).withContext('Expected control to be dirty on blur.').toBe(true);
 
         control.reset();
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(input.value).withContext('Expected view value to reset').toEqual('');
         expect(control.value).withContext('Expected pending value to reset.').toBe(null);
         expect(control.dirty).withContext('Expected pending dirty value to reset.').toBe(false);
       });
 
-      it('should be able to remove a control as a result of another control being reset', () => {
+      it('should be able to remove a control as a result of another control being reset', async () => {
         @Component({
           template: `
             <form [formGroup]="form">
@@ -2252,25 +2252,23 @@ describe('reactive forms integration tests', () => {
         }
 
         const fixture = initTest(App);
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(fixture.componentInstance.form.value).toEqual({name: 'Frodo', surname: 'Baggins'});
 
-        expect(() => {
-          fixture.componentInstance.form.reset();
-          fixture.detectChanges();
-        }).not.toThrow();
+        fixture.componentInstance.form.reset();
+        await expectAsync(fixture.whenStable()).toBeResolved();
 
         expect(fixture.componentInstance.form.value).toEqual({name: null});
       });
 
-      it('should not emit valueChanges or statusChanges until blur', () => {
+      it('should not emit valueChanges or statusChanges until blur', async () => {
         const fixture = initTest(FormControlComp);
         const control: FormControl = new FormControl('', {
           validators: Validators.required,
           updateOn: 'blur',
         });
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
         const values: string[] = [];
 
         const sub = merge(control.valueChanges, control.statusChanges).subscribe((val) =>
@@ -2280,14 +2278,14 @@ describe('reactive forms integration tests', () => {
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(values)
           .withContext('Expected no valueChanges or statusChanges on input.')
           .toEqual([]);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(values)
           .withContext('Expected valueChanges and statusChanges on blur.')
@@ -2296,14 +2294,14 @@ describe('reactive forms integration tests', () => {
         sub.unsubscribe();
       });
 
-      it('should not emit valueChanges or statusChanges on blur if value unchanged', () => {
+      it('should not emit valueChanges or statusChanges on blur if value unchanged', async () => {
         const fixture = initTest(FormControlComp);
         const control: FormControl = new FormControl('', {
           validators: Validators.required,
           updateOn: 'blur',
         });
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
         const values: string[] = [];
 
         const sub = merge(control.valueChanges, control.statusChanges).subscribe((val) =>
@@ -2312,27 +2310,27 @@ describe('reactive forms integration tests', () => {
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values)
           .withContext('Expected no valueChanges or statusChanges if value unchanged.')
           .toEqual([]);
 
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values)
           .withContext('Expected no valueChanges or statusChanges on input.')
           .toEqual([]);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values).toEqual(
           ['Nancy', 'VALID'],
           'Expected valueChanges and statusChanges on blur if value changed.',
         );
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values).toEqual(
           ['Nancy', 'VALID'],
           'Expected valueChanges and statusChanges not to fire again on blur unless value changed.',
@@ -2340,14 +2338,14 @@ describe('reactive forms integration tests', () => {
 
         input.value = 'Bess';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values).toEqual(
           ['Nancy', 'VALID'],
           'Expected valueChanges and statusChanges not to fire on input after blur.',
         );
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values).toEqual(
           ['Nancy', 'VALID', 'Bess', 'VALID'],
           'Expected valueChanges and statusChanges to fire again on blur if value changed.',
@@ -2356,40 +2354,40 @@ describe('reactive forms integration tests', () => {
         sub.unsubscribe();
       });
 
-      it('should mark as pristine properly if pending dirty', () => {
+      it('should mark as pristine properly if pending dirty', async () => {
         const fixture = initTest(FormControlComp);
         const control = new FormControl('', {updateOn: 'blur'});
         fixture.componentInstance.control = control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'aa';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         control.markAsPristine();
         expect(control.dirty).withContext('Expected control to become pristine.').toBe(false);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.dirty).withContext('Expected pending dirty value to reset.').toBe(false);
       });
 
-      it('should update on blur with group updateOn', () => {
+      it('should update on blur with group updateOn', async () => {
         const fixture = initTest(FormGroupComp);
         const control = new FormControl('', Validators.required);
         const formGroup = new FormGroup({login: control}, {updateOn: 'blur'});
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to remain unchanged until blur.')
@@ -2399,7 +2397,7 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to change once control is blurred.')
@@ -2409,19 +2407,19 @@ describe('reactive forms integration tests', () => {
           .toBe(true);
       });
 
-      it('should update on blur with array updateOn', () => {
+      it('should update on blur with array updateOn', async () => {
         const fixture = initTest(FormArrayComp);
         const control = new FormControl('', Validators.required);
         const cityArray = new FormArray([control], {updateOn: 'blur'});
         const formGroup = new FormGroup({cities: cityArray});
         fixture.componentInstance.form = formGroup;
         fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to remain unchanged until blur.')
@@ -2431,7 +2429,7 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to change once control is blurred.')
@@ -2441,7 +2439,7 @@ describe('reactive forms integration tests', () => {
           .toBe(true);
       });
 
-      it('should allow child control updateOn blur to override group updateOn', () => {
+      it('should allow child control updateOn blur to override group updateOn', async () => {
         const fixture = initTest(NestedFormGroupNameComp);
         const loginControl = new FormControl('', {
           validators: Validators.required,
@@ -2453,19 +2451,19 @@ describe('reactive forms integration tests', () => {
           {updateOn: 'blur'},
         );
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const [loginInput, passwordInput] = fixture.debugElement.queryAll(By.css('input'));
         loginInput.nativeElement.value = 'Nancy';
         dispatchEvent(loginInput.nativeElement, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(loginControl.value).withContext('Expected value change on input.').toEqual('Nancy');
         expect(loginControl.valid).withContext('Expected validation to run on input.').toBe(true);
 
         passwordInput.nativeElement.value = 'Carson';
         dispatchEvent(passwordInput.nativeElement, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(passwordControl.value)
           .withContext('Expected value to remain unchanged until blur.')
@@ -2475,7 +2473,7 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
 
         dispatchEvent(passwordInput.nativeElement, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(passwordControl.value)
           .withContext('Expected value to change once control is blurred.')
@@ -2487,13 +2485,13 @@ describe('reactive forms integration tests', () => {
     });
 
     describe('on submit', () => {
-      it('should set initial value and validity on init', () => {
+      it('should set initial value and validity on init', async () => {
         const fixture = initTest(FormGroupComp);
         const form = new FormGroup({
           login: new FormControl('Nancy', {validators: Validators.required, updateOn: 'submit'}),
         });
         fixture.componentInstance.form = form;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         expect(input.value)
@@ -2507,18 +2505,18 @@ describe('reactive forms integration tests', () => {
           .toBe(true);
       });
 
-      it('should not update value or validity until submit', () => {
+      it('should not update value or validity until submit', async () => {
         const fixture = initTest(FormGroupComp);
         const formGroup = new FormGroup({
           login: new FormControl('', {validators: Validators.required, updateOn: 'submit'}),
         });
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.value)
           .withContext('Expected form value to remain unchanged on input.')
@@ -2528,7 +2526,7 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.value)
           .withContext('Expected form value to remain unchanged on blur.')
@@ -2539,7 +2537,7 @@ describe('reactive forms integration tests', () => {
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.value).withContext('Expected form value to update on submit.').toEqual({
           login: 'Nancy',
@@ -2549,26 +2547,26 @@ describe('reactive forms integration tests', () => {
           .toBe(true);
       });
 
-      it('should not update after submit until a second submit', () => {
+      it('should not update after submit until a second submit', async () => {
         const fixture = initTest(FormGroupComp);
         const formGroup = new FormGroup({
           login: new FormControl('', {validators: Validators.required, updateOn: 'submit'}),
         });
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         input.value = '';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.value)
           .withContext('Expected value not to change until a second submit.')
@@ -2578,7 +2576,7 @@ describe('reactive forms integration tests', () => {
           .toBe(true);
 
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.value)
           .withContext('Expected value to update on the second submit.')
@@ -2588,16 +2586,16 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
       });
 
-      it('should not wait for submit to set value programmatically', () => {
+      it('should not wait for submit to set value programmatically', async () => {
         const fixture = initTest(FormGroupComp);
         const formGroup = new FormGroup({
           login: new FormControl('', {validators: Validators.required, updateOn: 'submit'}),
         });
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         formGroup.setValue({login: 'Nancy'});
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         expect(input.value)
@@ -2611,39 +2609,39 @@ describe('reactive forms integration tests', () => {
           .toBe(true);
       });
 
-      it('should not update dirty until submit', () => {
+      it('should not update dirty until submit', async () => {
         const fixture = initTest(FormGroupComp);
         const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.dirty).withContext('Expected dirty not to change on input.').toBe(false);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.dirty).withContext('Expected dirty not to change on blur.').toBe(false);
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.dirty).withContext('Expected dirty to update on submit.').toBe(true);
       });
 
-      it('should not update touched until submit', () => {
+      it('should not update touched until submit', async () => {
         const fixture = initTest(FormGroupComp);
         const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.touched)
           .withContext('Expected touched not to change until submit.')
@@ -2651,29 +2649,29 @@ describe('reactive forms integration tests', () => {
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.touched).withContext('Expected touched to update on submit.').toBe(true);
       });
 
-      it('should reset properly', () => {
+      it('should reset properly', async () => {
         const fixture = initTest(FormGroupComp);
         const formGroup = new FormGroup({
           login: new FormControl('', {validators: Validators.required, updateOn: 'submit'}),
         });
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         formGroup.reset();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(input.value).withContext('Expected view value to reset.').toEqual('');
         expect(formGroup.value).withContext('Expected form value to reset').toEqual({login: null});
@@ -2684,7 +2682,7 @@ describe('reactive forms integration tests', () => {
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.value).withContext('Expected form value to stay empty on submit').toEqual({
           login: null,
@@ -2695,12 +2693,12 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
       });
 
-      it('should not emit valueChanges or statusChanges until submit', () => {
+      it('should not emit valueChanges or statusChanges until submit', async () => {
         const fixture = initTest(FormGroupComp);
         const control = new FormControl('', {validators: Validators.required, updateOn: 'submit'});
         const formGroup = new FormGroup({login: control});
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const values: any[] = [];
         const streams = merge(
@@ -2714,20 +2712,20 @@ describe('reactive forms integration tests', () => {
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(values)
           .withContext('Expected no valueChanges or statusChanges on input')
           .toEqual([]);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(values).withContext('Expected no valueChanges or statusChanges on blur').toEqual([]);
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(values).toEqual(
           ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
@@ -2737,12 +2735,12 @@ describe('reactive forms integration tests', () => {
         sub.unsubscribe();
       });
 
-      it('should not emit valueChanges or statusChanges on submit if value unchanged', () => {
+      it('should not emit valueChanges or statusChanges on submit if value unchanged', async () => {
         const fixture = initTest(FormGroupComp);
         const control = new FormControl('', {validators: Validators.required, updateOn: 'submit'});
         const formGroup = new FormGroup({login: control});
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const values: any[] = [];
         const streams = merge(
@@ -2755,7 +2753,7 @@ describe('reactive forms integration tests', () => {
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values)
           .withContext('Expected no valueChanges or statusChanges if value unchanged.')
           .toEqual([]);
@@ -2763,20 +2761,20 @@ describe('reactive forms integration tests', () => {
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values)
           .withContext('Expected no valueChanges or statusChanges on input.')
           .toEqual([]);
 
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values).toEqual(
           ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
           'Expected valueChanges and statusChanges on submit if value changed.',
         );
 
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(values).toEqual(
           ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
           'Expected valueChanges and statusChanges not to fire again if value unchanged.',
@@ -2784,7 +2782,7 @@ describe('reactive forms integration tests', () => {
 
         input.value = 'Bess';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(values).toEqual(
           ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
@@ -2792,7 +2790,7 @@ describe('reactive forms integration tests', () => {
         );
 
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(values).toEqual(
           ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID', 'Bess', 'VALID', {login: 'Bess'}, 'VALID'],
@@ -2802,7 +2800,7 @@ describe('reactive forms integration tests', () => {
         sub.unsubscribe();
       });
 
-      it('should not run validation for onChange controls on submit', () => {
+      it('should not run validation for onChange controls on submit', async () => {
         const validatorSpy = jasmine.createSpy('validator');
         const groupValidatorSpy = jasmine.createSpy('groupValidatorSpy');
 
@@ -2812,54 +2810,54 @@ describe('reactive forms integration tests', () => {
           email: new FormControl('', {updateOn: 'submit'}),
         });
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         formGroup.get('signin.login')!.setValidators(validatorSpy);
         formGroup.get('signin')!.setValidators(groupValidatorSpy);
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(validatorSpy).not.toHaveBeenCalled();
         expect(groupValidatorSpy).not.toHaveBeenCalled();
       });
 
-      it('should mark as untouched properly if pending touched', () => {
+      it('should mark as untouched properly if pending touched', async () => {
         const fixture = initTest(FormGroupComp);
         const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         formGroup.markAsUntouched();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.touched).withContext('Expected group to become untouched.').toBe(false);
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(formGroup.touched)
           .withContext('Expected touched to stay false on submit.')
           .toBe(false);
       });
 
-      it('should update on submit with group updateOn', () => {
+      it('should update on submit with group updateOn', async () => {
         const fixture = initTest(FormGroupComp);
         const control = new FormControl('', Validators.required);
         const formGroup = new FormGroup({login: control}, {updateOn: 'submit'});
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to remain unchanged until submit.')
@@ -2869,7 +2867,7 @@ describe('reactive forms integration tests', () => {
           .toBe(false);
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to remain unchanged until submit.')
@@ -2880,25 +2878,25 @@ describe('reactive forms integration tests', () => {
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value).withContext('Expected value to change on submit.').toEqual('Nancy');
         expect(control.valid).withContext('Expected validation to run on submit.').toBe(true);
       });
 
-      it('should update on submit with array updateOn', () => {
+      it('should update on submit with array updateOn', async () => {
         const fixture = initTest(FormArrayComp);
         const control = new FormControl('', Validators.required);
         const cityArray = new FormArray([control], {updateOn: 'submit'});
         const formGroup = new FormGroup({cities: cityArray});
         fixture.componentInstance.form = formGroup;
         fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to remain unchanged until submit.')
@@ -2909,7 +2907,7 @@ describe('reactive forms integration tests', () => {
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(control.value)
           .withContext('Expected value to change once control on submit')
@@ -2917,7 +2915,7 @@ describe('reactive forms integration tests', () => {
         expect(control.valid).withContext('Expected validation to run on submit.').toBe(true);
       });
 
-      it('should allow child control updateOn submit to override group updateOn', () => {
+      it('should allow child control updateOn submit to override group updateOn', async () => {
         const fixture = initTest(NestedFormGroupNameComp);
         const loginControl = new FormControl('', {
           validators: Validators.required,
@@ -2929,19 +2927,19 @@ describe('reactive forms integration tests', () => {
           {updateOn: 'submit'},
         );
         fixture.componentInstance.form = formGroup;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const [loginInput, passwordInput] = fixture.debugElement.queryAll(By.css('input'));
         loginInput.nativeElement.value = 'Nancy';
         dispatchEvent(loginInput.nativeElement, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(loginControl.value).withContext('Expected value change on input.').toEqual('Nancy');
         expect(loginControl.valid).withContext('Expected validation to run on input.').toBe(true);
 
         passwordInput.nativeElement.value = 'Carson';
         dispatchEvent(passwordInput.nativeElement, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(passwordControl.value)
           .withContext('Expected value to remain unchanged until submit.')
@@ -2952,7 +2950,7 @@ describe('reactive forms integration tests', () => {
 
         const form = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(form, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(passwordControl.value)
           .withContext('Expected value to change on submit.')
@@ -2968,10 +2966,10 @@ describe('reactive forms integration tests', () => {
         }
 
         const fixture = initTest(NativeDialogForm);
-        fixture.detectChanges();
+        await fixture.whenStable();
         await timeout();
         const event = dispatchEvent(fixture.componentInstance.form.nativeElement, 'submit');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(event.defaultPrevented).toBe(false);
       });
@@ -2996,7 +2994,7 @@ describe('reactive forms integration tests', () => {
           'login': new FormControl(''),
           'password': new FormControl(''),
         });
-        fixture.detectChanges();
+        await fixture.whenStable();
         await timeout();
 
         expect(warnSpy.calls.count()).toEqual(1);
@@ -3006,7 +3004,7 @@ describe('reactive forms integration tests', () => {
 
         fixture.componentInstance.login = 'some value';
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
         await timeout();
 
         expect(warnSpy.calls.count()).toEqual(1);
@@ -3016,7 +3014,7 @@ describe('reactive forms integration tests', () => {
         const fixture = initTest(FormControlNgModel);
         fixture.componentInstance.control = new FormControl('');
         fixture.componentInstance.passwordControl = new FormControl('');
-        fixture.detectChanges();
+        await fixture.whenStable();
         await timeout();
 
         expect(warnSpy.calls.count()).toEqual(1);
@@ -3026,7 +3024,7 @@ describe('reactive forms integration tests', () => {
 
         fixture.componentInstance.login = 'some value';
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
         await timeout();
 
         expect(warnSpy.calls.count()).toEqual(1);
@@ -3041,7 +3039,7 @@ describe('reactive forms integration tests', () => {
         const fixture = TestBed.createComponent(FormControlNgModel);
         fixture.componentInstance.control = new FormControl('');
         fixture.componentInstance.passwordControl = new FormControl('');
-        fixture.detectChanges();
+        await fixture.whenStable();
         await timeout();
 
         expect(warnSpy.calls.count()).toEqual(2);
@@ -3059,7 +3057,7 @@ describe('reactive forms integration tests', () => {
         const fixture = TestBed.createComponent(FormControlNgModel);
         fixture.componentInstance.control = new FormControl('');
         fixture.componentInstance.passwordControl = new FormControl('');
-        fixture.detectChanges();
+        await fixture.whenStable();
         await timeout();
 
         expect(warnSpy).not.toHaveBeenCalled();
@@ -3073,7 +3071,7 @@ describe('reactive forms integration tests', () => {
         'password': new FormControl(''),
       });
       fixture.componentInstance.login = 'oldValue';
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -3091,7 +3089,7 @@ describe('reactive forms integration tests', () => {
       fixture.componentInstance.control = new FormControl('');
       fixture.componentInstance.passwordControl = new FormControl('');
       fixture.componentInstance.login = 'oldValue';
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -3109,7 +3107,7 @@ describe('reactive forms integration tests', () => {
       const fixture = initTest(FormControlNgModel);
       fixture.componentInstance.control = new FormControl('');
       fixture.componentInstance.passwordControl = new FormControl('');
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -3117,7 +3115,7 @@ describe('reactive forms integration tests', () => {
       input.setSelectionRange(1, 2);
       dispatchEvent(input, 'input');
 
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       // selection start has not changed because we did not reset the value
@@ -3132,13 +3130,13 @@ describe('reactive forms integration tests', () => {
       });
       fixture.componentInstance.form = formGroup;
       fixture.componentInstance.login = 'initial';
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       input.value = 'Nancy';
       dispatchEvent(input, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       expect(fixture.componentInstance.login)
@@ -3147,7 +3145,7 @@ describe('reactive forms integration tests', () => {
 
       const form = fixture.debugElement.query(By.css('form')).nativeElement;
       dispatchEvent(form, 'submit');
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       expect(fixture.componentInstance.login)
@@ -3157,11 +3155,11 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('validations', () => {
-    it('required validator should validate checkbox', () => {
+    it('required validator should validate checkbox', async () => {
       const fixture = initTest(FormControlCheckboxRequiredValidator);
       const control = new FormControl(false, Validators.requiredTrue);
       fixture.componentInstance.control = control;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const checkbox = fixture.debugElement.query(By.css('input'));
       expect(checkbox.nativeElement.checked).toBe(false);
@@ -3169,14 +3167,14 @@ describe('reactive forms integration tests', () => {
 
       checkbox.nativeElement.checked = true;
       dispatchEvent(checkbox.nativeElement, 'change');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(checkbox.nativeElement.checked).toBe(true);
       expect(control.hasError('required')).toEqual(false);
 
       checkbox.nativeElement.required = false;
       dispatchEvent(checkbox.nativeElement, 'change');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(checkbox.nativeElement.checked).toBe(true);
       expect(control.hasError('required')).toEqual(false);
@@ -3184,7 +3182,7 @@ describe('reactive forms integration tests', () => {
       checkbox.nativeElement.checked = false;
       checkbox.nativeElement.required = true;
       dispatchEvent(checkbox.nativeElement, 'change');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(checkbox.nativeElement.checked).toBe(false);
       expect(control.hasError('required')).toEqual(true);
@@ -3196,18 +3194,18 @@ describe('reactive forms integration tests', () => {
     // The goal of this test is to prevent regressions for validators that return falsy values by
     // mistake and rely on the `Validators.compose` side-effects to normalize the value to `null`
     // instead.
-    it('should treat validators that return `undefined` as successful', () => {
+    it('should treat validators that return `undefined` as successful', async () => {
       const fixture = initTest(FormControlComp);
       const validatorFn = (control: AbstractControl) => control.value ?? undefined;
       const control = new FormControl(undefined, validatorFn);
       fixture.componentInstance.control = control;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(control.status).toBe('VALID');
       expect(control.errors).toBe(null);
     });
 
-    it('should use sync validators defined in html', () => {
+    it('should use sync validators defined in html', async () => {
       const fixture = initTest(LoginIsEmptyWrapper, LoginIsEmptyValidator);
       const form = new FormGroup({
         'login': new FormControl(''),
@@ -3216,7 +3214,7 @@ describe('reactive forms integration tests', () => {
         'pattern': new FormControl(''),
       });
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const required = fixture.debugElement.query(By.css('[required]'));
       const minLength = fixture.debugElement.query(By.css('[minlength]'));
@@ -3252,7 +3250,7 @@ describe('reactive forms integration tests', () => {
       expect(form.valid).toEqual(true);
     });
 
-    it('should use sync validators using bindings', () => {
+    it('should use sync validators using bindings', async () => {
       const fixture = initTest(ValidationBindingsForm);
       const form = new FormGroup({
         'login': new FormControl(''),
@@ -3265,7 +3263,7 @@ describe('reactive forms integration tests', () => {
       fixture.componentInstance.minLen = 3;
       fixture.componentInstance.maxLen = 3;
       fixture.componentInstance.pattern = '.{3,}';
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const required = fixture.debugElement.query(By.css('[name=required]'));
       const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
@@ -3300,7 +3298,7 @@ describe('reactive forms integration tests', () => {
       expect(form.valid).toEqual(true);
     });
 
-    it('changes on bound properties should change the validation state of the form', () => {
+    it('changes on bound properties should change the validation state of the form', async () => {
       const fixture = initTest(ValidationBindingsForm);
       const form = new FormGroup({
         'login': new FormControl(''),
@@ -3309,7 +3307,7 @@ describe('reactive forms integration tests', () => {
         'pattern': new FormControl(''),
       });
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const required = fixture.debugElement.query(By.css('[name=required]'));
       const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
@@ -3336,7 +3334,7 @@ describe('reactive forms integration tests', () => {
       fixture.componentInstance.minLen = 3;
       fixture.componentInstance.maxLen = 3;
       fixture.componentInstance.pattern = '.{3,}';
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       dispatchEvent(required.nativeElement, 'input');
       dispatchEvent(minLength.nativeElement, 'input');
@@ -3364,7 +3362,7 @@ describe('reactive forms integration tests', () => {
       fixture.componentInstance.minLen = null!;
       fixture.componentInstance.maxLen = null!;
       fixture.componentInstance.pattern = null!;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(form.hasError('required', ['login'])).toEqual(false);
       expect(form.hasError('minlength', ['min'])).toEqual(false);
@@ -3378,7 +3376,7 @@ describe('reactive forms integration tests', () => {
       expect(required.nativeElement.getAttribute('pattern')).toEqual(null);
     });
 
-    it('should support rebound controls with rebound validators', () => {
+    it('should support rebound controls with rebound validators', async () => {
       const fixture = initTest(ValidationBindingsForm);
       const form = new FormGroup({
         'login': new FormControl(''),
@@ -3391,7 +3389,7 @@ describe('reactive forms integration tests', () => {
       fixture.componentInstance.minLen = 3;
       fixture.componentInstance.maxLen = 3;
       fixture.componentInstance.pattern = '.{3,}';
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const newForm = new FormGroup({
         'login': new FormControl(''),
@@ -3401,14 +3399,14 @@ describe('reactive forms integration tests', () => {
       });
       fixture.componentInstance.form = newForm;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       fixture.componentInstance.required = false;
       fixture.componentInstance.minLen = null!;
       fixture.componentInstance.maxLen = null!;
       fixture.componentInstance.pattern = null!;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(newForm.hasError('required', ['login'])).toEqual(false);
       expect(newForm.hasError('minlength', ['min'])).toEqual(false);
@@ -3422,7 +3420,6 @@ describe('reactive forms integration tests', () => {
       const form = new FormGroup({'login': new FormControl('')});
       fixture.componentInstance.form = form;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
       await fixture.whenStable();
 
       expect(form.pending).toEqual(true);
@@ -3439,11 +3436,11 @@ describe('reactive forms integration tests', () => {
       expect(form.valid).toEqual(true);
     });
 
-    it('should use sync validators defined in the model', () => {
+    it('should use sync validators defined in the model', async () => {
       const fixture = initTest(FormGroupComp);
       const form = new FormGroup({'login': new FormControl('aa', Validators.required)});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(form.valid).toEqual(true);
 
       const input = fixture.debugElement.query(By.css('input'));
@@ -3458,7 +3455,7 @@ describe('reactive forms integration tests', () => {
       const control = new FormControl('', Validators.required, uniqLoginAsyncValidator('expected'));
       const form = new FormGroup({'login': control});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       expect(form.hasError('required', ['login'])).toEqual(true);
@@ -3487,7 +3484,7 @@ describe('reactive forms integration tests', () => {
         uniqLoginAsyncValidator('expected', 100),
       );
       fixture.componentInstance.form = new FormGroup({'login': control});
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       expect(control.hasError('required')).toEqual(true);
@@ -3518,7 +3515,7 @@ describe('reactive forms integration tests', () => {
         asyncValidator((c) => c.get('login')!.value.includes('angular'), 200),
       );
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout();
 
       // Initially, the form is invalid because the nested mandatory control is empty
@@ -3584,7 +3581,7 @@ describe('reactive forms integration tests', () => {
         null!,
         observableValidator(resultArr),
       );
-      fixture.detectChanges();
+      await fixture.whenStable();
       await timeout(100);
 
       expect(resultArr.length)
@@ -3594,11 +3591,11 @@ describe('reactive forms integration tests', () => {
       const input = fixture.debugElement.query(By.css('input'));
       input.nativeElement.value = 'a';
       dispatchEvent(input.nativeElement, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       input.nativeElement.value = 'aa';
       dispatchEvent(input.nativeElement, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       await timeout(100);
       expect(resultArr.length)
@@ -3607,7 +3604,7 @@ describe('reactive forms integration tests', () => {
     });
 
     describe('enabling validators conditionally', () => {
-      it('should not activate minlength and maxlength validators if input is null', () => {
+      it('should not activate minlength and maxlength validators if input is null', async () => {
         @Component({
           selector: 'min-max-length-null',
           template: `
@@ -3633,7 +3630,7 @@ describe('reactive forms integration tests', () => {
 
         const fixture = initTest(MinMaxLengthComponent);
         const control = fixture.componentInstance.control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const form = fixture.componentInstance.form;
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -3648,16 +3645,16 @@ describe('reactive forms integration tests', () => {
           failedValidator?: string;
         }
 
-        const setInputValue = (value: number) => {
+        const setInputValue = async (value: number) => {
           input.value = value;
           dispatchEvent(input, 'input');
-          fixture.detectChanges();
+          await fixture.whenStable();
         };
-        const setValidatorValues = (values: minmax) => {
+        const setValidatorValues = async (values: minmax) => {
           fixture.componentInstance.minlen = values.minlength;
           fixture.componentInstance.maxlen = values.maxlength;
           fixture.changeDetectorRef.markForCheck();
-          fixture.detectChanges();
+          await fixture.whenStable();
         };
         const verifyValidatorAttrValues = (values: {minlength: any; maxlength: any}) => {
           expect(input.getAttribute('minlength')).toBe(values.minlength);
@@ -3673,40 +3670,40 @@ describe('reactive forms integration tests', () => {
 
         ////////// Actual test scenarios start below //////////
         // 1. Verify that validators are disabled when input is `null`.
-        setValidatorValues({minlength: null, maxlength: null});
+        await setValidatorValues({minlength: null, maxlength: null});
         verifyValidatorAttrValues({minlength: null, maxlength: null});
         verifyFormState({isValid: true});
 
         // 2. Verify that setting validator inputs (to a value different from `null`) activate
         // validators.
-        setInputValue(12345);
-        setValidatorValues({minlength: 2, maxlength: 4});
+        await setInputValue(12345);
+        await setValidatorValues({minlength: 2, maxlength: 4});
         verifyValidatorAttrValues({minlength: '2', maxlength: '4'});
         verifyFormState({isValid: false, failedValidator: 'maxlength'});
 
         // 3. Changing value to the valid range should make the form valid.
-        setInputValue(123);
+        await setInputValue(123);
         verifyFormState({isValid: true});
 
         // 4. Changing value to trigger `minlength` validator.
-        setInputValue(1);
+        await setInputValue(1);
         verifyFormState({isValid: false, failedValidator: 'minlength'});
 
         // 5. Changing validator inputs to verify that attribute values are updated (and the form
         // is now valid).
-        setInputValue(1);
-        setValidatorValues({minlength: 1, maxlength: 5});
+        await setInputValue(1);
+        await setValidatorValues({minlength: 1, maxlength: 5});
         verifyValidatorAttrValues({minlength: '1', maxlength: '5'});
         verifyFormState({isValid: true});
 
         // 6. Reset validator inputs back to `null` should deactivate validators.
-        setInputValue(123);
-        setValidatorValues({minlength: null, maxlength: null});
+        await setInputValue(123);
+        await setValidatorValues({minlength: null, maxlength: null});
         verifyValidatorAttrValues({minlength: null, maxlength: null});
         verifyFormState({isValid: true});
       });
 
-      it('should not activate min and max validators if input is null', () => {
+      it('should not activate min and max validators if input is null', async () => {
         @Component({
           selector: 'min-max-null',
           template: `
@@ -3733,7 +3730,7 @@ describe('reactive forms integration tests', () => {
 
         const fixture = initTest(MinMaxComponent);
         const control = fixture.componentInstance.control;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const form = fixture.componentInstance.form;
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -3748,16 +3745,16 @@ describe('reactive forms integration tests', () => {
           failedValidator?: string;
         }
 
-        const setInputValue = (value: number) => {
+        const setInputValue = async (value: number) => {
           input.value = value;
           dispatchEvent(input, 'input');
-          fixture.detectChanges();
+          await fixture.whenStable();
         };
-        const setValidatorValues = (values: minmax) => {
+        const setValidatorValues = async (values: minmax) => {
           fixture.componentInstance.minlen = values.min;
           fixture.componentInstance.maxlen = values.max;
           fixture.changeDetectorRef.markForCheck();
-          fixture.detectChanges();
+          await fixture.whenStable();
         };
         const verifyValidatorAttrValues = (values: {min: any; max: any}) => {
           expect(input.getAttribute('min')).toBe(values.min);
@@ -3773,35 +3770,35 @@ describe('reactive forms integration tests', () => {
 
         ////////// Actual test scenarios start below //////////
         // 1. Verify that validators are disabled when input is `null`.
-        setValidatorValues({min: null, max: null});
+        await setValidatorValues({min: null, max: null});
         verifyValidatorAttrValues({min: null, max: null});
         verifyFormState({isValid: true});
 
         // 2. Verify that setting validator inputs (to a value different from `null`) activate
         // validators.
-        setInputValue(12345);
-        setValidatorValues({min: 2, max: 4});
+        await setInputValue(12345);
+        await setValidatorValues({min: 2, max: 4});
         verifyValidatorAttrValues({min: '2', max: '4'});
         verifyFormState({isValid: false, failedValidator: 'max'});
 
         // 3. Changing value to the valid range should make the form valid.
-        setInputValue(3);
+        await setInputValue(3);
         verifyFormState({isValid: true});
 
         // 4. Changing value to trigger `minlength` validator.
-        setInputValue(1);
+        await setInputValue(1);
         verifyFormState({isValid: false, failedValidator: 'min'});
 
         // 5. Changing validator inputs to verify that attribute values are updated (and the form
         // is now valid).
-        setInputValue(1);
-        setValidatorValues({min: 1, max: 5});
+        await setInputValue(1);
+        await setValidatorValues({min: 1, max: 5});
         verifyValidatorAttrValues({min: '1', max: '5'});
         verifyFormState({isValid: true});
 
         // 6. Reset validator inputs back to `null` should deactivate validators.
-        setInputValue(123);
-        setValidatorValues({min: null, max: null});
+        await setInputValue(123);
+        await setValidatorValues({min: null, max: null});
         verifyValidatorAttrValues({min: null, max: null});
         verifyFormState({isValid: true});
       });
@@ -3813,12 +3810,12 @@ describe('reactive forms integration tests', () => {
       }
       // Run tests for both `FormControlName` and `FormControl` directives
       ['formControl', 'formControlName'].forEach((dir: string) => {
-        it(`should validate max for ${dir}`, () => {
+        it(`should validate max for ${dir}`, async () => {
           const fixture = initTest(getComponent(dir));
           const control = new FormControl(5);
           fixture.componentInstance.control = control;
           fixture.componentInstance.form = new FormGroup({'pin': control});
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
           const form = fixture.componentInstance.form;
@@ -3835,7 +3832,7 @@ describe('reactive forms integration tests', () => {
 
           fixture.componentInstance.max = 1;
           fixture.changeDetectorRef.markForCheck();
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(input.getAttribute('max')).toEqual('1');
           expect(form.valid).toBeFalse();
@@ -3844,7 +3841,7 @@ describe('reactive forms integration tests', () => {
           fixture.componentInstance.min = 0;
           fixture.componentInstance.max = 0;
           fixture.changeDetectorRef.markForCheck();
-          fixture.detectChanges();
+          await fixture.whenStable();
           expect(input.getAttribute('min')).toEqual('0');
           expect(input.getAttribute('max')).toEqual('0');
           expect(form.valid).toBeFalse();
@@ -3852,18 +3849,18 @@ describe('reactive forms integration tests', () => {
 
           input.value = 0;
           dispatchEvent(input, 'input');
-          fixture.detectChanges();
+          await fixture.whenStable();
           expect(form.valid).toBeTruthy();
           expect(form.controls['pin'].errors).toBeNull();
         });
 
-        it(`should validate max for float number for ${dir}`, () => {
+        it(`should validate max for float number for ${dir}`, async () => {
           const fixture = initTest(getComponent(dir));
           const control = new FormControl(10.25);
           fixture.componentInstance.control = control;
           fixture.componentInstance.form = new FormGroup({'pin': control});
           fixture.componentInstance.max = 10.35;
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
           const form = fixture.componentInstance.form;
@@ -3880,7 +3877,7 @@ describe('reactive forms integration tests', () => {
           expect(form.controls['pin'].errors).toBeNull();
 
           fixture.componentInstance.max = 10.05;
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           expect(input.getAttribute('max')).toEqual('10.05');
           expect(form.valid).toBeFalse();
@@ -3893,12 +3890,12 @@ describe('reactive forms integration tests', () => {
           expect(form.controls['pin'].errors).toBeNull();
         });
 
-        it(`should apply max validation when control value is defined as a string for ${dir}`, () => {
+        it(`should apply max validation when control value is defined as a string for ${dir}`, async () => {
           const fixture = initTest(getComponent(dir));
           const control = new FormControl('5');
           fixture.componentInstance.control = control;
           fixture.componentInstance.form = new FormGroup({'pin': control});
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
           const form = fixture.componentInstance.form;
@@ -3914,18 +3911,18 @@ describe('reactive forms integration tests', () => {
           expect(form.controls['pin'].errors).toBeNull();
 
           fixture.componentInstance.max = 1;
-          fixture.detectChanges();
+          await fixture.whenStable();
           expect(input.getAttribute('max')).toEqual('1');
           expect(form.valid).toBeFalse();
           expect(form.controls['pin'].errors).toEqual({max: {max: 1, actual: 2}});
         });
 
-        it(`should validate min for ${dir}`, () => {
+        it(`should validate min for ${dir}`, async () => {
           const fixture = initTest(getComponent(dir));
           const control = new FormControl(5);
           fixture.componentInstance.control = control;
           fixture.componentInstance.form = new FormGroup({'pin': control});
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
           const form = fixture.componentInstance.form;
@@ -3941,7 +3938,7 @@ describe('reactive forms integration tests', () => {
           expect(form.controls['pin'].errors).toBeNull();
 
           fixture.componentInstance.min = 5;
-          fixture.detectChanges();
+          await fixture.whenStable();
           expect(input.getAttribute('min')).toEqual('5');
           expect(form.valid).toBeFalse();
           expect(form.controls['pin'].errors).toEqual({min: {min: 5, actual: 2}});
@@ -3949,26 +3946,26 @@ describe('reactive forms integration tests', () => {
           fixture.componentInstance.min = 0;
           input.value = -5;
           dispatchEvent(input, 'input');
-          fixture.detectChanges();
+          await fixture.whenStable();
           expect(input.getAttribute('min')).toEqual('0');
           expect(form.valid).toBeFalse();
           expect(form.controls['pin'].errors).toEqual({min: {min: 0, actual: -5}});
 
           input.value = 0;
           dispatchEvent(input, 'input');
-          fixture.detectChanges();
+          await fixture.whenStable();
           expect(form.valid).toBeTruthy();
           expect(form.controls['pin'].errors).toBeNull();
         });
 
-        it(`should validate min for float number for ${dir}`, () => {
+        it(`should validate min for float number for ${dir}`, async () => {
           const fixture = initTest(getComponent(dir));
           const control = new FormControl(10.25);
           fixture.componentInstance.control = control;
           fixture.componentInstance.form = new FormGroup({'pin': control});
           fixture.componentInstance.max = 10.5;
           fixture.componentInstance.min = 10.25;
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
           const form = fixture.componentInstance.form;
@@ -3986,7 +3983,7 @@ describe('reactive forms integration tests', () => {
           expect(form.controls['pin'].errors).toBeNull();
 
           fixture.componentInstance.min = 10.4;
-          fixture.detectChanges();
+          await fixture.whenStable();
           expect(input.getAttribute('min')).toEqual('10.4');
           expect(form.valid).toBeFalse();
           expect(form.controls['pin'].errors).toEqual({min: {min: 10.4, actual: 10.35}});
@@ -3998,12 +3995,12 @@ describe('reactive forms integration tests', () => {
           expect(form.controls['pin'].errors).toBeNull();
         });
 
-        it(`should apply min validation when control value is defined as a string for ${dir}`, () => {
+        it(`should apply min validation when control value is defined as a string for ${dir}`, async () => {
           const fixture = initTest(getComponent(dir));
           const control = new FormControl('5');
           fixture.componentInstance.control = control;
           fixture.componentInstance.form = new FormGroup({'pin': control});
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
           const form = fixture.componentInstance.form;
@@ -4019,13 +4016,13 @@ describe('reactive forms integration tests', () => {
           expect(form.controls['pin'].errors).toBeNull();
 
           fixture.componentInstance.min = 5;
-          fixture.detectChanges();
+          await fixture.whenStable();
           expect(input.getAttribute('min')).toEqual('5');
           expect(form.valid).toBeFalse();
           expect(form.controls['pin'].errors).toEqual({min: {min: 5, actual: 2}});
         });
 
-        it(`should run min/max validation for empty values for ${dir}`, () => {
+        it(`should run min/max validation for empty values for ${dir}`, async () => {
           const fixture = initTest(getComponent(dir));
           const minValidateFnSpy = spyOn(MinValidator.prototype, 'validate');
           const maxValidateFnSpy = spyOn(MaxValidator.prototype, 'validate');
@@ -4033,7 +4030,7 @@ describe('reactive forms integration tests', () => {
           const control = new FormControl();
           fixture.componentInstance.control = control;
           fixture.componentInstance.form = new FormGroup({'pin': control});
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
           const form = fixture.componentInstance.form;
@@ -4045,7 +4042,7 @@ describe('reactive forms integration tests', () => {
           expect(maxValidateFnSpy).toHaveBeenCalled();
         });
 
-        it(`should run min/max validation when constraints are represented as strings for ${dir}`, () => {
+        it(`should run min/max validation when constraints are represented as strings for ${dir}`, async () => {
           const fixture = initTest(getComponent(dir));
           const control = new FormControl(5);
 
@@ -4055,7 +4052,7 @@ describe('reactive forms integration tests', () => {
 
           fixture.componentInstance.control = control;
           fixture.componentInstance.form = new FormGroup({'pin': control});
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
           const form = fixture.componentInstance.form;
@@ -4082,14 +4079,14 @@ describe('reactive forms integration tests', () => {
           expect(form.controls['pin'].errors).toEqual({max: {max: 10, actual: 20}});
         });
 
-        it(`should run min/max validation for negative values for ${dir}`, () => {
+        it(`should run min/max validation for negative values for ${dir}`, async () => {
           const fixture = initTest(getComponent(dir));
           const control = new FormControl(-30);
           fixture.componentInstance.control = control;
           fixture.componentInstance.form = new FormGroup({'pin': control});
           fixture.componentInstance.min = -20;
           fixture.componentInstance.max = -10;
-          fixture.detectChanges();
+          await fixture.whenStable();
 
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
           const form = fixture.componentInstance.form;
@@ -4118,7 +4115,7 @@ describe('reactive forms integration tests', () => {
         });
       });
 
-      it('should fire registerOnValidatorChange for validators attached to the formGroups', () => {
+      it('should fire registerOnValidatorChange for validators attached to the formGroups', async () => {
         let registerOnValidatorChangeFired = 0;
         let registerOnAsyncValidatorChangeFired = 0;
 
@@ -4189,14 +4186,14 @@ describe('reactive forms integration tests', () => {
         }
 
         const fixture = initTest(NgModelNoOpValidation, NoOpValidator, NoOpAsyncValidator);
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(registerOnValidatorChangeFired).toBe(1);
         expect(registerOnAsyncValidatorChangeFired).toBe(1);
 
         fixture.componentInstance.validatorInput = 'baz';
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         // Changing the validator input should not cause the onValidatorChange to be called
         // again.
@@ -4207,15 +4204,24 @@ describe('reactive forms integration tests', () => {
   });
 
   describe('errors', () => {
-    it("should throw if a form isn't passed into formGroup", () => {
+    async function getRenderError(fixture: ComponentFixture<any>): Promise<Error> {
+      try {
+        await fixture.whenStable();
+      } catch (error) {
+        return error as Error;
+      }
+      throw new Error('Expected rendering to fail');
+    }
+
+    it("should throw if a form isn't passed into formGroup", async () => {
       const fixture = initTest(FormGroupComp);
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(`formGroup expects a FormGroup instance`),
       );
     });
 
-    it('should throw if formControlName is used without a control container', () => {
+    it('should throw if formControlName is used without a control container', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4225,24 +4231,14 @@ describe('reactive forms integration tests', () => {
       });
 
       const fixture = initTest(FormGroupComp);
-      expect(() => fixture.detectChanges()).toThrowMatching((e: Error) => {
-        if (
-          !e.message.includes(
-            `formControlName must be used with a parent formGroup or formArray directive`,
-          )
-        ) {
-          return false;
-        }
-
-        if (!e.message.includes(`Affected Form Control name: "login"`)) {
-          return false;
-        }
-
-        return true;
-      });
+      const error = await getRenderError(fixture);
+      expect(error.message).toContain(
+        `formControlName must be used with a parent formGroup or formArray directive`,
+      );
+      expect(error.message).toContain(`Affected Form Control name: "login"`);
     });
 
-    it('should throw if formControlName, with an index, is used without a control container', () => {
+    it('should throw if formControlName, with an index, is used without a control container', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4252,24 +4248,14 @@ describe('reactive forms integration tests', () => {
       });
 
       const fixture = initTest(FormGroupComp);
-      expect(() => fixture.detectChanges()).toThrowMatching((e: Error) => {
-        if (
-          !e.message.includes(
-            `formControlName must be used with a parent formGroup or formArray directive`,
-          )
-        ) {
-          return false;
-        }
-
-        if (!e.message.includes(`Affected Form Control index: "0"`)) {
-          return false;
-        }
-
-        return true;
-      });
+      const error = await getRenderError(fixture);
+      expect(error.message).toContain(
+        `formControlName must be used with a parent formGroup or formArray directive`,
+      );
+      expect(error.message).toContain(`Affected Form Control index: "0"`);
     });
 
-    it('should throw, without indicating the affected form control, if formControlName is used without a control container', () => {
+    it('should throw, without indicating the affected form control, if formControlName is used without a control container', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4279,24 +4265,14 @@ describe('reactive forms integration tests', () => {
       });
 
       const fixture = initTest(FormGroupComp);
-      expect(() => fixture.detectChanges()).toThrowMatching((e: Error) => {
-        if (
-          !e.message.includes(
-            `formControlName must be used with a parent formGroup or formArray directive`,
-          )
-        ) {
-          return false;
-        }
-
-        if (e.message.includes(`Affected Form Control`)) {
-          return false;
-        }
-
-        return true;
-      });
+      const error = await getRenderError(fixture);
+      expect(error.message).toContain(
+        `formControlName must be used with a parent formGroup or formArray directive`,
+      );
+      expect(error.message).not.toContain(`Affected Form Control`);
     });
 
-    it('should throw if formControlName is used with NgForm', () => {
+    it('should throw if formControlName is used with NgForm', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4308,12 +4284,12 @@ describe('reactive forms integration tests', () => {
       });
       const fixture = initTest(FormGroupComp);
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(`formControlName must be used with a parent formGroup or formArray directive.`),
       );
     });
 
-    it('should throw if formControlName is used with NgModelGroup', () => {
+    it('should throw if formControlName is used with NgModelGroup', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4327,12 +4303,12 @@ describe('reactive forms integration tests', () => {
       });
       const fixture = initTest(FormGroupComp);
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(`formControlName cannot be used with an ngModelGroup parent.`),
       );
     });
 
-    it('should throw if formGroupName is used without a control container', () => {
+    it('should throw if formGroupName is used without a control container', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4344,12 +4320,12 @@ describe('reactive forms integration tests', () => {
       });
       const fixture = initTest(FormGroupComp);
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(`formGroupName must be used with a parent formGroup directive`),
       );
     });
 
-    it('should throw if formGroupName is used with NgForm', () => {
+    it('should throw if formGroupName is used with NgForm', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4363,12 +4339,12 @@ describe('reactive forms integration tests', () => {
       });
       const fixture = initTest(FormGroupComp);
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(`formGroupName must be used with a parent formGroup directive.`),
       );
     });
 
-    it('should throw if formArrayName is used without a control container', () => {
+    it('should throw if formArrayName is used without a control container', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4379,12 +4355,12 @@ describe('reactive forms integration tests', () => {
       });
       const fixture = initTest(FormGroupComp);
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(`formArrayName must be used with a parent formGroup directive`),
       );
     });
 
-    it('should throw if ngModel is used alone under formGroup', () => {
+    it('should throw if ngModel is used alone under formGroup', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4397,14 +4373,14 @@ describe('reactive forms integration tests', () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({});
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(
           `ngModel cannot be used to register form controls with a parent formGroup directive.`,
         ),
       );
     });
 
-    it('should not throw if ngModel is used alone under formGroup with standalone: true', () => {
+    it('should not throw if ngModel is used alone under formGroup with standalone: true', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4417,10 +4393,10 @@ describe('reactive forms integration tests', () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({});
 
-      expect(() => fixture.detectChanges()).not.toThrowError();
+      await expectAsync(fixture.whenStable()).toBeResolved();
     });
 
-    it('should throw if ngModel is used alone with formGroupName', () => {
+    it('should throw if ngModel is used alone with formGroupName', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4435,14 +4411,14 @@ describe('reactive forms integration tests', () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({person: new FormGroup({})});
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(
           `ngModel cannot be used to register form controls with a parent formGroupName or formArrayName directive.`,
         ),
       );
     });
 
-    it('should throw if ngModelGroup is used with formGroup', () => {
+    it('should throw if ngModelGroup is used with formGroup', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4457,12 +4433,12 @@ describe('reactive forms integration tests', () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({});
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(`ngModelGroup cannot be used with a parent formGroup directive`),
       );
     });
 
-    it('should throw if radio button name does not match formControlName attr', () => {
+    it('should throw if radio button name does not match formControlName attr', async () => {
       TestBed.overrideComponent(FormGroupComp, {
         set: {
           template: `
@@ -4474,19 +4450,19 @@ describe('reactive forms integration tests', () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({'food': new FormControl('fish')});
 
-      expect(() => fixture.detectChanges()).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp('If you define both a name and a formControlName'),
       );
     });
   });
 
   describe('radio groups', () => {
-    it('should respect the attr.disabled state as an initial value', () => {
+    it('should respect the attr.disabled state as an initial value', async () => {
       const fixture = initTest(RadioForm);
       const choice = new FormControl('one');
       const form = new FormGroup({'choice': choice});
       fixture.componentInstance.form = form;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const oneInput = fixture.debugElement.query(By.css('input'));
 
@@ -4500,27 +4476,27 @@ describe('reactive forms integration tests', () => {
       // as expected. Once the initial `disabled` value is setup, the model
       // becomes the source of truth.
       oneInput.nativeElement.setAttribute('disabled', 'false');
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(oneInput.attributes['disabled']).toBe('false');
       expect(choice.disabled).toBe(false);
 
       oneInput.nativeElement.setAttribute('disabled', 'true');
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(oneInput.attributes['disabled']).toBe('true');
       expect(choice.disabled).toBe(false);
 
       oneInput.nativeElement.setAttribute('disabled', 'false');
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(oneInput.attributes['disabled']).toBe('false');
       expect(choice.disabled).toBe(false);
     });
   });
 
   describe('IME events', () => {
-    it('should determine IME event handling depending on platform by default', () => {
+    it('should determine IME event handling depending on platform by default', async () => {
       const fixture = initTest(FormControlComp);
       fixture.componentInstance.control = new FormControl('oldValue');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
       const inputNativeEl = inputEl.nativeElement;
@@ -4540,18 +4516,18 @@ describe('reactive forms integration tests', () => {
         expect(fixture.componentInstance.control.value).toEqual('oldValue');
 
         inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(fixture.componentInstance.control.value).toEqual('updatedValue');
       }
     });
 
-    it('should hold IME events until compositionend if composition mode', () => {
+    it('should hold IME events until compositionend if composition mode', async () => {
       TestBed.overrideComponent(FormControlComp, {
         set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: true}]},
       });
       const fixture = initTest(FormControlComp);
       fixture.componentInstance.control = new FormControl('oldValue');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
       const inputNativeEl = inputEl.nativeElement;
@@ -4567,19 +4543,19 @@ describe('reactive forms integration tests', () => {
 
       inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
 
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // should update when compositionend
       expect(fixture.componentInstance.control.value).toEqual('updatedValue');
     });
 
-    it('should work normally with composition events if composition mode is off', () => {
+    it('should work normally with composition events if composition mode is off', async () => {
       TestBed.overrideComponent(FormControlComp, {
         set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: false}]},
       });
       const fixture = initTest(FormControlComp);
       fixture.componentInstance.control = new FormControl('oldValue');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
       const inputNativeEl = inputEl.nativeElement;
@@ -4589,7 +4565,7 @@ describe('reactive forms integration tests', () => {
 
       inputNativeEl.value = 'updatedValue';
       dispatchEvent(inputNativeEl, 'input');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // formControl should update normally
       expect(fixture.componentInstance.control.value).toEqual('updatedValue');
@@ -4702,7 +4678,7 @@ describe('reactive forms integration tests', () => {
     }
 
     // Init a test with a predefined set of validator and value accessor classes.
-    function initCleanupTest(component: Type<any>) {
+    async function initCleanupTest(component: Type<any>) {
       const fixture = initTest(
         component,
         ViewValidatorA,
@@ -4714,13 +4690,13 @@ describe('reactive forms integration tests', () => {
         ValueAccessorA,
         ValueAccessorB,
       );
-      fixture.detectChanges();
+      await fixture.whenStable();
       return fixture;
     }
 
-    it('should clean up validators when FormGroup is replaced', () => {
+    it('should clean up validators when FormGroup is replaced', async () => {
       const fixture = initTest(FormGroupWithValidators, ViewValidatorA, AsyncViewValidatorA);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const newForm = new FormGroup({login: new FormControl('NEW')});
       const oldForm = fixture.componentInstance.form;
@@ -4728,7 +4704,7 @@ describe('reactive forms integration tests', () => {
       // Update `form` input with a new value.
       fixture.componentInstance.form = newForm;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const validatorSpy = validatorSpyOn(ViewValidatorA);
       const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
@@ -4743,9 +4719,9 @@ describe('reactive forms integration tests', () => {
       expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newForm, count: 1});
     });
 
-    it('should clean up validators when FormControl inside FormGroup is replaced', () => {
+    it('should clean up validators when FormControl inside FormGroup is replaced', async () => {
       const fixture = initTest(FormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const newControl = new FormControl('NEW')!;
       const oldControl = fixture.componentInstance.form.get('login')!;
@@ -4756,7 +4732,7 @@ describe('reactive forms integration tests', () => {
       // Update `login` form control with a new `FormControl` instance.
       fixture.componentInstance.form.removeControl('login');
       fixture.componentInstance.form.addControl('login', newControl);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       validatorSpy.calls.reset();
       asyncValidatorSpy.calls.reset();
@@ -4773,7 +4749,7 @@ describe('reactive forms integration tests', () => {
 
     it('should keep control in pending state if async validator never emits', async () => {
       const fixture = initTest(FormControlWithAsyncValidatorFn);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const control = fixture.componentInstance.form.get('login')!;
       expect(control.status).toBe('PENDING');
@@ -4786,9 +4762,9 @@ describe('reactive forms integration tests', () => {
       expect(control.errors).toBe(null);
     });
 
-    it('should call validators defined via `set[Async]Validators` after view init', () => {
+    it('should call validators defined via `set[Async]Validators` after view init', async () => {
       const fixture = initTest(FormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const control = fixture.componentInstance.form.get('login')!;
 
@@ -4829,9 +4805,9 @@ describe('reactive forms integration tests', () => {
       expectValidatorsToBeCalled(newValidatorSpy, newAsyncValidatorSpy, {ctx: control, count: 1});
     });
 
-    it('should cleanup validators on a control used for multiple `formControlName` directives', () => {
+    it('should cleanup validators on a control used for multiple `formControlName` directives', async () => {
       const fixture = initTest(NgForFormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const newControl = new FormControl('b')!;
       const oldControl = fixture.componentInstance.form.get('login')!;
@@ -4842,7 +4818,7 @@ describe('reactive forms integration tests', () => {
       // Case 1: replace `login` form control with a new `FormControl` instance.
       fixture.componentInstance.form.removeControl('login');
       fixture.componentInstance.form.addControl('login', newControl);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Check that validators were called with a new control as a context
       // and each validator function was called for each control (so 3 times each).
@@ -4864,7 +4840,8 @@ describe('reactive forms integration tests', () => {
 
       // Case 2: update `logins` to render a new list of elements.
       fixture.componentInstance.logins = ['a', 'b', 'c', 'd', 'e', 'f'];
-      fixture.detectChanges();
+      fixture.changeDetectorRef.markForCheck();
+      await fixture.whenStable();
 
       validatorSpy.calls.reset();
       asyncValidatorSpy.calls.reset();
@@ -4877,9 +4854,9 @@ describe('reactive forms integration tests', () => {
       expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 6});
     });
 
-    it('should cleanup directive-specific callbacks only', () => {
+    it('should cleanup directive-specific callbacks only', async () => {
       const fixture = initTest(MultipleFormControls, ViewValidatorA, AsyncViewValidatorA);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const sharedControl = fixture.componentInstance.control;
 
@@ -4887,7 +4864,7 @@ describe('reactive forms integration tests', () => {
       const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
 
       sharedControl.setValue('b');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Check that validators were called for each `formControlName` directive instance
       // (2 times total).
@@ -4898,21 +4875,21 @@ describe('reactive forms integration tests', () => {
       const newFormA = new FormGroup({login: new FormControl('new-a')});
       fixture.componentInstance.formA = newFormA;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       validatorSpy.calls.reset();
       asyncValidatorSpy.calls.reset();
 
       // Update control with a new value.
       sharedControl.setValue('d');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // We should still see an update to the second <input>.
       expect(fixture.nativeElement.querySelector('#login').value).toBe('d');
       expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: sharedControl, count: 1});
     });
 
-    it('should clean up callbacks when FormControlDirective is destroyed (simple)', () => {
+    it('should clean up callbacks when FormControlDirective is destroyed (simple)', async () => {
       // Scenario:
       // ---------
       // [formControl] *ngIf
@@ -4936,13 +4913,13 @@ describe('reactive forms integration tests', () => {
         control = control;
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(control);
 
       // Case 1: update control value and verify all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(control, {
         ownValidators: control,
@@ -4955,7 +4932,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) were invoked.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(control);
@@ -4976,7 +4953,7 @@ describe('reactive forms integration tests', () => {
       // attached.
       fixture.componentInstance.visible = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(control);
@@ -4991,7 +4968,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up when FormControlDirective is destroyed (multiple instances)', () => {
+    it('should clean up when FormControlDirective is destroyed (multiple instances)', async () => {
       // Scenario:
       // ---------
       // [formControl] *ngIf
@@ -5017,7 +4994,7 @@ describe('reactive forms integration tests', () => {
         control = control;
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       // Value accessor for the second <input> without *ngIf.
       const valueAccessorBSpy = spyOn(ValueAccessorB.prototype, 'writeValue');
@@ -5028,7 +5005,7 @@ describe('reactive forms integration tests', () => {
 
       // Case 1: update control value and verify all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(valueAccessorBSpy).toHaveBeenCalledWith('Initial value');
       verifySpies(control, {
@@ -5042,7 +5019,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) were invoked.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       valueAccessorBSpy.calls.reset();
@@ -5066,7 +5043,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up callbacks when FormControlName directive is destroyed', () => {
+    it('should clean up callbacks when FormControlName directive is destroyed', async () => {
       // Scenario:
       // ---------
       // [formGroup]
@@ -5095,7 +5072,7 @@ describe('reactive forms integration tests', () => {
         group = new FormGroup({control});
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       // DefaultValueAccessor will be used for the second <input> where no custom CVA is defined.
       const valueAccessorBSpy = spyOn(ValueAccessorB.prototype, 'writeValue');
@@ -5106,7 +5083,7 @@ describe('reactive forms integration tests', () => {
 
       // Case 1: update control value and verify all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(valueAccessorBSpy).toHaveBeenCalledWith('Initial value');
       verifySpies(control, {
@@ -5120,7 +5097,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) were invoked.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       valueAccessorBSpy.calls.reset();
@@ -5144,7 +5121,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up callbacks when FormGroupDirective is destroyed', () => {
+    it('should clean up callbacks when FormGroupDirective is destroyed', async () => {
       // Scenario:
       // ---------
       // [formGroup] *ngIf
@@ -5179,13 +5156,13 @@ describe('reactive forms integration tests', () => {
         group = group;
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(group, control);
 
       // Case 1: update control value and verify that all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(control, {
         viewValidators: control,
@@ -5203,7 +5180,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, control);
@@ -5230,7 +5207,7 @@ describe('reactive forms integration tests', () => {
       // attached and invoked.
       fixture.componentInstance.visible = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, control);
@@ -5250,7 +5227,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up when FormControl is destroyed (but parent FormGroup exists)', () => {
+    it('should clean up when FormControl is destroyed (but parent FormGroup exists)', async () => {
       // Scenario:
       // ---------
       // [formGroup]
@@ -5283,13 +5260,13 @@ describe('reactive forms integration tests', () => {
         group = group;
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(group, control);
 
       // Case 1: update control value and verify that all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(control, {
         viewValidators: control,
@@ -5307,7 +5284,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, control);
@@ -5332,7 +5309,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up controls produced by *ngFor', () => {
+    it('should clean up controls produced by *ngFor', async () => {
       // Scenario:
       // ---------
       // [formGroup]
@@ -5368,13 +5345,13 @@ describe('reactive forms integration tests', () => {
         logins = ['a', 'b', 'c'];
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(group, control);
 
       // Case 1: update control value and verify that all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(control, {
         viewValidatorCallCount: 3, // since *ngFor produces 3 [formControl]s
@@ -5395,7 +5372,7 @@ describe('reactive forms integration tests', () => {
       // (thus destroyed) directives.
       fixture.componentInstance.logins = ['c', 'd'];
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, control);
@@ -5421,7 +5398,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, control);
@@ -5441,7 +5418,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up when FormArrayName is destroyed (but parent FormGroup exists)', () => {
+    it('should clean up when FormArrayName is destroyed (but parent FormGroup exists)', async () => {
       // Scenario:
       // ---------
       // [formGroup]
@@ -5481,13 +5458,13 @@ describe('reactive forms integration tests', () => {
         group = group;
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(group, arr, control);
 
       // Case 1: update control value and verify that all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(control, {
         viewValidators: control,
@@ -5510,7 +5487,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, arr, control);
@@ -5541,7 +5518,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up when FormArrayName is destroyed (but parent FormGroup exists, ngIf on formArrayName)', () => {
+    it('should clean up when FormArrayName is destroyed (but parent FormGroup exists, ngIf on formArrayName)', async () => {
       // Scenario:
       // ---------
       // [formGroup]
@@ -5581,13 +5558,13 @@ describe('reactive forms integration tests', () => {
         group = group;
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(group, arr, control);
 
       // Case 1: update control value and verify that all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(control, {
         viewValidators: control,
@@ -5610,7 +5587,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, arr, control);
@@ -5642,7 +5619,7 @@ describe('reactive forms integration tests', () => {
       // correctly attached and invoked.
       fixture.componentInstance.visible = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, arr, control);
@@ -5667,7 +5644,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up all child controls (formArrayName) when FormGroup is destroyed', () => {
+    it('should clean up all child controls (formArrayName) when FormGroup is destroyed', async () => {
       // Scenario:
       // ---------
       // [formGroup] *ngIf
@@ -5707,13 +5684,13 @@ describe('reactive forms integration tests', () => {
         group = group;
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(group, arr, control);
 
       // Case 1: update control value and verify that all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(control, {
         viewValidators: control,
@@ -5736,7 +5713,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, arr, control);
@@ -5768,7 +5745,7 @@ describe('reactive forms integration tests', () => {
       // attached and invoked.
       fixture.componentInstance.visible = true;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, arr, control);
@@ -5793,7 +5770,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up all child controls (with *ngFor) when FormArrayName is destroyed', () => {
+    it('should clean up all child controls (with *ngFor) when FormArrayName is destroyed', async () => {
       // Scenario:
       // ---------
       // [formGroup]
@@ -5842,13 +5819,13 @@ describe('reactive forms integration tests', () => {
         ids = [0, 1];
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(group, arr, controlA, controlB);
 
       // Case 1: update control value and verify that all spies were called.
       controlA.setValue('Updated A');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(controlA, {
         viewValidators: controlA,
@@ -5878,7 +5855,7 @@ describe('reactive forms integration tests', () => {
       // Verify that ControlA is detached from the view, but ControlB still works.
       fixture.componentInstance.ids = [1];
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, arr, controlA, controlB);
@@ -5912,7 +5889,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(group, arr, controlA, controlB);
@@ -5947,7 +5924,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up all child controls when FormGroupName is destroyed', () => {
+    it('should clean up all child controls when FormGroupName is destroyed', async () => {
       // Scenario:
       // ---------
       // [formGroup]
@@ -5987,13 +5964,13 @@ describe('reactive forms integration tests', () => {
         root = root;
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(root, group, control);
 
       // Case 1: update control value and verify that all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(control, {
         viewValidators: control,
@@ -6016,7 +5993,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(root, group, control);
@@ -6045,7 +6022,7 @@ describe('reactive forms integration tests', () => {
       });
     });
 
-    it('should clean up all child controls (formGroupName) when FormGroup is destroyed', () => {
+    it('should clean up all child controls (formGroupName) when FormGroup is destroyed', async () => {
       // Scenario:
       // ---------
       // [formGroup] *ngIf
@@ -6085,13 +6062,13 @@ describe('reactive forms integration tests', () => {
         root = root;
       }
 
-      const fixture = initCleanupTest(App);
+      const fixture = await initCleanupTest(App);
 
       resetSpies(root, group, control);
 
       // Case 1: update control value and verify that all spies were called.
       control.setValue('Initial value');
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       verifySpies(control, {
         viewValidators: control,
@@ -6114,7 +6091,7 @@ describe('reactive forms integration tests', () => {
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
       fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // Reset all spies again, prepare for next check.
       resetSpies(root, group, control);
@@ -6144,7 +6121,7 @@ describe('reactive forms integration tests', () => {
     });
 
     // See https://github.com/angular/angular/issues/40521.
-    it('should properly clean up when FormControlName has no CVA', () => {
+    it('should properly clean up when FormControlName has no CVA', async () => {
       @Component({
         selector: 'no-cva-compo',
         template: `
@@ -6160,9 +6137,7 @@ describe('reactive forms integration tests', () => {
       }
 
       const fixture = initTest(NoCVAComponent);
-      expect(() => {
-        fixture.detectChanges();
-      }).toThrowError(
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         /NG01203: No value accessor for form control name: 'control'\. Find more at https:\/\/(?:next\.)?angular\.dev\/errors\/NG01203/,
       );
 
@@ -6192,9 +6167,9 @@ describe('reactive forms integration tests', () => {
         @ViewChild('formElement') formElement!: ElementRef<HTMLFormElement>;
       }
 
-      it('basic functionality ', () => {
+      it('basic functionality ', async () => {
         const fixture = initTest(FormArrayComp);
-        fixture.detectChanges();
+        await fixture.whenStable();
         const controls = fixture.componentInstance.controls;
 
         // model -> view
@@ -6208,17 +6183,17 @@ describe('reactive forms integration tests', () => {
         expect(controls[1].value).toEqual('updated value');
       });
 
-      it('should add novalidate by default to form', () => {
+      it('should add novalidate by default to form', async () => {
         const fixture = initTest(FormArrayComp);
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const form = fixture.debugElement.query(By.css('form'));
         expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
       });
 
-      it('should mark formArray as submitted on submit event', () => {
+      it('should mark formArray as submitted on submit event', async () => {
         const fixture = initTest(FormArrayComp);
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const formGroupDir = fixture.debugElement.children[0].injector.get(FormArrayDirective);
         expect(formGroupDir.submitted).toBe(false);
@@ -6226,58 +6201,58 @@ describe('reactive forms integration tests', () => {
         const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(formEl, 'submit');
 
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(formGroupDir.submitted).toEqual(true);
       });
 
-      it('should reset properly', () => {
+      it('should reset properly', async () => {
         const fixture = initTest(FormArrayComp);
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const control = fixture.componentInstance.controls[0];
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
 
         input.value = 'aa';
         dispatchEvent(input, 'input');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(control.dirty).withContext('Expected control to be dirty on blur.').toBe(true);
 
         control.reset();
 
         dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(input.value).withContext('Expected view value to reset').toEqual('');
         expect(control.value).withContext('Expected pending value to reset.').toBe(null);
         expect(control.dirty).withContext('Expected pending dirty value to reset.').toBe(false);
       });
 
-      it('should support add/removing controls', () => {
+      it('should support add/removing controls', async () => {
         const fixture = initTest(FormArrayComp);
         const controls = fixture.componentInstance.controls;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         let inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs.length).toBe(3);
 
         controls.push(new FormControl('pineapple'));
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
         inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs.length).toBe(4);
 
         controls.pop();
         controls.pop();
         fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+        await fixture.whenStable();
         inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs.length).toBe(2);
       });
 
-      it('should support formArrayName', () => {
+      it('should support formArrayName', async () => {
         @Component({
           template: `
             <form [formArray]="form">
@@ -6298,7 +6273,7 @@ describe('reactive forms integration tests', () => {
         }
 
         const fixture = initTest(FormWithFormArrayName);
-        fixture.detectChanges();
+        await fixture.whenStable();
         const input = fixture.debugElement.query(By.css('input'));
         expect(input.nativeElement.value).toEqual('Cat');
       });


### PR DESCRIPTION
Rely on zoneless scheduling throughout reactive forms tests instead of triggering change detection manually.  
 
