### PR TITLE
docs: document deprecated allowSignalWrites option in v19 update guide

### DIFF
--- a/adev/src/app/features/update/recommendations.ts
+++ b/adev/src/app/features/update/recommendations.ts
@@ -2544,6 +2544,14 @@ export const RECOMMENDATIONS: Step[] = [
   },
   {
     action:
+      'Remove the `allowSignalWrites` option from `effect()` calls. The option is deprecated and no longer required, as signal writes inside effects are allowed by default.',
+    level: ApplicationComplexity.Medium,
+    necessaryAsOf: 1900,
+    possibleIn: 1900,
+    step: '19.0.0-remove-allow-signal-writes',
+  },
+  {
+    action:
       "In the application's project directory, run `ng update @angular/core@20 @angular/cli@20` to update your application to Angular v20.",
     level: ApplicationComplexity.Basic,
     necessaryAsOf: 2000,


### PR DESCRIPTION
The `allowSignalWrites` option of `effect()` became a no-op and was deprecated in v19, but the update guide never mentioned it. Applications upgrading from v18 or earlier still carry the option at their `effect()` call sites, where it now only produces a dev-mode warning.

Add an entry to the v19 recommendations instructing those applications to remove it, mirroring the wording of the deprecation notice on `CreateEffectOptions`.

https://angular.dev/api/core/CreateEffectOptions#allowSignalWrites 