### PR TITLE
ci: add local skills to the fw-general scope

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -120,6 +120,7 @@ groups:
     conditions:
       - >
         contains_any_globs(files.exclude('packages/core/primitives/*'), [
+          '.agent/skills/**/{*,.*}',
           'contributing-docs/public-api-surface.md',
           'dev-app/**/{*,.*}',
           'integration/**/{*,.*}',


### PR DESCRIPTION
They were caught by dev-infra which isn't the best scope for the imho
