### PR TITLE
fix(compiler): prevent false positive NG8107 in @for loop optional chains

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
@@ -400,5 +400,32 @@ runInEachFileSystem(() => {
     expect(diags.length).toBe(0);
   });
 
-  it('should not produce a warning on function calls with consecutive optional chaining with legacy behavior', () => {});
+  it('should not produce a warning for optional chaining in @for loop expression', () => {
+    const fileName = absoluteFrom('/main.ts');
+    const {program, templateTypeChecker} = setup([
+      {
+        fileName,
+        templates: {
+          'TestCmp': `@for (item of type().one?.two?.three?.array; track item.name) { {{ item.name }} }`,
+        },
+        source: `
+          export class TestCmp {
+            type(): { one?: { two?: { three?: { array: { name: string }[] } } } } {
+              return {};
+            }
+          }
+        `,
+      },
+    ]);
+    const sf = getSourceFileOrError(program, fileName);
+    const component = getClass(sf, 'TestCmp');
+    const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+      templateTypeChecker,
+      program.getTypeChecker(),
+      [optionalChainNotNullableFactory],
+      {strictNullChecks: true} /* options */,
+    );
+    const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+    expect(diags.length).toBe(0);
+  });
 });

--- a/packages/compiler/src/typecheck/ops/for_block.ts
+++ b/packages/compiler/src/typecheck/ops/for_block.ts
@@ -43,11 +43,14 @@ export class TcbForOfOp extends TcbOp {
     const initializer = new TcbExpr(`const ${initializerId.print()}`);
     initializer.addParseSpanInfo(this.block.item.keySpan);
 
+    // Emit the un-asserted expression as a statement so that symbol queries (e.g. extended
+    // diagnostics like optional_chain_not_nullable) do not see types narrowed by the trailing `!`.
+    const rawExpression = tcbExpression(this.block.expression, this.tcb, this.scope);
+    this.scope.addStatement(rawExpression);
+
     // It's common to have a for loop over a nullable value (e.g. produced by the `async` pipe).
     // Add a non-null expression to allow such values to be assigned.
-    const expression = new TcbExpr(
-      `${tcbExpression(this.block.expression, this.tcb, this.scope).print()}!`,
-    );
+    const expression = new TcbExpr(`${rawExpression.print()}!`);
 
     let statements: TcbExpr[];
 


### PR DESCRIPTION
Fixes #70085

### Summary
Fixes a false positive `NG8107` (`optional_chain_not_nullable`) extended diagnostic warning when optional chaining (`?.`) is used inside `@for` loop collection expressions (e.g. `@for (item of type().one?.two?.three?.array; track item.name)`).

### Problem & Root Cause
In Type Check Block (TCB) generation for `@for` loops (`TcbForOfOp`), collection expressions are emitted into a `for...of` loop statement with a trailing non-null assertion `!` (e.g. `for (const _t1 of (type().one?.two?.three?.array)!)`).

Under TypeScript's Control Flow Analysis (CFA), the trailing `!` assertion flows backward through optional chain receivers (`type().one`, `type().one?.two`, `type().one?.two?.three`) and narrows their inferred types to non-nullable (excluding `null`/`undefined`). Consequently, when `OptionalChainNotNullableCheck` queried the type of receivers in the TCB via `templateTypeChecker.getSymbolOfNode()`, TypeScript reported them as non-nullable, causing `NG8107` to misidentify valid optional chains as redundant.

### Solution
`TcbForOfOp` now emits the un-asserted collection expression as a standalone statement in the TCB before the `for...of` loop statement. `TemplateTypeChecker` symbol resolution matches the un-asserted AST node where intermediate receivers retain their proper nullable types (`Type | undefined`), while the `for...of` loop statement continues to provide the non-null assertion required for loop iteration.
