### PR TITLE
fix(devtools): clarify disabled View Source tooltip and update demo app 

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/shared/button/button.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/shared/button/button.component.scss
@@ -6,6 +6,11 @@
   cursor: pointer;
   padding: 0.375rem 0.75rem;
 
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
+
   &.size-mid {
     padding: 0.25rem 0.75rem;
   }

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-details.component.html
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-details.component.html
@@ -12,7 +12,9 @@
         btnType="secondary"
         (click)="gotoSource.emit(node)"
         [disabled]="!node.debuggable"
-        matTooltip="View source"
+        [matTooltip]="
+          node.debuggable ? 'View source' : 'Source location is not available for this node'
+        "
       >
         <mat-icon> code </mat-icon>
       </button>

--- a/devtools/src/app/demo-app/demo-app.component.html
+++ b/devtools/src/app/demo-app/demo-app.component.html
@@ -10,3 +10,4 @@
 <app-sample-properties></app-sample-properties>
 <app-cookies />
 <p>Resource value: {{ demoRsrc.value() }}</p>
+<p>Linked signal value: {{ linkedPrimitive() }}</p>

--- a/devtools/src/app/demo-app/demo-app.component.ts
+++ b/devtools/src/app/demo-app/demo-app.component.ts
@@ -16,6 +16,7 @@ import {
   ElementRef,
   inject,
   input,
+  linkedSignal,
   output,
   resource,
   signal,
@@ -79,6 +80,10 @@ export class DemoAppComponent {
   objectComputed = computed(() => {
     const original = this.objectSignal();
     return {...original, age: original.age + 1};
+  });
+  linkedPrimitive = linkedSignal({
+    source: this.primitiveSignal,
+    computation: (value) => value * 2,
   });
 
   demoRsrc = resource({

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -201,6 +201,8 @@ export interface EffectNode extends BaseEffectNode, SchedulableEffect {
   injector: Injector;
   notifier: ChangeDetectionScheduler;
 
+  userFn: (onCleanup: EffectCleanupRegisterFn) => void;
+
   onDestroyFns: (() => void)[] | null;
 }
 
@@ -212,7 +214,7 @@ export interface RootEffectNode extends EffectNode {
   scheduler: EffectScheduler;
 }
 
-export const EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 'notifier'> =
+export const EFFECT_NODE: Omit<EffectNode, 'fn' | 'userFn' | 'destroy' | 'injector' | 'notifier'> =
   /* @__PURE__ */ (() => ({
     ...BASE_EFFECT_NODE,
     cleanupFns: undefined,
@@ -251,48 +253,52 @@ export const EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 'noti
     },
   }))();
 
-export const ROOT_EFFECT_NODE: Omit<RootEffectNode, 'fn' | 'scheduler' | 'notifier' | 'injector'> =
-  /* @__PURE__ */ (() => ({
-    ...EFFECT_NODE,
-    consumerMarkedDirty(this: RootEffectNode) {
-      this.scheduler.schedule(this);
-      this.notifier.notify(NotificationSource.RootEffect);
-    },
-    destroy(this: RootEffectNode) {
-      consumerDestroy(this);
+export const ROOT_EFFECT_NODE: Omit<
+  RootEffectNode,
+  'fn' | 'userFn' | 'scheduler' | 'notifier' | 'injector'
+> = /* @__PURE__ */ (() => ({
+  ...EFFECT_NODE,
+  consumerMarkedDirty(this: RootEffectNode) {
+    this.scheduler.schedule(this);
+    this.notifier.notify(NotificationSource.RootEffect);
+  },
+  destroy(this: RootEffectNode) {
+    consumerDestroy(this);
 
-      if (this.onDestroyFns !== null) {
-        for (const fn of this.onDestroyFns) {
-          fn();
-        }
+    if (this.onDestroyFns !== null) {
+      for (const fn of this.onDestroyFns) {
+        fn();
       }
+    }
 
-      this.cleanup();
-      this.scheduler.remove(this);
-    },
-  }))();
+    this.cleanup();
+    this.scheduler.remove(this);
+  },
+}))();
 
-export const VIEW_EFFECT_NODE: Omit<ViewEffectNode, 'fn' | 'view' | 'injector' | 'notifier'> =
-  /* @__PURE__ */ (() => ({
-    ...EFFECT_NODE,
-    consumerMarkedDirty(this: ViewEffectNode): void {
-      this.view[FLAGS] |= LViewFlags.HasChildViewsToRefresh;
-      markAncestorsForTraversal(this.view);
-      this.notifier.notify(NotificationSource.ViewEffect);
-    },
-    destroy(this: ViewEffectNode): void {
-      consumerDestroy(this);
+export const VIEW_EFFECT_NODE: Omit<
+  ViewEffectNode,
+  'fn' | 'userFn' | 'view' | 'injector' | 'notifier'
+> = /* @__PURE__ */ (() => ({
+  ...EFFECT_NODE,
+  consumerMarkedDirty(this: ViewEffectNode): void {
+    this.view[FLAGS] |= LViewFlags.HasChildViewsToRefresh;
+    markAncestorsForTraversal(this.view);
+    this.notifier.notify(NotificationSource.ViewEffect);
+  },
+  destroy(this: ViewEffectNode): void {
+    consumerDestroy(this);
 
-      if (this.onDestroyFns !== null) {
-        for (const fn of this.onDestroyFns) {
-          fn();
-        }
+    if (this.onDestroyFns !== null) {
+      for (const fn of this.onDestroyFns) {
+        fn();
       }
+    }
 
-      this.cleanup();
-      this.view[EFFECTS]?.delete(this);
-    },
-  }))();
+    this.cleanup();
+    this.view[EFFECTS]?.delete(this);
+  },
+}))();
 
 export function createViewEffect(
   view: LView,
@@ -303,6 +309,7 @@ export function createViewEffect(
   node.view = view;
   node.zone = typeof Zone !== 'undefined' ? Zone.current : null;
   node.notifier = notifier;
+  node.userFn = fn;
   node.fn = createEffectFn(node, fn);
 
   view[EFFECTS] ??= new Set();
@@ -318,6 +325,7 @@ export function createRootEffect(
   notifier: ChangeDetectionScheduler,
 ): RootEffectNode {
   const node = Object.create(ROOT_EFFECT_NODE) as RootEffectNode;
+  node.userFn = fn;
   node.fn = createEffectFn(node, fn);
   node.scheduler = scheduler;
   node.notifier = notifier;

--- a/packages/core/src/render3/util/signal_debug.ts
+++ b/packages/core/src/render3/util/signal_debug.ts
@@ -5,22 +5,29 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {ReactiveLViewConsumer} from '../reactive_lview_consumer';
-import {assertTNode, assertLView} from '../assert';
-import {getFrameworkDIDebugData} from '../debug/framework_injector_profiler';
-import {NodeInjector, getNodeInjectorTNode, getNodeInjectorLView} from '../di';
-import {REACTIVE_TEMPLATE_CONSUMER, HOST, LView, CONTEXT} from '../interfaces/view';
-import {EffectNode, EffectRefImpl} from '../reactivity/effect';
-import {Injector} from '../../di/injector';
-import {R3Injector} from '../../di/r3_injector';
-import {throwError} from '../../util/assert';
-import {ComputedNode, ReactiveNode, SIGNAL, SignalNode} from '../../../primitives/signals';
-import {isLView} from '../interfaces/type_checks';
 import type {
   DebugSignalGraph,
   DebugSignalGraphEdge,
   DebugSignalGraphNode,
 } from '../../../primitives/devtools';
+import {
+  ComputedNode,
+  LinkedSignalNode,
+  ReactiveNode,
+  SIGNAL,
+  SignalNode,
+} from '../../../primitives/signals';
+import { Injector } from '../../di/injector';
+import { R3Injector } from '../../di/r3_injector';
+import { throwError } from '../../util/assert';
+import { assertLView, assertTNode } from '../assert';
+import { getFrameworkDIDebugData } from '../debug/framework_injector_profiler';
+import { NodeInjector, getNodeInjectorLView, getNodeInjectorTNode } from '../di';
+import { isLView } from '../interfaces/type_checks';
+import { CONTEXT, HOST, LView, REACTIVE_TEMPLATE_CONSUMER } from '../interfaces/view';
+import { ReactiveLViewConsumer } from '../reactive_lview_consumer';
+import type { AfterRenderPhaseEffectNode } from '../reactivity/after_render_effect';
+import { EffectNode, EffectRefImpl } from '../reactivity/effect';
 
 function isComputedNode(node: ReactiveNode): node is ComputedNode<unknown> {
   return node.kind === 'computed';
@@ -36,6 +43,14 @@ function isEffectNode(node: ReactiveNode): node is EffectNode {
 
 function isSignalNode(node: ReactiveNode): node is SignalNode<unknown> {
   return node.kind === 'signal';
+}
+
+function isLinkedSignalNode(node: ReactiveNode): node is LinkedSignalNode<unknown, unknown> {
+  return node.kind === 'linkedSignal';
+}
+
+function isAfterRenderEffectPhaseNode(node: ReactiveNode): node is AfterRenderPhaseEffectNode {
+  return node.kind === 'afterRenderEffectPhase';
 }
 
 /**
@@ -86,6 +101,15 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         debuggableFn: consumer.computation,
         id,
       });
+    } else if (isLinkedSignalNode(consumer)) {
+      debugSignalGraphNodes.push({
+        label: consumer.debugName,
+        value: consumer.value,
+        kind: consumer.kind,
+        epoch: consumer.version,
+        debuggableFn: consumer.computation as () => unknown,
+        id,
+      });
     } else if (isSignalNode(consumer)) {
       debugSignalGraphNodes.push({
         label: consumer.debugName,
@@ -109,7 +133,15 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         label: consumer.debugName,
         kind: consumer.kind,
         epoch: consumer.version,
-        debuggableFn: consumer.fn,
+        debuggableFn: consumer.userFn as (() => unknown) | undefined,
+        id,
+      });
+    } else if (isAfterRenderEffectPhaseNode(consumer)) {
+      debugSignalGraphNodes.push({
+        label: consumer.debugName,
+        kind: consumer.kind,
+        epoch: consumer.version,
+        debuggableFn: consumer.userFn as () => unknown,
         id,
       });
     } else {

--- a/packages/core/src/render3/util/signal_debug.ts
+++ b/packages/core/src/render3/util/signal_debug.ts
@@ -17,17 +17,17 @@ import {
   SIGNAL,
   SignalNode,
 } from '../../../primitives/signals';
-import { Injector } from '../../di/injector';
-import { R3Injector } from '../../di/r3_injector';
-import { throwError } from '../../util/assert';
-import { assertLView, assertTNode } from '../assert';
-import { getFrameworkDIDebugData } from '../debug/framework_injector_profiler';
-import { NodeInjector, getNodeInjectorLView, getNodeInjectorTNode } from '../di';
-import { isLView } from '../interfaces/type_checks';
-import { CONTEXT, HOST, LView, REACTIVE_TEMPLATE_CONSUMER } from '../interfaces/view';
-import { ReactiveLViewConsumer } from '../reactive_lview_consumer';
-import type { AfterRenderPhaseEffectNode } from '../reactivity/after_render_effect';
-import { EffectNode, EffectRefImpl } from '../reactivity/effect';
+import {Injector} from '../../di/injector';
+import {R3Injector} from '../../di/r3_injector';
+import {throwError} from '../../util/assert';
+import {assertLView, assertTNode} from '../assert';
+import {getFrameworkDIDebugData} from '../debug/framework_injector_profiler';
+import {NodeInjector, getNodeInjectorLView, getNodeInjectorTNode} from '../di';
+import {isLView} from '../interfaces/type_checks';
+import {CONTEXT, HOST, LView, REACTIVE_TEMPLATE_CONSUMER} from '../interfaces/view';
+import {ReactiveLViewConsumer} from '../reactive_lview_consumer';
+import type {AfterRenderPhaseEffectNode} from '../reactivity/after_render_effect';
+import {EffectNode, EffectRefImpl} from '../reactivity/effect';
 
 function isComputedNode(node: ReactiveNode): node is ComputedNode<unknown> {
   return node.kind === 'computed';

--- a/packages/core/test/acceptance/signal_debug_spec.ts
+++ b/packages/core/test/acceptance/signal_debug_spec.ts
@@ -19,6 +19,7 @@ import {
   Injector,
   ApplicationRef,
   afterRenderEffect,
+  linkedSignal,
 } from '../../src/core';
 import {
   getFrameworkDIDebugData,
@@ -465,5 +466,111 @@ describe('getSignalGraph', () => {
 
     ref.destroy();
     expect(getFrameworkDIDebugData().resolverToEffects.get(injector)?.length).toBe(0);
+  });
+
+  describe('debuggableFn', () => {
+    it('should expose the computation of a computed', async () => {
+      const computation = () => 1;
+
+      @Component({selector: 'with-computed', template: `{{ computedSignal() }}`})
+      class WithComputed {
+        computedSignal = computed(computation, {debugName: 'computedSignal'});
+      }
+      const fixture = TestBed.createComponent(WithComputed);
+
+      await fixture.whenStable();
+
+      const {nodes} = getSignalGraph(fixture.componentRef.injector);
+      const node = nodes.find((n) => n.label === 'computedSignal')!;
+
+      expect(node.kind).toBe('computed');
+      expect(node.debuggableFn).toBe(computation);
+    });
+
+    it('should expose the computation of a linkedSignal', async () => {
+      const computation = (source: number) => source * 2;
+
+      @Component({selector: 'with-linked-signal', template: `{{ linked() }}`})
+      class WithLinkedSignal {
+        source = signal(1, {debugName: 'source'});
+        linked = linkedSignal({
+          source: this.source,
+          computation,
+          debugName: 'linked',
+        });
+      }
+      const fixture = TestBed.createComponent(WithLinkedSignal);
+
+      await fixture.whenStable();
+
+      const {nodes} = getSignalGraph(fixture.componentRef.injector);
+      const node = nodes.find((n) => n.label === 'linked')!;
+
+      expect(node.kind).toBe('linkedSignal');
+      expect(node.value).toBe(2);
+      expect(node.debuggableFn).toBe(computation);
+    });
+
+    it('should expose the callback of an effect', async () => {
+      const effectFn = () => {};
+
+      @Component({selector: 'with-effect', template: ``})
+      class WithEffect {
+        constructor() {
+          effect(effectFn, {debugName: 'myEffect'});
+        }
+      }
+      const fixture = TestBed.createComponent(WithEffect);
+
+      await fixture.whenStable();
+
+      const {nodes} = getSignalGraph(fixture.componentRef.injector);
+      const node = nodes.find((n) => n.label === 'myEffect')!;
+
+      expect(node.kind).toBe('effect');
+      expect(node.debuggableFn).toBe(effectFn);
+    });
+
+    it('should expose the user callback of an afterRenderEffect phase', async () => {
+      const phaseFn = () => {};
+
+      @Component({selector: 'with-after-render-effect', template: ``})
+      class WithAfterRenderEffect {
+        constructor() {
+          afterRenderEffect(phaseFn);
+        }
+      }
+      const fixture = TestBed.createComponent(WithAfterRenderEffect);
+
+      await fixture.whenStable();
+
+      const {nodes} = getSignalGraph(fixture.componentRef.injector);
+      const node = nodes.find((n) => n.kind === 'afterRenderEffectPhase')!;
+
+      expect(node).toBeDefined();
+      expect(node.debuggableFn).toBe(phaseFn);
+    });
+
+    it('should expose the user callback of an afterRenderEffect phase object with multiple phases', async () => {
+      const earlyReadFn = () => {};
+      const writeFn = () => {};
+
+      @Component({selector: 'with-after-render-effect-object', template: ``})
+      class WithAfterRenderEffectObject {
+        constructor() {
+          afterRenderEffect({earlyRead: earlyReadFn, write: writeFn});
+        }
+      }
+      const fixture = TestBed.createComponent(WithAfterRenderEffectObject);
+
+      await fixture.whenStable();
+
+      const {nodes} = getSignalGraph(fixture.componentRef.injector);
+      const phaseNodes = nodes.filter((n) => n.kind === 'afterRenderEffectPhase');
+
+      expect(phaseNodes.length).toBe(2);
+      expect(phaseNodes.map((n) => n.debuggableFn)).toContain(earlyReadFn);
+      expect(phaseNodes.map((n) => n.debuggableFn)).toContain(writeFn);
+    });
   });
 });


### PR DESCRIPTION
Depends on #70052 

Before: The View Source button tooltip in signal details static ('View source') even when disabled and disabled styling does not apply

After: The tooltip explains 'Source location is not available for this node' when disabled and disabled styling is applied
