### PR TITLE
fix(zone.js): guard against null handle when detecting refreshable timers

### DIFF
--- a/packages/zone.js/lib/common/timers.ts
+++ b/packages/zone.js/lib/common/timers.ts
@@ -49,7 +49,7 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
     } else {
       data.handle = handleOrId;
       // On Node.js a timeout and interval can be restarted over and over again by using the `.refresh` method.
-      data.isRefreshable = isFunction(handleOrId.refresh);
+      data.isRefreshable = isFunction(handleOrId?.refresh);
     }
 
     return task;

--- a/packages/zone.js/test/common/setTimeout.spec.ts
+++ b/packages/zone.js/test/common/setTimeout.spec.ts
@@ -151,4 +151,17 @@ describe('setTimeout', function () {
     clearTimeout(null as any);
     clearTimeout(<any>{});
   });
+
+  it('should not throw when the native timer returns null', function () {
+    // A wrapper that blocks a timer (e.g. a browser extension or automation
+    // harness) can return null instead of a handle, see issue #70044.
+    const fakeGlobal = {
+      setTimeout: function () {
+        return null;
+      },
+      clearTimeout: function () {},
+    };
+    patchTimer(fakeGlobal, 'set', 'clear', 'Timeout');
+    expect(() => (fakeGlobal as any).setTimeout(() => {}, 0)).not.toThrow();
+  });
 });


### PR DESCRIPTION
A timer wrapper such as a browser extension or automation harness can block a call and return null instead of a handle. `patchTimer` then read `.refresh` on that null value and threw `TypeError: Cannot read properties of null (reading 'refresh')`.

This guards the refresh lookup so a nullish handle counts as non-refreshable, which keeps the numeric and Node.js handle behavior unchanged.

Fixes #70044