### PR TITLE
fix(core): reject aliased href SVG animation targets

### DIFF
--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -405,10 +405,33 @@ function getSecuritySensitiveSVGAnimationAttributeName(
     }
 
     const attributeNameValue = element.getAttribute(attributeName);
-    if (attributeNameValue !== null && validationConfig.has(attributeNameValue.toLowerCase())) {
+    if (
+      attributeNameValue !== null &&
+      isSecuritySensitiveSVGAnimationAttributeName(attributeNameValue, validationConfig)
+    ) {
       return attributeNameValue;
     }
   }
 
   return null;
+}
+
+/** Whether an SVG animation attribute name can target a security-sensitive local name. */
+function isSecuritySensitiveSVGAnimationAttributeName(
+  attributeName: string,
+  validationConfig: ReadonlySet<string>,
+): boolean {
+  const normalizedAttributeName = attributeName.toLowerCase();
+  if (validationConfig.has(normalizedAttributeName)) {
+    return true;
+  }
+
+  // Namespace mappings can change after validation, so resolve QName aliases by local name rather
+  // than relying on the prefix or its current namespace URI.
+  const namespaceSeparatorIndex = normalizedAttributeName.indexOf(':');
+  return (
+    namespaceSeparatorIndex > 0 &&
+    namespaceSeparatorIndex === normalizedAttributeName.lastIndexOf(':') &&
+    validationConfig.has(normalizedAttributeName.slice(namespaceSeparatorIndex + 1))
+  );
 }

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -816,6 +816,8 @@ describe('iframe processing', () => {
 });
 
 describe('SVG animation processing', () => {
+  const X_LINK_NAMESPACE_URI = 'http://www.w3.org/1999/xlink';
+
   it('should error when `attributeName` is bound', () => {
     @Component({
       template: '<svg><animate [attr.attributeName]="attr"></animate></svg>',
@@ -858,6 +860,82 @@ describe('SVG animation processing', () => {
     }).toThrowError(
       /NG0910: Angular has detected that the `attributeName` was applied as a binding to the <animate>/,
     );
+  });
+
+  for (const {elementName, boundAttributeName} of [
+    {elementName: 'set', boundAttributeName: 'to'},
+    {elementName: 'animate', boundAttributeName: 'to'},
+    {elementName: 'animate', boundAttributeName: 'from'},
+    {elementName: 'animate', boundAttributeName: 'values'},
+  ]) {
+    it(`should reject ${elementName} ${boundAttributeName} bindings when attributeName is an aliased XLink href QName`, async () => {
+      @Component({
+        template: `
+          <section xmlns:foo="${X_LINK_NAMESPACE_URI}">
+            <svg>
+              <a>
+                <${elementName}
+                  attributeName="foo:href"
+                  [attr.${boundAttributeName}]="destination"
+                />
+              </a>
+            </svg>
+          </section>
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class AliasedXLinkHrefAnimation {
+        destination = 'javascript:alert(1)';
+      }
+
+      const fixture = TestBed.createComponent(AliasedXLinkHrefAnimation);
+
+      await expectAsync(fixture.whenStable()).toBeRejectedWithError(
+        new RegExp(
+          `NG0910: Angular has detected that the \`${boundAttributeName}\` was applied as a binding to the <${elementName}>`,
+        ),
+      );
+    });
+  }
+
+  it('should reject unresolved href QName aliases before their namespace mapping can change', async () => {
+    @Component({
+      template: `
+        <svg>
+          <set attributeName="unresolved:href" [attr.to]="destination" />
+        </svg>
+      `,
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
+    class UnresolvedHrefAliasAnimation {
+      destination = 'javascript:alert(1)';
+    }
+
+    const fixture = TestBed.createComponent(UnresolvedHrefAliasAnimation);
+
+    await expectAsync(fixture.whenStable()).toBeRejectedWithError(
+      /NG0910: Angular has detected that the `to` was applied as a binding to the <set>/,
+    );
+  });
+
+  it('should allow animation value bindings for a namespaced non-href attributeName', async () => {
+    @Component({
+      template: `
+        <svg xmlns:foo="urn:angular:svg-animation">
+          <animate attributeName="foo:opacity" [attr.to]="destination" />
+        </svg>
+      `,
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
+    class NamespacedNonHrefAnimation {
+      destination = '1';
+    }
+
+    const fixture = TestBed.createComponent(NamespacedNonHrefAnimation);
+
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('animate').getAttribute('to')).toBe('1');
   });
 });
 


### PR DESCRIPTION
SVG animation validation only recognizes the literal `href` and `xlink:href` values. SMIL interprets `attributeName` as a QName, so an arbitrary prefix mapped to the XLink namespace can bypass this check and allow a bound `javascript:` URL to reach an SVG link.

Treat any QName whose local name is `href` as security-sensitive, even when its prefix is unresolved or remapped after validation.
