### PR TITLE
fix(devtools): Extension name for non googlers.

### DIFF
--- a/devtools/projects/shell-browser/src/app/background.ts
+++ b/devtools/projects/shell-browser/src/app/background.ts
@@ -34,7 +34,10 @@ function checkGoogler(): void {
     mode: 'no-cors',
     method: 'HEAD',
   })
-    .then(() => chrome.storage.local.set({isGoogler: true}))
+    .then((response) => {
+      // For non Googlers the Promise will resolve with status: 0/ok: false.
+      chrome.storage.local.set({isGoogler: response.status !== 0});
+    })
     .catch(() => chrome.storage.local.set({isGoogler: false}));
 }
 


### PR DESCRIPTION
For corps urls the promise is actually resolved but returns a `status:0` . 

fixes #70023
