### PR TITLE
build: remove explicit strict options

### DIFF
--- a/.github/actions/deploy-docs-site/tsconfig.json
+++ b/.github/actions/deploy-docs-site/tsconfig.json
@@ -5,7 +5,6 @@
     "types": ["node"],
     "lib": ["es2021"],
     "experimentalDecorators": true,
-    "strict": true,
     "skipLibCheck": true,
     "noImplicitOverride": true,
     "esModuleInterop": true,

--- a/.ng-dev/tsconfig.json
+++ b/.ng-dev/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "target": "es2020",
     "module": "Node16",
     "noEmit": true,

--- a/adev/scripts/synonyms/tsconfig.json
+++ b/adev/scripts/synonyms/tsconfig.json
@@ -2,7 +2,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,

--- a/adev/shared-docs/pipeline/examples/template/tsconfig.json
+++ b/adev/shared-docs/pipeline/examples/template/tsconfig.json
@@ -16,20 +16,16 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "useDefineForClassFields": false,
-    "strictNullChecks": true,
     "noImplicitReturns": true,
-    "strictFunctionTypes": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
-    "strictBindCallApply": true,
     "esModuleInterop": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   }
 }

--- a/adev/shared-docs/pipeline/tutorials/common/tsconfig.json
+++ b/adev/shared-docs/pipeline/tutorials/common/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -22,8 +21,6 @@
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true,
-    "_enabledBlockTypes": ["if", "for"]
+    "strictInputAccessModifiers": true
   }
 }

--- a/adev/shared-docs/tsconfig.json
+++ b/adev/shared-docs/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
-    "strict": true,
     "declaration": true,
     "sourceMap": true,
     "lib": ["ES2022", "dom"],
@@ -18,7 +17,6 @@
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   }
 }

--- a/adev/src/content/examples/angular-compiler-options/tsconfig.app.json
+++ b/adev/src/content/examples/angular-compiler-options/tsconfig.app.json
@@ -2,44 +2,39 @@
 /* To learn more about this file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
 // #docregion angular-compiler-options-app
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-      "outDir": "./out-tsc/app",
-      // #enddocregion angular-compiler-options-app
-      "types": []
-      // #docregion angular-compiler-options-app
-    },
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
     // #enddocregion angular-compiler-options-app
-    "files": [
-      "src/main.ts"
-    ],
-    "include": [
-      "src/**/*.d.ts"
-    ],
-    "exclude": [
-      "src/test.ts",
-      "src/**/*.spec.ts",
-      "src/**/*-specs.ts",
-      "src/**/*.avoid.ts",
-      "src/**/*.0.ts",
-      "src/**/*.1.ts",
-      "src/**/*.1b.ts",
-      "src/**/*.2.ts",
-      "src/**/*.3.ts",
-      "src/**/*.4.ts",
-      "src/**/*.5.ts",
-      "src/**/*.6.ts",
-      "src/**/*.7.ts",
-      "src/**/testing"
-    ],
+    "types": []
     // #docregion angular-compiler-options-app
-    "angularCompilerOptions": {
-      "strictTemplates": true,
-      "preserveWhitespaces": true,
-      // #enddocregion angular-compiler-options-app
-      "sourceMap": true,
-      "declaration": false
-      // #docregion angular-compiler-options-app
-    }
-  }
+  },
   // #enddocregion angular-compiler-options-app
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"],
+  "exclude": [
+    "src/test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*-specs.ts",
+    "src/**/*.avoid.ts",
+    "src/**/*.0.ts",
+    "src/**/*.1.ts",
+    "src/**/*.1b.ts",
+    "src/**/*.2.ts",
+    "src/**/*.3.ts",
+    "src/**/*.4.ts",
+    "src/**/*.5.ts",
+    "src/**/*.6.ts",
+    "src/**/*.7.ts",
+    "src/**/testing"
+  ],
+  // #docregion angular-compiler-options-app
+  "angularCompilerOptions": {
+    "preserveWhitespaces": true,
+    // #enddocregion angular-compiler-options-app
+    "sourceMap": true,
+    "declaration": false
+    // #docregion angular-compiler-options-app
+  }
+}
+// #enddocregion angular-compiler-options-app

--- a/adev/src/content/examples/angular-compiler-options/tsconfig.json
+++ b/adev/src/content/examples/angular-compiler-options/tsconfig.json
@@ -7,7 +7,6 @@
     // #enddocregion angular-compiler-options
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -26,8 +25,7 @@
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     // #enddocregion angular-compiler-options
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
     // #docregion angular-compiler-options
   }
 }

--- a/adev/src/content/examples/schematics-for-libraries/projects/my-lib/tsconfig.lib.json
+++ b/adev/src/content/examples/schematics-for-libraries/projects/my-lib/tsconfig.lib.json
@@ -11,17 +11,10 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "types": [],
-    "lib": [
-      "dom",
-      "es2018"
-    ]
+    "lib": ["dom", "es2018"]
   },
   "angularCompilerOptions": {
-    "strictTemplates": true,
     "strictInjectionParameters": true
   },
-  "exclude": [
-    "src/test.ts",
-    "**/*.spec.ts"
-  ]
+  "exclude": ["src/test.ts", "**/*.spec.ts"]
 }

--- a/adev/src/content/examples/schematics-for-libraries/projects/my-lib/tsconfig.schematics.json
+++ b/adev/src/content/examples/schematics-for-libraries/projects/my-lib/tsconfig.schematics.json
@@ -1,10 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": [
-      "es2018",
-      "dom"
-    ],
+    "lib": ["es2018", "dom"],
     "declaration": true,
     "module": "commonjs",
     "moduleResolution": "node",
@@ -19,17 +16,9 @@
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strictNullChecks": true,
     "target": "es6",
-    "types": [
-      "jasmine",
-      "node"
-    ]
+    "types": ["jasmine", "node"]
   },
-  "include": [
-    "schematics/**/*"
-  ],
-  "exclude": [
-    "schematics/*/files/**/*"
-  ]
+  "include": ["schematics/**/*"],
+  "exclude": ["schematics/*/files/**/*"]
 }

--- a/adev/src/context/tsconfig.json
+++ b/adev/src/context/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "skipLibCheck": true,
     "declaration": true,
     "sourceMap": true,

--- a/adev/tsconfig.json
+++ b/adev/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -25,7 +24,6 @@
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   }
 }

--- a/dev-app/tsconfig.json
+++ b/dev-app/tsconfig.json
@@ -2,7 +2,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "stableTypeOrdering": true,
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -20,8 +19,7 @@
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   },
   "files": [],
   "references": [

--- a/dev-app/tsconfig.json
+++ b/dev-app/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -19,8 +18,7 @@
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   },
   "files": [],
   "references": [

--- a/devtools/tsconfig.json
+++ b/devtools/tsconfig.json
@@ -3,7 +3,6 @@
     "sourceMap": true,
     "inlineSources": true,
     "declaration": true,
-    "strict": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "downlevelIteration": true,
@@ -22,8 +21,11 @@
     }
   },
   "angularCompilerOptions": {
-    "strictTemplates": true,
     "strictInjectionParameters": true,
-    "unusedStandaloneImports": "error"
+    "extendedDiagnostics": {
+      "checks": {
+        "unusedStandaloneImports": "error"
+      }
+    }
   }
 }

--- a/integration/animations/tsconfig.json
+++ b/integration/animations/tsconfig.json
@@ -13,7 +13,5 @@
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"]
   },
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  }
+  "angularCompilerOptions": {}
 }

--- a/integration/cli-hello-world/tsconfig.json
+++ b/integration/cli-hello-world/tsconfig.json
@@ -13,7 +13,5 @@
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"]
   },
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  }
+  "angularCompilerOptions": {}
 }

--- a/integration/cli-signal-inputs/tsconfig.json
+++ b/integration/cli-signal-inputs/tsconfig.json
@@ -4,7 +4,6 @@
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "esModuleInterop": true,
-    "strict": true,
     "declaration": false,
     "experimentalDecorators": true,
     "module": "es2022",
@@ -14,7 +13,5 @@
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"]
   },
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  }
+  "angularCompilerOptions": {}
 }

--- a/integration/ng-add-localize/tsconfig.json
+++ b/integration/ng-add-localize/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -22,7 +21,6 @@
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   }
 }

--- a/integration/ng-modules-importability/index.mts
+++ b/integration/ng-modules-importability/index.mts
@@ -1,7 +1,7 @@
 import {performCompilation} from '@angular/compiler-cli';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 import ts from 'typescript';
 import {findAllEntryPointsAndExportedModules} from './find-all-modules.mjs';
 
@@ -78,9 +78,7 @@ async function main() {
         noEmit: true,
         module: ts.ModuleKind.ESNext,
         moduleResolution: ts.ModuleResolutionKind.Bundler,
-        strictTemplates: true,
         preserveSymlinks: true,
-        strict: true,
         // Note: HMR is needed as it will disable the Angular compiler's tree-shaking of used
         // directives/components. This is critical for this test as it allows us to simply all
         // modules and automatically validate that all symbols are reachable/importable.

--- a/integration/ng-modules-importability/tsconfig.json
+++ b/integration/ng-modules-importability/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "declaration": true,
     "sourceMap": true,
     "module": "esnext",

--- a/integration/ng_elements/tsconfig.json
+++ b/integration/ng_elements/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "angularCompilerOptions": {
     "annotationsAs": "static fields",
-    "annotateForClosureCompiler": true,
+    "annotateForClosureCompiler": true
   },
   "compilerOptions": {
     "module": "es2015",
     "moduleResolution": "bundler",
-    "strictNullChecks": true,
     "target": "es2022",
     "sourceMap": false,
     "experimentalDecorators": true,
@@ -15,11 +14,5 @@
     "declaration": true,
     "types": []
   },
-  "exclude": [
-    "vendor",
-    "node_modules",
-    "built",
-    "dist",
-    "e2e"
-  ]
+  "exclude": ["vendor", "node_modules", "built", "dist", "e2e"]
 }

--- a/integration/nodenext_resolution/tsconfig.json
+++ b/integration/nodenext_resolution/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,

--- a/integration/platform-server-hydration/tsconfig.json
+++ b/integration/platform-server-hydration/tsconfig.json
@@ -3,7 +3,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -23,7 +22,6 @@
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   }
 }

--- a/integration/platform-server-zoneless/tsconfig.json
+++ b/integration/platform-server-zoneless/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -23,7 +22,6 @@
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   }
 }

--- a/integration/platform-server/tsconfig.json
+++ b/integration/platform-server/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -23,7 +22,6 @@
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   }
 }

--- a/integration/trusted-types/tsconfig.json
+++ b/integration/trusted-types/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
-    "strict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
@@ -19,7 +18,6 @@
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   }
 }

--- a/integration/typings_test_rxjs7/tsconfig.json
+++ b/integration/typings_test_rxjs7/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,

--- a/integration/typings_test_ts60/tsconfig.json
+++ b/integration/typings_test_ts60/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,

--- a/modules/benchmarks/tsconfig-e2e.json
+++ b/modules/benchmarks/tsconfig-e2e.json
@@ -4,7 +4,6 @@
     "types": ["node", "jasmine"],
     "module": "esnext",
     "moduleResolution": "nodenext",
-    "strict": true,
     "sourceMap": true,
     "declaration": true
   }

--- a/modules/benchmarks/tsconfig.json
+++ b/modules/benchmarks/tsconfig.json
@@ -6,14 +6,13 @@
     "emitDecoratorMetadata": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "strict": true,
     "outDir": "../../dist/all/",
     "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
       "selenium-webdriver": ["../../node_modules/@types/selenium-webdriver/index.d.ts"],
       "rxjs/*": ["../../node_modules/rxjs/*"],
-      "@angular/*": ["../../packages/*"],
+      "@angular/*": ["../../packages/*"]
     },
     "rootDir": ".",
     "inlineSourceMap": true,

--- a/modules/playground/tsconfig-e2e.json
+++ b/modules/playground/tsconfig-e2e.json
@@ -4,7 +4,6 @@
     "types": ["node", "jasmine", "selenium-webdriver"],
     "module": "esnext",
     "moduleResolution": "nodenext",
-    "strict": true,
     "sourceMap": true,
     "declaration": true
   }

--- a/modules/playground/tsconfig-e2e.json
+++ b/modules/playground/tsconfig-e2e.json
@@ -4,7 +4,6 @@
     "types": ["node", "jasmine"],
     "module": "esnext",
     "moduleResolution": "nodenext",
-    "strict": true,
     "sourceMap": true,
     "declaration": true
   }

--- a/modules/ssr-benchmarks/tsconfig.json
+++ b/modules/ssr-benchmarks/tsconfig.json
@@ -4,7 +4,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -22,7 +21,6 @@
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictInputAccessModifiers": true
   }
 }

--- a/modules/tsconfig.json
+++ b/modules/tsconfig.json
@@ -25,7 +25,6 @@
   },
   "exclude": ["payload_tests", "playground/", "benchmarks/"],
   "angularCompilerOptions": {
-    "strictTemplates": true,
     "skipTemplateCodegen": true
   }
 }

--- a/modules/tsconfig.json
+++ b/modules/tsconfig.json
@@ -22,13 +22,8 @@
     "target": "es5",
     "types": ["angular"]
   },
-  "exclude": [
-    "payload_tests",
-    "playground/",
-    "benchmarks/"
-  ],
+  "exclude": ["payload_tests", "playground/", "benchmarks/"],
   "angularCompilerOptions": {
-    "strictTemplates": true,
     "skipTemplateCodegen": true
   }
 }

--- a/packages/core/schematics/tsconfig.json
+++ b/packages/core/schematics/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/core/test/acceptance/selectorless/tsconfig.json
+++ b/packages/core/test/acceptance/selectorless/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true
   },
   "angularCompilerOptions": {
-    "strictTemplates": true,
     "_enableSelectorless": true
   }
 }

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -35,7 +35,6 @@ describe('language service adapter', () => {
     it('should initialize with angularCompilerOptions from tsconfig.json', () => {
       expect(ngLS.getCompilerOptions()).toEqual(
         jasmine.objectContaining({
-          strictTemplates: true,
           strictInjectionParameters: true,
         }),
       );
@@ -44,7 +43,6 @@ describe('language service adapter', () => {
     it('should reparse angularCompilerOptions on tsconfig.json change', () => {
       expect(ngLS.getCompilerOptions()).toEqual(
         jasmine.objectContaining({
-          strictTemplates: true,
           strictInjectionParameters: true,
         }),
       );

--- a/packages/language-service/test/legacy/project/tsconfig.json
+++ b/packages/language-service/test/legacy/project/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "stableTypeOrdering": true,
     "lib": ["es2015", "dom"],
-    "strict": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "target": "es2015",
@@ -13,7 +12,6 @@
     }
   },
   "angularCompilerOptions": {
-    "strictTemplates": true,
     "strictInjectionParameters": true
   }
 }

--- a/packages/language-service/test/legacy/project/tsconfig.json
+++ b/packages/language-service/test/legacy/project/tsconfig.json
@@ -1,23 +1,16 @@
 {
   "//00": "This file is used for both IDE and the actual Project creation in Ivy language service for testing purpose",
   "compilerOptions": {
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "strict": true,
+    "lib": ["es2015", "dom"],
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "target": "es2015",
     "baseUrl": "../../../../../",
     "paths": {
-      "@angular/*": [
-        "packages/*"
-      ]
+      "@angular/*": ["packages/*"]
     }
   },
   "angularCompilerOptions": {
-    "strictTemplates": true,
     "strictInjectionParameters": true
   }
 }

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -9,13 +9,10 @@
     "stripInternal": true,
     "noImplicitAny": true,
     "noImplicitOverride": true,
-    "strictNullChecks": true,
     "stableTypeOrdering": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "esModuleInterop": true,
-    "strict": true,
-    "strictPropertyInitialization": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "bundler",
     "module": "esnext",
@@ -46,8 +43,5 @@
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true
   },
-  "angularCompilerOptions": {
-    "strictTemplates": true,
-    "typeCheckHostBindings": true
-  }
+  "angularCompilerOptions": {}
 }

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -9,12 +9,9 @@
     "stripInternal": true,
     "noImplicitAny": true,
     "noImplicitOverride": true,
-    "strictNullChecks": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "esModuleInterop": true,
-    "strict": true,
-    "strictPropertyInitialization": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "bundler",
     "module": "esnext",
@@ -36,17 +33,14 @@
       "@angular/common/locales/*": ["./common/locales/*"],
       "@angular/compiler-cli": ["./compiler-cli"],
       "@angular/compiler-cli/*": ["./compiler-cli/*"],
-      "@angular/compiler-cli/src/ngtsc/reflection":  ["./compiler-cli/src/ngtsc/reflection/index"],
-      "@angular/compiler-cli/src/ngtsc/metadata":  ["./compiler-cli/src/ngtsc/metadata/index"],
-      "@angular/compiler-cli/private/migrations":  ["./compiler-cli/private/migrations"],
+      "@angular/compiler-cli/src/ngtsc/reflection": ["./compiler-cli/src/ngtsc/reflection/index"],
+      "@angular/compiler-cli/src/ngtsc/metadata": ["./compiler-cli/src/ngtsc/metadata/index"],
+      "@angular/compiler-cli/private/migrations": ["./compiler-cli/private/migrations"],
       "@angular/core/schematics/utils/tsurge/*": ["./core/schematics/utils/tsurge/*"]
     }
   },
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true
   },
-  "angularCompilerOptions": {
-    "strictTemplates": true,
-    "typeCheckHostBindings": true
-  }
+  "angularCompilerOptions": {}
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -9,14 +9,11 @@
     "emitDecoratorMetadata": true,
     "module": "esnext",
     "target": "es2020",
-    "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "strictNullChecks": true,
     "stableTypeOrdering": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
-    "strictPropertyInitialization": true,
     "outDir": "../dist/all/@angular",
     "noImplicitAny": true,
     "noImplicitOverride": true,
@@ -37,9 +34,7 @@
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true
   },
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  },
+  "angularCompilerOptions": {},
   "exclude": [
     "common/locales",
     "compiler-cli/integrationtest",

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -9,13 +9,10 @@
     "emitDecoratorMetadata": true,
     "module": "esnext",
     "target": "es2020",
-    "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "strictNullChecks": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
-    "strictPropertyInitialization": true,
     "outDir": "../dist/all/@angular",
     "noImplicitAny": true,
     "noImplicitOverride": true,
@@ -36,9 +33,7 @@
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true
   },
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  },
+  "angularCompilerOptions": {},
   "exclude": [
     "common/locales",
     "compiler-cli/integrationtest",

--- a/packages/zone.js/test/typings/tsconfig.json
+++ b/packages/zone.js/test/typings/tsconfig.json
@@ -13,7 +13,6 @@
     "moduleResolution": "Node16",
     "noEmitOnError": false,
     "stripInternal": false,
-    "strict": true,
     "lib": ["es5", "dom", "es2015.collection", "es2015.iterable", "es2015.promise", "es2022.object"]
   },
   "files": ["./type.test.ts", "./node_modules/zone.js/zone.ts"]

--- a/packages/zone.js/test/typings/tsconfig.json
+++ b/packages/zone.js/test/typings/tsconfig.json
@@ -12,7 +12,6 @@
     "moduleResolution": "Node16",
     "noEmitOnError": false,
     "stripInternal": false,
-    "strict": true,
     "lib": ["es5", "dom", "es2015.collection", "es2015.iterable", "es2015.promise", "es2022.object"]
   },
   "files": ["./type.test.ts", "./node_modules/zone.js/zone.ts"]

--- a/packages/zone.js/tsconfig.json
+++ b/packages/zone.js/tsconfig.json
@@ -10,7 +10,6 @@
     "declaration": true,
     "noEmitOnError": false,
     "stripInternal": true,
-    "strict": true,
     "sourceMap": true,
     "noImplicitOverride": true,
     "lib": [

--- a/packages/zone.js/tsconfig.json
+++ b/packages/zone.js/tsconfig.json
@@ -9,7 +9,6 @@
     "declaration": true,
     "noEmitOnError": false,
     "stripInternal": true,
-    "strict": true,
     "sourceMap": true,
     "noImplicitOverride": true,
     "lib": [

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["es2020"],
     "module": "Node16",
     "types": ["node"],
-    "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/tools/symbol-extractor/symbol_extractor_spec/tsconfig.json
+++ b/tools/symbol-extractor/symbol_extractor_spec/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "module": "ESNext",
     "target": "ES2022",
     "sourceMap": true,

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "skipLibCheck": true,
     "declaration": true,
     "esModuleInterop": true,

--- a/vscode-ng-language-service/integration/project/tsconfig.json
+++ b/vscode-ng-language-service/integration/project/tsconfig.json
@@ -3,7 +3,6 @@
     "moduleResolution": "bundler",
     "experimentalDecorators": true,
     "target": "es2015",
-    "strict": true,
     "typeRoots": ["node_modules/@types"],
     "paths": {
       "post": ["./dist/post"]

--- a/vscode-ng-language-service/tools/tsconfig.json
+++ b/vscode-ng-language-service/tools/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "node16",
     "moduleResolution": "node16",
     "types": ["node"],
-    "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true
   }

--- a/vscode-ng-language-service/tsconfig.json
+++ b/vscode-ng-language-service/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleResolution": "node",
     "types": ["node"],
     "sourceMap": true,
-    "strict": true,
     "esModuleInterop": true,
     "declaration": true,
     "skipLibCheck": true

--- a/vscode-ng-language-service/tsconfig.json
+++ b/vscode-ng-language-service/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "node",
     "types": ["node"],
     "sourceMap": true,
-    "strict": true,
     "esModuleInterop": true,
     "declaration": true,
     "skipLibCheck": true


### PR DESCRIPTION
Those options are enabled by default, they don't need to be explicit.
