### PR TITLE
fix(compiler): bind setClassMetadataAsync parameters to local symbol names

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -985,6 +985,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
         explicitlyDeferredTypes ??= [];
         explicitlyDeferredTypes.push({
           symbolName: importDetails.name,
+          localSymbolName: deferredType.text,
           importPath: importDetails.from,
           isDefaultImport: isDefaultImport(importDetails.node),
         });
@@ -2251,8 +2252,12 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
     for (const [_, deps] of resolution.deferPerBlockDependencies) {
       for (const deferBlockDep of deps) {
         const node = deferBlockDep.declaration.node;
-        const importInfo = resolution.deferrableDeclToImportDecl.get(node) ?? null;
-        if (importInfo !== null && this.deferredSymbolTracker.canDefer(importInfo.node)) {
+        const deferrableImport = resolution.deferrableDeclToImportDecl.get(node) ?? null;
+        if (
+          deferrableImport !== null &&
+          this.deferredSymbolTracker.canDefer(deferrableImport.importInfo.node)
+        ) {
+          const {importInfo, localSymbolName} = deferrableImport;
           deferBlockDep.isDeferrable = true;
           deferBlockDep.symbolName = importInfo.name;
           deferBlockDep.importPath = importInfo.from;
@@ -2264,7 +2269,12 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
           // because the object literals are different between each block.
           if (!seenDeps.has(node)) {
             seenDeps.add(node);
-            deferrableTypes.push(deferBlockDep as R3DeferPerComponentDependency);
+            deferrableTypes.push({
+              symbolName: importInfo.name,
+              localSymbolName,
+              importPath: importInfo.from,
+              isDefaultImport: deferBlockDep.isDefaultImport,
+            });
           }
         }
       }
@@ -2528,10 +2538,13 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
       return;
     }
 
-    // Keep track of how this class made it into the current source file.
-    // Store the full `Import` info so that callers can correctly determine the
-    // exported name (handling aliasing) and the module specifier.
-    resolutionData.deferrableDeclToImportDecl.set(decl.node, imp);
+    // Keep track of how this class made it into the current source file. Both the `Import` and
+    // the local name are necessary, because an aliased import (e.g. `import {Foo as Bar}`) has a
+    // different exported and local name and the generated code needs to refer to both.
+    resolutionData.deferrableDeclToImportDecl.set(decl.node, {
+      importInfo: imp,
+      localSymbolName: node.text,
+    });
 
     this.deferredSymbolTracker.markAsDeferrableCandidate(
       node,
@@ -2632,7 +2645,11 @@ function removeDeferrableTypesFromComponentDecorator(
   deferrableTypes: R3DeferPerComponentDependency[],
 ) {
   if (analysis.classMetadata) {
-    const deferrableSymbols = new Set(deferrableTypes.map((t) => t.symbolName));
+    // Note that the decorator refers to the dependencies by their local names, which is what has
+    // to be matched here. They can differ from the exported names for an aliased import.
+    const deferrableSymbols = new Set(
+      deferrableTypes.map((t) => t.localSymbolName ?? t.symbolName),
+    );
     const rewrittenDecoratorsNode = removeIdentifierReferences(
       (analysis.classMetadata.decorators as o.WrappedNodeExpr<ts.Node>).node,
       deferrableSymbols,

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -133,11 +133,9 @@ export interface ComponentResolutionData {
 
   /**
    * Map of all types that can be defer loaded (ts.ClassDeclaration) ->
-   * corresponding import information (reflection `Import`) within
-   * the current source file. The `Import` preserves the exported name
-   * as seen by the importing module so aliasing is handled correctly.
+   * corresponding import information within the current source file.
    */
-  deferrableDeclToImportDecl: Map<ClassDeclaration, Import>;
+  deferrableDeclToImportDecl: Map<ClassDeclaration, DeferrableImport>;
 
   /**
    * Map of `@defer` blocks -> their corresponding dependencies.
@@ -160,6 +158,21 @@ export interface ComponentResolutionData {
 
   /** Whether the component is standalone and has any directly-imported directive dependencies. */
   hasDirectiveDependencies: boolean;
+}
+
+/**
+ * Describes how a class that can be defer loaded made it into the current source file.
+ */
+export interface DeferrableImport {
+  /**
+   * Import through which the class was brought into the file. Note that `Import.name` is the name
+   * that the class is *exported* under which, in the case of an aliased import, is different from
+   * the name that the current file refers to it by.
+   */
+  importInfo: Import;
+
+  /** Name that the current file binds the imported class to. */
+  localSymbolName: string;
 }
 
 /**

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
@@ -1148,6 +1148,151 @@ export declare class TestCmp {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: defer_aliased_deps_a.js
+ ****************************************************************************************************/
+import { Directive } from '@angular/core';
+import * as i0 from "@angular/core";
+export class Dep {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dep, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+    static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Dep, isStandalone: true, selector: "dep-a", ngImport: i0 });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dep, decorators: [{
+            type: Directive,
+            args: [{ selector: 'dep-a' }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: defer_aliased_deps_a.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class Dep {
+    static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Dep, "dep-a", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: defer_aliased_deps.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    @defer {
+      <dep-a/>
+    }
+  `, isInline: true, deferBlockDependencies: [() => [/* @ts-ignore */
+                import("./defer_aliased_deps_a").then(m => m.Dep)]] });
+}
+i0.ɵɵngDeclareClassMetadataAsync({ minVersion: "18.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, resolveDeferredDeps: () => [/* @ts-ignore */
+        import("./defer_aliased_deps_a").then(m => m.Dep)], resolveMetadata: AliasedDep => ({ decorators: [{
+                type: Component,
+                args: [{
+                        template: `
+    @defer {
+      <dep-a/>
+    }
+  `,
+                        imports: [AliasedDep],
+                    }]
+            }], ctorParameters: null, propDecorators: null }) });
+
+/****************************************************************************************************
+ * PARTIAL FILE: defer_aliased_deps.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: defer_aliased_deps_a.js
+ ****************************************************************************************************/
+import { Directive } from '@angular/core';
+import * as i0 from "@angular/core";
+export class Dep {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dep, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+    static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Dep, isStandalone: true, selector: "dep-a", ngImport: i0 });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dep, decorators: [{
+            type: Directive,
+            args: [{ selector: 'dep-a' }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: defer_aliased_deps_a.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class Dep {
+    static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Dep, "dep-a", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: defer_aliased_deps_b.js
+ ****************************************************************************************************/
+import { Directive } from '@angular/core';
+import * as i0 from "@angular/core";
+export class Dep {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dep, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+    static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Dep, isStandalone: true, selector: "dep-b", ngImport: i0 });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dep, decorators: [{
+            type: Directive,
+            args: [{ selector: 'dep-b' }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: defer_aliased_deps_b.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class Dep {
+    static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Dep, "dep-b", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: defer_shared_export_name.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    @defer {
+      <dep-a/>
+      <dep-b/>
+    }
+  `, isInline: true, deferBlockDependencies: [() => [/* @ts-ignore */
+                import("./defer_aliased_deps_a").then(m => m.Dep), /* @ts-ignore */
+                import("./defer_aliased_deps_b").then(m => m.Dep)]] });
+}
+i0.ɵɵngDeclareClassMetadataAsync({ minVersion: "18.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, resolveDeferredDeps: () => [/* @ts-ignore */
+        import("./defer_aliased_deps_a").then(m => m.Dep), /* @ts-ignore */
+        import("./defer_aliased_deps_b").then(m => m.Dep)], resolveMetadata: (AliasedDepA, AliasedDepB) => ({ decorators: [{
+                type: Component,
+                args: [{
+                        template: `
+    @defer {
+      <dep-a/>
+      <dep-b/>
+    }
+  `,
+                        imports: [AliasedDepA, AliasedDepB],
+                    }]
+            }], ctorParameters: null, propDecorators: null }) });
+
+/****************************************************************************************************
+ * PARTIAL FILE: defer_shared_export_name.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: lazy_with_blocks.js
  ****************************************************************************************************/
 import { Component } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -311,6 +311,40 @@
       ]
     },
     {
+      "description": "should refer to a deferred dependency by its local name in the class metadata",
+      "inputFiles": ["defer_aliased_deps.ts", "defer_aliased_deps_a.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "defer_aliased_deps_template.js",
+              "generated": "defer_aliased_deps.js"
+            }
+          ],
+          "failureMessage": "Incorrect class metadata"
+        }
+      ]
+    },
+    {
+      "description": "should support deferred dependencies that are exported under the same name",
+      "inputFiles": [
+        "defer_shared_export_name.ts",
+        "defer_aliased_deps_a.ts",
+        "defer_aliased_deps_b.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "defer_shared_export_name_template.js",
+              "generated": "defer_shared_export_name.js"
+            }
+          ],
+          "failureMessage": "Incorrect class metadata"
+        }
+      ]
+    },
+    {
       "description": "should generate a lazy deferred block with empty and placeholder",
       "inputFiles": ["lazy_with_blocks.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+
+import {Dep as AliasedDep} from './defer_aliased_deps_a';
+
+@Component({
+  template: `
+    @defer {
+      <dep-a/>
+    }
+  `,
+  imports: [AliasedDep],
+})
+export class MyApp {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_a.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_a.ts
@@ -1,0 +1,5 @@
+import {Directive} from '@angular/core';
+
+@Directive({selector: 'dep-a'})
+export class Dep {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_a_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_a_isolated.golden.d.ts
@@ -1,0 +1,5 @@
+import * as i0 from "@angular/core";
+export declare class Dep {
+    static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Dep, "dep-a", never, {}, {}, never, never, true, never>;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_b.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_b.ts
@@ -1,0 +1,5 @@
+import {Directive} from '@angular/core';
+
+@Directive({selector: 'dep-b'})
+export class Dep {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_b_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_b_isolated.golden.d.ts
@@ -1,0 +1,5 @@
+import * as i0 from "@angular/core";
+export declare class Dep {
+    static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Dep, "dep-b", never, {}, {}, never, never, true, never>;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_isolated.golden.d.ts
@@ -1,0 +1,5 @@
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_aliased_deps_template.js
@@ -1,0 +1,16 @@
+…
+
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵsetClassMetadataAsync(MyApp, () => [
+    /* @ts-ignore */
+    import("./defer_aliased_deps_a").then(m => m.Dep)
+  ], AliasedDep => {
+    $r3$.ɵsetClassMetadata(MyApp, [{
+      type: Component,
+      args: [{
+        template: …,
+        imports: [AliasedDep]…
+      }]
+    }], null, null);
+  });
+})();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_shared_export_name.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_shared_export_name.ts
@@ -1,0 +1,16 @@
+import {Component} from '@angular/core';
+
+import {Dep as AliasedDepA} from './defer_aliased_deps_a';
+import {Dep as AliasedDepB} from './defer_aliased_deps_b';
+
+@Component({
+  template: `
+    @defer {
+      <dep-a/>
+      <dep-b/>
+    }
+  `,
+  imports: [AliasedDepA, AliasedDepB],
+})
+export class MyApp {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_shared_export_name_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_shared_export_name_isolated.golden.d.ts
@@ -1,0 +1,5 @@
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_shared_export_name_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/defer_shared_export_name_template.js
@@ -1,0 +1,18 @@
+…
+
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && $r3$.ɵsetClassMetadataAsync(MyApp, () => [
+    /* @ts-ignore */
+    import("./defer_aliased_deps_a").then(m => m.Dep),
+    /* @ts-ignore */
+    import("./defer_aliased_deps_b").then(m => m.Dep)
+  ], (AliasedDepA, AliasedDepB) => {
+    $r3$.ɵsetClassMetadata(MyApp, [{
+      type: Component,
+      args: [{
+        template: …,
+        imports: [AliasedDepA, AliasedDepB]…
+      }]
+    }], null, null);
+  });
+})();

--- a/packages/compiler/src/render3/partial/class_metadata.ts
+++ b/packages/compiler/src/render3/partial/class_metadata.ts
@@ -65,7 +65,12 @@ export function compileComponentDeclareClassMetadata(
   definitionMap.set(
     'resolveMetadata',
     o.arrowFn(
-      dependencies.map((dep) => new o.FnParam(dep.symbolName, o.DYNAMIC_TYPE)),
+      // The callback returns metadata that is reproduced from the original source, which refers
+      // to the dependencies by their local names. The parameters have to bind those names, rather
+      // than the exported ones used to read the symbols off of the loaded modules.
+      dependencies.map(
+        (dep) => new o.FnParam(dep.localSymbolName ?? dep.symbolName, o.DYNAMIC_TYPE),
+      ),
       callbackReturnDefinitionMap.toLiteralMap(),
     ),
   );

--- a/packages/compiler/src/render3/r3_class_metadata_compiler.ts
+++ b/packages/compiler/src/render3/r3_class_metadata_compiler.ts
@@ -87,7 +87,10 @@ export function compileComponentClassMetadata(
 
   return internalCompileSetClassMetadataAsync(
     metadata,
-    dependencies.map((dep) => new o.FnParam(dep.symbolName, o.DYNAMIC_TYPE)),
+    // The callback wraps a `setClassMetadata` call that is reproduced from the original source,
+    // which refers to the dependencies by their local names. The parameters have to bind those
+    // names, rather than the exported ones used to read the symbols off of the loaded modules.
+    dependencies.map((dep) => new o.FnParam(dep.localSymbolName ?? dep.symbolName, o.DYNAMIC_TYPE)),
     compileComponentMetadataAsyncResolver(dependencies),
   );
 }

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -364,9 +364,7 @@ export interface R3TemplateDependency {
  * A dependency that's used within a component template
  */
 export type R3TemplateDependencyMetadata =
-  | R3DirectiveDependencyMetadata
-  | R3PipeDependencyMetadata
-  | R3NgModuleDependencyMetadata;
+  R3DirectiveDependencyMetadata | R3PipeDependencyMetadata | R3NgModuleDependencyMetadata;
 
 /**
  * Information about a directive that is used in a component template. Only the stable, public
@@ -579,9 +577,23 @@ export interface R3DeferPerBlockDependency {
  */
 export interface R3DeferPerComponentDependency {
   /**
-   * Dependency class name.
+   * Name that the dependency is exported under by its module. This is the name that has to be
+   * read off of the dynamically-imported module, e.g. `import('./cmp').then(m => m.CmpA)`.
    */
   symbolName: string;
+
+  /**
+   * Name that the dependency is referred to by inside the file that declares the component.
+   * Usually identical to `symbolName`, but it can differ when the symbol is imported under an
+   * alias, e.g. `import {CmpA as AliasedCmp} from './cmp';`. Code that is reproduced from the
+   * original source, like the decorators inside `setClassMetadataAsync`, refers to the dependency
+   * by this name.
+   *
+   * Optional so that callers written against an earlier version of this interface keep compiling
+   * and keep their current output; `symbolName` is used when it is absent, which is what those
+   * callers were getting before. The compiler always populates it.
+   */
+  localSymbolName?: string;
 
   /**
    * Import path where this dependency is located.


### PR DESCRIPTION
When `@defer` blocks are compiled in dev mode, `setClassMetadataAsync` (and partial declaration `resolveMetadata`) wraps a callback that replays the component's original decorator metadata. This replayed decorator refers to any deferred dependencies using the local identifiers bound in the declaring file.

Previously, `R3DeferPerComponentDependency` tracked a single `symbolName` that was used both for dereferencing the exported property on the dynamic import (`m => m.Dep`) and as the parameter name in the metadata callback:

```ts
import {Dep as AliasedDep} from './dep';

// Generated setClassMetadataAsync before this fix:
setClassMetadataAsync(MyApp,
  () => [import('./dep').then(m => m.Dep)],
  Dep => setClassMetadata(MyApp, [{..., imports: [AliasedDep]}], null, null));
```

Because the static import is stripped in favor of the dynamic loader, `AliasedDep` remains unbound in the callback scope, causing a runtime `ReferenceError` as soon as the defer block resolves. Even worse, if a component imports dependencies from two separate modules that happen to share the same export name under different local aliases (e.g. `import {Dep as DepA} from './a'; import {Dep as DepB} from './b'`), both parameters were generated using `Dep`, yielding duplicate parameter names `(Dep, Dep) => ...` which is a strict-mode syntax error.

In addition, `removeDeferrableTypesFromComponentDecorator` relied on the exported `symbolName` when stripping identifiers from the component decorator node, which failed to match aliased identifiers.

### Solution

This PR updates `R3DeferPerComponentDependency` (and internal resolution tracking) to distinguish between `symbolName` (the module export key) and `localSymbolName` (the local binding identifier):

1. **Dynamic imports** continue to dereference `symbolName` (`m => m[symbolName]`), leaving the dynamic loader mechanism unchanged.
2. **Metadata callbacks** (`setClassMetadataAsync` and `resolveMetadata`) now bind parameters using `localSymbolName`.
3. **Decorator cleanup** (`removeDeferrableTypesFromComponentDecorator`) matches against `localSymbolName` to correctly remove aliased imports from original decorators.

Because local identifiers are inherently unique within a file scope, parameter name collisions like `(Dep, Dep) => ...` are naturally prevented. For standard, non-aliased imports where `localSymbolName === symbolName`, the emitted code is completely unchanged, making this a safe, additive fix. Compliance test cases have been added to cover both single aliased deferred dependencies and multi-dependency export collisions.