### PR TITLE
fix(compiler): check reverse assignability for two-way model bindings in TCB

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -3045,6 +3045,9 @@ describe('type check blocks', () => {
 
       expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
+        '(typeof (((((this).f)()).value)) extends { [i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: infer W } ? W : typeof (((((this).f)()).value)))',
+      );
+      expect(block).toContain(
         '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
       );
       expect(block).toContain('var _t2 = null! as i0.FormField;');
@@ -3179,6 +3182,33 @@ describe('type check blocks', () => {
       );
       expect(block).toContain('var _t2 = null! as i0.FormField;');
       expect(block).toContain('_t2.field = (((this).f));');
+    });
+
+    it('should generate reverse direction assignment check for custom controls with two-way value bindings', () => {
+      const block = tcb('<custom-control [formField]="f"/>', [
+        FieldMock,
+        {
+          type: 'directive',
+          name: 'CustomControl',
+          selector: 'custom-control',
+          inputs: {
+            value: {
+              classPropertyName: 'value',
+              bindingPropertyName: 'value',
+              required: false,
+              isSignal: true,
+              transform: null,
+            },
+          },
+          outputs: {
+            valueChange: 'valueChange',
+          },
+        },
+      ]);
+
+      expect(block).toContain(
+        '(typeof (((((this).f)()).value)) extends { [i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: infer W } ? W : typeof (((((this).f)()).value)))',
+      );
     });
 
     it('should not report diagnostics for aliased directive references via PropertyAccessExpression', () => {

--- a/packages/compiler/src/typecheck/ops/inputs.ts
+++ b/packages/compiler/src/typecheck/ops/inputs.ts
@@ -166,6 +166,8 @@ export class TcbDirectiveInputsOp extends TcbOp {
             : new TcbExpr(`${dirId.print()}.${fieldName}`);
         }
 
+        const dirPropTarget = target;
+
         // For signal inputs, we unwrap the target `InputSignal`. Note that
         // we intentionally do the following things:
         //   1. keep the direct access to `dir.[field]` so that modifiers are honored.
@@ -186,7 +188,25 @@ export class TcbDirectiveInputsOp extends TcbOp {
 
         // Two-way bindings accept `T | WritableSignal<T>` so we have to unwrap the value.
         if (isTwoWayBinding && this.tcb.env.config.allowSignalsInTwoWayBindings) {
+          const rawAssignment = assignment;
           assignment = unwrapWritableSignal(assignment, this.tcb);
+
+          const inputSignalBrandWriteSymbol = this.tcb.env.referenceExternalSymbol(
+            R3Identifiers.InputSignalBrandWriteType.moduleName,
+            R3Identifiers.InputSignalBrandWriteType.name,
+          );
+          const reverseId = new TcbExpr(this.tcb.allocateId());
+          const reverseType = new TcbExpr(
+            `(typeof ${rawAssignment.wrapForTypeChecker().print()} extends { [${inputSignalBrandWriteSymbol.print()}]: infer W } ? W : typeof ${rawAssignment.wrapForTypeChecker().print()})`,
+          );
+          const reverseVar = declareVariable(reverseId, reverseType);
+          const reverseValue = unwrapWritableSignal(dirPropTarget, this.tcb);
+          const reverseAssignment = new TcbExpr(
+            `${reverseId.print()} = ${reverseValue.print()}`,
+          );
+          reverseAssignment.addParseSpanInfo(attr.sourceSpan);
+          this.scope.addStatement(reverseVar);
+          this.scope.addStatement(reverseAssignment);
         }
 
         // Finally the assignment is extended by assigning it into the target expression.


### PR DESCRIPTION
Fixes #70093

### Problem & Root Cause
When type checking two-way model bindings (such as `[formField]` on custom controls implementing `FormValueControl<T>`), the compiler previously only verified that the field signal value was assignable to the control's model input (forward direction). It did **not** check the reverse direction (writing from the control's model back into the field's `WritableSignal`).

As a result, a custom control with a broader union value type (e.g. `FormValueControl<string | string[]>`) bound via `[formField]` to a narrower field signal (`WritableSignal<string>`) silently passed template type checking. At runtime, when the custom control called `this.value.set(['a', 'b'])`, it wrote an incompatible type into the developer's underlying model signal without any diagnostic at compile time.

### Solution
Updated `TcbDirectiveInputsOp` in `packages/compiler/src/typecheck/ops/inputs.ts` to emit a reverse assignment statement in the Type Check Block (`fieldSignal[ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ɵunwrapWritableSignal(control.value)`). 

TypeScript now checks type assignability in **both directions** for two-way model bindings:
1. `control.value = fieldSignal` (Forward: field value can fill input)
2. `fieldSignal = control.value` (Reverse: control value can be written back into field signal)

### Tests
Added unit tests in `packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts` verifying that reverse direction assignment checks are emitted for custom controls with two-way model bindings.
