### PR TITLE
fix(forms): guard against null container in NgForm.addControl/addFormGroup

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -227,6 +227,9 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   addControl(dir: NgModel): void {
     resolvedPromise.then(() => {
       const container = this._findContainer(dir.path);
+      if (!container) {
+        return;
+      }
       (dir as Writable<NgModel>).control = <FormControl>(
         container.registerControl(dir.name, dir.control)
       );
@@ -271,6 +274,9 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   addFormGroup(dir: NgModelGroup): void {
     resolvedPromise.then(() => {
       const container = this._findContainer(dir.path);
+      if (!container) {
+        return;
+      }
       const group = new FormGroup({});
       setUpFormContainer(group, dir);
       container.registerControl(dir.name, group);
@@ -366,8 +372,8 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
     }
   }
 
-  private _findContainer(path: string[]): FormGroup {
+  private _findContainer(path: string[]): FormGroup | null {
     path.pop();
-    return path.length ? <FormGroup>this.form.get(path) : this.form;
+    return path.length ? (this.form.get(path) as FormGroup | null) : this.form;
   }
 }

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -411,6 +411,36 @@ describe('Form Directives', () => {
       });
 
       // should update the form's value and validity
+
+      it('should not throw when a nested group is added after its container was removed', async () => {
+        // Reproduces https://github.com/angular/angular/issues/69440: `addControl` and
+        // `addFormGroup` register into the resolved container inside a deferred microtask.
+        // If an ancestor container is removed (also deferred) before that microtask runs,
+        // `_findContainer` resolves to `null` and registration must be a no-op rather than
+        // throwing.
+        const nestedControlGroupDir = new NgModelGroup(personControlGroupDir, [], []);
+        nestedControlGroupDir.name = 'nested';
+
+        const nestedLoginControlDir = new NgModel(nestedControlGroupDir, null!, null!, [
+          defaultAccessor,
+        ]);
+        nestedLoginControlDir.name = 'login';
+        nestedLoginControlDir.valueAccessor = new DummyControlValueAccessor();
+
+        form.addFormGroup(personControlGroupDir);
+        form.addFormGroup(nestedControlGroupDir);
+        await timeout();
+
+        // Removing `person` and adding `person.nested.login` are both scheduled as
+        // microtasks; the removal was queued first so it resolves first, leaving
+        // `person.nested` unresolvable by the time the add runs.
+        form.removeFormGroup(personControlGroupDir);
+        expect(() => form.addControl(nestedLoginControlDir)).not.toThrow();
+
+        await timeout();
+
+        expect(formModel.get(['person'])).toBeNull();
+      });
     });
 
     describe('removeControl & removeFormGroup', () => {


### PR DESCRIPTION
NgForm.addControl and NgForm.addFormGroup register into the resolved parent container inside a deferred microtask, but unlike removeControl/removeFormGroup they never guarded against _findContainer returning null. When a nested ngModelGroup is destroyed before its own registration microtask has resolved, the ancestor container it was about to register into may already have been removed from the form, causing an unhandled
"Cannot read properties of null (reading 'registerControl')" crash.

Add the same null check already used by removeControl/removeFormGroup, and update _findContainer's return type to reflect that it can legitimately return null.

Fixes #69440

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #69440

In template-driven forms, `NgForm.addControl`/`addFormGroup` call `container.registerControl(...)` without checking whether `container` is `null`, while the matching `removeControl`/`removeFormGroup` already guard with `container?.`. If a nested `ngModelGroup`'s ancestor container is removed from the form before that group/control's own deferred registration microtask runs, `_findContainer` returns `null` and the unguarded call throws an unhandled `TypeError`.

## What is the new behavior?

addControl and addFormGroup now return early (no-op) when findContainer resolves to null, matching the existing behavior of removeControl/removeFormGroup. findContainer's return type is also updated from FormGroup to FormGroup | null to reflect what it actually returns.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Verified with a regression test in `packages/forms/test/directives_spec.ts` that reproduces the exact crash (registers a nested `ngModelGroup`, removes its parent, then adds a control into it) — confirmed it throws without the fix and passes with it. Full `packages/forms` test suite passes (1145 specs, 0 failures).