### PR TITLE
fix(http): always decode JSON responses as UTF-8

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -342,7 +342,7 @@ export class FetchBackend implements HttpBackend {
     switch (request.responseType) {
       case 'json':
         // stripping the XSSI when present
-        const text = getTextDecoder(contentType).decode(binContent).replace(XSSI_PREFIX, '');
+        const text = new TextDecoder().decode(binContent).replace(XSSI_PREFIX, '');
         if (text === '') {
           return null;
         }

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -230,6 +230,16 @@ describe('FetchBackend', () => {
     expect(res.body!.data).toBe('some data');
   });
 
+  it('decodes a json response as UTF-8 regardless of its declared charset', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', JSON.stringify({data: 'café'}), {
+      'Content-Type': 'application/json; charset=windows-1251',
+    });
+    const events = await promise;
+    const res = events[1] as HttpResponse<{data: string}>;
+    expect(res.body!.data).toBe('café');
+  });
+
   it('handles a blank json response', async () => {
     const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
     fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', '');


### PR DESCRIPTION
Keep the charset handling added in #70062 limited to text responses. JSON bytes must stay UTF-8 regardless of the Content-Type charset.

Fetch defines Body.json() using "parse JSON from bytes". Infra specifies that step as: "Let string be the result of running UTF-8 decode on bytes."

https://fetch.spec.whatwg.org/#dom-body-json
https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value

