### PR TITLE
fix(router): do not discard the rest of the URL after a redundant slash

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -661,7 +661,18 @@ class UrlParser {
       segments.push(this.parseSegment());
     }
 
-    while (this.peekStartsWith('/') && !this.peekStartsWith('//') && !this.peekStartsWith('/(')) {
+    while (this.peekStartsWith('/')) {
+      // Inside a parenthesised group `//` separates outlets, so it must be left for
+      // `parseParens` to consume. At the top level it carries no meaning, and stopping
+      // here without consuming it left the remainder of the URL — the rest of the path,
+      // the query string and the fragment — unparsed and silently discarded.
+      if (this.peekStartsWith('//')) {
+        if (depth > 0) break;
+        while (this.peekStartsWith('//')) {
+          this.consumeOptional('/');
+        }
+      }
+      if (this.peekStartsWith('/(')) break;
       this.capture('/');
       segments.push(this.parseSegment());
     }

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -447,6 +447,40 @@ describe('url serializer', () => {
     });
   });
 
+  describe('redundant slashes inside a path', () => {
+    // A `//` outside a parenthesised outlet group used to stop segment parsing without
+    // consuming it. Neither of the parenthesis branches matched either, so everything
+    // after it — the rest of the path, the query string and the fragment — was left
+    // unparsed and silently dropped.
+    it('should not discard the rest of the path', () => {
+      expect(url.serialize(url.parse('/a//b'))).toEqual('/a/b');
+    });
+
+    it('should not discard query params or the fragment', () => {
+      const tree = url.parse('/a//b?x=1#frag');
+      expect(tree.queryParams).toEqual({x: '1'});
+      expect(tree.fragment).toEqual('frag');
+      expect(url.serialize(tree)).toEqual('/a/b?x=1#frag');
+    });
+
+    it('should collapse any number of redundant slashes', () => {
+      expect(url.serialize(url.parse('/a///b'))).toEqual('/a/b');
+      expect(url.serialize(url.parse('/a////b'))).toEqual('/a/b');
+    });
+
+    it('should still recognize an auxiliary outlet group after redundant slashes', () => {
+      expect(url.serialize(url.parse('/a//(aux:c)'))).toEqual(
+        url.serialize(url.parse('/a/(aux:c)')),
+      );
+    });
+
+    it('should keep `//` as the outlet separator inside parentheses', () => {
+      expect(url.serialize(url.parse('/one/(two//left:three)'))).toEqual(
+        '/one/(two//left:three)',
+      );
+    });
+  });
+
   describe('error handling', () => {
     it('should throw when invalid characters inside children', () => {
       expect(() => url.parse('/one/(left#one)')).toThrowError();


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## What is the current behavior?

`DefaultUrlSerializer.parse()` silently drops everything after a `//` that appears outside a parenthesised outlet group — the rest of the path, the query string and the fragment — without raising an error.

```ts
const url = new DefaultUrlSerializer();

url.serialize(url.parse('/a//b'));    // '/a'    — 'b' is gone
url.parse('/a//b?x=1').queryParams;   // {}      — the query string is gone
url.parse('/a//b#frag').fragment;     // null    — the fragment is gone
```

The segment loop in `UrlParser.parseChildren` stops when it sees `//`:

```ts
while (this.peekStartsWith('/') && !this.peekStartsWith('//') && !this.peekStartsWith('/(')) {
```

Neither the `/(` branch nor the `(` branch below it matches either, so the parser returns with the remainder still in `remaining`. `parseQueryParams` and `parseFragment` each require their marker at the *start* of `remaining`, so both fail as well and the leftover input is discarded.

The stop condition is there because `//` separates outlets inside a parenthesised group (`(two//left:three)`), where `parseParens` consumes it.

This is the same character sequence as the leading-slash case fixed in #66233, one position over. That fix normalises leading slashes only; the mid-path case has no test.

## What is the new behavior?

Outside a parenthesised group, redundant slashes are collapsed and parsing continues, so the rest of the URL is preserved. Inside parentheses `//` is untouched and still separates outlets.

Added specs cover the path remainder, the query string and fragment, runs of three and four slashes, a following auxiliary outlet group, and a regression assertion that `//` still works as the outlet separator inside parentheses.

## Does this PR introduce a breaking change?

- [x] Yes

`/a//b` now resolves to `/a/b` rather than `/a`. URLs that were previously accepted and silently truncated will now resolve to a different route. Happy to put this behind a deprecation cycle instead if you would prefer.