### PR TITLE
refactor(devtools): collapse injected services section in the side pane by default

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.html
@@ -3,7 +3,7 @@
     @let deps = dependencies();
     @if (deps && deps.length > 0) {
       <div class="mat-accordion-content">
-        <mat-expansion-panel [expanded]="true">
+        <mat-expansion-panel [expanded]="false">
           <mat-expansion-panel-header collapsedHeight="28px" expandedHeight="28px">
             <mat-panel-title>
               Injected Services

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/BUILD.bazel
@@ -24,5 +24,6 @@ ng_project(
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/material",
         "//devtools/projects/ng-devtools/src/lib/application-services:frame_manager",
+        "//devtools/projects/ng-devtools/src/lib/shared/button",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/property-view-header.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/property-view-header.component.html
@@ -2,13 +2,17 @@
   {{ directive() }}
   <span class="button-wrapper">
     <button
-      (click)="handlelogInstance($event)"
-      [matTooltip]="'Log directive instance to console'"
-      [attr.aria-label]="'Log directive instance to console'"
+      ng-button
+      btnType="icon"
+      (click)="handleLogInstance($event)"
+      matTooltip="Log directive instance to console"
+      aria-label="Log directive instance to console"
     >
       <mat-icon> terminal </mat-icon>
     </button>
     <button
+      ng-button
+      btnType="icon"
       [disabled]="disableViewSourceButton()"
       (click)="handleViewSource($event)"
       [matTooltip]="viewSourceTooltip()"

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/property-view-header.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/property-view-header.component.scss
@@ -2,32 +2,28 @@
 
 mat-toolbar {
   @extend %body-medium-01;
-  padding: 0.25rem 0.625rem;
+  padding: 0.45rem 0.625rem;
   justify-content: space-between;
   text-overflow: ellipsis;
   overflow: hidden;
-  line-height: 25px;
   height: auto;
 
   .button-wrapper {
     display: flex;
-    gap: 8px;
+    gap: 0.75rem;
   }
 }
 
-.mat-icon-button {
-  font-size: 16px;
-  line-height: 10px;
-}
-
 button {
-  padding: 0;
-  background: none;
-  border: none;
-  height: 24px;
-  width: 24px;
-  cursor: pointer;
   opacity: 0.5;
+  width: 18px;
+  height: 18px;
+
+  mat-icon {
+    width: inherit;
+    height: inherit;
+    font-size: 18px;
+  }
 
   &:hover {
     opacity: 0.75;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/property-view-header.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/property-view-header.component.ts
@@ -12,12 +12,13 @@ import {MatTooltip} from '@angular/material/tooltip';
 import {MatToolbar} from '@angular/material/toolbar';
 import {Platform} from '@angular/cdk/platform';
 import {FrameManager} from '../../../../../application-services/frame_manager';
+import {ButtonComponent} from '../../../../../shared/button/button.component';
 
 @Component({
   selector: 'ng-property-view-header',
   templateUrl: './property-view-header.component.html',
   styleUrls: ['./property-view-header.component.scss'],
-  imports: [MatToolbar, MatTooltip, MatIcon],
+  imports: [MatToolbar, MatTooltip, MatIcon, ButtonComponent],
 })
 export class PropertyViewHeaderComponent {
   readonly directive = input.required<string>();
@@ -39,13 +40,12 @@ export class PropertyViewHeaderComponent {
       : 'Open Source',
   );
 
-  // output that emits directive
   handleViewSource(event: MouseEvent): void {
     event.stopPropagation();
     this.viewSource.emit();
   }
 
-  handlelogInstance(event: MouseEvent): void {
+  handleLogInstance(event: MouseEvent): void {
     event.stopPropagation();
     this.logInstance.emit();
   }


### PR DESCRIPTION
Collapse the section since it takes a significant portion of the vertical space, whereas most of the times users are exploring the properties leading them to scroll.

Addtiotionally, introduce some other minor UI improvements.