### PR TITLE
refactor(compiler): diagnostics should assume `strict` by default

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/nullish_coalescing_not_nullable/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/nullish_coalescing_not_nullable/index.ts
@@ -81,7 +81,9 @@ export const factory: TemplateCheckFactory<
   create: (options: NgCompilerOptions) => {
     // Require `strictNullChecks` to be enabled.
     const strictNullChecks =
-      options.strictNullChecks === undefined ? !!options.strict : !!options.strictNullChecks;
+      options.strictNullChecks === undefined
+        ? options.strict !== false
+        : !!options.strictNullChecks;
     if (!strictNullChecks) {
       return null;
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/optional_chain_not_nullable/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/optional_chain_not_nullable/index.ts
@@ -108,7 +108,9 @@ export const factory: TemplateCheckFactory<
   create: (options: NgCompilerOptions) => {
     // Require `strictNullChecks` to be enabled.
     const strictNullChecks =
-      options.strictNullChecks === undefined ? !!options.strict : !!options.strictNullChecks;
+      options.strictNullChecks === undefined
+        ? options.strict !== false
+        : !!options.strictNullChecks;
     if (!strictNullChecks) {
       return null;
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/nullish_coalescing_not_nullable/nullish_coalescing_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/nullish_coalescing_not_nullable/nullish_coalescing_not_nullable_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DiagnosticCategoryLabel} from '../../../../../core/api';
 import ts from 'typescript';
+import {DiagnosticCategoryLabel} from '../../../../../core/api';
 
 import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';
 import {absoluteFrom, getSourceFileOrError} from '../../../../../file_system';
@@ -32,19 +32,22 @@ runInEachFileSystem(() => {
       expect(nullishCoalescingNotNullableFactory.create({strictNullChecks: true})).toBeDefined();
     });
 
-    it('should return a check if `strictNullChecks` is not configured but `strict` is enabled', () => {
-      expect(nullishCoalescingNotNullableFactory.create({strict: true})).toBeDefined();
+    it('should return a check if `strictNullChecks` is not configured but `strict` is enabled by default', () => {
+      expect(nullishCoalescingNotNullableFactory.create({})).toBeDefined();
     });
 
     it('should not return a check if `strictNullChecks` is disabled', () => {
-      expect(nullishCoalescingNotNullableFactory.create({strictNullChecks: false})).toBeNull();
-      expect(nullishCoalescingNotNullableFactory.create({})).toBeNull(); // Defaults disabled.
+      expect(
+        nullishCoalescingNotNullableFactory.create({strict: false, strictNullChecks: false}),
+      ).toBeNull();
+    });
+
+    it('should not return a check if `strict` is disabled and `strictNullChecks` is not configured', () => {
+      expect(nullishCoalescingNotNullableFactory.create({strict: false})).toBeNull();
     });
 
     it('should not return a check if `strict` is enabled but `strictNullChecks` is disabled', () => {
-      expect(
-        nullishCoalescingNotNullableFactory.create({strict: true, strictNullChecks: false}),
-      ).toBeNull();
+      expect(nullishCoalescingNotNullableFactory.create({strictNullChecks: false})).toBeNull();
     });
 
     it('should produce nullish coalescing warning', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
@@ -30,19 +30,22 @@ runInEachFileSystem(() => {
       expect(optionalChainNotNullableFactory.create({strictNullChecks: true})).toBeDefined();
     });
 
-    it('should return a check if `strictNullChecks` is not configured but `strict` is enabled', () => {
-      expect(optionalChainNotNullableFactory.create({strict: true})).toBeDefined();
+    it('should return a check if `strictNullChecks` is not configured but `strict` is enabled by default', () => {
+      expect(optionalChainNotNullableFactory.create({})).toBeDefined();
     });
 
     it('should not return a check if `strictNullChecks` is disabled', () => {
-      expect(optionalChainNotNullableFactory.create({strictNullChecks: false})).toBeNull();
-      expect(optionalChainNotNullableFactory.create({})).toBeNull(); // Defaults disabled.
+      expect(
+        optionalChainNotNullableFactory.create({strict: false, strictNullChecks: false}),
+      ).toBeNull();
     });
 
     it('should not return a check if `strict` is enabled but `strictNullChecks` is disabled', () => {
-      expect(
-        optionalChainNotNullableFactory.create({strict: true, strictNullChecks: false}),
-      ).toBeNull();
+      expect(optionalChainNotNullableFactory.create({strictNullChecks: false})).toBeNull();
+    });
+
+    it('should not return a check if `strict` is disabled and `strictNullChecks` is not configured', () => {
+      expect(optionalChainNotNullableFactory.create({strict: false})).toBeNull();
     });
 
     it('should produce optional chain warning for property access', () => {


### PR DESCRIPTION
Since ts 6.0, `strict` is implicitly `true`.
