### PR TITLE
fix(core): ensure i18n_util hasOwnProperty checks are safe for property renaming

### DIFF
--- a/packages/core/src/render3/i18n/i18n_util.ts
+++ b/packages/core/src/render3/i18n/i18n_util.ts
@@ -12,6 +12,7 @@ import {
   assertGreaterThanOrEqual,
   throwError,
 } from '../../util/assert';
+import {getClosureSafeProperty} from '../../util/property';
 import {assertTIcu, assertTNode} from '../assert';
 import {IcuCreateOpCode, TIcu} from '../interfaces/i18n';
 import {TIcuContainerNode, TNode, TNodeType} from '../interfaces/node';
@@ -22,6 +23,13 @@ import {getInsertInFrontOfRNodeWithI18n, processI18nInsertBefore} from '../node_
 import {createTNodeAtIndex} from '../tnode_manipulation';
 
 import {addTNodeAndUpdateInsertBeforeIndex} from './i18n_insert_before_index';
+
+const CURRENT_CASE_LVIEW_INDEX = getClosureSafeProperty({
+  currentCaseLViewIndex: getClosureSafeProperty,
+});
+const TVIEW = getClosureSafeProperty({
+  tView: getClosureSafeProperty,
+});
 
 /**
  * Retrieve `TIcu` at a given `index`.
@@ -41,15 +49,15 @@ export function getTIcu(tView: TView, index: number): TIcu | null {
   if (value === null || typeof value === 'string') return null;
   if (
     ngDevMode &&
-    !(value.hasOwnProperty('tView') || value.hasOwnProperty('currentCaseLViewIndex'))
+    !(value.hasOwnProperty(TVIEW) || value.hasOwnProperty(CURRENT_CASE_LVIEW_INDEX))
   ) {
     throwError("We expect to get 'null'|'TIcu'|'TIcuContainer', but got: " + value);
   }
-  // Here the `value.hasOwnProperty('currentCaseLViewIndex')` is a polymorphic read as it can be
+  // Here the `value.hasOwnProperty(CURRENT_CASE_LVIEW_INDEX)` is a polymorphic read as it can be
   // either TIcu or TIcuContainerNode. This is not ideal, but we still think it is OK because it
   // will be just two cases which fits into the browser inline cache (inline cache can take up to
   // 4)
-  const tIcu = value.hasOwnProperty('currentCaseLViewIndex')
+  const tIcu = value.hasOwnProperty(CURRENT_CASE_LVIEW_INDEX)
     ? (value as TIcu)
     : (value as TIcuContainerNode).value;
   ngDevMode && assertTIcu(tIcu);
@@ -74,7 +82,7 @@ export function setTIcu(tView: TView, index: number, tIcu: TIcu): void {
   const tNode = tView.data[index] as null | TIcuContainerNode;
   ngDevMode &&
     assertEqual(
-      tNode === null || tNode.hasOwnProperty('tView'),
+      tNode === null || tNode.hasOwnProperty(TVIEW),
       true,
       "We expect to get 'null'|'TIcuContainer'",
     );


### PR DESCRIPTION
`getTIcu` and `setTIcu` performed `hasOwnProperty` checks with string literals (`'currentCaseLViewIndex'` and `'tView'`). Under Closure Compiler property renaming optimizations, these properties are minified but the string literals are not, causing property lookups and type discriminations to fail.

This commit defines closure-safe property constants using `getClosureSafeProperty` so the property names are renamed consistently.