### PR TITLE
fix(http): avoid aborting completed requests in FetchBackend

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -84,9 +84,26 @@ export class FetchBackend implements HttpBackend {
   handle(request: HttpRequest<any>): Observable<HttpEvent<any>> {
     return new Observable((observer) => {
       const aborter = new AbortController();
+      let done = false;
+      const wrappedObserver: Observer<HttpEvent<any>> = {
+        next: (val) => {
+          if (val.type === HttpEventType.Response) {
+            done = true;
+          }
+          observer.next(val);
+        },
+        error: (err) => {
+          done = true;
+          observer.error(err);
+        },
+        complete: () => {
+          done = true;
+          observer.complete();
+        },
+      };
 
-      this.doRequest(request, aborter.signal, observer).then(noop, (error) =>
-        observer.error(new HttpErrorResponse({error})),
+      this.doRequest(request, aborter.signal, wrappedObserver).then(noop, (error) =>
+        wrappedObserver.error(new HttpErrorResponse({error})),
       );
 
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -106,7 +123,9 @@ export class FetchBackend implements HttpBackend {
         if (timeoutId !== undefined) {
           clearTimeout(timeoutId);
         }
-        aborter.abort();
+        if (!done && !aborter.signal.aborted) {
+          aborter.abort();
+        }
       };
     });
   }

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -679,6 +679,27 @@ describe('FetchBackend', () => {
       expect((events[1] as HttpResponse<string>).body).toBe('ok');
     });
   });
+
+  describe('cancellation behavior', () => {
+    it('should not abort signal when the request completes successfully', async () => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'text'});
+      const promise = trackEvents(backend.handle(req));
+      fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'ok');
+      const events = await promise;
+
+      expect(events.length).toBe(2);
+      expect(fetchMock.request.signal?.aborted).toBeFalse();
+    });
+
+    it('should abort signal when unsubscribed before request completion', () => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'text'});
+      const sub = backend.handle(req).subscribe();
+      expect(fetchMock.request.signal?.aborted).toBeFalse();
+
+      sub.unsubscribe();
+      expect(fetchMock.request.signal?.aborted).toBeTrue();
+    });
+  });
 });
 
 export class MockFetchFactory extends FetchFactory {
@@ -700,6 +721,7 @@ export class MockFetchFactory extends FetchFactory {
     this.request.body = init?.body;
     this.request.headers = init?.headers;
     this.request.credentials = init?.credentials;
+    this.request.signal = init?.signal;
 
     if (init?.signal) {
       init?.signal.addEventListener('abort', () => {
@@ -778,6 +800,7 @@ class MockFetchRequest {
   public body: any;
   public credentials?: RequestCredentials;
   public headers?: HeadersInit;
+  public signal?: AbortSignal | null;
 }
 
 class InfiniteStreamFetchFactory extends FetchFactory {


### PR DESCRIPTION
Prevent `AbortController.abort()` from executing during `Observable` teardown when a `FetchBackend` HTTP request has already completed successfully or errored. 
Previously, FetchBackend unconditionally called `abort()` upon stream termination. 

Fixes #70071
