### PR TITLE
feat(forms): add validatePromise for simple promise-based async function validation

### DIFF
--- a/adev/src/content/guide/forms/signals/async-operations.md
+++ b/adev/src/content/guide/forms/signals/async-operations.md
@@ -1,6 +1,6 @@
 # Async operations
 
-Some validation requires data from external sources like backend APIs or third-party services. Signal Forms provides two functions for asynchronous validation: `validateHttp()` for HTTP-based validation and `validateAsync()` for custom resource-based validation.
+Some validation requires data from external sources like backend APIs or third-party services. Signal Forms provides three functions for asynchronous validation: `validateHttp()` for HTTP-based validation, `validatePromise()` for simple promise-based function validation, and `validateAsync()` for custom resource-based validation.
 
 ## When to use async validation
 
@@ -788,5 +788,6 @@ For detailed API documentation, see:
 
 - [`validateHttp()`](api/forms/signals/validateHttp) - HTTP-based async validation
 - [`validateAsync()`](api/forms/signals/validateAsync) - Custom resource-based async validation
+- [`validatePromise()`](api/forms/signals/validatePromise) - Promise-based async validation
 - [`httpResource()`](api/common/http/httpResource) - Angular's HTTP resource API
 - [`resource()`](api/core/resource) - Angular's resource primitive

--- a/adev/src/content/guide/forms/signals/async-operations.md
+++ b/adev/src/content/guide/forms/signals/async-operations.md
@@ -244,7 +244,7 @@ TIP: See the [httpResource API documentation](api/common/http/httpResource) for 
 
 Most applications should use `validateHttp()` for async validation. It handles HTTP requests with minimal configuration and covers the majority of use cases.
 
-`validateAsync()` is a lower-level API that exposes Angular's resource primitive directly. It offers complete control but requires more code and familiarity with Angular's resource API.
+`validateAsync()` is a lower-level API that exposes Angular's resource primitive. It supports both a simple async function for standard checks and full resource configuration for complete control, which requires more code and familiarity with Angular's resource API.
 
 Consider `validateAsync()` only when `validateHttp()` can't meet your needs. Some examples include:
 
@@ -253,9 +253,54 @@ Consider `validateAsync()` only when `validateHttp()` can't meet your needs. Som
 - **Complex retry logic** - Custom backoff strategies or conditional retries
 - **Direct resource access** - When you need the full resource lifecycle
 
-### Creating a custom validation rule
+### Using a simple async validator
 
-The `validateAsync()` function requires four properties: `params`, `factory`, `onSuccess`, and `onError`. The `params` function returns the parameters for your resource, while `factory` creates the resource:
+Pass an async validator function that receives the field context and returns validation errors or `null` or `undefined`. You can optionally supply a config object to handle debouncing, conditional execution (`when`), or error handling (`onError`):
+
+```ts
+import {Component, inject, signal} from '@angular/core';
+import {FieldContext, form, FormField, validateAsync} from '@angular/forms/signals';
+import {UsernameValidator} from './username-validator';
+
+@Component({
+  selector: 'app-registration',
+  imports: [FormField],
+  template: `...`,
+})
+export class Registration {
+  registrationModel = signal({username: ''});
+  private usernameValidator = inject(UsernameValidator);
+
+  registrationForm = form(this.registrationModel, (schemaPath) => {
+    validateAsync(schemaPath.username, (ctx) => this.validateUsername(ctx), {
+      debounce: 300,
+      when: ({value}) => value().length >= 3,
+      onError: (error) => ({
+        kind: 'serverError',
+        message: 'Could not verify username',
+      }),
+    });
+  });
+
+  private async validateUsername({value}: FieldContext<string>) {
+    const result = await this.usernameValidator.checkAvailability(value());
+
+    return result?.available ? null : {kind: 'usernameTaken', message: 'Username taken'};
+  }
+}
+```
+
+#### Optional Configuration Options
+
+| **Config Option** | **Type**                  | **Description**                                                                                                        |
+| ----------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `debounce`        | `number \| DebounceTimer` | Duration in milliseconds to wait before triggering the async operation, or a function returning a timing promise.      |
+| `when`            | `LogicFn`                 | A function that receives the field context and returns `true` if the async validation should run.                      |
+| `onError`         | `Function`                | A handler for errors thrown by the validator. Defaults to an `{ kind: 'asyncError', message: ... }` object if omitted. |
+
+### Using Resouce-based validator
+
+For advanced control, pass an options object containing `params`, `factory`, `onSuccess`, and `onError`. The params function returns parameters for your resource, while `factory` creates the resource:
 
 ```ts
 import {Component, inject, signal, resource, Signal} from '@angular/core';

--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -492,6 +492,61 @@ NOTE: Child fields also have a `key` signal, and array item fields have both `ke
 
 Return an error object with `kind` and `message` when validation fails. Return `null` or `undefined` when validation passes.
 
+### Using validateAsync()
+
+The `validateAsync()` function creates custom asynchronous validation rules. It receives a validator function that accesses the field context and returns a `Promise` resolving to:
+
+| Return Value          | Meaning          |
+| --------------------- | ---------------- |
+| Error object          | Value is invalid |
+| `null` or `undefined` | Value is valid   |
+
+```angular-ts
+import {Component, inject, signal} from '@angular/core';
+import {FieldContext, form, FormField, validateAsync} from '@angular/forms/signals';
+import {UserService} from './user.service';
+
+@Component({
+  selector: 'app-username-form',
+  imports: [FormField],
+  template: `
+    <form novalidate>
+      <label>
+        Username
+        <input [formField]="usernameForm.username" />
+      </label>
+    </form>
+  `,
+})
+export class UsernameFormComponent {
+  private userService = inject(UserService);
+
+  usernameModel = signal({username: ''});
+
+  usernameForm = form(this.usernameModel, (schemaPath) => {
+    validateAsync(schemaPath.username, (ctx) => this.validateUsername(ctx));
+  });
+
+  private async validateUsername({value}: FieldContext<string>) {
+    const username = value();
+    const available = await this.userService.checkUsernameAvailability(username);
+
+    if (!available) {
+      return {
+        kind: 'usernameTaken',
+        message: 'Username is already taken',
+      };
+    }
+
+    return null;
+  }
+}
+```
+
+The validator function receives the same `FieldContext` object as synchronous `validate()`.
+
+NOTE: For advanced async validation and complex scenarios requiring execution delays, conditional checks, unhandled error fallbacks, or direct access to Angular's `resource()` primitive, see the [Custom async validation with validateAsync() guide](guide/forms/signals/async-operations#custom-async-validation-with-validateasync).
+
 ### Using validateTree()
 
 The `validateTree()` function creates custom validation rules that can target multiple fields or provide complex validation logic for a whole subtree.
@@ -505,9 +560,7 @@ interface User {
   lastName: string;
 }
 
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class UserFormComponent {
   readonly userModel = model<User>({
     firstName: '',
@@ -750,9 +803,7 @@ import {Component, computed, signal} from '@angular/core';
 import {form, FormField, validateStandardSchema} from '@angular/forms/signals';
 import z from 'zod';
 
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class DynamicSchema {
   model = signal({document: '', type: 'dni'});
 

--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -492,6 +492,58 @@ NOTE: Child fields also have a `key` signal, and array item fields have both `ke
 
 Return an error object with `kind` and `message` when validation fails. Return `null` or `undefined` when validation passes.
 
+### Using validatePromise()
+
+The `validatePromise()` function creates custom asynchronous validation rules. It receives a validator function that accesses the field context and returns a `Promise` resolving to:
+
+| Return Value          | Meaning          |
+| --------------------- | ---------------- |
+| Error object          | Value is invalid |
+| `null` or `undefined` | Value is valid   |
+
+```angular-ts
+import {Component, inject, signal} from '@angular/core';
+import {FieldContext, form, FormField, validatePromise} from '@angular/forms/signals';
+import {UserService} from './user.service';
+
+@Component({/* ... */})
+export class UsernameFormComponent {
+  private userService = inject(UserService);
+
+  usernameModel = signal({username: ''});
+
+  usernameForm = form(this.usernameModel, (schemaPath) => {
+    validatePromise(schemaPath.username, (ctx) => this.validateUsername(ctx));
+  });
+
+  private async validateUsername({value}: FieldContext<string>) {
+    const username = value();
+    const available = await this.userService.checkUsernameAvailability(username);
+
+    if (!available) {
+      return {
+        kind: 'usernameTaken',
+        message: 'Username is already taken',
+      };
+    }
+
+    return null;
+  }
+}
+```
+
+The validator function receives the same `FieldContext` object as synchronous `validate()`.
+
+NOTE: For advanced async validation and complex scenarios requiring execution delays, conditional checks, unhandled error fallbacks, or direct access to Angular's `resource()` primitive, see the [Custom async validation with validateAsync() guide](guide/forms/signals/async-operations#custom-async-validation-with-validateasync).
+
+#### Optional Configuration Options
+
+| **Config Option** | **Type**                  | **Description**                                                                                                        |
+| ----------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `debounce`        | `number \| DebounceTimer` | Duration in milliseconds to wait before triggering the async operation, or a function returning a timing promise.      |
+| `when`            | `LogicFn`                 | A function that receives the field context and returns `true` if the async validation should run.                      |
+| `onError`         | `Function`                | A handler for errors thrown by the validator. Defaults to an `{ kind: 'asyncError', message: ... }` object if omitted. |
+
 ### Using validateTree()
 
 The `validateTree()` function creates custom validation rules that can target multiple fields or provide complex validation logic for a whole subtree.
@@ -505,9 +557,7 @@ interface User {
   lastName: string;
 }
 
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class UserFormComponent {
   readonly userModel = model<User>({
     firstName: '',
@@ -750,9 +800,7 @@ import {Component, computed, signal} from '@angular/core';
 import {form, FormField, validateStandardSchema} from '@angular/forms/signals';
 import z from 'zod';
 
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class DynamicSchema {
   model = signal({document: '', type: 'dni'});
 

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -160,6 +160,9 @@ export type FieldTree<TModel, TKey extends string | number = string | number, TM
 export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<TValue, ValidationResult<ValidationError.WithoutFieldTree>, TPathKind>;
 
 // @public
+export type FieldValidatorPromise<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<TValue, Promise<ValidationResult<ValidationError.WithoutFieldTree>>, TPathKind>;
+
+// @public
 export function form<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;
 
 // @public
@@ -758,6 +761,13 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
 
 // @public
 export function validateHttp<TValue, TResult = unknown, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, opts: HttpValidatorOptions<TValue, TResult, TPathKind>): void;
+
+// @public
+export function validatePromise<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, logic: NoInfer<FieldValidatorPromise<TValue, TPathKind>>, config?: {
+    debounce?: DebounceTimer<FieldContext<TValue, TPathKind> | undefined>;
+    when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>;
+    onError?: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
+}): void;
 
 // @public
 export function validateStandardSchema<TSchema, TModel extends IgnoreUnknownProperties<TSchema>>(path: SchemaPath<TModel> & SchemaPathTree<TModel>, schema: StandardSchemaV1<TSchema> | LogicFn<TModel, StandardSchemaV1<unknown> | undefined>): void;

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -764,7 +764,7 @@ export function validateHttp<TValue, TResult = unknown, TPathKind extends PathKi
 
 // @public
 export function validatePromise<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, logic: NoInfer<FieldValidatorPromise<TValue, TPathKind>>, config?: {
-    debounce?: DebounceTimer<FieldContext<TValue, TPathKind> | undefined>;
+    debounce?: DebounceTimer<TValue | undefined>;
     when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>;
     onError?: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
 }): void;

--- a/packages/forms/signals/src/api/rules/validation/index.ts
+++ b/packages/forms/signals/src/api/rules/validation/index.ts
@@ -19,5 +19,6 @@ export * from './standard_schema';
 export * from './validate';
 export * from './validate_async';
 export * from './validate_http';
+export * from './validate_promise';
 export * from './validate_tree';
 export * from './validation_errors';

--- a/packages/forms/signals/src/api/rules/validation/validate_async.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_async.ts
@@ -6,13 +6,22 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DebounceTimer, Resource, Signal, computed, debounced, ɵchain} from '@angular/core';
+import {
+  DebounceTimer,
+  Resource,
+  resource,
+  Signal,
+  computed,
+  debounced,
+  ɵchain,
+} from '@angular/core';
 import {FieldNode} from '../../../field/node';
 import {addDefaultField} from '../../../field/validation';
 import {FieldPathNode} from '../../../schema/path_node';
 import {assertPathIsCurrent} from '../../../schema/schema';
 import {
   FieldContext,
+  FieldValidatorAsync,
   LogicFn,
   PathKind,
   SchemaPath,
@@ -117,19 +126,167 @@ export interface AsyncValidatorOptions<
  * @param opts The async validation options.
  * @template TValue The type of value stored in the field being validated.
  * @template TParams The type of parameters to the resource.
- * @template TResult The type of result returned by the resource
- * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
+ * @template TResult The type of result returned by the resource.
+ * @template TPathKind The kind of path being validated (a root path, child path, or item of an array).
  *
  * @see [Signal Form Async Validation](guide/forms/signals/validation#async-validation)
  * @see [Custom async validation](guide/forms/signals/async-operations#custom-async-validation-with-validateasync)
+ * @see [Custom validation rules](guide/forms/signals/validation#using-validateasync)
  * @category validation
  * @publicApi 22.0
  */
 export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
   opts: AsyncValidatorOptions<TValue, TParams, TResult, TPathKind>,
+): void;
+
+/**
+ * Adds async validation to the field corresponding to the given path using a simple validator function.
+ *
+ * @param path A path indicating the field to bind the async validation logic to.
+ * @param logic A validator function that returns the validation errors asynchronously.
+ * @param config Optional, allows providing any of the following options for the async validation over the simple validator function:
+ *  - `debounce`: Duration in milliseconds to wait before triggering the async operation, or a function that
+ *    returns a promise that resolves when the update should proceed.
+ *  - `when`: A function that receives the field context and returns true if the async validation should be run.
+ *  - `onError`: A function to handle errors thrown by the async validator (HTTP errors, network errors, etc.).
+ *    Receives the error and the field context, returns a list of validation errors.
+ * @template TValue The type of value stored in the field being validated.
+ * @template TPathKind The kind of path being validated (a root path, child path, or item of an array).
+ *
+ * @see [Signal Form Async Validation](guide/forms/signals/validation#async-validation)
+ * @see [Custom async validation](guide/forms/signals/async-operations#custom-async-validation-with-validateasync)
+ * @see [Custom validation rules](guide/forms/signals/validation#using-validateasync)
+ * @category validation
+ * @publicApi 22.0
+ */
+export function validateAsync<TValue, TPathKind extends PathKind = PathKind.Root>(
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  logic: NoInfer<FieldValidatorAsync<TValue, TPathKind>>,
+  config?: {
+    debounce?: DebounceTimer<FieldContext<TValue, TPathKind> | undefined>;
+    when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>;
+    onError?: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
+  },
+): void;
+
+/**
+ * Internal implementation for registering async validation on a field via resource options
+ * or a simple validator function.
+ *
+ * @param path A path indicating the field to bind the async validation logic to.
+ * @param optsOrLogic Either an object with full resource validator options or a simple async validator function.
+ * @param config Optional, allows providing any of the following options for the async validation over the simple validator function:
+ *  - `debounce`: Duration in milliseconds to wait before triggering the async operation, or a function that
+ *    returns a promise that resolves when the update should proceed.
+ *  - `when`: A function that receives the field context and returns true if the async validation should be run.
+ *  - `onError`: A function to handle errors thrown by the async validator (HTTP errors, network errors, etc.).
+ *    Receives the error and the field context, returns a list of validation errors.
+ * @template TValue The type of value stored in the field being validated.
+ * @template TParams The type of parameters to the resource.
+ * @template TResult The type of result returned by the resource.
+ * @template TPathKind The kind of path being validated (a root path, child path, or item of an array).
+ *
+ * @internal
+ */
+export function validateAsync<
+  TValue,
+  TParams = unknown,
+  TResult = unknown,
+  TPathKind extends PathKind = PathKind.Root,
+>(
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  optsOrLogic:
+    | AsyncValidatorOptions<TValue, TParams, TResult, TPathKind>
+    | FieldValidatorAsync<TValue, TPathKind>,
+  config?: {
+    debounce?: DebounceTimer<FieldContext<TValue, TPathKind> | undefined>;
+    when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>;
+    onError?: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
+  },
 ): void {
   assertPathIsCurrent(path);
+
+  if (typeof optsOrLogic === 'function') {
+    const logic = optsOrLogic;
+    const configOpts = config ?? {};
+
+    // Check if debounce option is a function, wrap it to pass the field context and last value.
+    const debounce =
+      typeof configOpts.debounce === 'function'
+        ? (
+            value: {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined,
+            lastValue: unknown,
+          ) => (configOpts.debounce as Function)(value?.ctx, lastValue)
+        : configOpts.debounce;
+
+    // Map the simple validator function to the full AsyncValidatorOptions structure.
+    // Reading `ctx.value()` inside `params` ensures signal dependencies are tracked
+    // so the resource loader re-runs whenever the field value changes.
+    const mappedOpts: AsyncValidatorOptions<
+      TValue,
+      {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined,
+      TreeValidationResult | undefined,
+      TPathKind
+    > = {
+      params: (ctx: FieldContext<TValue, TPathKind>) => ({
+        ctx,
+        value: ctx.value(),
+      }),
+      debounce: debounce as DebounceTimer<
+        {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined
+      >,
+      factory: (
+        paramsSignal: Signal<{ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined>,
+      ) =>
+        resource({
+          params: () => paramsSignal(),
+          loader: async ({
+            params,
+          }: {
+            params: {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined;
+          }) => {
+            if (!params) return undefined;
+            const res = await logic(params.ctx);
+            return res as TreeValidationResult | undefined;
+          },
+        }),
+      onSuccess: (result: TreeValidationResult | undefined) => result,
+      onError:
+        configOpts.onError ??
+        ((error: unknown) => ({
+          kind: 'asyncError',
+          message: String(error ?? 'Async validation failed'),
+        })),
+      when: configOpts.when,
+    };
+
+    registerAsyncResourceValidator(path, mappedOpts);
+    return;
+  }
+
+  registerAsyncResourceValidator(path, optsOrLogic);
+}
+
+/**
+ * Registers an async resource validator for the given path and options.
+ *
+ * @template TValue The type of value stored in the field being validated.
+ * @template TParams The type of parameters to the resource.
+ * @template TResult The type of result returned by the resource
+ * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
+ * @param path
+ * @param opts
+ */
+function registerAsyncResourceValidator<
+  TValue,
+  TParams,
+  TResult,
+  TPathKind extends PathKind = PathKind.Root,
+>(
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  opts: AsyncValidatorOptions<TValue, TParams, TResult, TPathKind>,
+): void {
   const pathNode = FieldPathNode.unwrapFieldPath(path);
 
   const RESOURCE = createManagedMetadataKey<ReturnType<typeof opts.factory>, TParams | undefined>(

--- a/packages/forms/signals/src/api/rules/validation/validate_promise.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_promise.ts
@@ -33,7 +33,7 @@ import {validateAsync} from './validate_async';
  * @see [Signal Form Async Validation](guide/forms/signals/validation#async-validation)
  * @see [Custom validation rules](guide/forms/signals/validation#using-validatepromise)
  * @category validation
- * @publicApi 22.0
+ * @publicApi 22.2
  */
 export function validatePromise<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/validate_promise.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_promise.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DebounceTimer, resource, Signal} from '@angular/core';
+import {DebounceTimer, ResourceSnapshot, resource, Signal} from '@angular/core';
 import {
   FieldContext,
   FieldValidatorPromise,
@@ -39,7 +39,7 @@ export function validatePromise<TValue, TPathKind extends PathKind = PathKind.Ro
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
   logic: NoInfer<FieldValidatorPromise<TValue, TPathKind>>,
   config?: {
-    debounce?: DebounceTimer<FieldContext<TValue, TPathKind> | undefined>;
+    debounce?: DebounceTimer<TValue | undefined>;
     when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>;
     onError?: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
   },
@@ -48,9 +48,21 @@ export function validatePromise<TValue, TPathKind extends PathKind = PathKind.Ro
   const debounce =
     typeof configOpts.debounce === 'function'
       ? (
-          value: {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined,
-          lastValue: unknown,
-        ) => (configOpts.debounce as Function)(value?.ctx, lastValue)
+          params: {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined,
+          lastValue: ResourceSnapshot<
+            {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined
+          >,
+        ) => {
+          const mappedLastValue =
+            lastValue.status === 'error'
+              ? lastValue
+              : ({
+                  status: lastValue.status,
+                  value: lastValue.value?.value,
+                } as ResourceSnapshot<TValue | undefined>);
+
+          return (configOpts.debounce as Function)(params?.value, mappedLastValue);
+        }
       : configOpts.debounce;
 
   validateAsync(path, {

--- a/packages/forms/signals/src/api/rules/validation/validate_promise.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_promise.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {DebounceTimer, resource, Signal} from '@angular/core';
+import {
+  FieldContext,
+  FieldValidatorPromise,
+  LogicFn,
+  PathKind,
+  SchemaPath,
+  SchemaPathRules,
+  TreeValidationResult,
+} from '../../types';
+import {validateAsync} from './validate_async';
+
+/**
+ * Adds async validation to the field corresponding to the given path using a promise-returning validator function.
+ *
+ * @param path A path indicating the field to bind the async validation logic to.
+ * @param logic A validator function that returns the validation errors asynchronously.
+ * @param config Optional, configuration for the async validation behavior:
+ * - `debounce`: Configures the debounce behavior for the async validation.
+ * - `when`: A condition that determines whether the async validation should run.
+ * - `onError`: A callback to handle errors that occur during async validation.
+ * @template TValue The type of value stored in the field being validated.
+ * @template TPathKind The kind of path being validated (a root path, child path, or item of an array).
+ *
+ * @see [Signal Form Async Validation](guide/forms/signals/validation#async-validation)
+ * @see [Custom validation rules](guide/forms/signals/validation#using-validatepromise)
+ * @category validation
+ * @publicApi 22.0
+ */
+export function validatePromise<TValue, TPathKind extends PathKind = PathKind.Root>(
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  logic: NoInfer<FieldValidatorPromise<TValue, TPathKind>>,
+  config?: {
+    debounce?: DebounceTimer<FieldContext<TValue, TPathKind> | undefined>;
+    when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>;
+    onError?: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
+  },
+): void {
+  const configOpts = config ?? {};
+  const debounce =
+    typeof configOpts.debounce === 'function'
+      ? (
+          value: {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined,
+          lastValue: unknown,
+        ) => (configOpts.debounce as Function)(value?.ctx, lastValue)
+      : configOpts.debounce;
+
+  validateAsync(path, {
+    params: (ctx: FieldContext<TValue, TPathKind>) => ({
+      ctx,
+      value: ctx.value(),
+    }),
+    debounce: debounce as DebounceTimer<
+      {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined
+    >,
+    factory: (
+      paramsSignal: Signal<{ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined>,
+    ) =>
+      resource({
+        params: () => paramsSignal(),
+        loader: async ({
+          params,
+        }: {
+          params: {ctx: FieldContext<TValue, TPathKind>; value: TValue} | undefined;
+        }) => {
+          if (!params) return undefined;
+          return (await logic(params.ctx)) as TreeValidationResult | undefined;
+        },
+      }),
+    onSuccess: (result: TreeValidationResult | undefined) => result,
+    onError:
+      configOpts.onError ??
+      ((error: unknown) => ({
+        kind: 'asyncError',
+        message: String(error ?? 'Async validation failed'),
+      })),
+    when: configOpts.when,
+  });
+}

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -901,6 +901,24 @@ export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> =
 >;
 
 /**
+ * A function that takes the `FieldContext` for the field being validated and returns a promise
+ * that resolves to a `ValidationResult` indicating errors for the field.
+ *
+ * @template TValue The type of value stored in the field being validated
+ * @template TPathKind The kind of path being validated (root field, child field, or item of an array)
+ *
+ * @see [Custom validation rules](guide/forms/signals/validation#using-validatepromise)
+ *
+ * @category validation
+ * @publicApi 22.0
+ */
+export type FieldValidatorPromise<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
+  TValue,
+  Promise<ValidationResult<ValidationError.WithoutFieldTree>>,
+  TPathKind
+>;
+
+/**
  * A function that takes the `FieldContext` for the field being validated and returns a
  * `TreeValidationResult` indicating errors for the field and its sub-fields.
  *

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -910,7 +910,7 @@ export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> =
  * @see [Custom validation rules](guide/forms/signals/validation#using-validatepromise)
  *
  * @category validation
- * @publicApi 22.0
+ * @publicApi 22.2
  */
 export type FieldValidatorPromise<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -902,6 +902,26 @@ export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> =
 
 /**
  * A function that takes the `FieldContext` for the field being validated and returns a
+ * `ValidationResult` or pending status indicating errors for the field asynchronously.
+ *
+ * @template TValue The type of value stored in the field being validated
+ * @template TPathKind The kind of path being validated (root field, child field, or item of an array)
+ *
+ * @see [Custom validation rules](guide/forms/signals/validation#using-validateasync)
+ *
+ * @category validation
+ * @publicApi 22.0
+ */
+export type FieldValidatorAsync<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
+  TValue,
+  | ValidationResult<ValidationError.WithoutFieldTree>
+  | Promise<ValidationResult<ValidationError.WithoutFieldTree>>
+  | 'pending',
+  TPathKind
+>;
+
+/**
+ * A function that takes the `FieldContext` for the field being validated and returns a
  * `TreeValidationResult` indicating errors for the field and its sub-fields.
  *
  * @template TValue The type of value stored in the field being validated

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -18,6 +18,7 @@ import {
   requiredError,
   validate,
   validateAsync,
+  validatePromise,
   validateTree,
   ValidationError,
 } from '../../public_api';
@@ -237,6 +238,34 @@ describe('validation status', () => {
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(false);
 
+      await appRef.whenStable();
+
+      expect(f().pending()).toBe(false);
+      expect(f().valid()).toBe(false);
+      expect(f().invalid()).toBe(true);
+    });
+
+    it('should support promise-based async validators', async () => {
+      const f = form(
+        signal('VALID'),
+        (p) => {
+          validatePromise(p, async ({value}) => {
+            return value() === 'VALID' ? null : [{kind: 'custom'}];
+          });
+        },
+        {injector},
+      );
+
+      await Promise.resolve();
+      await appRef.whenStable();
+
+      expect(f().pending()).toBe(false);
+      expect(f().valid()).toBe(true);
+      expect(f().invalid()).toBe(false);
+
+      f().value.set('INVALID');
+
+      await Promise.resolve();
       await appRef.whenStable();
 
       expect(f().pending()).toBe(false);

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -273,6 +273,85 @@ describe('validation status', () => {
       expect(f().invalid()).toBe(true);
     });
 
+    it('should support debounced promise-based async validators', async () => {
+      const f = form(
+        signal('VALID'),
+        (p) => {
+          validatePromise(p, async ({value}) => (value() === 'VALID' ? null : [{kind: 'custom'}]), {
+            debounce: 100,
+          });
+        },
+        {injector},
+      );
+
+      await appRef.whenStable();
+      expect(f().pending()).toBe(false);
+
+      f().value.set('INVALID');
+      await appRef.whenStable();
+
+      expect(f().pending()).toBe(true);
+      expect(f().valid()).toBe(false);
+      expect(f().invalid()).toBe(false);
+
+      await timeout(150);
+      await appRef.whenStable();
+
+      expect(f().pending()).toBe(false);
+      expect(f().valid()).toBe(false);
+      expect(f().invalid()).toBe(true);
+
+      f().value.set('VALID');
+      await appRef.whenStable();
+
+      expect(f().pending()).toBe(true);
+
+      await timeout(150);
+      await appRef.whenStable();
+
+      expect(f().pending()).toBe(false);
+      expect(f().valid()).toBe(true);
+      expect(f().invalid()).toBe(false);
+    });
+
+    it('should pass the previous value to custom debounce functions', async () => {
+      const debounceSpy = jasmine
+        .createSpy('debounce')
+        .and.callFake(
+          (value: string | undefined, lastValue: {status: string; value?: string} | undefined) => {
+            expect(value).toBe('INVALID');
+            expect(lastValue).toEqual({status: 'resolved', value: 'VALID'});
+            return new Promise<void>((resolve) => setTimeout(resolve, 10));
+          },
+        );
+
+      const f = form(
+        signal('VALID'),
+        (p) => {
+          validatePromise(p, async ({value}) => (value() === 'VALID' ? null : [{kind: 'custom'}]), {
+            debounce: debounceSpy,
+          });
+        },
+        {injector},
+      );
+
+      await appRef.whenStable();
+      expect(debounceSpy).not.toHaveBeenCalled();
+
+      f().value.set('INVALID');
+      await appRef.whenStable();
+
+      expect(debounceSpy).toHaveBeenCalledTimes(1);
+      expect(debounceSpy.calls.mostRecent().args[1]).toEqual({status: 'resolved', value: 'VALID'});
+
+      await timeout(20);
+      await appRef.whenStable();
+
+      expect(f().pending()).toBe(false);
+      expect(f().valid()).toBe(false);
+      expect(f().invalid()).toBe(true);
+    });
+
     it('should affect validity of targeted field', async () => {
       let res: Resource<unknown>;
 

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -244,6 +244,36 @@ describe('validation status', () => {
       expect(f().invalid()).toBe(true);
     });
 
+    it('should support the simple async validator overload', async () => {
+      const f = form(
+        signal('VALID'),
+        (p) => {
+          validateAsync(p, async ({value}) => {
+            return value() === 'VALID' ? null : [{kind: 'custom'}];
+          });
+        },
+        {injector},
+      );
+
+      await Promise.resolve();
+      await appRef.whenStable();
+
+      expect(f().pending()).toBe(false);
+      expect(f().valid()).toBe(true);
+      expect(f().invalid()).toBe(false);
+
+      f().value.set('INVALID');
+
+      // Trigger change detection to notify resource signal dependencies
+      appRef.tick();
+      await Promise.resolve();
+      await appRef.whenStable();
+
+      expect(f().pending()).toBe(false);
+      expect(f().valid()).toBe(false);
+      expect(f().invalid()).toBe(true);
+    });
+
     it('should affect validity of targeted field', async () => {
       let res: Resource<unknown>;
 

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -136,6 +136,40 @@ describe('field directive', () => {
       });
       expect(component.model()).toEqual({x: 'a', y: 'c'});
     });
+
+    it('should support simple async validator functions with formField bindings', async () => {
+      @Component({
+        imports: [FormField],
+        template: `<input [formField]="f" />`,
+      })
+      class TestCmp {
+        readonly f = form(signal('VALID'), (p) => {
+          validateAsync(p, async ({value}) => {
+            return value() === 'VALID' ? null : [{kind: 'custom'}];
+          });
+        });
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const component = fixture.componentInstance;
+
+      await Promise.resolve();
+      await fixture.whenStable();
+
+      expect(component.f().pending()).toBe(false);
+      expect(component.f().valid()).toBe(true);
+
+      act(() => {
+        component.f().value.set('INVALID');
+        fixture.detectChanges();
+      });
+
+      await Promise.resolve();
+      await fixture.whenStable();
+
+      expect(component.f().pending()).toBe(false);
+      expect(component.f().invalid()).toBe(true);
+    });
   });
 
   describe('host directive mapping', () => {

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -59,6 +59,7 @@ import {
   required,
   requiredError,
   validateAsync,
+  validatePromise,
   transformedValue,
   type DisabledReason,
   type Field,
@@ -135,6 +136,39 @@ describe('field directive', () => {
         input.dispatchEvent(new Event('input'));
       });
       expect(component.model()).toEqual({x: 'a', y: 'c'});
+    });
+
+    it('should support promise-based async validator functions with formField bindings', async () => {
+      @Component({
+        imports: [FormField],
+        template: `<input [formField]="f" />`,
+      })
+      class TestCmp {
+        readonly f = form(signal('VALID'), (p) => {
+          validatePromise(p, async ({value}) => {
+            return value() === 'VALID' ? null : [{kind: 'custom'}];
+          });
+        });
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const component = fixture.componentInstance;
+
+      await Promise.resolve();
+      await fixture.whenStable();
+
+      expect(component.f().pending()).toBe(false);
+      expect(component.f().valid()).toBe(true);
+
+      act(() => {
+        component.f().value.set('INVALID');
+      });
+
+      await Promise.resolve();
+      await fixture.whenStable();
+
+      expect(component.f().pending()).toBe(false);
+      expect(component.f().invalid()).toBe(true);
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

- `validateAsync()`lacked full overload definitions to support lightweight async validation logic (similar to synchronous `validate()`

Issue Number: #69779 

## What is the new behavior?

- Adds public API overloads and implementation logic for `validatePromise()`:
   - Accepts a lightweight async validator function alongside an optional configuration object (`debounce`, `when`, `onError`)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- Supports parameter `debouncing` via DebounceTimer and signal chaining for reactive updates
