### PR TITLE
fix(docs-infra): keep inline code in links as an atomic inline box

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -87,6 +87,7 @@ $code-font-size: 0.875rem;
       width: 100%;
 
       a:not(.docs-anchor) > & {
+        display: inline-block;
         position: relative;
         padding: 0 0.3rem;
         white-space: nowrap;


### PR DESCRIPTION
Links whose text includes an inline code span render with the link underline drawn straight through the code chip. This lays the chip out as an atomic inline box so the underline is no longer drawn across it, leaving code outside of links unchanged.

Before:
<img width="805" height="174" alt="image" src="https://github.com/user-attachments/assets/81241f02-8bc1-4056-8883-5f36b3d25519" />


After:
<img width="810" height="182" alt="image" src="https://github.com/user-attachments/assets/a1f72360-e155-47bd-9fc6-f989399a8ef9" />


