### PR TITLE
refactor(compiler): remove explicit `strict: true`

### DIFF
--- a/integration/ng-modules-importability/index.mts
+++ b/integration/ng-modules-importability/index.mts
@@ -1,7 +1,7 @@
 import {performCompilation} from '@angular/compiler-cli';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 import ts from 'typescript';
 import {findAllEntryPointsAndExportedModules} from './find-all-modules.mjs';
 
@@ -78,9 +78,7 @@ async function main() {
         noEmit: true,
         module: ts.ModuleKind.ESNext,
         moduleResolution: ts.ModuleResolutionKind.Bundler,
-        strictTemplates: true,
         preserveSymlinks: true,
-        strict: true,
         // Note: HMR is needed as it will disable the Angular compiler's tree-shaking of used
         // directives/components. This is critical for this test as it allows us to simply all
         // modules and automatically validate that all symbols are reachable/importable.

--- a/packages/compiler-cli/test/compliance/codegen/codegen_compile_spec.ts
+++ b/packages/compiler-cli/test/compliance/codegen/codegen_compile_spec.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {NgtscIsolatedPreprocessor} from '@angular/compiler-cli/src/ngtsc/preprocessor';
 import ts from 'typescript';
 import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
 import {NgtscTestCompilerHost} from '../../../src/ngtsc/testing';
 import {
+  CompileResult,
   getBuildOutputDirectory,
   getOptions,
   getRootDirectory,
-  CompileResult,
 } from '../test_helpers/compile_test';
 import {ComplianceTest} from '../test_helpers/get_compliance_tests';
-import {NgtscIsolatedPreprocessor} from '@angular/compiler-cli/src/ngtsc/preprocessor';
 import {runTests} from '../test_helpers/test_runner';
 
 runTests('instruction compile', compileTests, {
@@ -55,8 +55,7 @@ function compileTests(fs: FileSystem, test: ComplianceTest): CompileResult {
 
   const verifyHost = new NgtscTestCompilerHost(fs, options);
   const extraPaths = test.compilerOptions?.['paths'] as unknown as
-    | Record<string, string[]>
-    | undefined;
+    Record<string, string[]> | undefined;
   const verifyProgram = ts.createProgram({
     rootNames: [...emittedFiles],
     options: {
@@ -71,7 +70,6 @@ function compileTests(fs: FileSystem, test: ComplianceTest): CompileResult {
       // than 'Bundler' or 'NodeNext' which expect specific package.json exports.
       moduleResolution: ts.ModuleResolutionKind.Node16,
       module: ts.ModuleKind.Node16,
-      strict: true,
       target: ts.ScriptTarget.ES2015,
       experimentalDecorators: true,
       types: [],

--- a/packages/compiler-cli/test/ngtsc/defer_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/defer_spec.ts
@@ -827,7 +827,7 @@ runInEachFileSystem(() => {
 
         @Pipe({name: 'test'})
         export class TestPipe {
-          transform() {
+          transform(arg: unknown) {
             return 1;
           }
         }
@@ -865,7 +865,7 @@ runInEachFileSystem(() => {
 
         @Pipe({name: 'test'})
         export class TestPipe {
-          transform() {
+          transform(arg: unknown) {
             return 1;
           }
         }
@@ -903,7 +903,7 @@ runInEachFileSystem(() => {
 
         @Pipe({name: 'test'})
         export class TestPipe {
-          transform() {
+          transform(arg: unknown) {
             return 1;
           }
         }
@@ -973,6 +973,7 @@ runInEachFileSystem(() => {
             name: 'pipea',
           })
           export class PipeA {
+            transform(arg: unknown) {}
           }
         `,
         );
@@ -1295,7 +1296,7 @@ runInEachFileSystem(() => {
               import {Pipe} from '@angular/core';
               @Pipe({name: 'deferredPipeA'})
               export class DeferredPipeA {
-                transform() {}
+                transform(arg: unknown) {}
               }
             `,
           );
@@ -1306,7 +1307,7 @@ runInEachFileSystem(() => {
               import {Pipe} from '@angular/core';
               @Pipe({name: 'deferredPipeB'})
               export class DeferredPipeB {
-                transform() {}
+                transform(arg: unknown) {}
               }
             `,
           );

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -35,12 +35,7 @@ import {TemplateTypeChecker} from '../../src/ngtsc/typecheck/api';
 import {setWrapHostForTest} from '../../src/transformers/compiler_host';
 
 type TsConfigOptionsValue =
-  | string
-  | boolean
-  | number
-  | null
-  | TsConfigOptionsValue[]
-  | {[key: string]: TsConfigOptionsValue};
+  string | boolean | number | null | TsConfigOptionsValue[] | {[key: string]: TsConfigOptionsValue};
 
 export type TsConfigOptions = {
   [key: string]: TsConfigOptionsValue;
@@ -100,7 +95,6 @@ export class NgtscTestEnvironment {
         "skipLibCheck": true,
         "noImplicitAny": true,
         "noEmitOnError": true,
-        "strictNullChecks": true,
         "outDir": "built",
         "rootDir": ".",
         "allowJs": true,
@@ -229,11 +223,6 @@ export class NgtscTestEnvironment {
     compilerOptions?: TsCompilerOptions,
     files?: string[],
   ): void {
-    // TODO: all tests should have template that pass strictness
-    if (!('strictTemplates' in extraOpts)) {
-      extraOpts['strictTemplates'] = false;
-    }
-
     let tsconfig: {[key: string]: any} = {
       extends: './tsconfig-base.json',
       angularCompilerOptions: extraOpts,
@@ -273,7 +262,12 @@ export class NgtscTestEnvironment {
       reuseProgram,
       this.changedResources,
     );
+
+    if (errorSpy.calls.count() > 0) {
+      console.error('>>>', errorSpy.calls.allArgs().join('\n'));
+    }
     expect(errorSpy).not.toHaveBeenCalled();
+
     expect(exitCode).toBe(0);
     if (this.multiCompileHostExt !== null) {
       this.oldProgram = reuseProgram!.program!;

--- a/packages/compiler-cli/test/ngtsc/extended_template_diagnostics_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/extended_template_diagnostics_spec.ts
@@ -77,6 +77,7 @@ runInEachFileSystem(() => {
     });
 
     it(`should produce nullish coalescing not nullable warning`, () => {
+      env.tsconfig({strict: true}); // TODO: remove when #70090 is merged
       env.write(
         'test.ts',
         `

--- a/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
@@ -21,7 +21,7 @@ runInEachFileSystem(() => {
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
-      env.tsconfig({strictTemplates: true});
+      env.tsconfig({});
     });
 
     function extractMessage(diag: ts.Diagnostic) {

--- a/packages/compiler-cli/test/ngtsc/incremental_semantic_changes_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_semantic_changes_spec.ts
@@ -20,7 +20,7 @@ runInEachFileSystem(() => {
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
       env.enableMultipleCompilations();
-      env.tsconfig();
+      env.tsconfig({strictTemplates: false});
     });
 
     function expectToHaveWritten(files: string[]): void {

--- a/packages/compiler-cli/test/ngtsc/incremental_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_spec.ts
@@ -1291,7 +1291,7 @@ runInEachFileSystem(() => {
       standalone: false,
     })
     export class FooPipe {
-      transform() {}
+      transform(arg: unknown) {}
     }
   `,
     );
@@ -1345,7 +1345,7 @@ runInEachFileSystem(() => {
       standalone: false,
     })
     export class BarPipe {
-      transform() {}
+      transform(arg: unknown) {}
     }
   `,
     );

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1315,7 +1315,6 @@ runInEachFileSystem((os: string) => {
     });
 
     it('should pick a Pipe defined in `declarations` over imported Pipes', () => {
-      env.tsconfig({});
       env.write(
         'test.ts',
         `
@@ -1344,7 +1343,7 @@ runInEachFileSystem((os: string) => {
           standalone: false,
         })
         class PipeB {
-          transform() {}
+          transform(arg: unknown) {}
         }
 
         @Component({
@@ -1371,7 +1370,7 @@ runInEachFileSystem((os: string) => {
     });
 
     it('should respect imported module order when selecting Pipe (last imported Pipe is used)', () => {
-      env.tsconfig({});
+      env.tsconfig({strictTemplates: false});
       env.write(
         'test.ts',
         `
@@ -2565,7 +2564,7 @@ runInEachFileSystem((os: string) => {
           standalone: false,
         })
         export class TestPipe {
-          transform() {}
+          transform(arg: unknown) {}
         }
 
         @Component({
@@ -6167,6 +6166,7 @@ runInEachFileSystem((os: string) => {
     });
 
     it('should compile a banana-in-a-box inside of a template', () => {
+      env.tsconfig({strictTemplates: false});
       env.write(
         'test.ts',
         `
@@ -11568,8 +11568,7 @@ runInEachFileSystem((os: string) => {
         );
 
         const options: CompilerOptions = {
-          strict: true,
-          strictTemplates: true,
+          // strict: true & strictTemplates: true are set by default
           target: ts.ScriptTarget.Latest,
           module: ts.ModuleKind.ESNext,
           annotateForClosureCompiler: true,

--- a/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
@@ -19,11 +19,7 @@ runInEachFileSystem(() => {
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
-      env.tsconfig({
-        // This is the default in Angular apps so we enable it to ensure consistent behavior.
-        strict: true,
-        strictTemplates: true,
-      });
+      env.tsconfig();
     });
 
     function extractMessage(diag: ts.Diagnostic) {

--- a/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
@@ -806,7 +806,7 @@ runInEachFileSystem((os) => {
           standalone: false,
         })
         export class PercentPipe {
-          transform(v: any) {}
+          transform(arg1: unknown, arg2?: unknown) {}
         }
 
         @Component({

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -2015,7 +2015,7 @@ runInEachFileSystem(() => {
       });
 
       it("should be treated as 'any' without strictTemplates", () => {
-        env.tsconfig();
+        env.tsconfig({strictTemplates: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(0);

--- a/packages/core/schematics/migrations/safe-optional-chaining/safe-optional-chaining.spec.ts
+++ b/packages/core/schematics/migrations/safe-optional-chaining/safe-optional-chaining.spec.ts
@@ -500,11 +500,11 @@ describe('SafeOptionalChainingMigration', () => {
 
     mockFs.writeFile(
       tsconfig1,
-      JSON.stringify({compilerOptions: {strict: true, rootDir: '/'}, files: [sharedFile]}),
+      JSON.stringify({compilerOptions: {rootDir: '/'}, files: [sharedFile]}),
     );
     mockFs.writeFile(
       tsconfig2,
-      JSON.stringify({compilerOptions: {strict: true, rootDir: '/'}, files: [sharedFile]}),
+      JSON.stringify({compilerOptions: {rootDir: '/'}, files: [sharedFile]}),
     );
 
     const migration = new SafeOptionalChainingMigration();

--- a/packages/core/schematics/utils/tsurge/testing/run_single.ts
+++ b/packages/core/schematics/utils/tsurge/testing/run_single.ts
@@ -8,10 +8,10 @@
 
 import {absoluteFrom, AbsoluteFsPath, getFileSystem} from '@angular/compiler-cli';
 import {MockFileSystem} from '@angular/compiler-cli/private/testing';
-import {TsurgeFunnelMigration, TsurgeMigration} from '../migration';
-import {groupReplacementsByFile} from '../helpers/group_replacements';
-import {applyTextUpdates} from '../replacement';
 import ts from 'typescript';
+import {groupReplacementsByFile} from '../helpers/group_replacements';
+import {TsurgeFunnelMigration, TsurgeMigration} from '../migration';
+import {applyTextUpdates} from '../replacement';
 import {TestRun} from './test_run';
 
 /**
@@ -46,7 +46,6 @@ export async function runTsurgeMigration<Stats>(
     absoluteFrom('/tsconfig.json'),
     JSON.stringify({
       compilerOptions: {
-        strict: true,
         rootDir: '/',
         ...compilerOptions,
       },


### PR DESCRIPTION
This flag is set by default in TS 6.0

The test changes were made to satisfy the now required strictness. 