### PR TITLE
Allow readonly array typings for the preprocessor

### DIFF
--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -623,4 +623,4 @@ export type RawScopeInfoFromDecorator =
   | ModuleWithProviders<any>
   | (() => Type<any>)
   | (() => ModuleWithProviders<any>)
-  | any[];
+  | readonly any[];

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -403,8 +403,7 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
    * A function used by the framework to create standalone injectors.
    */
   getStandaloneInjector:
-    | ((parentInjector: EnvironmentInjector) => EnvironmentInjector | null)
-    | null;
+    ((parentInjector: EnvironmentInjector) => EnvironmentInjector | null) | null;
 
   /**
    * A function used by the framework to create the list of external runtime style URLs.

--- a/packages/core/src/render3/metadata.ts
+++ b/packages/core/src/render3/metadata.ts
@@ -86,7 +86,7 @@ export function setClassMetadataAsync(
  */
 export function setClassMetadata(
   type: any,
-  decorators: any[] | null,
+  decorators: readonly any[] | null,
   ctorParameters: (() => any[]) | null,
   propDecorators: {[field: string]: any} | null,
 ): void {
@@ -97,7 +97,7 @@ export function setClassMetadata(
       if (clazz.hasOwnProperty('decorators') && clazz.decorators !== undefined) {
         clazz.decorators.push(...decorators);
       } else {
-        clazz.decorators = decorators;
+        clazz.decorators = decorators as any[];
       }
     }
     if (ctorParameters !== null) {


### PR DESCRIPTION
Adjust the Angular APIs in a few places to only require `readonly` arrays. This allows us to avoid a `@ts-ignore` in cases when the preprocessor needs to call these APIs.