### PR TITLE
fix(compiler-cli): avoid false NG8107 diagnostic inside `@for` blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
@@ -336,6 +336,33 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(0);
     });
 
+    it('should not produce optional chain warning for a chain inside a `@for` block', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `@for (item of func().one?.two?.three?.items; track item) {}`,
+          },
+          source: `
+               export class TestCmp {
+                 func = (): {one?: {two: {three: {items?: string[]}}}} => ({});
+               }
+             `,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [optionalChainNotNullableFactory],
+        {strictNullChecks: true} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
     it('should respect configured diagnostic category', () => {
       const fileName = absoluteFrom('/main.ts');
       const {program, templateTypeChecker} = setup([

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
@@ -658,11 +658,7 @@ export class SymbolBuilder {
     const expressionTarget = this.boundTarget.getExpressionTarget(expression);
     if (expressionTarget !== null) {
       return this.getSymbol(expressionTarget) as
-        | VariableSymbol
-        | ReferenceSymbol
-        | ExpressionSymbol
-        | LetDeclarationSymbol
-        | null;
+        VariableSymbol | ReferenceSymbol | ExpressionSymbol | LetDeclarationSymbol | null;
     }
 
     let withSpan = expression.sourceSpan;
@@ -711,6 +707,7 @@ export class SymbolBuilder {
       if (nameNode !== null) {
         node = nameNode;
         while (
+          !isAccessExpression(node) &&
           node.parent !== undefined &&
           (ts.isParenthesizedExpression(node.parent) ||
             ts.isNonNullExpression(node.parent) ||


### PR DESCRIPTION
An optional chain used as the iterable of a `@for` block reports NG8107 on links that really can be nullish, for example `@for (item of type().one?.two?.three?.array; track item.name)`.

Resolving a safe property read back to a node in the type check block falls back to looking up the property name and walking up the parent nodes. The walk did not stop at the access expression the name belongs to, so every link of the chain resolved to the outermost expression. In a `@for` block that expression carries the non-null assertion the loop adds to its iterable, so the left side of the chain looked non-nullable.

Fixes #70085