### PR TITLE
refactor(devtools): Hide privately tracked signals by default

### DIFF
--- a/dev-app/src/app/app.ts
+++ b/dev-app/src/app/app.ts
@@ -1,12 +1,13 @@
 import {Component, signal} from '@angular/core';
-import {RouterOutlet} from '@angular/router';
+import {FormField, form} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
-  templateUrl: './app.html',
-  styleUrl: './app.css',
+  imports: [FormField],
+  template: `<input [formField]="f" />
+
+    {{ f().valid() }} - {{ f().value() }} - {{ f().dirty() }}`,
 })
 export class App {
-  protected readonly title = signal('dev-app');
+  f = form(signal('foo'));
 }

--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -660,6 +660,7 @@ const getSignalGraphCallback = (messageBus: MessageBus<Events>) => (element: Ele
         epoch: node.epoch,
         preview: serializeValue(node.value),
         debuggable: !!node.debuggableFn,
+        isPrivate: node.isPrivate,
       };
     });
     messageBus.emit('latestSignalGraph', [{nodes, edges: graph.edges}]);

--- a/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider.ts
@@ -102,6 +102,7 @@ export function applyMigrations(
       // No change
       'theme@general': currData['theme@general'],
       'show_hydration_overlays@components': currData['show_hydration_overlays@components'],
+      'show_private_signals@components': false,
 
       // Convert `timing_api_enabled` (cat: `general`) key to `performance_track` (cat: `profiling`).
       'performance_track@profiling': currData['timing_api_enabled@general'],

--- a/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider_spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/settings_provider_spec.ts
@@ -40,6 +40,7 @@ describe('applyMigrations', () => {
       'theme@general': 'dark',
       'active_tab@general': 'Profiler',
       'show_hydration_overlays@components': false,
+      'show_private_signals@components': false,
     } satisfies SettingsDataV2);
   });
 });

--- a/devtools/projects/ng-devtools/src/lib/application-providers/settings_versions.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/settings_versions.ts
@@ -38,6 +38,7 @@ export interface SettingsDataV2 extends SettingsDataBase {
   'theme@general': ThemePreference;
   'active_tab@general': string;
   'show_hydration_overlays@components': boolean;
+  'show_private_signals@components': boolean;
 }
 
 export interface SettingsDataV1 extends SettingsDataBase {

--- a/devtools/projects/ng-devtools/src/lib/application-services/settings.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/settings.ts
@@ -44,4 +44,10 @@ export class Settings {
     category: 'components',
     initialValue: false,
   });
+
+  readonly showPrivateSignals = this.settingsStore.create({
+    key: 'show_private_signals',
+    category: 'components',
+    initialValue: false,
+  });
 }

--- a/devtools/projects/ng-devtools/src/lib/application-services/test-utils/settings_mock.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/test-utils/settings_mock.ts
@@ -16,6 +16,7 @@ export class SettingsMock extends Settings {
   performanceTrack = signal(false);
   theme = signal<ThemePreference>('system');
   activeTab = signal('Components');
+  showPrivateSignals = signal(false);
 }
 
 export const SETTINGS_MOCK: Provider[] = [

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/settings/settings.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/settings/settings.component.html
@@ -35,6 +35,15 @@
       />
       <label for="show-hydration-overlays">Show hydration overlays</label>
     </li>
+    <li>
+      <input
+        id="show-private-signals"
+        type="checkbox"
+        (change)="settings.showPrivateSignals.set($event.target.checked)"
+        [checked]="settings.showPrivateSignals()"
+      />
+      <label for="show-private-signals">Show private signals in signal graph</label>
+    </li>
   </ul>
 
   <h3>Profiling</h3>

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-graph/devtools-signal-graph.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-graph/devtools-signal-graph.spec.ts
@@ -724,4 +724,32 @@ describe('convertToDevtoolsSignalGraph', () => {
       },
     });
   });
+
+  it('should preserve isPrivate property on nodes and edges', () => {
+    const debugGraph: DebugSignalGraph = {
+      nodes: [
+        {
+          id: 'a',
+          kind: 'signal',
+          epoch: 1,
+          debuggable: true,
+          preview: dummyPreview,
+          isPrivate: true,
+        },
+        {
+          id: 'b',
+          kind: 'computed',
+          epoch: 1,
+          debuggable: false,
+          preview: dummyPreview,
+        },
+      ],
+      edges: [{producer: 0, consumer: 1, isPrivate: true}],
+    };
+    const graph = convertToDevtoolsSignalGraph(debugGraph);
+
+    expect(graph.nodes[0].isPrivate).toBe(true);
+    expect(graph.nodes[1].isPrivate).toBeUndefined();
+    expect(graph.edges[0].isPrivate).toBe(true);
+  });
 });

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-graph/devtools-signal-graph.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-graph/devtools-signal-graph.ts
@@ -186,12 +186,18 @@ export function convertToDevtoolsSignalGraph(
 
   // Add cluster nodes and edges
   for (const cluster of clusters) {
+    const isPrivate = Array.from(cluster.nodes).every((id) => {
+      const node = debugSignalGraph.nodes.find((n) => n.id === id);
+      return node?.isPrivate === true;
+    });
+
     signalGraph.nodes.push({
       id: cluster.id,
       nodeType: 'cluster',
       clusterType: cluster.type,
       label: cluster.name,
       previewNode: cluster.previewNode,
+      ...(isPrivate ? {isPrivate: true} : {}),
     });
     clusterIdxMap.set(cluster.id, signalGraph.nodes.length - 1);
 

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-graph/signal-graph-types.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-graph/signal-graph-types.ts
@@ -47,6 +47,9 @@ export interface DevtoolsClusterNode {
 
   /** Index of a child/compound node of the cluster that acts as a preview of the whole cluster. */
   previewNode?: number;
+
+  /** Whether all nodes inside this cluster are privately tracked. */
+  isPrivate?: boolean;
 }
 
 export type DevtoolsSignalGraphNode = DevtoolsSignalNode | DevtoolsClusterNode;

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/BUILD.bazel
@@ -28,6 +28,7 @@ ng_project(
         "//devtools:node_modules/@types/d3",
         "//devtools:node_modules/d3",
         "//devtools:node_modules/dagre-d3-es",
+        "//devtools/projects/ng-devtools/src/lib/application-services:settings",
         "//devtools/projects/ng-devtools/src/lib/shared/button",
         "//devtools/projects/ng-devtools/src/lib/shared/filter",
         "//devtools/projects/ng-devtools/src/lib/shared/signal-graph",

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.component.ts
@@ -41,6 +41,7 @@ import {
   signalNodeFilterFnGenerator,
   SignalNodeFilterSource,
 } from './signal-node-filter-fn-generator';
+import {Settings} from '../../application-services/settings';
 
 const FILTER_INFO_TOOLTIP = 'You can filter signals by type via `type:signal|computed|effect|...`.';
 
@@ -67,6 +68,8 @@ export class SignalsVisualizerComponent {
   protected readonly currentSearchMatchIdx = signal<number>(-1);
   protected readonly searchMatches = signal<string[]>([]); // Node IDs
   protected readonly highlightedNodeLabel = signal<string | null>(null);
+  private readonly settings = inject(Settings);
+  protected readonly showPrivateSignals = this.settings.showPrivateSignals;
   private readonly expandedClustersIds = signal<Set<string>>(new Set());
   protected readonly expandedClusters = computed<DevtoolsSignalGraphCluster[]>(() => {
     const clusterIds = this.expandedClustersIds();
@@ -105,6 +108,11 @@ export class SignalsVisualizerComponent {
           effect(() => {
             const selected = this.selectedNodeId();
             this.signalsVisualizer!.highlightNode(selected);
+          });
+
+          effect(() => {
+            const show = this.showPrivateSignals();
+            this.signalsVisualizer!.setShowPrivate(show);
           });
 
           let lastElement: ElementPosition | undefined;
@@ -169,6 +177,10 @@ export class SignalsVisualizerComponent {
     const newMatches: string[] = [];
 
     for (const node of this.graph()?.nodes || []) {
+      if (!this.showPrivateSignals() && (node as {isPrivate?: boolean}).isPrivate) {
+        continue;
+      }
+
       let label = node.label || '';
 
       if (isSignalNode(node) && node.clusterId) {

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.ts
@@ -92,6 +92,7 @@ export class SignalsGraphVisualizer {
   private clustersStateChangeListeners: ((expandedClustersIds: Set<string>) => void)[] = [];
   private dependenciesHighlightListeners: ((e: DependenciesHighlightEvent) => void)[] = [];
   private expandedClustersIds = new Set<string>();
+  private showPrivate = false;
   private inputGraph: DevtoolsSignalGraph | null = null;
   private highlightedPath: {
     originNode: D3Selection | null;
@@ -342,7 +343,20 @@ export class SignalsGraphVisualizer {
     };
   }
 
+  setShowPrivate(show: boolean) {
+    if (this.showPrivate === show) {
+      return;
+    }
+    this.showPrivate = show;
+    if (this.inputGraph) {
+      this.render(this.inputGraph);
+    }
+  }
+
   private isNodeVisible(node: DevtoolsSignalGraphNode): boolean {
+    if (!this.showPrivate && (node as {isPrivate?: boolean}).isPrivate) {
+      return false;
+    }
     // Checks whether it's a:
     // 1. Standard signal node that's not part of a cluster
     // 2. Standard signal node that's part of an expanded cluster
@@ -476,19 +490,21 @@ export class SignalsGraphVisualizer {
     const newEdgeIds = new Set();
 
     for (const edge of signalGraph.edges) {
+      if (!this.showPrivate && edge.isPrivate) {
+        continue;
+      }
       const producerNode = signalGraph.nodes[edge.producer];
       const consumerNode = signalGraph.nodes[edge.consumer];
+      if (!this.isNodeVisible(producerNode) || !this.isNodeVisible(consumerNode)) {
+        continue;
+      }
       const producerId = producerNode.id;
       const consumerId = consumerNode.id;
 
       const edgeId = getEdgeId(producerId, consumerId);
       newEdgeIds.add(edgeId);
 
-      if (
-        !this.graph.hasEdge(producerId, consumerId, undefined) &&
-        this.isNodeVisible(producerNode) &&
-        this.isNodeVisible(consumerNode)
-      ) {
+      if (!this.graph.hasEdge(producerId, consumerId, undefined)) {
         const isClusterEdge = signalGraph.nodes.some(
           (node) =>
             isSignalNode(node) &&
@@ -508,11 +524,15 @@ export class SignalsGraphVisualizer {
 
     for (const edge of this.graph.edges()) {
       const edgeId = getEdgeId(edge.v, edge.w);
+      const producerNode = signalNodes.get(edge.v);
+      const consumerNode = signalNodes.get(edge.w);
 
       if (
         !newEdgeIds.has(edgeId) ||
-        !this.isNodeVisible(signalNodes.get(edge.v)!) ||
-        !this.isNodeVisible(signalNodes.get(edge.w)!)
+        !producerNode ||
+        !consumerNode ||
+        !this.isNodeVisible(producerNode) ||
+        !this.isNodeVisible(consumerNode)
       ) {
         this.graph.removeEdge(edge.v, edge.w, undefined);
       }

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -26,6 +26,7 @@ export interface DebugSignalGraphNode {
   label?: string;
   preview: Descriptor;
   debuggable: boolean;
+  isPrivate?: boolean;
 }
 
 export interface DebugSignalGraphEdge {
@@ -38,6 +39,7 @@ export interface DebugSignalGraphEdge {
    * Index of a signal node in the `nodes` array that is a producer of the signal consumed by the consumer node.
    */
   producer: number;
+  isPrivate?: boolean;
 }
 
 /**

--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -67,6 +67,9 @@ export function finalizeConsumerAfterComputation(node: ReactiveNode): void;
 // @public (undocumented)
 export function getActiveConsumer(): ReactiveNode | null;
 
+// @public (undocumented)
+export function getPrivateTracking(): boolean;
+
 // @public
 export function installDevToolsSignalFormatter(): void;
 
@@ -103,6 +106,9 @@ export type PreviousValue<S, D> = {
     source: S;
     value: D;
 };
+
+// @public
+export function privatelyTracked<T>(fn: () => T): T;
 
 // @public
 export function producerAccessed(node: ReactiveNode): void;
@@ -184,6 +190,9 @@ export function setPostProducerCreatedFn(fn: ReactiveHookFn | null): ReactiveHoo
 
 // @public (undocumented)
 export function setPostSignalSetFn(fn: ReactiveHookFn | null): ReactiveHookFn | null;
+
+// @public (undocumented)
+export function setPrivateTracking(isPrivate: boolean): boolean;
 
 // @public (undocumented)
 export function setThrowInvalidWriteToSignalError(fn: <T>(node: SignalNode<T>) => never): void;

--- a/packages/core/primitives/devtools/src/debug_signal_graph.ts
+++ b/packages/core/primitives/devtools/src/debug_signal_graph.ts
@@ -15,6 +15,7 @@ export interface DebugSignalGraphNode {
   label?: string;
   value?: unknown;
   debuggableFn?: () => unknown;
+  isPrivate?: boolean;
 }
 
 export interface DebugSignalGraphEdge {
@@ -27,6 +28,11 @@ export interface DebugSignalGraphEdge {
    * Index of a signal node in the `nodes` array that is a producer of the signal consumed by the consumer node.
    */
   producer: number;
+
+  /**
+   * Whether the link between producer and consumer was created through a private tracking context.
+   */
+  isPrivate?: boolean;
 }
 
 /**

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -34,8 +34,10 @@ export {
   consumerPollProducersForChange,
   finalizeConsumerAfterComputation,
   getActiveConsumer,
+  getPrivateTracking,
   isInNotificationPhase,
   isReactive,
+  onReactiveNodeCreated,
   producerAccessed,
   producerIncrementEpoch,
   producerMarkClean,
@@ -46,6 +48,7 @@ export {
   runPostProducerCreatedFn,
   setActiveConsumer,
   setPostProducerCreatedFn,
+  setPrivateTracking,
   Version,
 } from './src/graph';
 export {
@@ -62,6 +65,7 @@ export {
 export {Watch, WatchCleanupFn, WatchCleanupRegisterFn, createWatch} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';
 export {untracked} from './src/untracked';
+export {privatelyTracked} from './src/privately_tracked';
 export {runEffect, BASE_EFFECT_NODE, BaseEffectNode} from './src/effect';
 export {installDevToolsSignalFormatter} from './src/formatter';
 

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -17,6 +17,17 @@ declare const ngDevMode: boolean | undefined;
  */
 let activeConsumer: ReactiveNode | null = null;
 let inNotificationPhase = false;
+let inPrivateTracking = false;
+
+export function setPrivateTracking(isPrivate: boolean): boolean {
+  const prev = inPrivateTracking;
+  inPrivateTracking = isPrivate;
+  return prev;
+}
+
+export function getPrivateTracking(): boolean {
+  return inPrivateTracking;
+}
 
 export type Version = number & {__brand: 'Version'};
 
@@ -82,6 +93,7 @@ export const REACTIVE_NODE: ReactiveNode = {
 interface ReactiveLink {
   producer: ReactiveNode;
   consumer: ReactiveNode;
+  isPrivate?: boolean;
 
   /**
    * Stores the epoch that holds when this link was observed, allowing subsequent observations of the same producer to
@@ -204,10 +216,26 @@ export interface ReactiveNode {
    * Used in Angular DevTools to identify the kind of signal.
    */
   kind: ReactiveNodeKind;
+
+  /**
+   * Whether this node was created within a privately tracked execution context.
+   */
+  isCreatedPrivate?: boolean;
 }
 
 /**
  * Called by implementations when a producer's signal is read.
+ */
+function isPrivateAccess(consumer: ReactiveNode, producer: ReactiveNode): boolean {
+  return (
+    inPrivateTracking ||
+    !!(consumer as {isCreatedPrivate?: boolean}).isCreatedPrivate ||
+    !!(producer as {isCreatedPrivate?: boolean}).isCreatedPrivate
+  );
+}
+
+/**
+ * Record that the producer node was accessed in the current consumer context.
  */
 export function producerAccessed(node: ReactiveNode): void {
   if (inNotificationPhase) {
@@ -230,6 +258,11 @@ export function producerAccessed(node: ReactiveNode): void {
   // If the last producer we accessed is the same as the current one, we can skip adding a new
   // link
   if (prevProducerLink !== undefined && prevProducerLink.producer === node) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      if (!isPrivateAccess(activeConsumer, node)) {
+        prevProducerLink.isPrivate = undefined;
+      }
+    }
     return;
   }
 
@@ -249,6 +282,9 @@ export function producerAccessed(node: ReactiveNode): void {
       activeConsumer.producersTail = nextProducerLink;
       nextProducerLink.lastReadVersion = node.version;
       nextProducerLink.knownValidAtEpoch = epoch;
+      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+        nextProducerLink.isPrivate = isPrivateAccess(activeConsumer, node) ? true : undefined;
+      }
       return;
     }
   }
@@ -262,6 +298,11 @@ export function producerAccessed(node: ReactiveNode): void {
     prevConsumerLink.consumer === activeConsumer &&
     (!isRecomputing || prevConsumerLink.knownValidAtEpoch === epoch)
   ) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      if (!isPrivateAccess(activeConsumer, node)) {
+        prevConsumerLink.isPrivate = undefined;
+      }
+    }
     return;
   }
 
@@ -282,6 +323,11 @@ export function producerAccessed(node: ReactiveNode): void {
     lastReadVersion: node.version,
     nextConsumer: undefined,
   };
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    if (isPrivateAccess(activeConsumer, node)) {
+      newLink.isPrivate = true;
+    }
+  }
   activeConsumer.producersTail = newLink;
   if (prevProducerLink !== undefined) {
     prevProducerLink.nextProducer = newLink;
@@ -573,7 +619,16 @@ function consumerIsLive(node: ReactiveNode): boolean {
   return node.consumerIsAlwaysLive || node.consumers !== undefined;
 }
 
+export function onReactiveNodeCreated(node: ReactiveNode): void {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    if (inPrivateTracking) {
+      node.isCreatedPrivate = true;
+    }
+  }
+}
+
 export function runPostProducerCreatedFn(node: ReactiveNode): void {
+  onReactiveNodeCreated(node);
   postProducerCreatedFn?.(node);
 }
 

--- a/packages/core/primitives/signals/src/privately_tracked.ts
+++ b/packages/core/primitives/signals/src/privately_tracked.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {setPrivateTracking} from './graph';
+
+/**
+ * Execute an arbitrary function in a reactive context where signal dependencies are marked as privately tracked.
+ */
+export function privatelyTracked<T>(fn: () => T): T {
+  const prev = setPrivateTracking(true);
+  try {
+    return fn();
+  } finally {
+    setPrivateTracking(prev);
+  }
+}

--- a/packages/core/primitives/signals/src/watch.ts
+++ b/packages/core/primitives/signals/src/watch.ts
@@ -13,6 +13,7 @@ import {
   consumerMarkDirty,
   consumerPollProducersForChange,
   isInNotificationPhase,
+  onReactiveNodeCreated,
   REACTIVE_NODE,
   ReactiveNode,
   SIGNAL,
@@ -68,6 +69,7 @@ export function createWatch(
   allowSignalWrites: boolean,
 ): Watch {
   const node: WatchNode = Object.create(WATCH_NODE);
+  onReactiveNodeCreated(node);
   if (allowSignalWrites) {
     node.consumerAllowSignalWrites = true;
   }

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -188,3 +188,4 @@ export {performanceMarkFeature as ɵperformanceMarkFeature} from './util/perform
 export {promiseWithResolvers as ɵpromiseWithResolvers} from './util/promise_with_resolvers';
 export {stringify as ɵstringify, truncateMiddle as ɵtruncateMiddle} from './util/stringify';
 export {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from './view/provider_flags';
+export {getSignalGraph as ɵgetSignalGraph} from './render3/util/signal_debug';

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -18,6 +18,7 @@ export {
 } from './render3/reactivity/signal';
 export {linkedSignal} from './render3/reactivity/linked_signal';
 export {untracked} from './render3/reactivity/untracked';
+export {privatelyTracked as ɵprivatelyTracked} from './render3/reactivity/privately_tracked';
 export {
   CreateEffectOptions,
   effect,

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -12,6 +12,7 @@ import type {DirectiveDef} from '../interfaces/definition';
 import {type TNode, TNodeFlags} from '../interfaces/node';
 import {isComponentHost} from '../interfaces/type_checks';
 import {type LView, RENDERER, type TView} from '../interfaces/view';
+import {privatelyTracked} from '../reactivity/privately_tracked';
 import {
   getCurrentTNode,
   getLView,
@@ -19,8 +20,8 @@ import {
   getTView,
   isInCheckNoChangesMode,
 } from '../state';
-import {getNativeByTNode} from '../util/view_utils';
 import {debugStringifyTypeForError} from '../util/stringify_utils';
+import {getNativeByTNode} from '../util/view_utils';
 import {listenToDirectiveOutput} from '../view/directive_outputs';
 import {listenToDomEvent, wrapListener} from '../view/listeners';
 import {setDirectiveInput} from './shared';
@@ -36,7 +37,11 @@ import {writeToDirectiveInput} from './write_to_directive_input';
  * @codeGenApi
  */
 export function ɵɵcontrolCreate(): void {
-  controlCreateInternal();
+  if (ngDevMode) {
+    privatelyTracked(() => controlCreateInternal());
+  } else {
+    controlCreateInternal();
+  }
 }
 
 export function controlCreateInternal(): void {
@@ -64,7 +69,11 @@ export function controlCreateInternal(): void {
  * @codeGenApi
  */
 export function ɵɵcontrol(): void {
-  controlUpdateInternal();
+  if (ngDevMode) {
+    privatelyTracked(() => controlUpdateInternal());
+  } else {
+    controlUpdateInternal();
+  }
 }
 
 export function controlUpdateInternal(): void {

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -11,6 +11,7 @@ import {
   consumerBeforeComputation,
   consumerDestroy,
   consumerPollProducersForChange,
+  onReactiveNodeCreated,
   producerAccessed,
   SIGNAL,
   SIGNAL_NODE,
@@ -210,6 +211,7 @@ export class AfterRenderEffectSequence extends AfterRenderSequence {
       }
 
       const node = Object.create(AFTER_RENDER_PHASE_EFFECT_NODE) as AfterRenderPhaseEffectNode;
+      onReactiveNodeCreated(node);
       node.sequence = this;
       node.phase = phase;
       node.userFn = effectHook;

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -11,8 +11,9 @@ import {
   consumerDestroy,
   isInNotificationPhase,
   setActiveConsumer,
-  BaseEffectNode,
   BASE_EFFECT_NODE,
+  BaseEffectNode,
+  onReactiveNodeCreated,
   runEffect,
 } from '../../../primitives/signals';
 import {FLAGS, LViewFlags, LView, EFFECTS} from '../interfaces/view';
@@ -300,6 +301,7 @@ export function createViewEffect(
   fn: (onCleanup: EffectCleanupRegisterFn) => void,
 ): ViewEffectNode {
   const node = Object.create(VIEW_EFFECT_NODE) as ViewEffectNode;
+  onReactiveNodeCreated(node);
   node.view = view;
   node.zone = typeof Zone !== 'undefined' ? Zone.current : null;
   node.notifier = notifier;
@@ -318,6 +320,7 @@ export function createRootEffect(
   notifier: ChangeDetectionScheduler,
 ): RootEffectNode {
   const node = Object.create(ROOT_EFFECT_NODE) as RootEffectNode;
+  onReactiveNodeCreated(node);
   node.fn = createEffectFn(node, fn);
   node.scheduler = scheduler;
   node.notifier = notifier;

--- a/packages/core/src/render3/reactivity/privately_tracked.ts
+++ b/packages/core/src/render3/reactivity/privately_tracked.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {privatelyTracked as privatelyTrackedPrimitive} from '../../../primitives/signals';
+
+/**
+ * Execute an arbitrary function in a reactive context where signal dependencies are marked as privately tracked.
+ * @see [Reading without tracking dependencies](guide/signals)
+ */
+export function privatelyTracked<T>(fn: () => T): T {
+  return privatelyTrackedPrimitive(fn);
+}

--- a/packages/core/src/render3/util/signal_debug.ts
+++ b/packages/core/src/render3/util/signal_debug.ts
@@ -58,13 +58,36 @@ function getTemplateConsumer(injector: NodeInjector): ReactiveLViewConsumer | nu
 const signalDebugMap = new WeakMap<ReactiveNode, string>();
 let counter = 0;
 
-function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, ReactiveNode[]>): {
+function getNodesAndEdgesFromSignalMap(
+  signalMap: ReadonlyMap<ReactiveNode, Array<{producer: ReactiveNode; isPrivate?: boolean}>>,
+  rootNodes: ReactiveNode[],
+): {
   nodes: DebugSignalGraphNode[];
   edges: DebugSignalGraphEdge[];
 } {
   const nodes = Array.from(signalMap.keys());
   const debugSignalGraphNodes: DebugSignalGraphNode[] = [];
   const edges: DebugSignalGraphEdge[] = [];
+
+  const publicRoots = rootNodes.filter(
+    (node) => !(node as {isCreatedPrivate?: boolean}).isCreatedPrivate,
+  );
+  const publicNodes = new Set<ReactiveNode>(publicRoots);
+  const queue = [...publicRoots];
+  while (queue.length > 0) {
+    const curr = queue.shift()!;
+    const links = signalMap.get(curr) || [];
+    for (const link of links) {
+      if (
+        !link.isPrivate &&
+        !(link.producer as {isCreatedPrivate?: boolean}).isCreatedPrivate &&
+        !publicNodes.has(link.producer)
+      ) {
+        publicNodes.add(link.producer);
+        queue.push(link.producer);
+      }
+    }
+  }
 
   for (const [consumer, producers] of signalMap.entries()) {
     const consumerIndex = nodes.indexOf(consumer);
@@ -76,6 +99,8 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
       signalDebugMap.set(consumer, id);
     }
 
+    const isPrivate = !publicNodes.has(consumer);
+
     // collect node
     if (isComputedNode(consumer)) {
       debugSignalGraphNodes.push({
@@ -85,6 +110,7 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         epoch: consumer.version,
         debuggableFn: consumer.computation,
         id,
+        ...(isPrivate ? {isPrivate: true} : {}),
       });
     } else if (isSignalNode(consumer)) {
       debugSignalGraphNodes.push({
@@ -93,6 +119,7 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         kind: consumer.kind,
         epoch: consumer.version,
         id,
+        ...(isPrivate ? {isPrivate: true} : {}),
       });
     } else if (isTemplateEffectNode(consumer)) {
       debugSignalGraphNodes.push({
@@ -103,6 +130,7 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         // We get the constructor so that `inspect(.constructor)` shows the component class.
         debuggableFn: consumer.lView?.[CONTEXT]?.constructor as (() => unknown) | undefined,
         id,
+        ...(isPrivate ? {isPrivate: true} : {}),
       });
     } else {
       debugSignalGraphNodes.push({
@@ -110,12 +138,17 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         kind: consumer.kind,
         epoch: consumer.version,
         id,
+        ...(isPrivate ? {isPrivate: true} : {}),
       });
     }
 
     // collect edges for node
-    for (const producer of producers) {
-      edges.push({consumer: consumerIndex, producer: nodes.indexOf(producer)});
+    for (const link of producers) {
+      edges.push({
+        consumer: consumerIndex,
+        producer: nodes.indexOf(link.producer),
+        ...(link.isPrivate ? {isPrivate: true} : {}),
+      });
     }
   }
 
@@ -144,19 +177,24 @@ function extractEffectsFromInjector(injector: Injector): ReactiveNode[] {
 
 function extractSignalNodesAndEdgesFromRoots(
   nodes: ReactiveNode[],
-  signalDependenciesMap: Map<ReactiveNode, ReactiveNode[]> = new Map(),
-): Map<ReactiveNode, ReactiveNode[]> {
+  signalDependenciesMap: Map<
+    ReactiveNode,
+    Array<{producer: ReactiveNode; isPrivate?: boolean}>
+  > = new Map(),
+): Map<ReactiveNode, Array<{producer: ReactiveNode; isPrivate?: boolean}>> {
   for (const node of nodes) {
     if (signalDependenciesMap.has(node)) {
       continue;
     }
 
+    const producerLinks = [];
     const producerNodes = [];
     for (let link = node.producers; link !== undefined; link = link.nextProducer) {
       const producer = link.producer;
+      producerLinks.push({producer, isPrivate: (link as {isPrivate?: boolean}).isPrivate});
       producerNodes.push(producer);
     }
-    signalDependenciesMap.set(node, producerNodes);
+    signalDependenciesMap.set(node, producerLinks);
     extractSignalNodesAndEdgesFromRoots(producerNodes, signalDependenciesMap);
   }
 
@@ -192,5 +230,5 @@ export function getSignalGraph(injector: Injector): DebugSignalGraph {
 
   const signalDependenciesMap = extractSignalNodesAndEdgesFromRoots(signalNodes);
 
-  return getNodesAndEdgesFromSignalMap(signalDependenciesMap);
+  return getNodesAndEdgesFromSignalMap(signalDependenciesMap, signalNodes);
 }

--- a/packages/core/test/acceptance/signal_debug_spec.ts
+++ b/packages/core/test/acceptance/signal_debug_spec.ts
@@ -19,6 +19,7 @@ import {
   Injector,
   ApplicationRef,
   afterRenderEffect,
+  ɵprivatelyTracked as privatelyTracked,
 } from '../../src/core';
 import {
   getFrameworkDIDebugData,
@@ -463,5 +464,48 @@ describe('getSignalGraph', () => {
 
     ref.destroy();
     expect(getFrameworkDIDebugData().resolverToEffects.get(injector)?.length).toBe(0);
+  });
+
+  it('should correctly mark privately tracked signals in signal graph', async () => {
+    @Component({selector: 'component-with-private', template: ``})
+    class WithPrivate {
+      stateFromEffect = 0;
+      publicSignal = signal(123, {debugName: 'publicSignal'});
+      privateSignal = signal(456, {debugName: 'privateSignal'});
+
+      constructor() {
+        effect(
+          () => {
+            const pub = this.publicSignal();
+            const priv = privatelyTracked(() => this.privateSignal());
+            this.stateFromEffect = pub + priv;
+          },
+          {debugName: 'privateEffect'},
+        );
+      }
+    }
+
+    const fixture = TestBed.createComponent(WithPrivate);
+    await fixture.whenStable();
+
+    const injector = fixture.componentRef.injector;
+    const signalGraph = getSignalGraph(injector);
+
+    const {nodes, edges} = signalGraph;
+    expect(nodes.length).toBe(3);
+
+    const effectNode = nodes.find((node) => node.label === 'privateEffect')!;
+    const publicNode = nodes.find((node) => node.label === 'publicSignal')!;
+    const privateNode = nodes.find((node) => node.label === 'privateSignal')!;
+
+    expect(effectNode.isPrivate).toBeUndefined();
+    expect(publicNode.isPrivate).toBeUndefined();
+    expect(privateNode.isPrivate).toBe(true);
+
+    const publicEdge = edges.find((e) => e.producer === nodes.indexOf(publicNode))!;
+    const privateEdge = edges.find((e) => e.producer === nodes.indexOf(privateNode))!;
+
+    expect(publicEdge.isPrivate).toBeUndefined();
+    expect(privateEdge.isPrivate).toBe(true);
   });
 });

--- a/packages/forms/signals/compat/src/compat_field_node.ts
+++ b/packages/forms/signals/compat/src/compat_field_node.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, linkedSignal, runInInjectionContext, Signal, untracked} from '@angular/core';
+import {computed, linkedSignal, runInInjectionContext, Signal, untracked, ɵprivatelyTracked as privatelyTracked} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {AbstractControl} from '@angular/forms';
 import {Observable, ReplaySubject} from 'rxjs';
@@ -65,14 +65,18 @@ export function extractControlPropToSignal<T, R = T>(
   // Creates a subject that could be used in takeUntil.
   const createDestroySubject = makeCreateDestroySubject();
 
-  const signalOfControlSignal = linkedSignal({
-    source: options.control,
-    computation: (control) => {
-      return untracked(() => {
-        return runInInjectionContext(injector, () => makeSignal(control, createDestroySubject()));
-      });
-    },
-  });
+  const signalOfControlSignal = privatelyTracked(() =>
+    linkedSignal({
+      source: options.control,
+      computation: (control) => {
+        return untracked(() => {
+          return runInInjectionContext(injector, () =>
+            privatelyTracked(() => makeSignal(control, createDestroySubject())),
+          );
+        });
+      },
+    }),
+  );
 
   // We have to have computed, because we need to react to both:
   // linked signal changes as well as the inner signal changes.

--- a/packages/forms/signals/compat/src/compat_node_state.ts
+++ b/packages/forms/signals/compat/src/compat_node_state.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, Signal} from '@angular/core';
+import {computed, ɵprivatelyTracked as privatelyTracked, Signal} from '@angular/core';
 import {AbstractControl} from '@angular/forms';
 import {FieldNodeState} from '../../src/field/state';
 import {CompatFieldNode, getControlEventsSignal, getControlStatusSignal} from './compat_field_node';
@@ -29,7 +29,9 @@ export class CompatNodeState extends FieldNodeState {
     this.control = options.control;
     this.touched = getControlEventsSignal(options, (c) => c.touched);
     this.dirty = getControlEventsSignal(options, (c) => c.dirty);
-    const controlDisabled = getControlStatusSignal(options, (c) => c.disabled);
+    const controlDisabled = privatelyTracked(() =>
+      getControlStatusSignal(options, (c) => c.disabled),
+    );
 
     this.disabled = computed(() => {
       return controlDisabled() || this.disabledReasons().length > 0;

--- a/packages/forms/signals/compat/src/compat_structure.ts
+++ b/packages/forms/signals/compat/src/compat_structure.ts
@@ -8,6 +8,7 @@
 
 import {
   computed,
+  ɵprivatelyTracked as privatelyTracked,
   Signal,
   signal,
   WritableSignal,
@@ -111,8 +112,8 @@ export class CompatStructure extends FieldNodeStructure {
   override keyInParent: Signal<string>;
   override root: FieldNode;
   override pathKeys: Signal<readonly string[]>;
-  override readonly children = signal([]);
-  override readonly childrenMap = computed(() => undefined);
+  override readonly children = privatelyTracked(() => signal([]));
+  override readonly childrenMap = privatelyTracked(() => computed(() => undefined));
   override readonly parent: ParentFieldNode | undefined;
   override readonly fieldManager: FormFieldManager;
   override readonly isOrphaned: Signal<boolean>;
@@ -140,8 +141,10 @@ export class CompatStructure extends FieldNodeStructure {
     this.keyInParent = signals.keyInParent;
     this.isOrphaned = signals.isOrphaned;
 
-    this.pathKeys = computed(() =>
-      this.parent ? [...this.parent.structure.pathKeys(), this.keyInParent()] : [],
+    this.pathKeys = privatelyTracked(() =>
+      computed(() =>
+        this.parent ? [...this.parent.structure.pathKeys(), this.keyInParent()] : [],
+      ),
     );
   }
 

--- a/packages/forms/signals/compat/src/compat_validation_state.ts
+++ b/packages/forms/signals/compat/src/compat_validation_state.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, Signal} from '@angular/core';
+import {computed, Signal, ɵprivatelyTracked as privatelyTracked} from '@angular/core';
 import {AbstractControl} from '@angular/forms';
 import {ValidationError} from '../../src/api/rules';
 import {calculateValidationSelfStatus, ValidationState} from '../../src/field/validation';
@@ -18,7 +18,7 @@ import {CompatFieldNode, getControlStatusSignal} from './compat_field_node';
 import {CompatFieldNodeOptions} from './compat_structure';
 
 // Readonly signal containing an empty array, used for optimization.
-const EMPTY_ARRAY_SIGNAL = computed(() => []);
+const EMPTY_ARRAY_SIGNAL = privatelyTracked(() => computed(() => []));
 
 /**
  * Compat version of a validation state that wraps a FormControl, and proxies it's validation state.
@@ -33,13 +33,17 @@ export class CompatValidationState implements ValidationState {
   readonly invalid: Signal<boolean>;
   readonly valid: Signal<boolean>;
 
-  readonly parseErrors: Signal<ValidationError.WithFormField[]> = computed(() => []);
+  readonly parseErrors: Signal<ValidationError.WithFormField[]> = privatelyTracked(() =>
+    computed(() => []),
+  );
 
   constructor(
     private readonly node: CompatFieldNode,
     options: CompatFieldNodeOptions,
   ) {
-    this.syncValid = getControlStatusSignal(options, (c: AbstractControl) => c.status === 'VALID');
+    this.syncValid = privatelyTracked(() =>
+      getControlStatusSignal(options, (c: AbstractControl) => c.status === 'VALID'),
+    );
     this.errors = getControlStatusSignal(options, extractNestedReactiveErrors);
     this.pending = getControlStatusSignal(options, (c) => c.pending);
 
@@ -62,8 +66,8 @@ export class CompatValidationState implements ValidationState {
 
   // Compat fields can't have validation rules applied to them; however, there are other
   // features that depend on this property, such as `markAsTouched()`.
-  readonly shouldSkipValidation = computed(
-    () => this.node.hidden() || this.node.disabled() || this.node.readonly(),
+  readonly shouldSkipValidation = privatelyTracked(() =>
+    computed(() => this.node.hidden() || this.node.disabled() || this.node.readonly()),
   );
 
   /**

--- a/packages/forms/signals/src/directive/control_cva.ts
+++ b/packages/forms/signals/src/directive/control_cva.ts
@@ -10,6 +10,7 @@ import {
   computed,
   signal,
   untracked,
+  ɵprivatelyTracked as privatelyTracked,
   type Signal,
   type WritableSignal,
   type ɵControlDirectiveHost as ControlDirectiveHost,
@@ -48,34 +49,36 @@ export function cvaControlCreate(
 
   const legacyValidators = parent.injector.get(NG_VALIDATORS, null, {optional: true, self: true});
   if (legacyValidators) {
-    let version: WritableSignal<number> | undefined;
+    privatelyTracked(() => {
+      let version: WritableSignal<number> | undefined;
 
-    for (const v of legacyValidators) {
-      if (isValidatorObject(v) && v.registerOnValidatorChange) {
-        version ??= signal(0);
-        v.registerOnValidatorChange(() => {
-          version!.update((n) => n + 1);
-        });
+      for (const v of legacyValidators) {
+        if (isValidatorObject(v) && v.registerOnValidatorChange) {
+          version ??= signal(0);
+          v.registerOnValidatorChange(() => {
+            version!.update((n) => n + 1);
+          });
+        }
       }
-    }
 
-    const validatorFns = legacyValidators.map((v) =>
-      typeof v === 'function' ? (v as ValidatorFn) : v.validate.bind(v),
-    );
-    const mergedValidator = Validators.compose(validatorFns);
+      const validatorFns = legacyValidators.map((v) =>
+        typeof v === 'function' ? (v as ValidatorFn) : v.validate.bind(v),
+      );
+      const mergedValidator = Validators.compose(validatorFns);
 
-    const parseErrors = computed(() => {
-      // Read the `version` signal to re-run the validator when legacy validators trigger their change callbacks.
-      version?.();
-      const errors = mergedValidator ? mergedValidator(parent.interopNgControl.control) : null;
-      return reactiveErrorsToSignalErrors(errors, parent.interopNgControl.control);
+      const parseErrors = computed(() => {
+        // Read the `version` signal to re-run the validator when legacy validators trigger their change callbacks.
+        version?.();
+        const errors = mergedValidator ? mergedValidator(parent.interopNgControl.control) : null;
+        return reactiveErrorsToSignalErrors(errors, parent.interopNgControl.control);
+      });
+      // We must cast here because `CompatValidationError` claims to have `fieldTree` statically (to
+      // satisfy `ValidationState` elsewhere), but at construction it is created without it and acts as
+      // `WithoutFieldTree` initially.
+      parent.parseErrorsSource.set(
+        parseErrors as unknown as Signal<readonly ValidationError.WithoutFieldTree[]>,
+      );
     });
-    // We must cast here because `CompatValidationError` claims to have `fieldTree` statically (to
-    // satisfy `ValidationState` elsewhere), but at construction it is created without it and acts as
-    // `WithoutFieldTree` initially.
-    parent.parseErrorsSource.set(
-      parseErrors as unknown as Signal<readonly ValidationError.WithoutFieldTree[]>,
-    );
   }
 
   parent.registerAsBinding({

--- a/packages/forms/signals/src/directive/form_field.ts
+++ b/packages/forms/signals/src/directive/form_field.ts
@@ -21,6 +21,7 @@ import {
   input,
   Renderer2,
   ɵRuntimeError as RuntimeError,
+  ɵprivatelyTracked as privatelyTracked,
   type Signal,
   signal,
   untracked,
@@ -168,9 +169,9 @@ export class FormField<T> {
   private readonly validityMonitor = inject(InputValidityMonitor);
 
   /** @internal */
-  readonly parseErrorsSource = signal<
-    Signal<readonly ValidationError.WithoutFieldTree[]> | undefined
-  >(undefined);
+  readonly parseErrorsSource = privatelyTracked(() =>
+    signal<Signal<readonly ValidationError.WithoutFieldTree[]> | undefined>(undefined),
+  );
 
   /** A lazily instantiated fake `NgControl`. */
   private _interopNgControl: InteropNgControl | undefined;
@@ -182,14 +183,16 @@ export class FormField<T> {
   }
 
   /** @internal */
-  readonly parseErrors = computed<ValidationError.WithFormField[]>(
-    () =>
-      this.parseErrorsSource()?.().map((err) => ({
-        ...err,
-        fieldTree: untracked(this.state).fieldTree,
-        formField: this as FormField<unknown>,
-      })) ?? [],
-    {equal: shallowArrayEquals},
+  readonly parseErrors = privatelyTracked(() =>
+    computed<ValidationError.WithFormField[]>(
+      () =>
+        this.parseErrorsSource()?.().map((err) => ({
+          ...err,
+          fieldTree: untracked(this.state).fieldTree,
+          formField: this as FormField<unknown>,
+        })) ?? [],
+      {equal: shallowArrayEquals},
+    ),
   );
 
   /** Errors associated with this form field. */
@@ -251,32 +254,34 @@ export class FormField<T> {
    * if needed.
    */
   private installClassBindingEffect(): void {
-    const classes = Object.entries(this.config?.classes ?? {}).map(
-      ([className, computation]) => [className, computed(() => computation(this))] as const,
-    );
-    if (classes.length === 0) {
-      return;
-    }
+    privatelyTracked(() => {
+      const classes = Object.entries(this.config?.classes ?? {}).map(
+        ([className, computation]) => [className, computed(() => computation(this))] as const,
+      );
+      if (classes.length === 0) {
+        return;
+      }
 
-    // If we have class bindings to apply, set up an afterRenderEffect to apply them.
-    const bindings = createBindings<string>();
-    afterRenderEffect(
-      {
-        write: () => {
-          for (const [className, computation] of classes) {
-            const active = computation();
-            if (bindingUpdated(bindings, className, active)) {
-              if (active) {
-                this.renderer.addClass(this.element, className);
-              } else {
-                this.renderer.removeClass(this.element, className);
+      // If we have class bindings to apply, set up an afterRenderEffect to apply them.
+      const bindings = createBindings<string>();
+      afterRenderEffect(
+        {
+          write: () => {
+            for (const [className, computation] of classes) {
+              const active = computation();
+              if (bindingUpdated(bindings, className, active)) {
+                if (active) {
+                  this.renderer.addClass(this.element, className);
+                } else {
+                  this.renderer.removeClass(this.element, className);
+                }
               }
             }
-          }
+          },
         },
-      },
-      {injector: this.injector},
-    );
+        {injector: this.injector},
+      );
+    });
   }
 
   /**

--- a/packages/forms/signals/src/field/context.ts
+++ b/packages/forms/signals/src/field/context.ts
@@ -5,9 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-
 import {
   computed,
+  ɵprivatelyTracked as privatelyTracked,
   Signal,
   untracked,
   WritableSignal,
@@ -132,19 +132,21 @@ export class FieldNodeContext implements FieldContext<unknown> {
     return this.node.structure.pathKeys;
   }
 
-  readonly index = computed(() => {
-    // Attempt to read the key first, this will throw an error if we're on a root field.
-    const key = this.key();
-    // Assert that the parent is actually an array.
-    if (!isArray(untracked(this.node.structure.parent!.value))) {
-      throw new RuntimeError(
-        RuntimeErrorCode.PARENT_NOT_ARRAY,
-        ngDevMode && 'Cannot access index, parent field is not an array.',
-      );
-    }
-    // Return the key as a number if we are indeed inside an array field.
-    return Number(key);
-  });
+  readonly index = privatelyTracked(() =>
+    computed(() => {
+      // Attempt to read the key first, this will throw an error if we're on a root field.
+      const key = this.key();
+      // Assert that the parent is actually an array.
+      if (!isArray(untracked(this.node.structure.parent!.value))) {
+        throw new RuntimeError(
+          RuntimeErrorCode.PARENT_NOT_ARRAY,
+          ngDevMode && 'Cannot access index, parent field is not an array.',
+        );
+      }
+      // Return the key as a number if we are indeed inside an array field.
+      return Number(key);
+    }),
+  );
 
   // Note: `fieldTreeOf` and `stateOf` are purposefully defined as overloaded class
   // methods rather than arrow-function properties. This allows their signatures

--- a/packages/forms/signals/src/field/manager.ts
+++ b/packages/forms/signals/src/field/manager.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {APP_ID, effect, Injector, untracked} from '@angular/core';
+import {
+  APP_ID,
+  effect,
+  Injector,
+  ɵprivatelyTracked as privatelyTracked,
+  untracked,
+} from '@angular/core';
 import type {FormSubmitOptions} from '../api/types';
 import type {FieldNodeStructure} from './structure';
 
@@ -53,20 +59,22 @@ export class FormFieldManager {
    * @param root The root field structure.
    */
   createFieldManagementEffect(root: FieldNodeStructure): void {
-    effect(
-      () => {
-        const liveStructures = new Set<FieldNodeStructure>();
-        this.markStructuresLive(root, liveStructures);
+    privatelyTracked(() =>
+      effect(
+        () => {
+          const liveStructures = new Set<FieldNodeStructure>();
+          this.markStructuresLive(root, liveStructures);
 
-        // Destroy all nodes that are no longer live.
-        for (const structure of this.structures) {
-          if (!liveStructures.has(structure)) {
-            this.structures.delete(structure);
-            untracked(() => structure.destroy());
+          // Destroy all nodes that are no longer live.
+          for (const structure of this.structures) {
+            if (!liveStructures.has(structure)) {
+              this.structures.delete(structure);
+              untracked(() => structure.destroy());
+            }
           }
-        }
-      },
-      {injector: this.injector},
+        },
+        {injector: this.injector},
+      ),
     );
   }
 

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -9,13 +9,15 @@
 import {
   computed,
   linkedSignal,
+  ɵprivatelyTracked as privatelyTracked,
+  type Resource,
   type Signal,
   untracked,
-  type WritableSignal,
-  type Resource,
   type WritableResource,
+  type WritableSignal,
 } from '@angular/core';
 import {
+  IS_ASYNC_VALIDATION_RESOURCE,
   MAX,
   MAX_LENGTH,
   type MetadataKey,
@@ -23,7 +25,6 @@ import {
   MIN_LENGTH,
   PATTERN,
   REQUIRED,
-  IS_ASYNC_VALIDATION_RESOURCE,
 } from '../api/rules/metadata';
 import type {NgValidationError, ValidationError} from '../api/rules/validation/validation_errors';
 import type {
@@ -117,8 +118,7 @@ export class FieldNode implements FieldState<unknown> {
    * first focusable binding in the DOM for any descendant node of this one.
    */
   private getBindingForFocus():
-    | (FormField<unknown> & {focus: (options?: FocusOptions) => void})
-    | undefined {
+    (FormField<unknown> & {focus: (options?: FocusOptions) => void}) | undefined {
     // First try to focus one of our own bindings.
     const own = this.formFieldBindings()
       .filter(
@@ -144,13 +144,16 @@ export class FieldNode implements FieldState<unknown> {
    * before the pending debounced sync resolves. It will also cancel any pending debounced sync
    * automatically when recomputed due to `value` being set directly from others sources.
    */
-  private readonly pendingSync: WritableSignal<AbortController | undefined> = linkedSignal({
-    source: () => this.value(),
-    computation: (_source, previous) => {
-      previous?.value?.abort();
-      return undefined;
-    },
-  });
+  private readonly pendingSync: WritableSignal<AbortController | undefined> = privatelyTracked(
+    () =>
+      linkedSignal({
+        source: () => this.value(),
+        computation: (_source, previous) => {
+          previous?.value?.abort();
+          return undefined;
+        },
+      }),
+  );
 
   get fieldTree(): FieldTree<unknown> {
     return this.fieldProxy;
@@ -510,8 +513,8 @@ export class FieldNode implements FieldState<unknown> {
   }
 }
 
-const EMPTY = computed(() => []);
-const FALSE = computed(() => false);
+const EMPTY = privatelyTracked(() => computed(() => []));
+const FALSE = privatelyTracked(() => computed(() => false));
 
 /**
  * Field node of a field that has children.

--- a/packages/forms/signals/src/field/state.ts
+++ b/packages/forms/signals/src/field/state.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal, Signal} from '@angular/core';
+import {computed, ɵprivatelyTracked as privatelyTracked, signal, Signal} from '@angular/core';
 import type {FormField} from '../directive/form_field';
 import type {Debouncer, DisabledReason} from '../api/types';
 import {DEBOUNCER} from './debounce';
@@ -25,7 +25,7 @@ export class FieldNodeState {
    *
    * A field is considered directly touched when a user stops editing it for the first time (i.e. on blur)
    */
-  private readonly selfTouched = signal(false);
+  private readonly selfTouched = privatelyTracked(() => signal(false));
 
   /**
    * Indicates whether this field has been dirtied directly by the user (as opposed to indirectly by
@@ -33,7 +33,7 @@ export class FieldNodeState {
    *
    * A field is considered directly dirtied if a user changed the value of the field at least once.
    */
-  private readonly selfDirty = signal(false);
+  private readonly selfDirty = privatelyTracked(() => signal(false));
 
   /**
    * Marks this specific field as touched.
@@ -164,23 +164,25 @@ export class FieldNodeState {
    * An optional {@link Debouncer} factory for this field.
    */
   readonly debouncer: Signal<((signal: AbortSignal) => Promise<void> | void) | undefined> =
-    computed(() => {
-      if (this.node.logicNode.logic.hasMetadata(DEBOUNCER)) {
-        const debouncerLogic = this.node.logicNode.logic.getMetadata(DEBOUNCER);
-        const debouncer = debouncerLogic.compute(this.node.context);
+    privatelyTracked(() =>
+      computed(() => {
+        if (this.node.logicNode.logic.hasMetadata(DEBOUNCER)) {
+          const debouncerLogic = this.node.logicNode.logic.getMetadata(DEBOUNCER);
+          const debouncer = debouncerLogic.compute(this.node.context);
 
-        // Even if this field has a `debounce()` rule, it could be applied conditionally and currently
-        // inactive, in which case `compute()` will return undefined.
-        if (debouncer) {
-          return (signal) => debouncer(this.node.context, signal);
+          // Even if this field has a `debounce()` rule, it could be applied conditionally and currently
+          // inactive, in which case `compute()` will return undefined.
+          if (debouncer) {
+            return (signal) => debouncer(this.node.context, signal);
+          }
         }
-      }
 
-      // Fallback to the parent's debouncer, if any. If there is no debouncer configured all the way
-      // up to the root field, this simply returns `undefined` indicating that the operation should
-      // not be debounced.
-      return this.node.structure.parent?.nodeState.debouncer?.();
-    });
+        // Fallback to the parent's debouncer, if any. If there is no debouncer configured all the way
+        // up to the root field, this simply returns `undefined` indicating that the operation should
+        // not be debounced.
+        return this.node.structure.parent?.nodeState.debouncer?.();
+      }),
+    );
 
   /** Whether this field is considered non-interactive.
    *
@@ -189,7 +191,7 @@ export class FieldNodeState {
    * - It is disabled
    * - It is readonly
    */
-  private readonly isNonInteractive = computed(
-    () => this.hidden() || this.disabled() || this.readonly(),
+  private readonly isNonInteractive = privatelyTracked(() =>
+    computed(() => this.hidden() || this.disabled() || this.readonly()),
   );
 }

--- a/packages/forms/signals/src/field/structure.ts
+++ b/packages/forms/signals/src/field/structure.ts
@@ -15,6 +15,7 @@ import {
   Signal,
   untracked,
   WritableSignal,
+  ɵprivatelyTracked as privatelyTracked,
 } from '@angular/core';
 
 import {RuntimeErrorCode} from '../errors';
@@ -28,7 +29,7 @@ import type {FormFieldManager} from './manager';
 import type {FieldNode, ParentFieldNode} from './node';
 
 const ORPHAN_TOKEN = Symbol(typeof ngDevMode !== 'undefined' && ngDevMode ? 'ORPHAN_TOKEN' : '');
-const FALSE_SIGNAL = computed(() => false);
+const FALSE_SIGNAL = privatelyTracked(() => computed(() => false));
 
 /**
  * Key by which a parent `FieldNode` tracks its children.
@@ -232,37 +233,39 @@ export abstract class FieldNodeStructure {
     const parent = this.parent!;
     let lastKnownKey = initialKeyInParent!;
 
-    const keyOrOrphan = computed(() => {
-      if (parent.structure.isOrphaned()) {
-        return ORPHAN_TOKEN;
-      }
-
-      const map = parent.structure.childrenMap();
-      if (!map) {
-        return ORPHAN_TOKEN;
-      }
-
-      // Fast path: check last known key
-      const lastKnownChild = map.byPropertyKey.get(lastKnownKey);
-      if (lastKnownChild && lastKnownChild.node === this.node) {
-        return lastKnownKey;
-      }
-
-      if (identityInParent === undefined) {
-        // Object property: if not at last known key, it's orphaned
-        return ORPHAN_TOKEN;
-      } else {
-        // Array element: scan for node in childrenMap
-        for (const [key, child] of map.byPropertyKey) {
-          if (child.node === this.node) {
-            return (lastKnownKey = key);
-          }
+    const keyOrOrphan = privatelyTracked(() =>
+      computed(() => {
+        if (parent.structure.isOrphaned()) {
+          return ORPHAN_TOKEN;
         }
-        return ORPHAN_TOKEN;
-      }
-    });
 
-    const isOrphaned = computed(() => keyOrOrphan() === ORPHAN_TOKEN);
+        const map = parent.structure.childrenMap();
+        if (!map) {
+          return ORPHAN_TOKEN;
+        }
+
+        // Fast path: check last known key
+        const lastKnownChild = map.byPropertyKey.get(lastKnownKey);
+        if (lastKnownChild && lastKnownChild.node === this.node) {
+          return lastKnownKey;
+        }
+
+        if (identityInParent === undefined) {
+          // Object property: if not at last known key, it's orphaned
+          return ORPHAN_TOKEN;
+        } else {
+          // Array element: scan for node in childrenMap
+          for (const [key, child] of map.byPropertyKey) {
+            if (child.node === this.node) {
+              return (lastKnownKey = key);
+            }
+          }
+          return ORPHAN_TOKEN;
+        }
+      }),
+    );
+
+    const isOrphaned = privatelyTracked(() => computed(() => keyOrOrphan() === ORPHAN_TOKEN));
 
     const keyInParent = computed(() => {
       const key = keyOrOrphan();
@@ -289,13 +292,15 @@ export abstract class FieldNodeStructure {
   }
 
   protected createChildrenMap(): Signal<ChildrenData | undefined> {
-    return linkedSignal({
-      source: this.value,
-      computation: (
-        value: unknown,
-        previous: {source: unknown; value: ChildrenData | undefined} | undefined,
-      ): ChildrenData | undefined => this.computeChildrenMap(value, previous?.value, false),
-    });
+    return privatelyTracked(() =>
+      linkedSignal({
+        source: this.value,
+        computation: (
+          value: unknown,
+          previous: {source: unknown; value: ChildrenData | undefined} | undefined,
+        ): ChildrenData | undefined => this.computeChildrenMap(value, previous?.value, false),
+      }),
+    );
   }
 
   private computeChildrenMap(
@@ -424,7 +429,7 @@ export abstract class FieldNodeStructure {
    * reactive consumers aren't notified unless the field at a key actually changes.
    */
   private createReader(key: string): Signal<FieldNode | undefined> {
-    return computed(() => this.childrenMap()?.byPropertyKey.get(key)?.node);
+    return privatelyTracked(() => computed(() => this.childrenMap()?.byPropertyKey.get(key)?.node));
   }
 }
 
@@ -518,7 +523,9 @@ export class ChildFieldNodeStructure extends FieldNodeStructure {
     this.isOrphaned = signals.isOrphaned;
     this.keyInParent = signals.keyInParent;
 
-    this.pathKeys = computed(() => [...parent.structure.pathKeys(), this.keyInParent()]);
+    this.pathKeys = privatelyTracked(() =>
+      computed(() => [...parent.structure.pathKeys(), this.keyInParent()]),
+    );
 
     this.value = deepSignal(this.parent.structure.value, this.keyInParent);
     this.childrenMap = this.createChildrenMap();
@@ -567,7 +574,7 @@ export interface ChildFieldNodeOptions {
 export type FieldNodeOptions = RootFieldNodeOptions | ChildFieldNodeOptions;
 
 /** A signal representing an empty list of path keys, used for root fields. */
-const ROOT_PATH_KEYS = computed<readonly string[]>(() => []);
+const ROOT_PATH_KEYS = privatelyTracked(() => computed<readonly string[]>(() => []));
 
 /**
  * A signal representing a non-existent key of the field in its parent, used for root fields which

--- a/packages/forms/signals/src/field/submit.ts
+++ b/packages/forms/signals/src/field/submit.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, linkedSignal, Signal, signal, WritableSignal} from '@angular/core';
+import {
+  computed,
+  linkedSignal,
+  ɵprivatelyTracked as privatelyTracked,
+  Signal,
+  signal,
+  WritableSignal,
+} from '@angular/core';
 import {ValidationError} from '../api/rules/validation/validation_errors';
 import type {FieldNode} from './node';
 
@@ -18,16 +25,18 @@ export class FieldSubmitState {
    * Whether this field was directly submitted (as opposed to indirectly by a parent field being submitted)
    * and is still in the process of submitting.
    */
-  readonly selfSubmitting = signal<boolean>(false);
+  readonly selfSubmitting = privatelyTracked(() => signal<boolean>(false));
 
   /** Submission errors that are associated with this field. */
   readonly submissionErrors: WritableSignal<readonly ValidationError.WithFieldTree[]>;
 
   constructor(private readonly node: FieldNode) {
-    this.submissionErrors = linkedSignal({
-      source: this.node.structure.value,
-      computation: () => [] as readonly ValidationError.WithFieldTree[],
-    });
+    this.submissionErrors = privatelyTracked(() =>
+      linkedSignal({
+        source: this.node.structure.value,
+        computation: () => [] as readonly ValidationError.WithFieldTree[],
+      }),
+    );
   }
 
   /**

--- a/packages/forms/signals/src/field/validation.ts
+++ b/packages/forms/signals/src/field/validation.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, Signal, untracked, ɵWritable} from '@angular/core';
+import {computed, ɵprivatelyTracked as privatelyTracked, Signal, untracked, ɵWritable} from '@angular/core';
 import type {ValidationError} from '../api/rules/validation/validation_errors';
 import type {ReadonlyFieldTree, TreeValidationResult, ValidationResult} from '../api/types';
 import {isArray} from '../util/type_guards';
@@ -154,18 +154,20 @@ export class FieldValidationState implements ValidationState {
    * The full set of synchronous tree errors visible to this field. This includes ones that are
    * targeted at a descendant field rather than at this field.
    */
-  readonly rawSyncTreeErrors: Signal<ValidationError.WithFieldTree[]> = computed(
-    () => {
-      if (this.shouldSkipValidation()) {
-        return [];
-      }
+  readonly rawSyncTreeErrors: Signal<ValidationError.WithFieldTree[]> = privatelyTracked(() =>
+    computed(
+      () => {
+        if (this.shouldSkipValidation()) {
+          return [];
+        }
 
-      return [
-        ...this.node.logicNode.logic.syncTreeErrors.compute(this.node.context),
-        ...(this.node.structure.parent?.validationState.rawSyncTreeErrors() ?? []),
-      ];
-    },
-    {equal: shallowArrayEquals},
+        return [
+          ...this.node.logicNode.logic.syncTreeErrors.compute(this.node.context),
+          ...(this.node.structure.parent?.validationState.rawSyncTreeErrors() ?? []),
+        ];
+      },
+      {equal: shallowArrayEquals},
+    ),
   );
 
   /**
@@ -174,46 +176,51 @@ export class FieldValidationState implements ValidationState {
    * added. From the perspective of the field state they are either there or not, they are never in a
    * pending state.
    */
-  readonly syncErrors: Signal<ValidationError.WithFieldTree[]> = computed(
-    () => {
-      // Short-circuit running validators if validation doesn't apply to this field.
-      if (this.shouldSkipValidation()) {
-        return [];
-      }
+  readonly syncErrors: Signal<ValidationError.WithFieldTree[]> = privatelyTracked(() =>
+    computed(
+      () => {
+        // Short-circuit running validators if validation doesn't apply to this field.
+        if (this.shouldSkipValidation()) {
+          return [];
+        }
 
-      return [
-        ...this.node.logicNode.logic.syncErrors.compute(this.node.context),
-        ...this.syncTreeErrors(),
-        ...normalizeErrors(this.node.submitState.submissionErrors()),
-      ];
-    },
-    {equal: shallowArrayEquals},
+        return [
+          ...this.node.logicNode.logic.syncErrors.compute(this.node.context),
+          ...this.syncTreeErrors(),
+          ...normalizeErrors(this.node.submitState.submissionErrors()),
+        ];
+      },
+      {equal: shallowArrayEquals},
+    ),
   );
 
   /**
    * Whether the field is considered valid according solely to its synchronous validators.
    * Errors resulting from a previous submit attempt are also considered for this state.
    */
-  readonly syncValid: Signal<boolean> = computed(() => {
-    // Short-circuit checking children if validation doesn't apply to this field.
-    if (this.shouldSkipValidation()) {
-      return true;
-    }
+  readonly syncValid: Signal<boolean> = privatelyTracked(() =>
+    computed(() => {
+      // Short-circuit checking children if validation doesn't apply to this field.
+      if (this.shouldSkipValidation()) {
+        return true;
+      }
 
-    return this.node.structure.reduceChildren(
-      this.syncErrors().length === 0,
-      (child, value) => value && child.validationState.syncValid(),
-      shortCircuitFalse,
-    );
-  });
+      return this.node.structure.reduceChildren(
+        this.syncErrors().length === 0,
+        (child, value) => value && child.validationState.syncValid(),
+        shortCircuitFalse,
+      );
+    }),
+  );
 
   /**
    * The synchronous tree errors visible to this field that are specifically targeted at this field
    * rather than a descendant.
    */
-  readonly syncTreeErrors: Signal<ValidationError.WithFieldTree[]> = computed(
-    () => this.rawSyncTreeErrors().filter((err) => err.fieldTree === this.node.fieldTree),
-    {equal: shallowArrayEquals},
+  readonly syncTreeErrors: Signal<ValidationError.WithFieldTree[]> = privatelyTracked(() =>
+    computed(() => this.rawSyncTreeErrors().filter((err) => err.fieldTree === this.node.fieldTree), {
+      equal: shallowArrayEquals,
+    }),
   );
 
   /**
@@ -221,21 +228,24 @@ export class FieldValidationState implements ValidationState {
    * targeted at a descendant field rather than at this field, as well as sentinel 'pending' values
    * indicating that the validator is still running and an error could still occur.
    */
-  readonly rawAsyncErrors: Signal<(ValidationError.WithFieldTree | 'pending')[]> = computed(
-    () => {
-      // Short-circuit running validators if validation doesn't apply to this field.
-      if (this.shouldSkipValidation()) {
-        return [];
-      }
+  readonly rawAsyncErrors: Signal<(ValidationError.WithFieldTree | 'pending')[]> = privatelyTracked(
+    () =>
+      computed(
+        () => {
+          // Short-circuit running validators if validation doesn't apply to this field.
+          if (this.shouldSkipValidation()) {
+            return [];
+          }
 
-      return [
-        // TODO: add field in `validateAsync` and remove this map
-        ...this.node.logicNode.logic.asyncErrors.compute(this.node.context),
-        // TODO: does it make sense to filter this to errors in this subtree?
-        ...(this.node.structure.parent?.validationState.rawAsyncErrors() ?? []),
-      ];
-    },
-    {equal: shallowArrayEquals},
+          return [
+            // TODO: add field in `validateAsync` and remove this map
+            ...this.node.logicNode.logic.asyncErrors.compute(this.node.context),
+            // TODO: does it make sense to filter this to errors in this subtree?
+            ...(this.node.structure.parent?.validationState.rawAsyncErrors() ?? []),
+          ];
+        },
+        {equal: shallowArrayEquals},
+      ),
   );
 
   /**
@@ -243,21 +253,24 @@ export class FieldValidationState implements ValidationState {
    * rather than a descendant. This also includes all 'pending' sentinel values, since those could
    * theoretically result in errors for this field.
    */
-  readonly asyncErrors: Signal<(ValidationError.WithFieldTree | 'pending')[]> = computed(
-    () => {
-      if (this.shouldSkipValidation()) {
-        return [];
-      }
-      return this.rawAsyncErrors().filter(
-        (err) => err === 'pending' || err.fieldTree === this.node.fieldTree,
-      );
-    },
-    {equal: shallowArrayEquals},
+  readonly asyncErrors: Signal<(ValidationError.WithFieldTree | 'pending')[]> = privatelyTracked(() =>
+    computed(
+      () => {
+        if (this.shouldSkipValidation()) {
+          return [];
+        }
+        return this.rawAsyncErrors().filter(
+          (err) => err === 'pending' || err.fieldTree === this.node.fieldTree,
+        );
+      },
+      {equal: shallowArrayEquals},
+    ),
   );
 
-  readonly parseErrors: Signal<ValidationError.WithFormField[]> = computed(
-    () => this.node.formFieldBindings().flatMap((field) => field.parseErrors()),
-    {equal: shallowArrayEquals},
+  readonly parseErrors: Signal<ValidationError.WithFormField[]> = privatelyTracked(() =>
+    computed(() => this.node.formFieldBindings().flatMap((field) => field.parseErrors()), {
+      equal: shallowArrayEquals,
+    }),
   );
 
   /**
@@ -363,12 +376,14 @@ export class FieldValidationState implements ValidationState {
    * Indicates whether validation should be skipped for this field because it is hidden, disabled,
    * or readonly.
    */
-  readonly shouldSkipValidation = computed(
-    () =>
-      this.node.hidden() ||
-      this.node.disabled() ||
-      this.node.readonly() ||
-      this.node.structure.isOrphaned(),
+  readonly shouldSkipValidation = privatelyTracked(() =>
+    computed(
+      () =>
+        this.node.hidden() ||
+        this.node.disabled() ||
+        this.node.readonly() ||
+        this.node.structure.isOrphaned(),
+    ),
   );
 }
 

--- a/packages/forms/signals/src/util/parser.ts
+++ b/packages/forms/signals/src/util/parser.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {type Signal, linkedSignal} from '@angular/core';
+import {type Signal, linkedSignal, ɵprivatelyTracked as privatelyTracked} from '@angular/core';
 import type {ValidationError} from '../api/rules';
 import {normalizeErrors} from '../api/rules/validation/util';
 import type {ParseResult} from '../api/transformed_value';
@@ -43,11 +43,13 @@ export function createParser<TValue, TRaw>(
   setValue: (value: TValue) => void,
   parse: (raw: TRaw) => ParseResult<TValue>,
 ): Parser<TRaw> {
-  const errors = linkedSignal({
-    source: getValue,
-    computation: () => [] as readonly ValidationError.WithoutFieldTree[],
-    equal: shallowArrayEquals,
-  });
+  const errors = privatelyTracked(() =>
+    linkedSignal({
+      source: getValue,
+      computation: () => [] as readonly ValidationError.WithoutFieldTree[],
+      equal: shallowArrayEquals,
+    }),
+  );
 
   const setRawValue = (rawValue: TRaw) => {
     const result = parse(rawValue);

--- a/packages/forms/signals/test/web/signal_graph.spec.ts
+++ b/packages/forms/signals/test/web/signal_graph.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, signal, ɵgetSignalGraph as getSignalGraph} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {form, FormField, required} from '../../public_api';
+
+describe('Signal Forms DevTools signal graph', () => {
+  it('should mark internal forms signals as private in getSignalGraph for component and directive injectors', async () => {
+    @Component({
+      standalone: true,
+      imports: [FormField],
+      template: `
+        <div>
+          <input [formField]="f.name" />
+          <span>{{ f.name().errors().length }}</span>
+          <span>{{ f.name().valid() }}</span>
+          <span>{{ f.name().dirty() }}</span>
+          <span>{{ f.name().touched() }}</span>
+          <span>{{ f.name().disabled() }}</span>
+        </div>
+      `,
+    })
+    class TestCmp {
+      readonly model = signal({name: ''}, {debugName: 'model'});
+      readonly f = form(this.model, (s) => {
+        required(s.name);
+      });
+    }
+
+    const fixture = TestBed.createComponent(TestCmp);
+    await fixture.whenStable();
+
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = 'test';
+    input.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+
+    const compInjector = fixture.componentRef.injector;
+    const compGraph = getSignalGraph(compInjector);
+
+    const inputDebugEl = fixture.debugElement.query(By.css('input'));
+    const inputInjector = inputDebugEl.injector;
+    const inputGraph = getSignalGraph(inputInjector);
+
+    const checkNoInternalSignals = (graph: any, injectorLabel: string) => {
+      const nonPrivateNodes = graph.nodes.filter((n: any) => !n.isPrivate);
+      const nonPrivateLabels = nonPrivateNodes
+        .map((n: any) => n.label || (n.debuggableFn ? n.debuggableFn.toString() : n.kind));
+
+      const expectedPrivateInternalSignals = [
+        'parseErrors',
+        'rawSyncTreeErrors',
+        'syncTreeErrors',
+        'rawAsyncErrors',
+        'asyncErrors',
+        'selfTouched',
+        'selfDirty',
+        'isNonInteractive',
+        'keyOrOrphan',
+        'isOrphaned',
+        'pathKeys',
+        'reader',
+        'shouldSkipValidation',
+      ];
+
+      for (const internalName of expectedPrivateInternalSignals) {
+        expect(nonPrivateLabels).not.toContain(
+          internalName,
+          `Expected internal signal '${internalName}' to be marked as private in DevTools signal graph for ${injectorLabel}, but it was public.`,
+        );
+      }
+    };
+
+    checkNoInternalSignals(compGraph, 'Component Injector');
+    checkNoInternalSignals(inputGraph, 'Input Directive Injector');
+
+    // For the component graph, public signals consumed by the template (like errors, valid, dirty, touched, disabled)
+    // should appear as non-private computed nodes in addition to the template consumer itself.
+    const compNonPrivate = compGraph.nodes.filter((n: any) => !n.isPrivate);
+    const compComputedNonPrivate = compNonPrivate.filter((n: any) => n.kind === 'computed');
+    expect(compComputedNonPrivate.length).toBeGreaterThan(
+      0,
+    );
+
+    // For the input directive graph, all internal effects and signals should remain private
+    const inputNonPrivate = inputGraph.nodes.filter((n: any) => !n.isPrivate);
+    expect(inputNonPrivate.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Signals forms use an instruction during the update phase that is responsible for tracking signals.

Those signals are unknown to the user, and can be confusing to see by default in the signal graph as consumed by the template. This commit introduces the concept of the private tracking.
