### PR TITLE
fix(router): bind route data to host directive inputs

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -150,6 +150,7 @@ export {
   setInjectorProfilerContext as ɵsetInjectorProfilerContext,
 } from './render3/debug/injector_profiler';
 export {getComponentDef as ɵgetComponentDef} from './render3/def_getters';
+export {getComponentInputNames as ɵgetComponentInputNames} from './render3/component_ref';
 export {getDocument as ɵgetDocument} from './render3/interfaces/document';
 export {
   SHARED_STYLES_HOST as ɵSHARED_STYLES_HOST,

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -624,6 +624,22 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
   override onDestroy(callback: () => void): void {
     this.hostView.onDestroy(callback);
   }
+
+  /** Returns the input names that can be passed to `setInput`. */
+  getInputNames(): ReadonlySet<string> {
+    const inputNames = new Set(Object.keys(this._tNode.inputs ?? {}));
+    for (const name of Object.keys(this._tNode.hostDirectiveInputs ?? {})) {
+      inputNames.add(name);
+    }
+    return inputNames;
+  }
+}
+
+/** Returns the input names that can be set on a component reference. */
+export function getComponentInputNames(
+  componentRef: AbstractComponentRef<unknown>,
+): ReadonlySet<string> {
+  return (componentRef as ComponentRef<unknown>).getInputNames();
 }
 
 /** Projects the `projectableNodes` that were specified when creating a root component. */

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -21,7 +21,7 @@ import {
   OnDestroy,
   OnInit,
   Output,
-  reflectComponentType,
+  ɵgetComponentInputNames as getComponentInputNames,
   ɵRuntimeError as RuntimeError,
   Signal,
   SimpleChanges,
@@ -509,12 +509,6 @@ export class RoutedComponentInputBinder {
           return;
         }
 
-        const mirror = reflectComponentType(activatedRoute.component);
-        if (!mirror) {
-          this.unsubscribeFromRouteData(outlet);
-          return;
-        }
-
         let seenKeys = this.outletSeenKeys.get(outlet);
         if (!seenKeys) {
           seenKeys = new Set<string>();
@@ -527,7 +521,7 @@ export class RoutedComponentInputBinder {
 
         const behavior = this.options.unmatchedInputBehavior ?? 'alwaysUndefined';
 
-        for (const {templateName} of mirror.inputs) {
+        for (const templateName of getComponentInputNames(outlet.activatedComponentRef)) {
           const value = data[templateName];
           if (value !== undefined || behavior === 'alwaysUndefined' || seenKeys.has(templateName)) {
             outlet.activatedComponentRef.setInput(templateName, value);

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, NgForOf} from '@angular/common';
-import {Component, inject, Input, Type, NgModule, signal} from '@angular/core';
+import {Component, Directive, inject, Input, Type, NgModule, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   provideRouter,
@@ -300,6 +300,47 @@ describe('component input binding', () => {
     const instance = await harness.navigateByUrl('/', MyComponent);
     expect(instance.resolveA).toEqual('My resolved data');
     expect(instance.dataA).toEqual('My static data');
+  });
+
+  it('sets component and host directive inputs from static data', async () => {
+    @Directive()
+    class HostDirective {
+      @Input('hostDirectiveInput') value?: string;
+    }
+
+    @Component({
+      template: '',
+      hostDirectives: [
+        {directive: HostDirective, inputs: ['hostDirectiveInput: exposedHostDirectiveInput']},
+      ],
+    })
+    class MyComponent {
+      @Input() componentInput?: string;
+      readonly hostDirective = inject(HostDirective);
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [
+            {
+              path: '**',
+              component: MyComponent,
+              data: {
+                componentInput: 'Component input value',
+                exposedHostDirectiveInput: 'Host directive input value',
+              },
+            },
+          ],
+          withComponentInputBinding(),
+        ),
+      ],
+    });
+    const harness = await RouterTestingHarness.create();
+
+    const instance = await harness.navigateByUrl('/', MyComponent);
+    expect(instance.componentInput).toEqual('Component input value');
+    expect(instance.hostDirective.value).toEqual('Host directive input value');
   });
 
   it('sets component inputs from path params', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (not applicable; this changes no public API or documented behavior)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When the router is configured with `withComponentInputBinding()`, route values are bound to inputs declared directly by the activated component. Inputs explicitly exposed by a host directive are skipped, even though they are accepted by `ComponentRef.setInput()`.

Issue Number: #60211

## What is the new behavior?

The route input binder reads the input names accepted by the activated `ComponentRef`, including aliased host directive inputs that the component explicitly exposes. Component inputs and exposed host directive inputs therefore receive route values consistently. Unexposed host directive inputs remain private, and the existing route-data precedence and unmatched-input behavior are unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated with:

- `corepack pnpm bazel test //packages/router/test:test`
- `corepack pnpm bazel test //packages/core/test/acceptance:acceptance //packages/router/testing/test:test //packages/core/test/bundling/router:symbol_test`
- `corepack pnpm bazel test //packages/core:core_api //packages/router:router_api`
- `corepack pnpm lint`
- Angular repository formatting checks and `git diff --check`

AI assistance: OpenAI Codex assisted with issue investigation, implementation, test creation, and validation.
