### PR TITLE
fix(docs-infra): contain scroll within version picker dropdown

### DIFF
--- a/adev/src/app/core/layout/navigation/mini-menu.scss
+++ b/adev/src/app/core/layout/navigation/mini-menu.scss
@@ -108,6 +108,7 @@
 
 .adev-version-picker {
   overflow-y: auto;
+  overscroll-behavior: contain;
   max-height: 70dvh;
   margin-inline-start: 10px;
 


### PR DESCRIPTION
Scrolling to the top or bottom of the version picker's dropdown list let the scroll event chain into the page behind it, causing the whole app to scroll. 

Before:

https://github.com/user-attachments/assets/ed6cd118-77bd-4f6f-96c0-7a2cdb17a7cc

After:

https://github.com/user-attachments/assets/b3d91b6a-d951-4472-86a3-01efad3a057e



