### PR TITLE
feat(router): add options to convertToParamMap

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -206,7 +206,7 @@ export interface ComponentInputBindingOptions {
 }
 
 // @public
-export function convertToParamMap(params: Params): ParamMap;
+export function convertToParamMap(params: Params, options?: ParamMapOptions): ParamMap;
 
 // @public
 export function createUrlTreeFromSnapshot(relativeTo: ActivatedRouteSnapshot, commands: readonly any[], queryParams?: Params | null, fragment?: string | null, urlSerializer?: DefaultUrlSerializer): UrlTree;

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -72,32 +72,74 @@ export interface ParamMap {
   readonly keys: string[];
 }
 
+/**
+ * Options to configure the behavior of a `ParamMap`.
+ * @see {@link convertToParamMap}
+ * @see {@link ParamMap}
+ *
+ * @publicApi
+ */
+export type ParamMapOptions = {
+  /** Whether to perform case-insensitive matching for parameter names. */
+  caseInsensitive?: boolean;
+};
+
+const DEFAULT_PARAM_MAP_OPTIONS: ParamMapOptions = Object.freeze({
+  caseInsensitive: false,
+});
+
 class ParamsAsMap implements ParamMap {
   private params: Params;
+  private readonly options: ParamMapOptions;
 
-  constructor(params: Params) {
-    this.params = params || {};
+  constructor(params: Params, options?: ParamMapOptions) {
+    const rawParams = params || {};
+    this.options = {
+      ...DEFAULT_PARAM_MAP_OPTIONS,
+      ...(options || {}),
+    };
+
+    // Normalize the parameter keys based on the caseInsensitive option.
+    if (this.options.caseInsensitive) {
+      this.params = {};
+      for (const key of Object.keys(rawParams)) {
+        this.params[key.toLowerCase()] = rawParams[key];
+      }
+    } else {
+      this.params = rawParams;
+    }
+  }
+
+  private getKey(name: string): string | null {
+    // Guard against invalid lookup keys (null, undefined, non-strings, or empty strings)
+    if (typeof name !== 'string' || name.trim() === '') {
+      return null;
+    }
+
+    const key = this.options.caseInsensitive ? name.toLowerCase() : name;
+
+    return Object.prototype.hasOwnProperty.call(this.params, key) ? key : null;
   }
 
   has(name: string): boolean {
-    return Object.prototype.hasOwnProperty.call(this.params, name);
+    return this.getKey(name) !== null;
   }
 
   get(name: string): string | null {
-    if (this.has(name)) {
-      const v = this.params[name];
+    const key = this.getKey(name);
+    if (key !== null) {
+      const v = this.params[key];
       return Array.isArray(v) ? v[0] : v;
     }
-
     return null;
   }
 
   getAll(name: string): string[] {
-    if (this.has(name)) {
-      const v = this.params[name];
+    const key = this.getKey(name);
+    if (key !== null) {
+      const v = this.params[key];
       return Array.isArray(v) ? v : [v];
     }
-
     return [];
   }
 
@@ -109,12 +151,14 @@ class ParamsAsMap implements ParamMap {
 /**
  * Converts a `Params` instance to a `ParamMap`.
  * @param params The instance to convert.
+ * @param options Optional, Options to configure the conversion.
+ * - `caseInsensitive`: Whether to perform case-insensitive matching for parameter names. Defaults to `false`.
  * @returns The new map instance.
  *
  * @publicApi
  */
-export function convertToParamMap(params: Params): ParamMap {
-  return new ParamsAsMap(params);
+export function convertToParamMap(params: Params, options?: ParamMapOptions): ParamMap {
+  return new ParamsAsMap(params, options);
 }
 
 function matchParts(

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -84,18 +84,17 @@ export type ParamMapOptions = {
   caseInsensitive?: boolean;
 };
 
-const DEFAULT_PARAM_MAP_OPTIONS: ParamMapOptions = Object.freeze({
-  caseInsensitive: false,
-});
-
 class ParamsAsMap implements ParamMap {
   private params: Params;
   private readonly options: ParamMapOptions;
+  private static readonly DEFAULT_OPTIONS: ParamMapOptions = {
+    caseInsensitive: false,
+  };
 
   constructor(params: Params, options?: ParamMapOptions) {
     const rawParams = params || {};
     this.options = {
-      ...DEFAULT_PARAM_MAP_OPTIONS,
+      ...ParamsAsMap.DEFAULT_OPTIONS,
       ...(options || {}),
     };
 
@@ -111,7 +110,7 @@ class ParamsAsMap implements ParamMap {
   }
 
   private getKey(name: string): string | null {
-    // Guard against invalid lookup keys (null, undefined, non-strings, or empty strings)
+    // Guard against invalid lookup keys (null, undefined, non-strings, or empty strings).
     if (typeof name !== 'string' || name.trim() === '') {
       return null;
     }

--- a/packages/router/test/shared.spec.ts
+++ b/packages/router/test/shared.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {convertToParamMap, ParamMap, Params} from '../src/shared';
+import {convertToParamMap, ParamMap, ParamMapOptions, Params} from '../src/shared';
 
 describe('ParamsMap', () => {
   it('should returns whether a parameter is present', () => {
@@ -50,5 +50,50 @@ describe('ParamsMap', () => {
     const paramMaps: ParamMap = convertToParamMap(objectToMap);
     expect(() => paramMaps.get('single')).not.toThrow();
     expect(paramMaps.get('single')).toEqual('s');
+  });
+
+  describe('options configuration', () => {
+    it('should use default options when options parameter is omitted', () => {
+      const map = convertToParamMap({Single: 's'});
+      expect(map.get('Single')).toEqual('s');
+      expect(map.get('single')).toEqual(null);
+    });
+
+    it('should handle undefined or null options gracefully', () => {
+      const mapWithUndefined = convertToParamMap({key: 'val'}, undefined);
+      const mapWithNull = convertToParamMap({key: 'val'}, null as unknown as ParamMapOptions);
+
+      expect(mapWithUndefined.get('key')).toEqual('val');
+      expect(mapWithNull.get('key')).toEqual('val');
+    });
+
+    describe('case sensitivity', () => {
+      it('should be case-sensitive by default', () => {
+        const map = convertToParamMap({ParamKey: 'value'});
+
+        expect(map.has('ParamKey')).toEqual(true);
+        expect(map.has('paramkey')).toEqual(false);
+        expect(map.get('paramkey')).toEqual(null);
+      });
+
+      it('should respect explicit caseInsensitive: false', () => {
+        const map = convertToParamMap({ParamKey: 'value'}, {caseInsensitive: false});
+
+        expect(map.has('ParamKey')).toEqual(true);
+        expect(map.has('paramkey')).toEqual(false);
+      });
+
+      it('should handle case-insensitive lookups across all getter methods when enabled', () => {
+        const map = convertToParamMap(
+          {SingleKey: 'one', ArrayKey: ['a', 'b']},
+          {caseInsensitive: true},
+        );
+
+        expect(map.has('singlekey')).toEqual(true);
+        expect(map.get('SINGLEKEY')).toEqual('one');
+        expect(map.getAll('ARRAYKEY')).toEqual(['a', 'b']);
+        expect(map.keys).toEqual(['singlekey', 'arraykey']);
+      });
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is currently no way to configure options like case-insensitive key lookups without manually transforming the input parameters object.

Issue Number: #55968

## What is the new behavior?

`convertToParamMap` now accepts an optional second argument `options?: ParamMapOptions`:

- Introduces `ParamMapOptions` interface with a `caseInsensitive?: boolean` property.
- When `caseInsensitive: true` is provided, parameter key lookups (`get`, `getAll`, `has`, `keys`) behave in a case-insensitive manner.
- Default behavior remains backwards compatible and case-sensitive when options are omitted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information