### PR TITLE
docs: fix self-referential link and merge intro tips in inputs guide

### DIFF
--- a/adev/src/content/guide/components/inputs.md
+++ b/adev/src/content/guide/components/inputs.md
@@ -1,8 +1,6 @@
 # Accepting data with input properties
 
-TIP: This guide assumes you've already read the [Essentials Guide](essentials). Read that first if you're new to Angular.
-
-TIP: If you're familiar with other web frameworks, input properties are similar to _props_.
+TIP: This guide assumes you've already read the [Essentials Guide](essentials). Read that first if you're new to Angular. If you're familiar with other web frameworks, input properties are similar to _props_.
 
 When you use a component, you commonly want to pass some data to it. A component specifies the data that it accepts by declaring
 **inputs**:
@@ -253,7 +251,7 @@ See [Custom events with outputs](guide/components/outputs) for more details on o
 
 ### Customizing model inputs
 
-You can mark a model input as required or provide an alias in the same way as a [standard input](guide/components/inputs).
+You can mark a model input as [required](#required-inputs) or provide an [alias](#input-aliases) in the same way as a standard input.
 
 Model inputs do not support input transforms.
 


### PR DESCRIPTION
The "Customizing model inputs" section linked "standard input" back to the inputs guide itself, a dead-end self-link. Point the sentence at the relevant in-page sections instead (#required-inputs and #input-aliases).

Also merge the two stacked intro TIP callouts into a single tip.

Before: 

<img width="857" height="793" alt="image" src="https://github.com/user-attachments/assets/4382e8c9-f479-4f5e-8076-aae2801c4457" />

After: 

<img width="837" height="640" alt="image" src="https://github.com/user-attachments/assets/f854fd09-6e93-48a2-897f-7d5e51c91260" />

