### PR TITLE
docs: remove duplicate aria-hidden attributes in aria examples

### DIFF
--- a/adev/src/content/examples/aria/grid/src/calendar/basic/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/calendar/basic/app/app.html
@@ -1,15 +1,11 @@
 <div class="calendar basic-calendar">
   <div class="calendar-header">
     <button class="month-control" aria-label="previous month" (click)="prevMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
-        >chevron_left</span
-      >
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_left</span>
     </button>
     <h3>{{ monthYearLabel() }}</h3>
     <button class="month-control" aria-label="next month" (click)="nextMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
-        >chevron_right</span
-      >
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_right</span>
     </button>
   </div>
 

--- a/adev/src/content/examples/aria/grid/src/calendar/material/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/calendar/material/app/app.html
@@ -1,15 +1,11 @@
 <div class="calendar material-calendar">
   <div class="calendar-header">
     <button class="month-control" aria-label="previous month" (click)="prevMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
-        >chevron_left</span
-      >
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_left</span>
     </button>
     <h3>{{ monthYearLabel() }}</h3>
     <button class="month-control" aria-label="next month" (click)="nextMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
-        >chevron_right</span
-      >
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_right</span>
     </button>
   </div>
 

--- a/adev/src/content/examples/aria/grid/src/calendar/retro/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/calendar/retro/app/app.html
@@ -1,15 +1,11 @@
 <div class="calendar retro-calendar">
   <div class="calendar-header">
     <button class="month-control" aria-label="previous month" (click)="prevMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
-        >chevron_left</span
-      >
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_left</span>
     </button>
     <h3>{{ monthYearLabel() }}</h3>
     <button class="month-control" aria-label="next month" (click)="nextMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
-        >chevron_right</span
-      >
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_right</span>
     </button>
   </div>
 

--- a/adev/src/content/examples/aria/grid/src/table/basic/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/table/basic/app/app.html
@@ -19,12 +19,7 @@
           (click)="sortTaskById()"
         >
           ID
-          <span
-            aria-hidden="true"
-            class="material-symbols-outlined"
-            translate="no"
-            aria-hidden="true"
-          >
+          <span aria-hidden="true" class="material-symbols-outlined" translate="no">
             {{ sortAscending ? 'arrow_upward' : 'arrow_downward' }}
           </span>
         </button>

--- a/adev/src/content/examples/aria/grid/src/table/retro/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/table/retro/app/app.html
@@ -19,12 +19,7 @@
           (click)="sortTaskById()"
         >
           Reward
-          <span
-            aria-hidden="true"
-            class="material-symbols-outlined"
-            translate="no"
-            aria-hidden="true"
-          >
+          <span aria-hidden="true" class="material-symbols-outlined" translate="no">
             {{ sortAscending ? 'arrow_upward' : 'arrow_downward' }}
           </span>
         </button>

--- a/adev/src/content/examples/aria/tree/src/disabled-focusable/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/disabled-focusable/basic/app/app.html
@@ -23,11 +23,7 @@
         node.children ? 'folder' : 'docs'
       }}</span>
       {{ node.name }}
-      <span
-        aria-hidden="true"
-        class="material-symbols-outlined selected-icon"
-        translate="no"
-        aria-hidden="true"
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/disabled-focusable/retro/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/disabled-focusable/retro/app/app.html
@@ -56,11 +56,7 @@
         }
       </span>
       {{ node.name }}
-      <span
-        aria-hidden="true"
-        class="material-symbols-outlined selected-icon"
-        translate="no"
-        aria-hidden="true"
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/multi-select/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/multi-select/basic/app/app.html
@@ -23,11 +23,7 @@
         node.children ? 'folder' : 'docs'
       }}</span>
       {{ node.name }}
-      <span
-        aria-hidden="true"
-        class="material-symbols-outlined selected-icon"
-        translate="no"
-        aria-hidden="true"
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/multi-select/retro/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/multi-select/retro/app/app.html
@@ -56,11 +56,7 @@
         }
       </span>
       {{ node.name }}
-      <span
-        aria-hidden="true"
-        class="material-symbols-outlined selected-icon"
-        translate="no"
-        aria-hidden="true"
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/nav/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/nav/basic/app/app.html
@@ -19,13 +19,9 @@
       href="#{{ node.name }}"
       (click)="$event.preventDefault()"
     >
-      <span
-        aria-hidden="true"
-        class="material-symbols-outlined"
-        translate="no"
-        aria-hidden="true"
-        >{{ node.icon }}</span
-      >
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">{{
+        node.icon
+      }}</span>
       {{ node.name }}
       <span aria-hidden="true" class="material-symbols-outlined expand-icon" translate="no">{{
         node.children ? 'keyboard_arrow_up' : ''

--- a/adev/src/content/examples/aria/tree/src/single-select-follow-focus/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/single-select-follow-focus/basic/app/app.html
@@ -23,11 +23,7 @@
         node.children ? 'folder' : 'docs'
       }}</span>
       {{ node.name }}
-      <span
-        aria-hidden="true"
-        class="material-symbols-outlined selected-icon"
-        translate="no"
-        aria-hidden="true"
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/single-select-follow-focus/retro/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/single-select-follow-focus/retro/app/app.html
@@ -56,11 +56,7 @@
         }
       </span>
       {{ node.name }}
-      <span
-        aria-hidden="true"
-        class="material-symbols-outlined selected-icon"
-        translate="no"
-        aria-hidden="true"
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/single-select/retro/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/single-select/retro/app/app.html
@@ -56,11 +56,7 @@
         }
       </span>
       {{ node.name }}
-      <span
-        aria-hidden="true"
-        class="material-symbols-outlined selected-icon"
-        translate="no"
-        aria-hidden="true"
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
         >check</span
       >
     </li>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

There are several instances of duplicate `aria-hidden` attributes in the examples. This seems to have been introduced with the commit https://github.com/angular/angular/commit/1c6049584ec8360ad1aa4afd96f4765bed449a79.

## What is the new behavior?

The duplicate `aria-hidden` attributes are removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No