### PR TITLE
fix(core): incorrect loop in defer blocks

### DIFF
--- a/packages/core/src/defer/triggering.ts
+++ b/packages/core/src/defer/triggering.ts
@@ -541,7 +541,7 @@ function cleanupRemainingHydrationQueue(
   dehydratedBlockRegistry: DehydratedBlockRegistry,
 ) {
   const blocksBeingHydrated = dehydratedBlockRegistry.hydrating;
-  for (const dehydratedBlockId in hydrationQueue) {
+  for (const dehydratedBlockId of hydrationQueue) {
     blocksBeingHydrated.get(dehydratedBlockId)?.reject();
   }
   dehydratedBlockRegistry.cleanup(hydrationQueue);


### PR DESCRIPTION
Fixes that we were running a `for in` loop on an array and silently doing the wrong thing.

Fixes #70113.
