### PR TITLE
fix(forms): keep radio inputs in sync when values change

### DIFF
--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -94,7 +94,7 @@ export function nativeControlCreate(
     );
   }
 
-  const bindings = createBindings<ControlBindingKey | 'controlValue'>();
+  const bindings = createBindings<ControlBindingKey | 'controlValue' | 'radioValue'>();
 
   return () => {
     const state = parent.state();
@@ -117,7 +117,11 @@ export function nativeControlCreate(
 
     // We need to update the value after setting the attributes as some attributes like min/max might prevent from setting the value
     const controlValue = state.controlValue();
-    if (bindingUpdated(bindings, 'controlValue', controlValue)) {
+    const controlValueChanged = bindingUpdated(bindings, 'controlValue', controlValue);
+    const radioValueChanged =
+      input.type === 'radio' && bindingUpdated(bindings, 'radioValue', input.value);
+
+    if (controlValueChanged || radioValueChanged) {
       setNativeControlValue(input, controlValue);
     }
 

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -4235,6 +4235,46 @@ describe('field directive', () => {
     expect(cmp.f().value()).toBe(ABC.B);
   });
 
+  it('synchronizes the checked state when a reused radio changes value', async () => {
+    interface RadioOption {
+      readonly id: string;
+      readonly value: string;
+    }
+
+    @Component({
+      imports: [FormField],
+      template: `
+        @for (option of options(); track option.id) {
+          <input type="radio" [formField]="f" [value]="option.value" />
+        }
+      `,
+    })
+    class TestCmp {
+      readonly f = form(signal('selected'), {name: 'test'});
+      readonly options = signal<ReadonlyArray<RadioOption>>([
+        {id: 'shared', value: 'other'},
+        {id: 'old', value: 'selected'},
+      ]);
+    }
+
+    const fixture = TestBed.createComponent(TestCmp);
+    await fixture.whenStable();
+    const getCheckedStates = () =>
+      Array.from(
+        (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLInputElement>('input'),
+      ).map((input) => input.checked);
+
+    expect(getCheckedStates()).toEqual([false, true]);
+
+    fixture.componentInstance.options.set([
+      {id: 'new', value: 'other'},
+      {id: 'shared', value: 'selected'},
+    ]);
+    await fixture.whenStable();
+
+    expect(getCheckedStates()).toEqual([false, true]);
+  });
+
   it('synchronizes with a textarea', () => {
     @Component({
       imports: [FormField],

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -17,6 +17,7 @@ import {
   OnInit,
   Provider,
   Renderer2,
+  SimpleChanges,
   ɵRuntimeError as RuntimeError,
   Service,
 } from '@angular/core';
@@ -177,6 +178,15 @@ export class RadioControlValueAccessor
     private _injector: Injector,
   ) {
     super(renderer, elementRef);
+  }
+
+  /** @internal */
+  ngOnChanges(changes: SimpleChanges): void {
+    const control = this._control?.control;
+
+    if (changes['value'] && control) {
+      this.writeValue(control.value);
+    }
   }
 
   /** @docs-private */

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -20,6 +20,7 @@ import {
   NgZone,
   Output,
   RendererFactory2,
+  signal,
   Type,
   ViewChild,
 } from '@angular/core';
@@ -658,6 +659,22 @@ describe('value accessors', () => {
         // programmatic change -> view
         expect(inputs[0].nativeElement.checked).toEqual(false);
         expect(inputs[1].nativeElement.checked).toEqual(true);
+      });
+
+      it('should update the checked state when a reused radio changes value', async () => {
+        const fixture = initTest(DynamicRadioForm);
+        await fixture.whenStable();
+
+        expect(getRadioCheckedStates(fixture)).toEqual([false, true]);
+
+        fixture.componentInstance.form.patchValue({answer: 'selected'});
+        fixture.componentInstance.options.set([
+          {id: 'new', value: 'other'},
+          {id: 'shared', value: 'selected'},
+        ]);
+        await fixture.whenStable();
+
+        expect(getRadioCheckedStates(fixture)).toEqual([false, true]);
       });
 
       it('should support an initial undefined value', () => {
@@ -2045,6 +2062,41 @@ class NgModelRangeForm {
 export class FormControlRadioButtons {
   form!: FormGroup;
   showRadio = new FormControl('yes');
+}
+
+interface RadioOption {
+  readonly id: string;
+  readonly value: string;
+}
+
+@Component({
+  selector: 'dynamic-radio-form',
+  template: `
+    <form [formGroup]="form">
+      @for (option of options(); track option.id) {
+        <input type="radio" formControlName="answer" [value]="option.value" />
+      }
+    </form>
+  `,
+  standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class DynamicRadioForm {
+  readonly form = new FormGroup({
+    answer: new FormControl('selected', {nonNullable: true}),
+  });
+  readonly options = signal<ReadonlyArray<RadioOption>>([
+    {id: 'shared', value: 'other'},
+    {id: 'old', value: 'selected'},
+  ]);
+}
+
+function getRadioCheckedStates(fixture: ComponentFixture<DynamicRadioForm>): boolean[] {
+  const element = fixture.nativeElement as HTMLElement;
+
+  return Array.from(element.querySelectorAll<HTMLInputElement>('input')).map(
+    (input) => input.checked,
+  );
 }
 
 @Component({


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added
- [x] Documentation is not required for this bug fix

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

When Angular reuses a radio input and its bound `value` changes, the input's checked state is not recomputed if the form model value remains unchanged. This can leave the rendered radio group out of sync with the model.

Issue Number: #38196

## What is the new behavior?

Radio inputs now recompute their checked state when their bound value changes.

The fix covers both reactive forms and signal forms. Regression tests verify the case where a radio element is reused while its value changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
