### PR TITLE
fix(platform-browser): prevent XSS through style binding DOM clobbering

### DIFF
--- a/integration/defer/size.json
+++ b/integration/defer/size.json
@@ -1,5 +1,5 @@
 {
-  "dist/main.js": 12709,
-  "dist/polyfills.js": 35677,
-  "dist/defer.component-[hash].js": 345
+  "dist/main.js": 13425,
+  "dist/polyfills.js": 35784,
+  "dist/defer.component-[hash].js": 331
 }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -549,6 +549,7 @@
       "getRuntimeErrorCode",
       "getSelectedIndex",
       "getSelectedTNode",
+      "getStyleDeclaration",
       "getStyleHost",
       "getTNode",
       "getTNodeFromLView",

--- a/packages/core/test/bundling/create_component/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/create_component/bundle.golden_symbols.json
@@ -454,6 +454,7 @@
       "getRuntimeErrorCode",
       "getSelectedIndex",
       "getSelectedTNode",
+      "getStyleDeclaration",
       "getStyleHost",
       "getTNode",
       "getTNodeFromLView",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -46,6 +46,7 @@
       "errorHandler",
       "getBaseElementHref",
       "getDOM",
+      "getStyleDeclaration",
       "initDomAdapter",
       "isTemplateNode",
       "parseCookieValue",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -652,6 +652,7 @@
       "getSelectedIndex",
       "getSelectedTNode",
       "getSimpleChangesStore",
+      "getStyleDeclaration",
       "getStyleHost",
       "getSuperType",
       "getSymbolIterator",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -648,6 +648,7 @@
       "getSelectedIndex",
       "getSelectedTNode",
       "getSimpleChangesStore",
+      "getStyleDeclaration",
       "getStyleHost",
       "getSuperType",
       "getSymbolIterator",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -629,6 +629,7 @@
       "getSegmentHead",
       "getSelectedIndex",
       "getSerializedContainerViews",
+      "getStyleDeclaration",
       "getStyleHost",
       "getSymbolIterator",
       "getTDeferBlockDetails",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -741,6 +741,7 @@
       "getSelectedIndex",
       "getSelectedTNode",
       "getSimpleChangesStore",
+      "getStyleDeclaration",
       "getStyleHost",
       "getSymbolIterator",
       "getTNode",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -415,6 +415,7 @@
       "getRootTViewTemplate",
       "getRuntimeErrorCode",
       "getSelectedIndex",
+      "getStyleDeclaration",
       "getStyleHost",
       "getTNode",
       "getTNodeFromLView",

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -439,10 +439,15 @@ class DefaultDomRenderer2 implements Renderer2 {
     if (isVariable) {
       style = style.replace('%NS%', this.cssVarNamespace);
     }
+    const styleDeclaration = getStyleDeclaration(el);
     if (isVariable || flags & (RendererStyleFlags2.DashCase | RendererStyleFlags2.Important)) {
-      el.style.setProperty(style, value, flags & RendererStyleFlags2.Important ? 'important' : '');
+      styleDeclaration.setProperty(
+        style,
+        value,
+        flags & RendererStyleFlags2.Important ? 'important' : '',
+      );
     } else {
-      el.style[style] = value;
+      (styleDeclaration as any)[style] = value;
     }
   }
 
@@ -451,11 +456,12 @@ class DefaultDomRenderer2 implements Renderer2 {
     if (isVariable) {
       style = style.replace('%NS%', this.cssVarNamespace);
     }
+    const styleDeclaration = getStyleDeclaration(el);
     if (isVariable || flags & RendererStyleFlags2.DashCase) {
       // removeProperty has no effect when used on camelCased properties.
-      el.style.removeProperty(style);
+      styleDeclaration.removeProperty(style);
     } else {
-      el.style[style] = '';
+      (styleDeclaration as any)[style] = '';
     }
   }
 
@@ -553,6 +559,32 @@ function checkNoSyntheticProp(name: string, nameKind: string) {
 
 function isTemplateNode(node: any): node is HTMLTemplateElement {
   return node.tagName === 'TEMPLATE' && node.content !== undefined;
+}
+
+function getStyleDeclaration(el: any): CSSStyleDeclaration {
+  const style = el.style;
+  // Named form controls expose an element or RadioNodeList here,
+  // neither of which has these methods.
+  if (
+    style != null &&
+    typeof style.setProperty === 'function' &&
+    typeof style.removeProperty === 'function'
+  ) {
+    return style;
+  }
+
+  for (
+    let prototype = Object.getPrototypeOf(el);
+    prototype;
+    prototype = Object.getPrototypeOf(prototype)
+  ) {
+    const styleGetter = Object.getOwnPropertyDescriptor(prototype, 'style')?.get;
+    if (styleGetter) {
+      // Form-associated controls can shadow inherited properties through named property access.
+      return styleGetter.call(el);
+    }
+  }
+  return el.style;
 }
 
 class ShadowDomRenderer extends DefaultDomRenderer2 {

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -5,9 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {NgIf} from '@angular/common';
+import {NgIf, NgStyle} from '@angular/common';
 import {ChangeDetectionStrategy} from '@angular/compiler';
-import {Component, Renderer2, ViewEncapsulation} from '@angular/core';
+import {Component, Renderer2, signal, ViewEncapsulation} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {isNode} from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
@@ -89,6 +89,198 @@ describe('DefaultDomRendererV2', () => {
 
         expect(div.hasAttributeNS(namespaceUri, 'name')).toBe(false);
       }
+    });
+  });
+
+  describe('style DOM clobbering', () => {
+    const unsafeValue = '<img data-injected>';
+
+    describe('[style] bindings', () => {
+      async function expectStyleBinding(options: {
+        template: string;
+        expectedNamespace?: string;
+        expectedStyle?: string;
+      }): Promise<void> {
+        @Component({
+          template: options.template,
+        })
+        class App {
+          readonly unsafeValue = unsafeValue;
+          readonly stringStyles = `color: red; outerHTML: ${unsafeValue}`;
+          readonly objectStyles = {color: 'red', outerHTML: unsafeValue};
+        }
+
+        TestBed.resetTestingModule();
+        const fixture = TestBed.createComponent(App);
+        await fixture.whenStable();
+
+        const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+        const control = fixture.nativeElement.querySelector('[data-control]') as HTMLElement;
+
+        expect(form.style as unknown as HTMLElement).toBe(control);
+        expect(fixture.nativeElement.querySelector('[data-injected]')).toBeNull();
+        expect(control.isConnected).toBeTrue();
+        expect(form.getAttribute('style')).toContain(options.expectedStyle ?? 'color: red');
+        if (options.expectedNamespace) {
+          expect(form.namespaceURI).toBe(options.expectedNamespace);
+        }
+      }
+
+      async function expectStyleRemoval(style: string, value: string): Promise<void> {
+        @Component({
+          template: `
+            <form [style]="styles()">
+              <input name="style" data-control />
+            </form>
+          `,
+        })
+        class App {
+          readonly styles = signal<Record<string, string>>({[style]: value});
+        }
+
+        TestBed.resetTestingModule();
+        const fixture = TestBed.createComponent(App);
+        await fixture.whenStable();
+
+        const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+        const control = fixture.nativeElement.querySelector('[data-control]') as HTMLElement;
+        expect(form.getAttribute('style')).toContain(`${style}: ${value}`);
+
+        fixture.componentInstance.styles.set({});
+        await fixture.whenStable();
+
+        expect(form.style as unknown as HTMLElement).toBe(control);
+        expect(control.isConnected).toBeTrue();
+        expect(form.getAttribute('style')).not.toContain(style);
+      }
+
+      it('should recover the style declaration for string style maps', async () => {
+        await expectStyleBinding({
+          template: `
+          <form [style]="stringStyles">
+            <input name="style" id="localName" data-control />
+          </form>
+        `,
+        });
+      });
+
+      it('should recover the style declaration for object style maps', async () => {
+        await expectStyleBinding({
+          template: `
+          <form [style]="objectStyles">
+            <input id="style" data-control />
+          </form>
+        `,
+        });
+      });
+
+      it('should recover the style declaration when multiple controls clobber it', async () => {
+        @Component({
+          template: `
+            <form [style]="styles">
+              <input name="style" data-control />
+              <input name="style" data-control />
+            </form>
+          `,
+        })
+        class App {
+          readonly styles = {color: 'red', outerHTML: unsafeValue};
+        }
+
+        TestBed.resetTestingModule();
+        const fixture = TestBed.createComponent(App);
+        await fixture.whenStable();
+
+        const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+        const controls = fixture.nativeElement.querySelectorAll('[data-control]');
+        const clobberedStyle = form.style as unknown as RadioNodeList;
+
+        expect(clobberedStyle.length).toBe(2);
+        expect(clobberedStyle[0]).toBe(controls[0]);
+        expect(fixture.nativeElement.querySelector('[data-injected]')).toBeNull();
+        expect(controls.length).toBe(2);
+        expect(form.getAttribute('style')).toContain('color: red');
+      });
+
+      it('should recover the style declaration for style property bindings', async () => {
+        await expectStyleBinding({
+          template: `
+          <form [style.color]="'red'" [style.outerHTML]="unsafeValue">
+            <button name="style" data-control></button>
+          </form>
+        `,
+        });
+      });
+
+      it('should recover the style declaration for prefixed XHTML forms', async () => {
+        await expectStyleBinding({
+          template: `
+          <xhtml:form xmlns:xhtml="http://www.w3.org/1999/xhtml" [style]="objectStyles">
+            <xhtml:input name="style" data-control />
+          </xhtml:form>
+        `,
+          expectedNamespace: NAMESPACE_URIS['xhtml'],
+        });
+      });
+
+      it('should set dash-cased styles on prefixed XHTML forms', async () => {
+        await expectStyleBinding({
+          template: `
+          <xhtml:form xmlns:xhtml="http://www.w3.org/1999/xhtml" [style.--token]="'blue'">
+            <xhtml:input name="style" data-control />
+          </xhtml:form>
+        `,
+          expectedNamespace: NAMESPACE_URIS['xhtml'],
+          expectedStyle: '--token: blue',
+        });
+      });
+
+      it('should remove camel-cased styles from forms with clobbered style properties', async () => {
+        await expectStyleRemoval('color', 'red');
+      });
+
+      it('should remove dash-cased styles from forms with clobbered style properties', async () => {
+        await expectStyleRemoval('--token', 'blue');
+      });
+    });
+
+    describe('NgStyle', () => {
+      async function expectNgStyleBinding(template: string): Promise<void> {
+        @Component({
+          imports: [NgStyle],
+          template,
+        })
+        class App {
+          readonly styles = {color: 'red', outerHTML: unsafeValue};
+        }
+
+        TestBed.resetTestingModule();
+        const fixture = TestBed.createComponent(App);
+        await fixture.whenStable();
+
+        const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+        const control = fixture.nativeElement.querySelector('[data-control]') as HTMLElement;
+
+        expect(form.style as unknown as HTMLElement).toBe(control);
+        expect(fixture.nativeElement.querySelector('[data-injected]')).toBeNull();
+        expect(control.isConnected).toBeTrue();
+        expect(form.getAttribute('style')).toContain('color: red');
+      }
+
+      it('should recover the style declaration for associated controls', async () => {
+        await expectNgStyleBinding(`
+          <form [ngStyle]="styles">
+            <textarea name="style" data-control></textarea>
+          </form>
+        `);
+      });
+
+      it('should recover the style declaration for externally associated controls', async () => {
+        await expectNgStyleBinding(`
+          <form id="ng-style" [ngStyle]="styles"></form>
+          <select form="ng-style" name="style" data-control></select>
+        `);
+      });
     });
   });
 


### PR DESCRIPTION
Recover the intrinsic `CSSStyleDeclaration` before applying or removing style bindings. HTML named-property resolution can otherwise make a form control named or identified as style shadow `HTMLFormElement.style`.

This lets attacker-controlled keys from `[style]`, `[style.property]`, or `NgStyle` reach unrelated DOM sinks such as `innerHTML` and `outerHTML`, enabling same-origin script execution during rendering without an explicit trust bypass.

Fixes #70021
More context https://issuetracker.google.com/u/1/issues/540666920
