### PR TITLE
refactor(common): modernize directive tests to rely on whenStable

### DIFF
--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -17,7 +17,6 @@ import {
   Injector,
   Input,
   NgModule,
-  NO_ERRORS_SCHEMA,
   Optional,
   QueryList,
   TemplateRef,
@@ -28,96 +27,88 @@ import {
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
-import {CommonModule} from '../../index';
 import {NgComponentOutlet} from '../../src/directives/ng_component_outlet';
 
 describe('insert/remove', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TestModule],
-    });
-  });
-
-  it('should do nothing if component is null', () => {
+  it('should do nothing if component is null', async () => {
     const template = `<ng-template *ngComponentOutlet="currentComponent"></ng-template>`;
     TestBed.overrideComponent(TestComponent, {set: {template: template}});
     let fixture = TestBed.createComponent(TestComponent);
 
     fixture.componentInstance.currentComponent = null;
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement).toHaveText('');
   });
 
-  it('should insert content specified by a component', () => {
+  it('should insert content specified by a component', async () => {
     let fixture = TestBed.createComponent(TestComponent);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('');
 
     fixture.componentInstance.currentComponent = InjectedComponent;
 
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('foo');
   });
 
-  it('should emit a ComponentRef once a component was created', () => {
+  it('should emit a ComponentRef once a component was created', async () => {
     let fixture = TestBed.createComponent(TestComponent);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('');
 
     fixture.componentInstance.cmpRef = undefined;
-    fixture.changeDetectorRef.markForCheck();
     fixture.componentInstance.currentComponent = InjectedComponent;
 
-    fixture.detectChanges();
+    fixture.changeDetectorRef.markForCheck();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('foo');
     expect(fixture.componentInstance.cmpRef).toBeInstanceOf(ComponentRef);
     expect(fixture.componentInstance.cmpRef!.instance).toBeInstanceOf(InjectedComponent);
   });
 
-  it('should clear view if component becomes null', () => {
+  it('should clear view if component becomes null', async () => {
     let fixture = TestBed.createComponent(TestComponent);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('');
 
     fixture.componentInstance.currentComponent = InjectedComponent;
 
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('foo');
 
     fixture.componentInstance.currentComponent = null;
 
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('');
   });
 
-  it('should swap content if component changes', () => {
+  it('should swap content if component changes', async () => {
     let fixture = TestBed.createComponent(TestComponent);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('');
 
     fixture.componentInstance.currentComponent = InjectedComponent;
 
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('foo');
 
     fixture.componentInstance.currentComponent = InjectedComponentAgain;
 
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('bar');
   });
 
-  it('should use the injector, if one supplied', () => {
+  it('should use the injector, if one supplied', async () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     const uniqueValue = {};
@@ -127,15 +118,14 @@ describe('insert/remove', () => {
       parent: fixture.componentRef.injector,
     });
 
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
     expect(cmpRef).toBeInstanceOf(ComponentRef);
     expect(cmpRef.instance).toBeInstanceOf(InjectedComponent);
     expect(cmpRef.instance.testToken).toBe(uniqueValue);
   });
 
-  it('should use the environmentInjector, if one supplied', () => {
+  it('should use the environmentInjector, if one supplied', async () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     const uniqueValue = {};
@@ -151,41 +141,37 @@ describe('insert/remove', () => {
       environmentInjector,
     );
 
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
     expect(cmpRef).toBeInstanceOf(ComponentRef);
     expect(cmpRef.instance).toBeInstanceOf(InjectedComponent);
     expect(cmpRef.instance.testToken).toBe(uniqueValue);
   });
 
-  it('should resolve with an injector', () => {
+  it('should resolve with an injector', async () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     // We are accessing a ViewChild (ngComponentOutlet) before change detection has run
     fixture.componentInstance.cmpRef = undefined;
     fixture.componentInstance.currentComponent = InjectedComponent;
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
     expect(cmpRef).toBeInstanceOf(ComponentRef);
     expect(cmpRef.instance).toBeInstanceOf(InjectedComponent);
     expect(cmpRef.instance.testToken).toBeNull();
   });
 
-  it('should render projectable nodes, if supplied', () => {
+  it('should render projectable nodes, if supplied', async () => {
     const template = `<ng-template>projected foo</ng-template>${TEST_CMP_TEMPLATE}`;
-    TestBed.overrideComponent(TestComponent, {set: {template: template}}).configureTestingModule({
-      schemas: [NO_ERRORS_SCHEMA],
-    });
+    TestBed.overrideComponent(TestComponent, {set: {template}});
 
     TestBed.overrideComponent(InjectedComponent, {
       set: {template: `<ng-content></ng-content>`},
-    }).configureTestingModule({schemas: [NO_ERRORS_SCHEMA]});
+    });
 
     let fixture = TestBed.createComponent(TestComponent);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('');
 
     fixture.componentInstance.currentComponent = InjectedComponent;
@@ -195,29 +181,29 @@ describe('insert/remove', () => {
     ];
 
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('projected foo');
   });
 
-  it('should resolve components from other modules, if supplied as an NgModule class reference', () => {
+  it('should resolve components from other modules, if supplied as an NgModule class reference', async () => {
     let fixture = TestBed.createComponent(TestComponent);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('');
 
     fixture.componentInstance.ngModule = TestModule2;
     fixture.componentInstance.currentComponent = Module2InjectedComponent;
 
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText('baz');
   });
 
-  it('should clean up moduleRef, if supplied as an NgModule class reference', () => {
+  it('should clean up moduleRef, if supplied as an NgModule class reference', async () => {
     const fixture = TestBed.createComponent(TestComponent);
     fixture.componentInstance.ngModule = TestModule2;
     fixture.componentInstance.currentComponent = Module2InjectedComponent;
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const moduleRef = fixture.componentInstance.ngComponentOutlet?.['_moduleRef']!;
     spyOn(moduleRef, 'destroy').and.callThrough();
@@ -227,24 +213,23 @@ describe('insert/remove', () => {
     expect(moduleRef.destroy).toHaveBeenCalled();
   });
 
-  it('should re-create moduleRef when changed (NgModule class reference)', () => {
+  it('should re-create moduleRef when changed (NgModule class reference)', async () => {
     const fixture = TestBed.createComponent(TestComponent);
     fixture.componentInstance.ngModule = TestModule2;
     fixture.componentInstance.currentComponent = Module2InjectedComponent;
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement).toHaveText('baz');
 
     fixture.componentInstance.ngModule = TestModule3;
     fixture.componentInstance.currentComponent = Module3InjectedComponent;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement).toHaveText('bat');
   });
 
-  it('should override providers from parent component using custom injector', () => {
+  it('should override providers from parent component using custom injector', async () => {
     TestBed.overrideComponent(InjectedComponent, {set: {template: 'Value: {{testToken}}'}});
     TestBed.overrideComponent(TestComponent, {
       set: {providers: [{provide: TEST_TOKEN, useValue: 'parent'}]},
@@ -255,13 +240,12 @@ describe('insert/remove', () => {
       providers: [{provide: TEST_TOKEN, useValue: 'child'}],
       parent: fixture.componentInstance.vcRef.injector,
     });
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement).toHaveText('Value: child');
   });
 
-  it('should be available as a standalone directive', () => {
+  it('should be available as a standalone directive', async () => {
     @Component({
       template: 'Hello World',
     })
@@ -277,105 +261,102 @@ describe('insert/remove', () => {
     }
 
     const fixture = TestBed.createComponent(TestComponent);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('Hello World');
   });
 
-  it('should be able to get the current component instance', () => {
+  it('should be able to get the current component instance', async () => {
     const fixture = TestBed.createComponent(TestComponent);
-    fixture.detectChanges();
+    await fixture.whenStable();
     const outlet = fixture.componentInstance.ngComponentOutlet!;
 
     expect(outlet.componentInstance).toBeNull();
 
     fixture.componentInstance.currentComponent = InjectedComponent;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(outlet.componentInstance).toBeInstanceOf(InjectedComponent);
   });
 });
 
 describe('inputs', () => {
-  it('should be binding the component input', () => {
+  it('should be binding the component input', async () => {
     const fixture = TestBed.createComponent(TestInputsComponent);
     fixture.componentInstance.currentComponent = ComponentWithInputs;
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: , baz: Baz');
 
     fixture.componentInstance.inputs = {};
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: , baz: Baz');
 
     fixture.componentInstance.inputs = {foo: 'Foo', bar: 'Bar'};
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Foo, bar: Bar, baz: Baz');
 
     fixture.componentInstance.inputs = {foo: 'Foo'};
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Foo, bar: , baz: Baz');
 
     fixture.componentInstance.inputs = {foo: 'Foo', baz: null};
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Foo, bar: , baz: ');
 
     fixture.componentInstance.inputs = undefined;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: , baz: ');
   });
 
-  it('should be binding the component input (with mutable inputs)', () => {
+  it('should be binding the component input (with mutable inputs)', async () => {
     const fixture = TestBed.createComponent(TestInputsComponent);
     fixture.componentInstance.currentComponent = ComponentWithInputs;
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: , baz: Baz');
 
     fixture.componentInstance.inputs = {foo: 'Hello', bar: 'World'};
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Hello, bar: World, baz: Baz');
 
     fixture.componentInstance.inputs['bar'] = 'Angular';
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Hello, bar: Angular, baz: Baz');
 
     delete fixture.componentInstance.inputs['foo'];
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: Angular, baz: Baz');
   });
 
-  it('should be binding the component input (with component type change)', () => {
+  it('should be binding the component input (with component type change)', async () => {
     const fixture = TestBed.createComponent(TestInputsComponent);
     fixture.componentInstance.currentComponent = ComponentWithInputs;
     fixture.componentInstance.inputs = {foo: 'Foo', bar: 'Bar'};
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Foo, bar: Bar, baz: Baz');
 
     fixture.componentInstance.currentComponent = AnotherComponentWithInputs;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('[ANOTHER] foo: Foo, bar: Bar, baz: Baz');
   });
@@ -385,7 +366,6 @@ const TEST_TOKEN = new InjectionToken('TestToken');
 @Component({
   selector: 'injected-component',
   template: 'foo',
-  standalone: false,
   changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InjectedComponent {
@@ -395,7 +375,6 @@ class InjectedComponent {
 @Component({
   selector: 'injected-component-again',
   template: 'bar',
-  standalone: false,
   changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InjectedComponentAgain {}
@@ -411,7 +390,7 @@ const TEST_CMP_TEMPLATE = `<ng-template *ngComponentOutlet="
 @Component({
   selector: 'test-cmp',
   template: TEST_CMP_TEMPLATE,
-  standalone: false,
+  imports: [NgComponentOutlet],
   changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
@@ -437,13 +416,6 @@ class TestComponent {
   constructor(public vcRef: ViewContainerRef) {}
 }
 
-@NgModule({
-  imports: [CommonModule],
-  declarations: [TestComponent, InjectedComponent, InjectedComponentAgain],
-  exports: [TestComponent, InjectedComponent, InjectedComponentAgain],
-})
-export class TestModule {}
-
 @Component({
   selector: 'module-2-injected-component',
   template: 'baz',
@@ -459,7 +431,6 @@ class Module2InjectedComponent {}
 class Module2InjectedComponent2 {}
 
 @NgModule({
-  imports: [CommonModule],
   declarations: [Module2InjectedComponent, Module2InjectedComponent2],
   exports: [Module2InjectedComponent, Module2InjectedComponent2],
 })
@@ -473,7 +444,6 @@ export class TestModule2 {}
 class Module3InjectedComponent {}
 
 @NgModule({
-  imports: [CommonModule],
   declarations: [Module3InjectedComponent],
   exports: [Module3InjectedComponent],
 })

--- a/packages/common/test/directives/ng_plural_spec.ts
+++ b/packages/common/test/directives/ng_plural_spec.ts
@@ -10,7 +10,7 @@ import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Component, Injectable} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
-import {CommonModule, NgLocalization, NgPlural, NgPluralCase} from '../../index';
+import {NgLocalization, NgPlural, NgPluralCase} from '../../index';
 
 describe('ngPlural', () => {
   let fixture: ComponentFixture<any>;
@@ -19,9 +19,8 @@ describe('ngPlural', () => {
     return fixture.componentInstance;
   }
 
-  function detectChangesAndExpectText(text: string): void {
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+  async function waitForStableAndExpectText(text: string): Promise<void> {
+    await fixture.whenStable();
     expect(fixture.nativeElement).toHaveText(text);
   }
 
@@ -29,15 +28,7 @@ describe('ngPlural', () => {
     fixture = null!;
   });
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [TestComponent],
-      providers: [{provide: NgLocalization, useClass: TestLocalization}],
-      imports: [CommonModule],
-    });
-  });
-
-  it('should display the template according to the exact value', () => {
+  it('should display the template according to the exact value', async () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="=0"><li>you have no messages.</li></ng-template>' +
@@ -47,13 +38,14 @@ describe('ngPlural', () => {
     fixture = createTestComponent(template);
 
     getComponent().switchValue = 0;
-    detectChangesAndExpectText('you have no messages.');
+    await waitForStableAndExpectText('you have no messages.');
 
     getComponent().switchValue = 1;
-    detectChangesAndExpectText('you have one message.');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('you have one message.');
   });
 
-  it('should display the template according to the exact numeric value', () => {
+  it('should display the template according to the exact numeric value', async () => {
     const template =
       '<div>' +
       '<ul [ngPlural]="switchValue">' +
@@ -64,15 +56,16 @@ describe('ngPlural', () => {
     fixture = createTestComponent(template);
 
     getComponent().switchValue = 0;
-    detectChangesAndExpectText('you have no messages.');
+    await waitForStableAndExpectText('you have no messages.');
 
     getComponent().switchValue = 1;
-    detectChangesAndExpectText('you have one message.');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('you have one message.');
   });
 
   // https://github.com/angular/angular/issues/9868
   // https://github.com/angular/angular/issues/9882
-  it('should not throw when ngPluralCase contains expressions', () => {
+  it('should not throw when ngPluralCase contains expressions', async () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="=0"><li>{{ switchValue }}</li></ng-template>' +
@@ -81,10 +74,10 @@ describe('ngPlural', () => {
     fixture = createTestComponent(template);
 
     getComponent().switchValue = 0;
-    expect(() => fixture.detectChanges()).not.toThrow();
+    await expectAsync(fixture.whenStable()).toBeResolved();
   });
 
-  it('should be applicable to <ng-container> elements', () => {
+  it('should be applicable to <ng-container> elements', async () => {
     const template =
       '<ng-container [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="=0">you have no messages.</ng-template>' +
@@ -94,13 +87,14 @@ describe('ngPlural', () => {
     fixture = createTestComponent(template);
 
     getComponent().switchValue = 0;
-    detectChangesAndExpectText('you have no messages.');
+    await waitForStableAndExpectText('you have no messages.');
 
     getComponent().switchValue = 1;
-    detectChangesAndExpectText('you have one message.');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('you have one message.');
   });
 
-  it('should display the template according to the category', () => {
+  it('should display the template according to the category', async () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
@@ -110,13 +104,14 @@ describe('ngPlural', () => {
     fixture = createTestComponent(template);
 
     getComponent().switchValue = 2;
-    detectChangesAndExpectText('you have a few messages.');
+    await waitForStableAndExpectText('you have a few messages.');
 
     getComponent().switchValue = 8;
-    detectChangesAndExpectText('you have many messages.');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('you have many messages.');
   });
 
-  it('should default to other when no matches are found', () => {
+  it('should default to other when no matches are found', async () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
@@ -126,10 +121,10 @@ describe('ngPlural', () => {
     fixture = createTestComponent(template);
 
     getComponent().switchValue = 100;
-    detectChangesAndExpectText('default message.');
+    await waitForStableAndExpectText('default message.');
   });
 
-  it('should prioritize value matches over category matches', () => {
+  it('should prioritize value matches over category matches', async () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
@@ -139,13 +134,14 @@ describe('ngPlural', () => {
     fixture = createTestComponent(template);
 
     getComponent().switchValue = 2;
-    detectChangesAndExpectText('you have two messages.');
+    await waitForStableAndExpectText('you have two messages.');
 
     getComponent().switchValue = 3;
-    detectChangesAndExpectText('you have a few messages.');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('you have a few messages.');
   });
 
-  it('should be available as a standalone directive', () => {
+  it('should be available as a standalone directive', async () => {
     @Component({
       selector: 'test-component',
       imports: [NgPlural, NgPluralCase],
@@ -160,7 +156,7 @@ describe('ngPlural', () => {
     }
 
     const fixture = TestBed.createComponent(TestComponent);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('one message');
   });
@@ -184,7 +180,8 @@ class TestLocalization extends NgLocalization {
 @Component({
   selector: 'test-cmp',
   template: '',
-  standalone: false,
+  imports: [NgPlural, NgPluralCase],
+  providers: [{provide: NgLocalization, useClass: TestLocalization}],
   changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -15,7 +15,6 @@ import {
   Injectable,
   InjectionToken,
   Injector,
-  NO_ERRORS_SCHEMA,
   OnDestroy,
   Optional,
   Provider,
@@ -26,7 +25,7 @@ import {
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
-import {CommonModule, NgTemplateOutlet} from '../../index';
+import {NgTemplateOutlet} from '../../index';
 
 describe('NgTemplateOutlet', () => {
   let fixture: ComponentFixture<any>;
@@ -35,9 +34,8 @@ describe('NgTemplateOutlet', () => {
     fixture.componentInstance.currentTplRef = value;
   }
 
-  function detectChangesAndExpectText(text: string): void {
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+  async function waitForStableAndExpectText(text: string): Promise<void> {
+    await fixture.whenStable();
     expect(fixture.debugElement.nativeElement).toHaveText(text);
   }
 
@@ -45,150 +43,141 @@ describe('NgTemplateOutlet', () => {
     fixture = null as any;
   });
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [
-        TestComponent,
-        CaptureTplRefs,
-        DestroyableCmpt,
-        MultiContextComponent,
-        InjectValueComponent,
-        ProvideValueComponent,
-        NestingCounter,
-      ],
-      imports: [CommonModule],
-      providers: [DestroyedSpyService],
-    });
-  });
-
   // https://github.com/angular/angular/issues/14778
-  it('should accept the component as the context', () => {
+  it('should accept the component as the context', async () => {
     const template =
       `<ng-container *ngTemplateOutlet="tpl; context: this"></ng-container>` +
       `<ng-template #tpl>{{context.foo}}</ng-template>`;
 
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('bar');
+    await waitForStableAndExpectText('bar');
   });
 
-  it('should do nothing if templateRef is `null`', () => {
+  it('should do nothing if templateRef is `null`', async () => {
     const template = `<ng-container [ngTemplateOutlet]="null"></ng-container>`;
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('');
+    await waitForStableAndExpectText('');
   });
 
-  it('should do nothing if templateRef is `undefined`', () => {
+  it('should do nothing if templateRef is `undefined`', async () => {
     const template = `<ng-container [ngTemplateOutlet]="undefined"></ng-container>`;
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('');
+    await waitForStableAndExpectText('');
   });
 
-  it('should insert content specified by TemplateRef', () => {
+  it('should insert content specified by TemplateRef', async () => {
     const template =
       `<ng-template #tpl>foo</ng-template>` +
       `<ng-container [ngTemplateOutlet]="tpl"></ng-container>`;
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('foo');
+    await waitForStableAndExpectText('foo');
   });
 
-  it('should clear content if TemplateRef becomes `null`', () => {
+  it('should clear content if TemplateRef becomes `null`', async () => {
     const template =
       `<tpl-refs #refs="tplRefs"><ng-template>foo</ng-template></tpl-refs>` +
       `<ng-container [ngTemplateOutlet]="currentTplRef"></ng-container>`;
     fixture = createTestComponent(template);
-    fixture.detectChanges();
+    await fixture.whenStable();
     const refs = fixture.debugElement.children[0].references!['refs'];
 
     setTplRef(refs.tplRefs.first);
-    detectChangesAndExpectText('foo');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('foo');
 
     setTplRef(null);
-    detectChangesAndExpectText('');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('');
   });
 
-  it('should clear content if TemplateRef becomes `undefined`', () => {
+  it('should clear content if TemplateRef becomes `undefined`', async () => {
     const template =
       `<tpl-refs #refs="tplRefs"><ng-template>foo</ng-template></tpl-refs>` +
       `<ng-container [ngTemplateOutlet]="currentTplRef"></ng-container>`;
     fixture = createTestComponent(template);
-    fixture.detectChanges();
+    await fixture.whenStable();
     const refs = fixture.debugElement.children[0].references!['refs'];
 
     setTplRef(refs.tplRefs.first);
-    detectChangesAndExpectText('foo');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('foo');
 
     setTplRef(undefined);
-    detectChangesAndExpectText('');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('');
   });
 
-  it('should swap content if TemplateRef changes', () => {
+  it('should swap content if TemplateRef changes', async () => {
     const template =
       `<tpl-refs #refs="tplRefs"><ng-template>foo</ng-template><ng-template>bar</ng-template></tpl-refs>` +
       `<ng-container [ngTemplateOutlet]="currentTplRef"></ng-container>`;
     fixture = createTestComponent(template);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
     const refs = fixture.debugElement.children[0].references!['refs'];
 
     setTplRef(refs.tplRefs.first);
-    detectChangesAndExpectText('foo');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('foo');
 
     setTplRef(refs.tplRefs.last);
-    detectChangesAndExpectText('bar');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('bar');
   });
 
-  it('should display template if context is `null`', () => {
+  it('should display template if context is `null`', async () => {
     const template =
       `<ng-template #tpl>foo</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: null"></ng-container>`;
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('foo');
+    await waitForStableAndExpectText('foo');
   });
 
-  it('should display template if context is `undefined`', () => {
+  it('should display template if context is `undefined`', async () => {
     const template =
       `<ng-template #tpl>foo</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: undefined"></ng-container>`;
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('foo');
+    await waitForStableAndExpectText('foo');
   });
 
-  it('should reflect initial context and changes', () => {
+  it('should reflect initial context and changes', async () => {
     const template =
       `<ng-template let-foo="foo" #tpl>{{foo}}</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: context"></ng-container>`;
     fixture = createTestComponent(template);
 
-    fixture.detectChanges();
-    detectChangesAndExpectText('bar');
+    await waitForStableAndExpectText('bar');
 
     fixture.componentInstance.context.foo = 'alter-bar';
-    detectChangesAndExpectText('alter-bar');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('alter-bar');
   });
 
-  it('should reflect user defined `$implicit` property in the context', () => {
+  it('should reflect user defined `$implicit` property in the context', async () => {
     const template =
       `<ng-template let-ctx #tpl>{{ctx.foo}}</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: context"></ng-container>`;
     fixture = createTestComponent(template);
     fixture.componentInstance.context = {$implicit: {foo: 'bra'}};
-    detectChangesAndExpectText('bra');
+    await waitForStableAndExpectText('bra');
   });
 
-  it('should reflect context re-binding', () => {
+  it('should reflect context re-binding', async () => {
     const template =
       `<ng-template let-shawshank="shawshank" #tpl>{{shawshank}}</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: context"></ng-container>`;
     fixture = createTestComponent(template);
 
     fixture.componentInstance.context = {shawshank: 'brooks'};
-    detectChangesAndExpectText('brooks');
+    await waitForStableAndExpectText('brooks');
 
     fixture.componentInstance.context = {shawshank: 'was here'};
-    detectChangesAndExpectText('was here');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('was here');
   });
 
-  it('should update but not destroy embedded view when context values change', () => {
+  it('should update but not destroy embedded view when context values change', async () => {
     const template =
       `<ng-template let-foo="foo" #tpl><destroyable-cmpt></destroyable-cmpt>:{{foo}}</ng-template>` +
       `<ng-template [ngTemplateOutlet]="tpl" [ngTemplateOutletContext]="{foo: value}"></ng-template>`;
@@ -196,15 +185,16 @@ describe('NgTemplateOutlet', () => {
     fixture = createTestComponent(template);
     const spyService = fixture.debugElement.injector.get(DestroyedSpyService);
 
-    detectChangesAndExpectText('Content to destroy:bar');
+    await waitForStableAndExpectText('Content to destroy:bar');
     expect(spyService.destroyed).toBeFalsy();
 
     fixture.componentInstance.value = 'baz';
-    detectChangesAndExpectText('Content to destroy:baz');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('Content to destroy:baz');
     expect(spyService.destroyed).toBeFalsy();
   });
 
-  it('should update but not destroy embedded view when context shape changes', () => {
+  it('should update but not destroy embedded view when context shape changes', async () => {
     const template =
       `<ng-template let-foo="foo" #tpl><destroyable-cmpt></destroyable-cmpt>:{{foo}}</ng-template>` +
       `<ng-template [ngTemplateOutlet]="tpl" [ngTemplateOutletContext]="context"></ng-template>`;
@@ -212,15 +202,16 @@ describe('NgTemplateOutlet', () => {
     fixture = createTestComponent(template);
     const spyService = fixture.debugElement.injector.get(DestroyedSpyService);
 
-    detectChangesAndExpectText('Content to destroy:bar');
+    await waitForStableAndExpectText('Content to destroy:bar');
     expect(spyService.destroyed).toBeFalsy();
 
     fixture.componentInstance.context = {foo: 'baz', other: true};
-    detectChangesAndExpectText('Content to destroy:baz');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('Content to destroy:baz');
     expect(spyService.destroyed).toBeFalsy();
   });
 
-  it('should destroy embedded view when context value changes and templateRef becomes undefined', () => {
+  it('should destroy embedded view when context value changes and templateRef becomes undefined', async () => {
     const template =
       `<ng-template let-foo="foo" #tpl><destroyable-cmpt></destroyable-cmpt>:{{foo}}</ng-template>` +
       `<ng-template [ngTemplateOutlet]="value === 'bar' ? tpl : undefined" [ngTemplateOutletContext]="{foo: value}"></ng-template>`;
@@ -228,90 +219,93 @@ describe('NgTemplateOutlet', () => {
     fixture = createTestComponent(template);
     const spyService = fixture.debugElement.injector.get(DestroyedSpyService);
 
-    detectChangesAndExpectText('Content to destroy:bar');
+    await waitForStableAndExpectText('Content to destroy:bar');
     expect(spyService.destroyed).toBeFalsy();
 
     fixture.componentInstance.value = 'baz';
-    detectChangesAndExpectText('');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('');
     expect(spyService.destroyed).toBeTruthy();
   });
 
-  it('should not try to update null / undefined context when context changes but template stays the same', () => {
+  it('should not try to update null / undefined context when context changes but template stays the same', async () => {
     const template =
       `<ng-template let-foo="foo" #tpl>{{foo}}</ng-template>` +
       `<ng-template [ngTemplateOutlet]="tpl" [ngTemplateOutletContext]="value === 'bar' ? null : undefined"></ng-template>`;
 
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('');
+    await waitForStableAndExpectText('');
 
     fixture.componentInstance.value = 'baz';
-    detectChangesAndExpectText('');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('');
   });
 
-  it('should not try to update null / undefined context when template changes', () => {
+  it('should not try to update null / undefined context when template changes', async () => {
     const template =
       `<ng-template let-foo="foo" #tpl1>{{foo}}</ng-template>` +
       `<ng-template let-foo="foo" #tpl2>{{foo}}</ng-template>` +
       `<ng-template [ngTemplateOutlet]="value === 'bar' ? tpl1 : tpl2" [ngTemplateOutletContext]="value === 'bar' ? null : undefined"></ng-template>`;
 
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('');
+    await waitForStableAndExpectText('');
 
     fixture.componentInstance.value = 'baz';
-    detectChangesAndExpectText('');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('');
   });
 
-  it('should not try to update context on undefined view', () => {
+  it('should not try to update context on undefined view', async () => {
     const template =
       `<ng-template let-foo="foo" #tpl>{{foo}}</ng-template>` +
       `<ng-template [ngTemplateOutlet]="value === 'bar' ? null : undefined" [ngTemplateOutletContext]="{foo: value}"></ng-template>`;
 
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('');
+    await waitForStableAndExpectText('');
 
     fixture.componentInstance.value = 'baz';
-    detectChangesAndExpectText('');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('');
   });
 
   // https://github.com/angular/angular/issues/30801
-  it('should not throw if the context is left blank', () => {
+  it('should not throw if the context is left blank', async () => {
     const template = `
       <ng-template #testTemplate>test</ng-template>
       <ng-template [ngTemplateOutlet]="testTemplate" [ngTemplateOutletContext]=""></ng-template>
     `;
 
-    expect(() => {
-      fixture = createTestComponent(template);
-      detectChangesAndExpectText('test');
-    }).not.toThrow();
+    fixture = createTestComponent(template);
+    await expectAsync(waitForStableAndExpectText('test')).toBeResolved();
   });
 
-  it('should not throw when switching from template to null and back to template', () => {
+  it('should not throw when switching from template to null and back to template', async () => {
     const template =
       `<tpl-refs #refs="tplRefs"><ng-template>foo</ng-template></tpl-refs>` +
       `<ng-container [ngTemplateOutlet]="currentTplRef"></ng-container>`;
     fixture = createTestComponent(template);
-    fixture.detectChanges();
+    await fixture.whenStable();
     const refs = fixture.debugElement.children[0].references!['refs'];
 
     setTplRef(refs.tplRefs.first);
-    detectChangesAndExpectText('foo');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('foo');
 
     setTplRef(null);
-    detectChangesAndExpectText('');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('');
 
-    expect(() => {
-      setTplRef(refs.tplRefs.first);
-      detectChangesAndExpectText('foo');
-    }).not.toThrow();
+    setTplRef(refs.tplRefs.first);
+    fixture.changeDetectorRef.markForCheck();
+    await expectAsync(waitForStableAndExpectText('foo')).toBeResolved();
   });
 
-  it('should not mutate context object if two contexts with an identical shape are swapped', () => {
+  it('should not mutate context object if two contexts with an identical shape are swapped', async () => {
     fixture = TestBed.createComponent(MultiContextComponent);
     const {componentInstance, nativeElement} = fixture;
     componentInstance.context1 = {name: 'one'};
     componentInstance.context2 = {name: 'two'};
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(nativeElement.textContent.trim()).toBe('one | two');
     expect(componentInstance.context1).toEqual({name: 'one'});
@@ -321,14 +315,14 @@ describe('NgTemplateOutlet', () => {
     componentInstance.context1 = componentInstance.context2;
     componentInstance.context2 = temp;
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(nativeElement.textContent.trim()).toBe('two | one');
     expect(componentInstance.context1).toEqual({name: 'two'});
     expect(componentInstance.context2).toEqual({name: 'one'});
   });
 
-  it('should be able to specify an injector', () => {
+  it('should be able to specify an injector', async () => {
     const template =
       `<ng-template #tpl><inject-value></inject-value></ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; injector: injector"></ng-container>`;
@@ -336,10 +330,10 @@ describe('NgTemplateOutlet', () => {
     fixture.componentInstance.injector = Injector.create({
       providers: [{provide: templateToken, useValue: 'world'}],
     });
-    detectChangesAndExpectText('Hello world');
+    await waitForStableAndExpectText('Hello world');
   });
 
-  it('should re-render if the injector changes', () => {
+  it('should re-render if the injector changes', async () => {
     const template =
       `<ng-template #tpl><inject-value></inject-value></ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; injector: injector"></ng-container>`;
@@ -347,15 +341,16 @@ describe('NgTemplateOutlet', () => {
     fixture.componentInstance.injector = Injector.create({
       providers: [{provide: templateToken, useValue: 'world'}],
     });
-    detectChangesAndExpectText('Hello world');
+    await waitForStableAndExpectText('Hello world');
 
     fixture.componentInstance.injector = Injector.create({
       providers: [{provide: templateToken, useValue: 'there'}],
     });
-    detectChangesAndExpectText('Hello there');
+    fixture.changeDetectorRef.markForCheck();
+    await waitForStableAndExpectText('Hello there');
   });
 
-  it('should override providers from parent component using custom injector', () => {
+  it('should override providers from parent component using custom injector', async () => {
     const template =
       `<ng-template #tpl><inject-value></inject-value></ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; injector: injector"></ng-container>`;
@@ -363,10 +358,10 @@ describe('NgTemplateOutlet', () => {
     fixture.componentInstance.injector = Injector.create({
       providers: [{provide: templateToken, useValue: 'world'}],
     });
-    detectChangesAndExpectText('Hello world');
+    await waitForStableAndExpectText('Hello world');
   });
 
-  it('should be able to inherit outlet injector', () => {
+  it('should be able to inherit outlet injector', async () => {
     const template = `
       <ng-template #tpl><inject-value></inject-value></ng-template>
       <provide-value>
@@ -374,10 +369,10 @@ describe('NgTemplateOutlet', () => {
       </provide-value>
     `;
     fixture = createTestComponent(template, [{provide: templateToken, useValue: 'root'}]);
-    detectChangesAndExpectText('Hello provide-value');
+    await waitForStableAndExpectText('Hello provide-value');
   });
 
-  it('should be able to inherit outlet injector in a deeply nested structure', () => {
+  it('should be able to inherit outlet injector in a deeply nested structure', async () => {
     // This template should create the following rendered structure
     // (Spaces & newlines added for readability):
     // <nesting-counter> 1
@@ -400,10 +395,10 @@ describe('NgTemplateOutlet', () => {
       </ng-template>
     `;
     fixture = createTestComponent(template);
-    detectChangesAndExpectText('12342');
+    await waitForStableAndExpectText('12342');
   });
 
-  it('should be available as a standalone directive', () => {
+  it('should be available as a standalone directive', async () => {
     @Component({
       selector: 'test-component',
       imports: [NgTemplateOutlet],
@@ -415,12 +410,12 @@ describe('NgTemplateOutlet', () => {
     class TestComponent {}
 
     const fixture = TestBed.createComponent(TestComponent);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('Hello World');
   });
 
-  it('should properly bind context if context is unset initially', () => {
+  it('should properly bind context if context is unset initially', async () => {
     @Component({
       imports: [NgTemplateOutlet],
       template: `
@@ -434,13 +429,13 @@ describe('NgTemplateOutlet', () => {
     }
 
     const fixture = TestBed.createComponent(TestComponent);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('Name:');
 
     fixture.componentInstance.ctx = {$implicit: 'Angular'};
     fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toBe('Name:Angular');
   });
@@ -456,7 +451,6 @@ class DestroyedSpyService {
 @Component({
   selector: 'destroyable-cmpt',
   template: 'Content to destroy',
-  standalone: false,
 })
 class DestroyableCmpt implements OnDestroy {
   constructor(private _spyService: DestroyedSpyService) {}
@@ -469,30 +463,15 @@ class DestroyableCmpt implements OnDestroy {
 @Directive({
   selector: 'tpl-refs',
   exportAs: 'tplRefs',
-  standalone: false,
 })
 class CaptureTplRefs {
   @ContentChildren(TemplateRef) tplRefs?: QueryList<TemplateRef<any>>;
 }
 
 @Component({
-  selector: 'test-cmp',
-  template: '',
-  standalone: false,
-  changeDetection: ChangeDetectionStrategy.Eager,
-})
-class TestComponent {
-  currentTplRef?: TemplateRef<any>;
-  context: any = {foo: 'bar'};
-  value = 'bar';
-  injector: Injector | null = null;
-}
-
-@Component({
   selector: 'provide-value',
   template: '<ng-content />',
   providers: [{provide: templateToken, useValue: 'provide-value'}],
-  standalone: false,
   changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ProvideValueComponent {}
@@ -500,7 +479,6 @@ class ProvideValueComponent {}
 @Component({
   selector: 'inject-value',
   template: 'Hello {{tokenValue}}',
-  standalone: false,
   changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InjectValueComponent {
@@ -514,7 +492,7 @@ class InjectValueComponent {
     |
     <ng-template [ngTemplateOutlet]="template" [ngTemplateOutletContext]="context2"></ng-template>
   `,
-  standalone: false,
+  imports: [NgTemplateOutlet],
   changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiContextComponent {
@@ -534,18 +512,38 @@ const NESTING_DEPTH = new InjectionToken<number>('NESTING_DEPTH');
       deps: [[new Optional(), new SkipSelf(), NESTING_DEPTH]],
     },
   ],
-  standalone: false,
   changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestingCounter {
   depth = inject(NESTING_DEPTH);
 }
 
+@Component({
+  selector: 'test-cmp',
+  template: '',
+  imports: [
+    CaptureTplRefs,
+    DestroyableCmpt,
+    InjectValueComponent,
+    NestingCounter,
+    NgTemplateOutlet,
+    ProvideValueComponent,
+  ],
+  providers: [DestroyedSpyService],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class TestComponent {
+  currentTplRef?: TemplateRef<any>;
+  context: any = {foo: 'bar'};
+  value = 'bar';
+  injector: Injector | null = null;
+}
+
 function createTestComponent(
   template: string,
   providers: Provider[] = [],
 ): ComponentFixture<TestComponent> {
-  return TestBed.overrideComponent(TestComponent, {set: {template: template, providers}})
-    .configureTestingModule({schemas: [NO_ERRORS_SCHEMA]})
-    .createComponent(TestComponent);
+  return TestBed.overrideComponent(TestComponent, {
+    set: {template, providers: [DestroyedSpyService, ...providers]},
+  }).createComponent(TestComponent);
 }


### PR DESCRIPTION
Replace synchronous detectChanges calls with zoneless-compatible scheduling and stability waits. Preserve `NgComponentOutlet` coverage for components declared by `NgModules`.
 