### PR TITLE
fix(compiler): remove namespaced MathML script elements

### DIFF
--- a/packages/compiler/src/template_parser/template_preparser.ts
+++ b/packages/compiler/src/template_parser/template_preparser.ts
@@ -15,7 +15,7 @@ const LINK_STYLE_REL_ATTR = 'rel';
 const LINK_STYLE_HREF_ATTR = 'href';
 const LINK_STYLE_REL_VALUE = 'stylesheet';
 const STYLE_ELEMENT = 'style';
-const SCRIPT_ELEMENTS: ReadonlySet<string> = new Set([':svg:script', 'script']);
+const SCRIPT_ELEMENTS: ReadonlySet<string> = new Set([':math:script', ':svg:script', 'script']);
 const NG_NON_BINDABLE_ATTR = 'ngNonBindable';
 const NG_PROJECT_AS = 'ngProjectAs';
 

--- a/packages/platform-server/test/render_spec.ts
+++ b/packages/platform-server/test/render_spec.ts
@@ -35,4 +35,15 @@ describe('renderApplication', () => {
     const html = await ssr(SomeComponent);
     expect(html).toContain('aria-label="a third label"');
   });
+  it('should not serialize MathML script elements', async () => {
+    @Component({
+      selector: 'app',
+      template: '<math><mtext><script>bad()</script></mtext></math>',
+    })
+    class SomeComponent {}
+
+    const html = await ssr(SomeComponent, {enableHydration: false});
+
+    expect(html).not.toContain('<script');
+  });
 });


### PR DESCRIPTION
## PR Checklist

* [x] The commit message follows the Angular commit message guidelines
* [x] Tests for the changes have been added
* [x] The affected test suite passes
* [x] Formatting checks pass

## PR Type

* [x] Bugfix
* [x] Security hardening
* [ ] Feature
* [ ] Code style update
* [ ] Refactoring
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other

## What is the current behavior?

Angular's template preparser removes regular HTML and SVG-namespaced script elements:

```ts
const SCRIPT_ELEMENTS: ReadonlySet<string> = new Set([':svg:script', 'script']);
```

A script nested inside MathML is represented internally by Angular as `:math:script`.

For example:

```html
<math>
  <mtext>
    <script>bad()</script>
  </mtext>
</math>
```

Since `:math:script` is absent from `SCRIPT_ELEMENTS`, the script survives template preprocessing.

A MathML script node created directly in the browser is inert. The security-relevant behavior occurs when the template passes through server-side rendering.

On current unpatched `main`, Angular's `renderApplication()` serializes the structure with the script still present:

```html
<math><mtext><script>bad()</script></mtext></math>
```

When that SSR response is subsequently parsed as HTML by a browser, `<mtext>` acts as a MathML HTML integration point. The nested script is parsed as an HTML `HTMLScriptElement` and can execute.

## What is the new behavior?

The template preparser also recognizes `:math:script`:

```ts
const SCRIPT_ELEMENTS: ReadonlySet<string> = new Set([
  ':math:script',
  ':svg:script',
  'script',
]);
```

The MathML-namespaced script is consequently removed before SSR serialization.

For the same structure, `renderApplication()` produces:

```html
<math><mtext></mtext></math>
```

## Security impact

The affected scenario requires an application that runtime-compiles attacker-influenced Angular template markup and server-renders the resulting template.

For example, this may occur in applications implementing template customization, CMS, or page-builder functionality using runtime Angular template compilation together with Angular SSR.

The demonstrated path is:

```text
attacker-influenced runtime template
        ↓
Angular template compilation
        ↓
MathML script survives
        ↓
renderApplication()
        ↓
script is serialized into the SSR response
        ↓
browser parses the HTML response
        ↓
<mtext> HTML integration point
        ↓
HTMLScriptElement
        ↓
JavaScript execution
```

This can result in cross-site scripting in the application's origin.

## Relation to CVE-2026-50557

CVE-2026-50557 introduced protection for namespaced script elements during Angular template compilation, including the `:svg:script` representation.

The current implementation does not include the MathML representation, `:math:script`.

This PR extends the existing script-element classification to cover that remaining namespace representation.

This does not claim that a MathML script executes directly when Angular creates it as a MathML DOM node. Exploitability depends on the additional SSR serialization and browser reparsing boundary described above.

Reference:

https://github.com/angular/angular/security/advisories/GHSA-f3m7-gqxr-g87x

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

This extends Angular's existing script-removal behavior to MathML-namespaced script elements.

## Tests

The regression test uses Angular's `renderApplication()` path.

Before this change:

```html
<math><mtext><script>bad()</script></mtext></math>
```

is serialized with the script intact.

After adding `:math:script` to `SCRIPT_ELEMENTS`, the script is absent from the SSR output.

The following checks pass locally:

```shell
pnpm ng-dev format changed
pnpm test //packages/platform-server/test:test --nocache_test_results
git diff --check
```

## Other information

The browser portion was also validated manually against current unpatched `main` (`96b80424c7`).

`renderApplication()` produced:

```html
<math><mtext><script>
  document.documentElement.setAttribute('data-mathml-xss', 'yes');
</script></mtext></math>
```

The exact SSR response was served over HTTP and loaded in Chrome. After parsing, the resulting document contained:

```text
data-mathml-xss="yes"
```

With this PR applied, the same SSR test produces:

```html
<math><mtext></mtext></math>
```

with no script available for the browser to execute.
