### PR TITLE
fix(core): reject prefixed SVG script hosts

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -184,8 +184,13 @@ function createHostElement(componentDef: ComponentDef<unknown>, renderer: Render
   return createElementNode(renderer, tagName, namespace);
 }
 
-function assertNotScriptHostElement(tagName: string | null | undefined): void {
-  if (tagName?.toLowerCase() === 'script') {
+function assertNotScriptHostElement(element: RElement | null | undefined): void {
+  const elementName =
+    element && 'localName' in element && typeof element.localName === 'string'
+      ? element.localName
+      : element?.tagName;
+
+  if (elementName?.toLowerCase() === 'script') {
     throw new RuntimeError(
       RuntimeErrorCode.UNSAFE_VALUE_IN_SCRIPT,
       ngDevMode && `"<script>" tag is not allowed as a component host element.`,
@@ -313,7 +318,7 @@ export class ComponentFactory<T> {
     const hostElement = rootSelectorOrNode
       ? locateHostElement(hostRenderer, rootSelectorOrNode, cmpDef.encapsulation, rootViewInjector)
       : createHostElement(cmpDef, hostRenderer);
-    assertNotScriptHostElement(hostElement?.tagName);
+    assertNotScriptHostElement(hostElement);
 
     const sharedStylesHost = rootViewInjector.get(SHARED_STYLES_HOST, null);
     const styleHost = getStyleHost(

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -1327,7 +1327,6 @@ describe('Component host element validation', () => {
   it('should reject a prefixed SVG script host element', () => {
     @Component({
       selector: 'my-prefixed-svg-script-host',
-      standalone: true,
       template: '',
     })
     class MyPrefixedSvgScriptHost {}

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -1323,6 +1323,26 @@ describe('Component host element validation', () => {
       svgScriptHost.remove();
     }
   });
+
+  it('should reject a prefixed SVG script host element', () => {
+    @Component({
+      selector: 'my-prefixed-svg-script-host',
+      standalone: true,
+      template: '',
+    })
+    class MyPrefixedSvgScriptHost {}
+
+    const host = document.createElementNS(SVG_NAMESPACE_URI, 'x:script');
+
+    expect(host.tagName).toBe('x:script');
+    expect(host.localName).toBe('script');
+    expect(() =>
+      createComponent(MyPrefixedSvgScriptHost, {
+        environmentInjector: TestBed.inject(EnvironmentInjector),
+        hostElement: host,
+      }),
+    ).toThrowError(/"<script>" tag is not allowed as a component host element/);
+  });
 });
 
 describe('SVG <script> bindings', () => {


### PR DESCRIPTION
## PR Checklist

* [x] The commit message follows the Angular commit message guidelines
* [x] Tests for the changes have been added
* [x] The affected acceptance test suites pass
* [x] Formatting and lint checks pass

## PR Type

* [x] Bugfix
* [x] Security hardening
* [ ] Feature
* [ ] Code style update
* [ ] Refactoring
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other

## What is the current behavior?

The dynamic component host validation introduced for CVE-2026-52725 compares the host element's qualified `tagName` with `script`.

This leaves an incomplete-fix gap for namespace-prefixed SVG script elements.

For example:

```ts
const host = document.createElementNS(
  'http://www.w3.org/2000/svg',
  'x:script',
);
```

In Chromium, this element has the following identity:

```text
tagName = "x:script"
localName = "script"
namespaceURI = "http://www.w3.org/2000/svg"
```

The current validation compares:

```ts
host.tagName.toLowerCase() === 'script'
```

which is false for `x:script`.

However, the browser still treats the element as a genuine SVG script element because its namespace-aware local name is `script`.

As a result, an application that passes such an attacker-controlled element as the `hostElement` of `createComponent()` can bypass Angular's script-host protection.

If Angular renders JavaScript text into that SVG script element, the browser may execute it in the application's origin, resulting in cross-site scripting.

This is therefore an incomplete fix for the security property introduced by CVE-2026-52725: rejecting executable HTML and SVG script elements as dynamic component hosts.

## What is the new behavior?

The validation receives the host element itself and checks its namespace-aware `localName` when available.

This correctly identifies both unprefixed and namespace-prefixed script elements.

It retains the existing `tagName` fallback for renderer implementations that do not expose `localName`.

The following are therefore rejected consistently:

```ts
document.createElement('script');
```

```ts
document.createElementNS(
  'http://www.w3.org/2000/svg',
  'script',
);
```

```ts
document.createElementNS(
  'http://www.w3.org/2000/svg',
  'x:script',
);
```

## Security impact

In an affected application, this bypass can allow JavaScript to execute in the Angular application's origin.

The practical impact depends on whether the application:

* accepts or imports attacker-controlled SVG or XML content;
* passes a node from that content as `hostElement` to `createComponent()`;
* renders JavaScript-compatible text or attacker-influenced content into the host element.

Under those conditions, the issue can result in cross-site scripting and may allow an attacker to:

* perform authenticated actions as the victim;
* access data available to page JavaScript;
* read non-HttpOnly tokens or application secrets;
* modify application or user data.

## Why this is an incomplete fix

The intended security property is:

> Reject executable HTML and SVG script elements as dynamic component hosts.

The current implementation instead enforces:

> Reject elements whose qualified `tagName` string is exactly `script`.

These are not equivalent for namespace-prefixed SVG elements.

A prefixed SVG script such as `x:script` has a qualified name that differs from `script`, but its namespace-aware local name remains `script`.

This PR updates the check to use the semantic element identity rather than the qualified name string.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

This only extends the existing script-host restriction to namespace-prefixed representations of the same native SVG script element.

## Tests

Regression coverage verifies that a prefixed SVG script element created as:

```ts
document.createElementNS(
  'http://www.w3.org/2000/svg',
  'x:script',
);
```

has:

```text
tagName = "x:script"
localName = "script"
```

and is rejected as a dynamic component host.

The following checks pass locally:

```text
//packages/core/test/acceptance:acceptance
//packages/core/test/acceptance:acceptance_web_chromium
//packages/core/test/acceptance:acceptance_web_firefox
pnpm lint
```

## Other information

This is a focused follow-up to the dynamic script-host validation introduced for CVE-2026-52725.
