### PR TITLE
fix(http): respect content-type charset in fetch backend text decoder

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -161,6 +161,8 @@ export class FetchBackend implements HttpBackend {
     }
 
     if (response.body) {
+      const contentType = response.headers.get(CONTENT_TYPE_HEADER) ?? '';
+
       // Read Progress
       const contentLength = response.headers.get('content-length');
       const contentLengthValue = contentLength !== null ? Number(contentLength) : NaN;
@@ -223,7 +225,7 @@ export class FetchBackend implements HttpBackend {
             partialText =
               request.responseType === 'text'
                 ? (partialText ?? '') +
-                  (decoder ??= new TextDecoder()).decode(value, {stream: true})
+                  (decoder ??= getTextDecoder(contentType)).decode(value, {stream: true})
                 : undefined;
 
             const reportProgress = () =>
@@ -250,7 +252,6 @@ export class FetchBackend implements HttpBackend {
       // Combine all chunks.
       const chunksAll = this.concatChunks(chunks, receivedLength);
       try {
-        const contentType = response.headers.get(CONTENT_TYPE_HEADER) ?? '';
         body = this.parseBody(request, chunksAll, contentType, status);
       } catch (error) {
         // Body loading or parsing failed
@@ -322,7 +323,7 @@ export class FetchBackend implements HttpBackend {
     switch (request.responseType) {
       case 'json':
         // stripping the XSSI when present
-        const text = new TextDecoder().decode(binContent).replace(XSSI_PREFIX, '');
+        const text = getTextDecoder(contentType).decode(binContent).replace(XSSI_PREFIX, '');
         if (text === '') {
           return null;
         }
@@ -339,7 +340,7 @@ export class FetchBackend implements HttpBackend {
           throw e;
         }
       case 'text':
-        return new TextDecoder().decode(binContent);
+        return getTextDecoder(contentType).decode(binContent);
       case 'blob':
         return new Blob([binContent], {type: contentType});
       case 'arraybuffer':
@@ -452,4 +453,25 @@ function throwBodyTooLargeError(maxResponseSize: number): never {
     ngDevMode &&
       `Fetch response body exceeded the configured buffer limit (${maxResponseSize} bytes).`,
   );
+}
+
+const CHARSET_REGEX = /charset=\s*["']?([^;"'\s]+)["']?/i;
+
+/**
+ * Creates a `TextDecoder` instance using the charset extracted from the `Content-Type` header,
+ * falling back to the default (`utf-8`) if no valid charset is specified or supported.
+ */
+function getTextDecoder(contentType: string): TextDecoder {
+  const match = contentType.match(CHARSET_REGEX);
+  if (match !== null) {
+    try {
+      return new TextDecoder(match[1]);
+    } catch {
+      // Catching `RangeError` thrown by `new TextDecoder(...)` when the encoding label is invalid or
+      // unsupported. There is no synchronous inspection API on `TextDecoder` to verify whether an
+      // encoding is supported without executing the constructor, so catching the error is required
+      // before falling back to default UTF-8.
+    }
+  }
+  return new TextDecoder();
 }

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -182,6 +182,45 @@ describe('FetchBackend', () => {
     expect(res.statusText).toBe('OK');
   });
 
+  it('handles a text response with iso-8859-1 charset', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST));
+    // "café" encoded in ISO-8859-1 (0x63, 0x61, 0x66, 0xE9)
+    const isoBytes = new Uint8Array([0x63, 0x61, 0x66, 0xe9]);
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', isoBytes, {
+      'Content-Type': 'text/html; charset=iso-8859-1',
+    });
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<string>;
+    expect(res.body).toBe('café');
+  });
+
+  it('handles a text response with windows-1252 charset in quotes', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST));
+    // "€" encoded in Windows-1252 (0x80)
+    const windowsBytes = new Uint8Array([0x80]);
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', windowsBytes, {
+      'Content-Type': 'text/plain; charset="windows-1252"',
+    });
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<string>;
+    expect(res.body).toBe('€');
+  });
+
+  it('falls back to default utf-8 when given an invalid charset', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST));
+    // "café" encoded in UTF-8
+    const utf8Bytes = new Uint8Array([0x63, 0x61, 0x66, 0xc3, 0xa9]);
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', utf8Bytes, {
+      'Content-Type': 'text/plain; charset=invalid-encoding-label',
+    });
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<string>;
+    expect(res.body).toBe('café');
+  });
+
   it('handles a json response', async () => {
     const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
     fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', JSON.stringify({data: 'some data'}));
@@ -723,7 +762,7 @@ export class MockFetchFactory extends FetchFactory {
   mockFlush(
     status: number,
     statusText: string,
-    body?: string | Blob,
+    body?: string | Blob | Uint8Array,
     headers?: Record<string, string>,
   ): void {
     this.clearWarningTimeout?.();
@@ -829,7 +868,7 @@ class MockFetchResponse {
     start: (controller) => {
       this.sub$.subscribe({
         next: (val) => {
-          controller.enqueue(new TextEncoder().encode(val));
+          controller.enqueue(val instanceof Uint8Array ? val : new TextEncoder().encode(val));
         },
         complete: () => {
           controller.close();


### PR DESCRIPTION
Extract the charset parameter from the Content-Type response header in FetchBackend and pass it to TextDecoder when decoding text and json responses. When no valid charset is provided or supported, gracefully fall back to default utf-8 decoding.

Fixes #70061
