### PR TITLE
feat(elements): reflect input property values to attributes

### DIFF
--- a/goldens/public-api/elements/index.api.md
+++ b/goldens/public-api/elements/index.api.md
@@ -25,6 +25,7 @@ export abstract class NgElement extends HTMLElement {
 // @public
 export interface NgElementConfig {
     injector: Injector;
+    reflectProperties?: boolean;
     strategyFactory?: NgElementStrategyFactory;
 }
 

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -11,7 +11,7 @@ import {Subscription} from 'rxjs';
 
 import {ComponentNgElementStrategyFactory} from './component-factory-strategy';
 import {NgElementStrategy, NgElementStrategyFactory} from './element-strategy';
-import {getComponentInputs, getDefaultAttributeToPropertyInputs} from './utils';
+import {camelToDashCase, getComponentInputs, getDefaultAttributeToPropertyInputs} from './utils';
 
 /**
  * Prototype for a class constructor based on an Angular component
@@ -105,6 +105,20 @@ export interface NgElementConfig {
    * The strategy controls how the transformation is performed.
    */
   strategyFactory?: NgElementStrategyFactory;
+  /**
+   * Whether to reflect input property values back to their corresponding HTML
+   * attributes. When `true`, assigning a primitive value (`string`, `number` or
+   * `boolean`) to an input property updates the matching attribute so the
+   * property and attribute stay in sync.
+   *
+   * Non-primitive values (objects, arrays, functions) are never reflected, since
+   * they cannot be meaningfully serialized to an attribute. A boolean `true`
+   * reflects as an empty attribute and `false`/`null`/`undefined` removes the
+   * attribute.
+   *
+   * Defaults to `false` to preserve the existing behavior.
+   */
+  reflectProperties?: boolean;
 }
 
 /**
@@ -140,6 +154,13 @@ export function createCustomElement<P>(
 
   const attributeToPropertyInputs = getDefaultAttributeToPropertyInputs(inputs);
 
+  // Reverse map (property name -> attribute name) used when reflecting property
+  // values back to attributes. Only built/used when `reflectProperties` is set.
+  const propertyToAttributeInputs = new Map<string, string>();
+  inputs.forEach(({propName, templateName}) => {
+    propertyToAttributeInputs.set(propName, camelToDashCase(templateName));
+  });
+
   class NgElementImpl extends NgElement {
     // Work around a bug in closure typed optimizations(b/79557487) where it is not honoring static
     // field externs. So using quoted access to explicitly prevent renaming.
@@ -174,6 +195,10 @@ export function createCustomElement<P>(
 
     private _ngElementStrategy?: NgElementStrategy;
 
+    // Attribute names currently being written by property reflection. Used to
+    // avoid feeding a reflected attribute change straight back into the strategy.
+    private _reflectingAttributes = new Set<string>();
+
     constructor(private readonly injector?: Injector) {
       super();
     }
@@ -184,8 +209,37 @@ export function createCustomElement<P>(
       newValue: string,
       namespace?: string,
     ): void {
+      // Ignore the change we caused ourselves while reflecting a property value.
+      if (this._reflectingAttributes.has(attrName)) {
+        return;
+      }
       const [propName, transform] = attributeToPropertyInputs[attrName]!;
       this.ngElementStrategy.setInputValue(propName, newValue, transform);
+    }
+
+    /**
+     * Reflects a primitive input property value to its matching attribute. No-op
+     * for non-primitive values, which cannot be serialized to an attribute.
+     */
+    private _reflectPropertyToAttribute(propName: string, value: unknown): void {
+      const attrName = propertyToAttributeInputs.get(propName);
+      if (attrName === undefined) {
+        return;
+      }
+
+      this._reflectingAttributes.add(attrName);
+      try {
+        if (value === null || value === undefined || value === false) {
+          this.removeAttribute(attrName);
+        } else if (value === true) {
+          this.setAttribute(attrName, '');
+        } else if (typeof value === 'string' || typeof value === 'number') {
+          this.setAttribute(attrName, String(value));
+        }
+        // Objects, arrays, functions and symbols are intentionally not reflected.
+      } finally {
+        this._reflectingAttributes.delete(attrName);
+      }
     }
 
     override connectedCallback(): void {
@@ -245,6 +299,9 @@ export function createCustomElement<P>(
       },
       set(newValue: any): void {
         this.ngElementStrategy.setInputValue(propName, newValue, transform);
+        if (config.reflectProperties) {
+          this._reflectPropertyToAttribute(propName, newValue);
+        }
       },
       configurable: true,
       enumerable: true,

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -155,11 +155,15 @@ export function createCustomElement<P>(
   const attributeToPropertyInputs = getDefaultAttributeToPropertyInputs(inputs);
 
   // Reverse map (property name -> attribute name) used when reflecting property
-  // values back to attributes. Only built/used when `reflectProperties` is set.
-  const propertyToAttributeInputs = new Map<string, string>();
-  inputs.forEach(({propName, templateName}) => {
-    propertyToAttributeInputs.set(propName, camelToDashCase(templateName));
-  });
+  // values back to attributes. Only built when `reflectProperties` is enabled,
+  // to avoid the allocation for the default (non-reflecting) case.
+  let propertyToAttributeInputs: Map<string, string> | undefined;
+  if (config.reflectProperties) {
+    propertyToAttributeInputs = new Map<string, string>();
+    inputs.forEach(({propName, templateName}) => {
+      propertyToAttributeInputs!.set(propName, camelToDashCase(templateName));
+    });
+  }
 
   class NgElementImpl extends NgElement {
     // Work around a bug in closure typed optimizations(b/79557487) where it is not honoring static
@@ -195,9 +199,11 @@ export function createCustomElement<P>(
 
     private _ngElementStrategy?: NgElementStrategy;
 
-    // Attribute names currently being written by property reflection. Used to
-    // avoid feeding a reflected attribute change straight back into the strategy.
-    private _reflectingAttributes = new Set<string>();
+    // Whether a property value is currently being reflected to an attribute.
+    // Set/removeAttribute fire `attributeChangedCallback` synchronously for the
+    // single attribute being written, so a boolean flag is enough to avoid
+    // feeding that reflected change straight back into the strategy.
+    private _isReflecting = false;
 
     constructor(private readonly injector?: Injector) {
       super();
@@ -210,7 +216,7 @@ export function createCustomElement<P>(
       namespace?: string,
     ): void {
       // Ignore the change we caused ourselves while reflecting a property value.
-      if (this._reflectingAttributes.has(attrName)) {
+      if (this._isReflecting) {
         return;
       }
       const [propName, transform] = attributeToPropertyInputs[attrName]!;
@@ -222,12 +228,12 @@ export function createCustomElement<P>(
      * for non-primitive values, which cannot be serialized to an attribute.
      */
     private _reflectPropertyToAttribute(propName: string, value: unknown): void {
-      const attrName = propertyToAttributeInputs.get(propName);
+      const attrName = propertyToAttributeInputs?.get(propName);
       if (attrName === undefined) {
         return;
       }
 
-      this._reflectingAttributes.add(attrName);
+      this._isReflecting = true;
       try {
         if (value === null || value === undefined || value === false) {
           this.removeAttribute(attrName);
@@ -238,7 +244,7 @@ export function createCustomElement<P>(
         }
         // Objects, arrays, functions and symbols are intentionally not reflected.
       } finally {
-        this._reflectingAttributes.delete(attrName);
+        this._isReflecting = false;
       }
     }
 

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -43,6 +43,8 @@ describe('createCustomElement', () => {
   let NgElementCtor: NgElementConstructor<WithFooBar>;
   let strategy: TestStrategy;
   let strategyFactory: TestStrategyFactory;
+  let reflectStrategy: TestStrategy;
+  let reflectStrategyFactory: TestStrategyFactory;
   let injector: Injector;
 
   beforeAll((done) => {
@@ -56,12 +58,18 @@ describe('createCustomElement', () => {
         strategyFactory = new TestStrategyFactory();
         strategy = strategyFactory.testStrategy;
 
+        reflectStrategyFactory = new TestStrategyFactory();
+        reflectStrategy = reflectStrategyFactory.testStrategy;
+
         NgElementCtor = createAndRegisterTestCustomElement(strategyFactory);
       })
       .then(done, done.fail);
   });
 
-  afterEach(() => strategy.reset());
+  afterEach(() => {
+    strategy.reset();
+    reflectStrategy?.reset();
+  });
 
   afterAll(() => {
     destroyPlatform();
@@ -342,7 +350,86 @@ describe('createCustomElement', () => {
     expect(isSignal(element.fooFoo)).toBe(true);
   });
 
+  describe('with `reflectProperties` enabled', () => {
+    it('should reflect a string property value to its attribute', () => {
+      const element = createAndRegisterReflectingElement();
+      element.fooFoo = 'from-property';
+      expect(element.getAttribute('foo-foo')).toBe('from-property');
+    });
+
+    it('should reflect a numeric property value as a string attribute', () => {
+      const element = createAndRegisterReflectingElement();
+      (element as any).fooFoo = 42;
+      expect(element.getAttribute('foo-foo')).toBe('42');
+    });
+
+    it('should reflect boolean `true` as an empty attribute and remove it for `false`', () => {
+      const element = createAndRegisterReflectingElement();
+
+      (element as any).fooFoo = true;
+      expect(element.getAttribute('foo-foo')).toBe('');
+
+      (element as any).fooFoo = false;
+      expect(element.hasAttribute('foo-foo')).toBe(false);
+    });
+
+    it('should remove the attribute when the property is set to `null` or `undefined`', () => {
+      const element = createAndRegisterReflectingElement();
+      element.fooFoo = 'value';
+      expect(element.getAttribute('foo-foo')).toBe('value');
+
+      (element as any).fooFoo = null;
+      expect(element.hasAttribute('foo-foo')).toBe(false);
+
+      element.fooFoo = 'value';
+      (element as any).fooFoo = undefined;
+      expect(element.hasAttribute('foo-foo')).toBe(false);
+    });
+
+    it('should not reflect non-primitive property values', () => {
+      const element = createAndRegisterReflectingElement();
+      (element as any).fooFoo = {toString: () => 'obj'};
+      expect(element.hasAttribute('foo-foo')).toBe(false);
+
+      (element as any).fooFoo = ['a', 'b'];
+      expect(element.hasAttribute('foo-foo')).toBe(false);
+    });
+
+    it('should use the mapped attribute name (e.g. an aliased input)', () => {
+      const element = createAndRegisterReflectingElement();
+      element.barBar = 'aliased';
+      // `barBar` is aliased to the `barbar` attribute.
+      expect(element.getAttribute('barbar')).toBe('aliased');
+    });
+
+    it('should keep the property value when reflecting (no attribute feedback loop)', () => {
+      const element = createAndRegisterReflectingElement();
+      element.fooFoo = 'from-property';
+      expect(reflectStrategy.getInputValue('fooFoo')).toBe('from-property');
+      expect(element.getAttribute('foo-foo')).toBe('from-property');
+    });
+  });
+
+  it('should not reflect properties to attributes by default', () => {
+    const element = new NgElementCtor(injector);
+    element.fooFoo = 'from-property';
+    expect(element.hasAttribute('foo-foo')).toBe(false);
+  });
+
   // Helpers
+  function createAndRegisterReflectingElement() {
+    const selector = `test-element-${++selectorUid}`;
+    const ElementCtor = createCustomElement<WithFooBar>(TestComponent, {
+      injector,
+      strategyFactory: reflectStrategyFactory,
+      reflectProperties: true,
+    });
+    customElements.define(selector, ElementCtor);
+    const element = document.createElement(selector) as HTMLElement & WithFooBar;
+    testContainer.appendChild(element);
+    return element;
+  }
+
   function createAndRegisterTestCustomElement(strategyFactory: NgElementStrategyFactory) {
     const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
 


### PR DESCRIPTION
Angular Elements syncs attributes to input properties, but not the reverse: assigning an input property never updated the corresponding attribute. This adds an opt-in `reflectProperties` option on `NgElementConfig`. When enabled, assigning a primitive value (string, number or boolean) to an input property writes it back to the matching attribute so the two stay in sync.

Non-primitive values are intentionally not reflected, since they cannot be meaningfully serialized to an attribute. A boolean `true` reflects as an empty attribute, while `false`, `null` and `undefined` remove it. A guard prevents the reflected attribute change from being fed back through `attributeChangedCallback`. The option defaults to `false`, preserving existing behavior.

Fixes #23557

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Angular Elements keeps input **properties** in sync when an **attribute** changes
(`setAttribute(...)` updates the property), but not the other way around. Assigning
an input **property** never updates the corresponding attribute, so the property and
attribute drift out of sync.

Issue Number: #23557

## What is the new behavior?

Adds an opt-in `reflectProperties` option on `NgElementConfig`. When enabled,
assigning a **primitive** value to an input property reflects it back to the matching
attribute so the two stay in sync:

- `string` / `number` → written to the attribute as a string
- `true` → empty attribute; `false` / `null` / `undefined` → attribute removed
- objects / arrays / functions are **not** reflected, avoiding meaningless
  `[Object object]` attributes (the concern raised earlier on the issue)

A guard prevents the reflected attribute change from being fed back through
`attributeChangedCallback`. Unit tests cover string, number, boolean, null/undefined,
non-primitive, aliased-attribute, and no-feedback-loop cases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The option defaults to `false`, so existing behavior is unchanged.

## Other information

Open to shaping the API — the opt-in flag lives on `NgElementConfig`, but a per-input
opt-in would also work if the team prefers. Happy to adjust based on review.