### PR TITLE
[Backport 20.3.X] Http root interceptor ordering and preserve immutable clones

### DIFF
--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -223,16 +223,17 @@ export class HttpHeaders {
         this.headers.set(key, base);
         break;
       case 'd':
-        const toDelete = update.value as string | undefined;
-        if (!toDelete) {
+        const toDelete = update.value;
+        if (toDelete === undefined) {
           this.headers.delete(key);
           this.normalizedNames.delete(key);
         } else {
+          const valuesToDelete = Array.isArray(toDelete) ? toDelete : [toDelete];
           let existing = this.headers.get(key);
           if (!existing) {
             return;
           }
-          existing = existing.filter((value) => toDelete.indexOf(value) === -1);
+          existing = existing.filter((value) => valuesToDelete.indexOf(value) === -1);
           if (existing.length === 0) {
             this.headers.delete(key);
             this.normalizedNames.delete(key);

--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -192,10 +192,10 @@ export class HttpHeaders {
 
   private copyFrom(other: HttpHeaders) {
     other.init();
-    Array.from(other.headers.keys()).forEach((key) => {
-      this.headers.set(key, other.headers.get(key)!);
+    for (const [key, values] of other.headers.entries()) {
+      this.headers.set(key, values);
       this.normalizedNames.set(key, other.normalizedNames.get(key)!);
-    });
+    }
   }
 
   private clone(update: Update): HttpHeaders {
@@ -218,7 +218,7 @@ export class HttpHeaders {
           return;
         }
         this.maybeSetNormalizedName(update.name, key);
-        const base = (update.op === 'a' ? this.headers.get(key) : undefined) || [];
+        const base = update.op === 'a' ? (this.headers.get(key) || []).slice() : [];
         base.push(...value);
         this.headers.set(key, base);
         break;

--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -307,11 +307,15 @@ export class HttpInterceptorHandler extends HttpHandler {
 
   override handle(initialRequest: HttpRequest<any>): Observable<HttpEvent<any>> {
     if (this.chain === null) {
+      const parentHandler = this.injector.get(HttpHandler, null, {skipSelf: true});
+      const isDelegating = parentHandler !== null && this.backend === parentHandler;
+      const rootInterceptorFns = this.injector.get(
+        HTTP_ROOT_INTERCEPTOR_FNS,
+        [],
+        isDelegating ? {self: true} : undefined,
+      );
       const dedupedInterceptorFns = Array.from(
-        new Set([
-          ...this.injector.get(HTTP_INTERCEPTOR_FNS),
-          ...this.injector.get(HTTP_ROOT_INTERCEPTOR_FNS, []),
-        ]),
+        new Set([...this.injector.get(HTTP_INTERCEPTOR_FNS), ...rootInterceptorFns]),
       );
 
       // Note: interceptors are wrapped right-to-left so that final execution order is

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -324,18 +324,22 @@ export class HttpParams {
     }
     if (this.cloneFrom !== null) {
       this.cloneFrom.init();
-      this.cloneFrom.keys().forEach((key) => this.map!.set(key, this.cloneFrom!.map!.get(key)!));
+
+      for (const [key, values] of this.cloneFrom.map!.entries()) {
+        this.map!.set(key, values);
+      }
+
       this.updates!.forEach((update) => {
         switch (update.op) {
           case 'a':
           case 's':
-            const base = (update.op === 'a' ? this.map!.get(update.param) : undefined) || [];
+            const base = update.op === 'a' ? (this.map!.get(update.param) || []).slice() : [];
             base.push(valueToString(update.value!));
             this.map!.set(update.param, base);
             break;
           case 'd':
             if (update.value !== undefined) {
-              let base = this.map!.get(update.param) || [];
+              const base = (this.map!.get(update.param) || []).slice();
               const idx = base.indexOf(valueToString(update.value));
               if (idx !== -1) {
                 base.splice(idx, 1);

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -113,9 +113,16 @@ export function provideHttpClient(
       featureKinds.has(HttpFeatureKind.CustomXsrfConfiguration)
     ) {
       throw new Error(
-        ngDevMode
-          ? `Configuration error: found both withXsrfConfiguration() and withNoXsrfProtection() in the same call to provideHttpClient(), which is a contradiction.`
-          : '',
+        `Configuration error: found both withXsrfConfiguration() and withNoXsrfProtection() in the same call to provideHttpClient(), which is a contradiction.`,
+      );
+    }
+
+    if (
+      featureKinds.has(HttpFeatureKind.RequestsMadeViaParent) &&
+      featureKinds.has(HttpFeatureKind.Fetch)
+    ) {
+      throw new Error(
+        `Configuration error: withRequestsMadeViaParent() cannot be combined with withFetch() in the same call to provideHttpClient().`,
       );
     }
   }
@@ -274,6 +281,8 @@ export function withJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport> {
  * `withRequestsMadeViaParent` to be used at multiple levels, which will cause the request to
  * "bubble up" until either reaching the root level or an `HttpClient` which was not configured with
  * this option.
+ *
+ * This feature cannot be combined with `withFetch` in the same `provideHttpClient()` call.
  *
  * @see [HTTP client setup](guide/http/setup#withrequestsmadeviaparent)
  * @see {@link provideHttpClient}

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -154,6 +154,34 @@ describe('HttpHeaders', () => {
       const fourth = third.delete('FOO');
       expect(fourth.has('foo')).toEqual(false);
     });
+
+    it('should delete only the exact matching string value', () => {
+      const headers = new HttpHeaders({
+        'X-Scopes': ['tenant:alpha', 'tenant:alpha:archive'],
+      });
+
+      const updated = headers.delete('X-Scopes', 'tenant:alpha:archive');
+
+      expect(updated.getAll('X-Scopes')).toEqual(['tenant:alpha']);
+    });
+
+    it('should delete only exact matching values from an array', () => {
+      const headers = new HttpHeaders({
+        'X-Scopes': ['tenant:alpha', 'tenant:alpha:archive'],
+      });
+
+      const updated = headers.delete('X-Scopes', ['tenant:alpha:archive']);
+
+      expect(updated.getAll('X-Scopes')).toEqual(['tenant:alpha']);
+    });
+
+    it('should treat an empty string as a value to delete', () => {
+      const headers = new HttpHeaders({foo: ['', 'bar']});
+
+      const updated = headers.delete('foo', '');
+
+      expect(updated.getAll('foo')).toEqual(['bar']);
+    });
   });
 
   describe('.append', () => {

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -165,6 +165,15 @@ describe('HttpHeaders', () => {
       expect(third.getAll('foo')).toEqual(['bar', 'baz']);
     });
 
+    it('should not mutate a materialized source', () => {
+      const source = new HttpHeaders().set('foo', 'bar');
+      expect(source.getAll('foo')).toEqual(['bar']);
+
+      const clone = source.append('foo', 'baz');
+      expect(clone.getAll('foo')).toEqual(['bar', 'baz']);
+      expect(source.getAll('foo')).toEqual(['bar']);
+    });
+
     it('should preserve the case of the first call', () => {
       const headers = new HttpHeaders();
       const second = headers.append('FOO', 'bar');

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -72,6 +72,15 @@ describe('HttpUrlEncodedParams', () => {
       expect(mutated.toString()).toEqual('a=b&a=true');
     });
 
+    it('should not mutate a materialized source when appending', () => {
+      const source = new HttpParams().append('a', 'b');
+      expect(source.getAll('a')).toEqual(['b']);
+
+      const clone = source.append('a', 'c');
+      expect(clone.getAll('a')).toEqual(['b', 'c']);
+      expect(source.getAll('a')).toEqual(['b']);
+    });
+
     it('should allow appending all string parameters', () => {
       const body = new HttpParams({fromString: 'a=a1&b=b1'});
       const mutated = body.appendAll({a: ['a2', 'a3'], b: 'b2'});
@@ -136,6 +145,15 @@ describe('HttpUrlEncodedParams', () => {
       const body = new HttpParams({fromString: 'a=1&a=2&a=3&a=4&a=5'});
       const mutated = body.delete('a', '2').delete('a', '4');
       expect(mutated.getAll('a')).toEqual(['1', '3', '5']);
+    });
+
+    it('should not mutate a materialized source when deleting a value', () => {
+      const source = new HttpParams().append('a', '1').append('a', '2');
+      expect(source.getAll('a')).toEqual(['1', '2']);
+
+      const clone = source.delete('a', '1');
+      expect(clone.getAll('a')).toEqual(['2']);
+      expect(source.getAll('a')).toEqual(['1', '2']);
     });
 
     it('should allow deletion of one value of a number parameter', () => {

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -34,8 +34,13 @@ import {
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {EMPTY, Observable, from} from 'rxjs';
+import {tap} from 'rxjs/operators';
 
-import {HttpInterceptorFn, resetFetchBackendWarningFlag} from '../src/interceptor';
+import {
+  HTTP_ROOT_INTERCEPTOR_FNS,
+  HttpInterceptorFn,
+  resetFetchBackendWarningFlag,
+} from '../src/interceptor';
 import {
   HttpFeature,
   HttpFeatureKind,
@@ -358,6 +363,12 @@ describe('provideHttpClient', () => {
   });
 
   describe('withRequestsMadeViaParent()', () => {
+    it('should error when combined with a backend override', () => {
+      expect(() => provideHttpClient(withRequestsMadeViaParent(), withFetch())).toThrowError(
+        'Configuration error: withRequestsMadeViaParent() cannot be combined with withFetch() in the same call to provideHttpClient().',
+      );
+    });
+
     for (const backend of ['fetch', 'xhr']) {
       describe(`given '${backend}' backend`, () => {
         const commonHttpFeatures: HttpFeature<HttpFeatureKind>[] = [];
@@ -435,18 +446,59 @@ describe('provideHttpClient', () => {
           req.flush('');
         });
 
-        it('should be able to connect to a legacy-provided HttpClient context', () => {
+        it('should include root interceptors in independent child contexts', () => {
           TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [provideLegacyInterceptor('parent')],
+            providers: [
+              provideHttpClient(...commonHttpFeatures),
+              {
+                provide: HTTP_ROOT_INTERCEPTOR_FNS,
+                useValue: makeLiteralTagInterceptorFn('root'),
+                multi: true,
+              },
+              provideHttpClientTesting(),
+            ],
+          });
+
+          const child = createEnvironmentInjector(
+            [
+              provideHttpClient(withInterceptors([makeLiteralTagInterceptorFn('child')])),
+              {
+                provide: HttpBackend,
+                useFactory: () => inject(HttpBackend, {skipSelf: true}),
+              },
+            ],
+            TestBed.inject(EnvironmentInjector),
+          );
+
+          child.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+          const req = TestBed.inject(HttpTestingController).expectOne('/test');
+          expect(req.request.headers.get('X-Tag')).toEqual('child,root');
+          req.flush('');
+        });
+
+        it('should run root interceptors once in the parent request and response chain', () => {
+          const order: string[] = [];
+
+          TestBed.configureTestingModule({
+            providers: [
+              provideHttpClient(
+                ...commonHttpFeatures,
+                withInterceptors([makeOrderedTagInterceptorFn('parent', order)]),
+              ),
+              {
+                provide: HTTP_ROOT_INTERCEPTOR_FNS,
+                useValue: makeOrderedTagInterceptorFn('root', order),
+                multi: true,
+              },
+              provideHttpClientTesting(),
+            ],
           });
 
           const child = createEnvironmentInjector(
             [
               provideHttpClient(
-                ...commonHttpFeatures,
                 withRequestsMadeViaParent(),
-                withInterceptors([makeLiteralTagInterceptorFn('child')]),
+                withInterceptors([makeOrderedTagInterceptorFn('child', order)]),
               ),
             ],
             TestBed.inject(EnvironmentInjector),
@@ -454,11 +506,112 @@ describe('provideHttpClient', () => {
 
           child.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
           const req = TestBed.inject(HttpTestingController).expectOne('/test');
-          expect(req.request.headers.get('X-Tag')).toEqual('child,parent');
+          expect(req.request.headers.get('X-Tag')).toEqual('child,parent,root');
+          expect(order).toEqual(['child:request', 'parent:request', 'root:request']);
           req.flush('');
+          expect(order).toEqual([
+            'child:request',
+            'parent:request',
+            'root:request',
+            'root:response',
+            'parent:response',
+            'child:response',
+          ]);
         });
       });
     }
+
+    it('should be able to connect to a legacy-provided HttpClient context', () => {
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [provideLegacyInterceptor('parent')],
+      });
+
+      const child = createEnvironmentInjector(
+        [
+          provideHttpClient(
+            withRequestsMadeViaParent(),
+            withInterceptors([makeLiteralTagInterceptorFn('child')]),
+          ),
+        ],
+        TestBed.inject(EnvironmentInjector),
+      );
+
+      child.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+      const req = TestBed.inject(HttpTestingController).expectOne('/test');
+      expect(req.request.headers.get('X-Tag')).toEqual('child,parent');
+      req.flush('');
+    });
+
+    it('should inherit root interceptors in independent child contexts', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(),
+          {
+            provide: HTTP_ROOT_INTERCEPTOR_FNS,
+            useValue: makeLiteralTagInterceptorFn('root'),
+            multi: true,
+          },
+          provideHttpClientTesting(),
+        ],
+      });
+
+      const delegatingParent = createEnvironmentInjector(
+        [provideHttpClient(withRequestsMadeViaParent())],
+        TestBed.inject(EnvironmentInjector),
+      );
+      const independentChild = createEnvironmentInjector(
+        [
+          provideHttpClient(withInterceptors([makeLiteralTagInterceptorFn('child')])),
+          {provide: HttpBackend, useValue: TestBed.inject(HttpBackend)},
+        ],
+        delegatingParent,
+      );
+
+      try {
+        independentChild.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+        const req = TestBed.inject(HttpTestingController).expectOne('/test');
+        expect(req.request.headers.get('X-Tag')).toEqual('child,root');
+        req.flush('');
+      } finally {
+        independentChild.destroy();
+        delegatingParent.destroy();
+      }
+    });
+
+    it('should inherit root interceptors when a custom provider overrides delegation', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(),
+          {
+            provide: HTTP_ROOT_INTERCEPTOR_FNS,
+            useValue: makeLiteralTagInterceptorFn('root'),
+            multi: true,
+          },
+          provideHttpClientTesting(),
+        ],
+      });
+
+      const child = createEnvironmentInjector(
+        [
+          provideHttpClient(
+            withRequestsMadeViaParent(),
+            withInterceptors([makeLiteralTagInterceptorFn('child')]),
+          ),
+          {provide: HttpBackend, useValue: TestBed.inject(HttpBackend)},
+        ],
+        TestBed.inject(EnvironmentInjector),
+      );
+
+      try {
+        child.get(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+        const req = TestBed.inject(HttpTestingController).expectOne('/test');
+        expect(req.request.headers.get('X-Tag')).toEqual('child,root');
+        req.flush('');
+      } finally {
+        child.destroy();
+      }
+    });
   });
 
   describe('compatibility with Http NgModules', () => {
@@ -599,6 +752,19 @@ function provideLegacyInterceptor(tag: string): Provider {
 
 function makeLiteralTagInterceptorFn(tag: string): HttpInterceptorFn {
   return (req, next) => next(addTagToRequest(req, tag));
+}
+
+function makeOrderedTagInterceptorFn(tag: string, order: string[]): HttpInterceptorFn {
+  return (req, next) => {
+    order.push(`${tag}:request`);
+    return next(addTagToRequest(req, tag)).pipe(
+      tap((event) => {
+        if (event instanceof HttpResponse) {
+          order.push(`${tag}:response`);
+        }
+      }),
+    );
+  };
 }
 
 function makeTokenTagInterceptorFn(tag: InjectionToken<string>): HttpInterceptorFn {

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -10,6 +10,8 @@ import {DOCUMENT} from '../../index';
 import {
   ApplicationRef,
   Component,
+  createEnvironmentInjector,
+  EnvironmentInjector,
   Injectable,
   PLATFORM_ID,
   TransferState,
@@ -26,6 +28,8 @@ import {
   HttpRequest,
   HttpResponse,
   provideHttpClient,
+  withInterceptors,
+  withRequestsMadeViaParent,
 } from '../public_api';
 import {
   BODY,
@@ -291,6 +295,124 @@ describe('TransferCache', () => {
 
       expect(firstNext).toHaveBeenCalledTimes(1);
       expect(secondNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('withRequestsMadeViaParent()', () => {
+    let childInjector: EnvironmentInjector;
+
+    beforeEach(() => {
+      globalThis['ngServerMode'] = true;
+
+      TestBed.configureTestingModule({
+        providers: [
+          TransferState,
+          withHttpTransferCache({
+            filter: (request) => !request.headers.has('X-API-Key'),
+          }),
+          provideHttpClient(
+            withInterceptors([
+              (request, next) => {
+                if (request.url === '/private') {
+                  request = request.clone({
+                    setHeaders: {Authorization: 'Bearer server-token'},
+                  });
+                } else if (request.url === '/secret') {
+                  request = request.clone({setHeaders: {'X-API-Key': 'secret-a'}});
+                } else if (request.url === '/public-alias') {
+                  request = request.clone({url: '/public'});
+                }
+
+                return next(request);
+              },
+            ]),
+          ),
+          provideHttpClientTesting(),
+        ],
+      });
+
+      childInjector = createEnvironmentInjector(
+        [
+          provideHttpClient(
+            withInterceptors([
+              (request, next) =>
+                next(request.clone({setHeaders: {'X-Trace-Id': 'feature-request'}})),
+            ]),
+            withRequestsMadeViaParent(),
+          ),
+        ],
+        TestBed.inject(EnvironmentInjector),
+      );
+    });
+
+    afterEach(() => {
+      childInjector.destroy();
+      TestBed.inject(HttpTestingController).verify();
+      globalThis['ngServerMode'] = undefined;
+    });
+
+    it('should evaluate cache eligibility and keys after parent interceptors', () => {
+      const httpClient = childInjector.get(HttpClient);
+      const httpTestingController = TestBed.inject(HttpTestingController);
+      const transferState = TestBed.inject(TransferState);
+
+      let privateResponse: unknown;
+      httpClient.get('/private').subscribe((response) => (privateResponse = response));
+      const privateRequest = httpTestingController.expectOne('/private');
+      expect(privateRequest.request.headers.get('Authorization')).toBe('Bearer server-token');
+      expect(privateRequest.request.headers.get('X-Trace-Id')).toBe('feature-request');
+      privateRequest.flush({internalSecret: 'server-only'});
+
+      expect(privateResponse).toEqual({internalSecret: 'server-only'});
+      expect(JSON.parse(transferState.toJson())).toEqual({});
+
+      let publicResponse: unknown;
+      httpClient.get('/public-alias').subscribe((response) => (publicResponse = response));
+      httpTestingController.expectOne('/public').flush({message: 'public'});
+
+      publicResponse = undefined;
+      httpClient.get('/public-alias').subscribe((response) => (publicResponse = response));
+      httpTestingController.expectNone('/public');
+      expect(publicResponse).toEqual({message: 'public'});
+    });
+
+    it('should evaluate cache filters after parent interceptors', () => {
+      const httpClient = childInjector.get(HttpClient);
+      const httpTestingController = TestBed.inject(HttpTestingController);
+      const transferState = TestBed.inject(TransferState);
+
+      let response: unknown;
+      httpClient.get('/secret').subscribe((value) => (response = value));
+      const request = httpTestingController.expectOne('/secret');
+      expect(request.request.headers.get('X-API-KEY')).toBe('secret-a');
+      request.flush({internalSecret: 'secret-only'});
+
+      expect(response).toEqual({internalSecret: 'secret-only'});
+      expect(JSON.parse(transferState.toJson())).toEqual({});
+    });
+
+    it('should evaluate cache eligibility through multiple parent clients', () => {
+      const grandchildInjector = createEnvironmentInjector(
+        [provideHttpClient(withRequestsMadeViaParent())],
+        childInjector,
+      );
+
+      try {
+        const httpClient = grandchildInjector.get(HttpClient);
+        const httpTestingController = TestBed.inject(HttpTestingController);
+        const transferState = TestBed.inject(TransferState);
+
+        let privateResponse: unknown;
+        httpClient.get('/private').subscribe((response) => (privateResponse = response));
+        const privateRequest = httpTestingController.expectOne('/private');
+        expect(privateRequest.request.headers.get('Authorization')).toBe('Bearer server-token');
+        privateRequest.flush({internalSecret: 'server-only'});
+
+        expect(privateResponse).toEqual({internalSecret: 'server-only'});
+        expect(JSON.parse(transferState.toJson())).toEqual({});
+      } finally {
+        grandchildInjector.destroy();
+      }
     });
   });
 


### PR DESCRIPTION
 Backport of https://github.com/angular/angular/pull/69778 and https://github.com/angular/angular/pull/69762
 
 Note : This seems similar to [GHSA-q6f4-qqrg-jv6x](https://github.com/angular/angular/security/advisories/GHSA-q6f4-qqrg-jv6x)