### PR TITLE
fix(router): avoid view transitions when the user agent provides one

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -429,6 +429,7 @@ export const LOCATION_INITIALIZED: InjectionToken<Promise<any>>;
 
 // @public
 export interface LocationChangeEvent {
+    hasUAVisualTransition?: boolean;
     // (undocumented)
     state: any;
     // (undocumented)
@@ -929,6 +930,7 @@ export enum Plural {
 
 // @public (undocumented)
 interface PopStateEvent_2 {
+    hasUAVisualTransition?: boolean;
     // (undocumented)
     pop?: boolean;
     // (undocumented)

--- a/integration/legacy-animations/size.json
+++ b/integration/legacy-animations/size.json
@@ -1,5 +1,5 @@
 {
-  "dist/main.js": 153915,
+  "dist/main.js": 158918,
   "dist/polyfills.js": 35726,
   "dist/open-close.component-[hash].js": 1190
 }

--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -18,6 +18,8 @@ export interface PopStateEvent {
   state?: any;
   type?: string;
   url?: string;
+  /** Whether the user agent performed a visual transition for this navigation. */
+  hasUAVisualTransition?: boolean;
 }
 
 /**
@@ -80,6 +82,7 @@ export class Location implements OnDestroy {
         'pop': true,
         'state': ev.state,
         'type': ev.type,
+        'hasUAVisualTransition': ev.hasUAVisualTransition,
       });
     });
   }

--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -77,13 +77,16 @@ export class Location implements OnDestroy {
     // https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#parameters
     this._basePath = _stripOrigin(stripTrailingSlash(_stripIndexHtml(baseHref)));
     this._locationStrategy.onPopState((ev) => {
-      this._subject.next({
+      const popStateEvent: PopStateEvent = {
         'url': this.path(true),
         'pop': true,
         'state': ev.state,
         'type': ev.type,
-        'hasUAVisualTransition': ev.hasUAVisualTransition,
-      });
+      };
+      if (ev.hasUAVisualTransition) {
+        popStateEvent.hasUAVisualTransition = true;
+      }
+      this._subject.next(popStateEvent);
     });
   }
 

--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -85,6 +85,8 @@ export const LOCATION_INITIALIZED = new InjectionToken<Promise<any>>(
 export interface LocationChangeEvent {
   type: string;
   state: any;
+  /** Whether the user agent performed a visual transition for this navigation. */
+  hasUAVisualTransition?: boolean;
 }
 
 /**

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -219,6 +219,23 @@ describe('Location Class', () => {
 
       expect(notificationCount).toBe(1);
     });
+
+    it('should preserve whether the user agent performed a visual transition', () => {
+      let hasUAVisualTransition: boolean | undefined;
+      location.subscribe((event) => {
+        hasUAVisualTransition = event.hasUAVisualTransition;
+      });
+
+      locationStrategy.internalPath = '/test';
+      (locationStrategy as any)._subject.next({
+        newUrl: '/test',
+        pop: true,
+        type: 'popstate',
+        hasUAVisualTransition: true,
+      } as any);
+
+      expect(hasUAVisualTransition).toBeTrue();
+    });
   });
 
   describe('location.normalize(url) should return only route', () => {

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -236,6 +236,17 @@ describe('Location Class', () => {
 
       expect(hasUAVisualTransition).toBeTrue();
     });
+
+    it('should not add a UA visual transition when the platform event does not provide one', () => {
+      let hasOwnUAVisualTransition: boolean | undefined;
+      location.subscribe((event) => {
+        hasOwnUAVisualTransition = Object.hasOwn(event, 'hasUAVisualTransition');
+      });
+
+      locationStrategy.simulatePopState('/test');
+
+      expect(hasOwnUAVisualTransition).toBeFalse();
+    });
   });
 
   describe('location.normalize(url) should return only route', () => {

--- a/packages/core/primitives/dom-navigation/src/navigation_types.ts
+++ b/packages/core/primitives/dom-navigation/src/navigation_types.ts
@@ -146,6 +146,7 @@ export declare class NavigateEvent extends Event {
   readonly canIntercept: boolean;
   readonly userInitiated: boolean;
   readonly hashChange: boolean;
+  readonly hasUAVisualTransition: boolean;
   readonly destination: NavigationDestination;
   readonly signal: AbortSignal;
   readonly formData: FormData | null;
@@ -161,6 +162,7 @@ export interface NavigateEventInit extends EventInit {
   canIntercept?: boolean;
   userInitiated?: boolean;
   hashChange?: boolean;
+  hasUAVisualTransition?: boolean;
   destination: NavigationDestination;
   signal: AbortSignal;
   formData?: FormData | null;

--- a/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
+++ b/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
@@ -540,6 +540,7 @@ export class FakeNavigation implements Navigation {
     // Happens as part of "updating the document" steps https://whatpr.org/html/10919/browsing-the-web.html#updating-the-document
     const popStateEvent = createPopStateEvent({
       state: navigateEvent.destination.getHistoryState(),
+      hasUAVisualTransition: navigateEvent.hasUAVisualTransition,
     });
     this._window.dispatchEvent(popStateEvent);
     if (navigateEvent.hashChange) {
@@ -810,6 +811,7 @@ function dispatchNavigateEvent({
   canIntercept,
   userInitiated,
   hashChange,
+  hasUAVisualTransition = false,
   navigationType,
   destination,
   info,
@@ -820,6 +822,7 @@ function dispatchNavigateEvent({
   canIntercept: boolean;
   userInitiated: boolean;
   hashChange: boolean;
+  hasUAVisualTransition?: boolean;
   navigationType: NavigationType;
   destination: FakeNavigationDestination;
   info: unknown;
@@ -838,6 +841,7 @@ function dispatchNavigateEvent({
   event.canIntercept = canIntercept;
   event.userInitiated = userInitiated;
   event.hashChange = hashChange;
+  event.hasUAVisualTransition = hasUAVisualTransition;
   event.signal = eventAbortController.signal;
   event.abortController = eventAbortController;
   event.info = info;
@@ -1162,12 +1166,19 @@ function createFakeNavigationCurrentEntryChangeEvent({
  * Create a fake equivalent of `PopStateEvent`. This does not use a class
  * because ES5 transpiled JavaScript cannot extend native Event.
  */
-function createPopStateEvent({state}: {state: unknown}) {
+function createPopStateEvent({
+  state,
+  hasUAVisualTransition,
+}: {
+  state: unknown;
+  hasUAVisualTransition: boolean;
+}) {
   const event = new Event('popstate', {
     bubbles: false,
     cancelable: false,
   }) as {-readonly [P in keyof PopStateEvent]: PopStateEvent[P]};
   event.state = state;
+  event.hasUAVisualTransition = hasUAVisualTransition;
   return event as PopStateEvent;
 }
 

--- a/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
+++ b/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
@@ -811,7 +811,7 @@ function dispatchNavigateEvent({
   canIntercept,
   userInitiated,
   hashChange,
-  hasUAVisualTransition = false,
+  hasUAVisualTransition,
   navigationType,
   destination,
   info,
@@ -841,7 +841,9 @@ function dispatchNavigateEvent({
   event.canIntercept = canIntercept;
   event.userInitiated = userInitiated;
   event.hashChange = hashChange;
-  event.hasUAVisualTransition = hasUAVisualTransition;
+  if (hasUAVisualTransition) {
+    event.hasUAVisualTransition = true;
+  }
   event.signal = eventAbortController.signal;
   event.abortController = eventAbortController;
   event.info = info;
@@ -1171,14 +1173,16 @@ function createPopStateEvent({
   hasUAVisualTransition,
 }: {
   state: unknown;
-  hasUAVisualTransition: boolean;
+  hasUAVisualTransition?: boolean;
 }) {
   const event = new Event('popstate', {
     bubbles: false,
     cancelable: false,
   }) as {-readonly [P in keyof PopStateEvent]: PopStateEvent[P]};
   event.state = state;
-  event.hasUAVisualTransition = hasUAVisualTransition;
+  if (hasUAVisualTransition) {
+    event.hasUAVisualTransition = true;
+  }
   return event as PopStateEvent;
 }
 

--- a/packages/core/primitives/dom-navigation/testing/test/fake_platform_navigation.spec.ts
+++ b/packages/core/primitives/dom-navigation/testing/test/fake_platform_navigation.spec.ts
@@ -156,7 +156,6 @@ describe('navigation', () => {
         jasmine.objectContaining({
           canIntercept: true,
           hashChange: false,
-          hasUAVisualTransition: false,
           info: undefined,
           navigationType: 'push',
           userInitiated: false,
@@ -170,6 +169,7 @@ describe('navigation', () => {
           }),
         }),
       );
+      expect(Object.hasOwn(navigateEvent, 'hasUAVisualTransition')).toBeFalse();
       expect(navigateEvent.destination.getState()).toBeUndefined();
       const committedEntry = await committed;
       expect(committedEntry).toEqual(
@@ -959,7 +959,7 @@ describe('navigation', () => {
       expect(locals.popStateEvents.length).toBe(1);
       const popStateEvent = locals.popStateEvents[0];
       expect(popStateEvent.state).toBeNull();
-      expect(popStateEvent.hasUAVisualTransition).toBeFalse();
+      expect(Object.hasOwn(popStateEvent, 'hasUAVisualTransition')).toBeFalse();
       expect(locals.navigation.canGoBack).toBeTrue();
       expect(locals.navigation.canGoForward).toBeTrue();
       const finishedEntry = await finished;

--- a/packages/core/primitives/dom-navigation/testing/test/fake_platform_navigation.spec.ts
+++ b/packages/core/primitives/dom-navigation/testing/test/fake_platform_navigation.spec.ts
@@ -156,6 +156,7 @@ describe('navigation', () => {
         jasmine.objectContaining({
           canIntercept: true,
           hashChange: false,
+          hasUAVisualTransition: false,
           info: undefined,
           navigationType: 'push',
           userInitiated: false,
@@ -958,6 +959,7 @@ describe('navigation', () => {
       expect(locals.popStateEvents.length).toBe(1);
       const popStateEvent = locals.popStateEvents[0];
       expect(popStateEvent.state).toBeNull();
+      expect(popStateEvent.hasUAVisualTransition).toBeFalse();
       expect(locals.navigation.canGoBack).toBeTrue();
       expect(locals.navigation.canGoForward).toBeTrue();
       const finishedEntry = await finished;
@@ -966,6 +968,18 @@ describe('navigation', () => {
       expect(locals.navigateEvents.length).toBe(1);
       expect(locals.navigationCurrentEntryChangeEvents.length).toBe(1);
       expect(locals.popStateEvents.length).toBe(1);
+    });
+
+    it('propagates a UA visual transition to the popstate event', async () => {
+      await setUpEntries();
+      locals.setExtraNavigateCallback((event) => {
+        Object.defineProperty(event, 'hasUAVisualTransition', {value: true});
+      });
+
+      await locals.navigation.back().finished;
+
+      expect(locals.navigateEvents[0].hasUAVisualTransition).toBeTrue();
+      expect(locals.popStateEvents[0].hasUAVisualTransition).toBeTrue();
     });
 
     it('traverses forward', async () => {

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -317,6 +317,7 @@ export interface NavigationTransition {
   urlAfterRedirects?: UrlTree;
   rawUrl: UrlTree;
   extras: NavigationExtras;
+  hasUAVisualTransition: boolean;
   resolve: (value: boolean | PromiseLike<boolean>) => void;
   reject: (reason?: any) => void;
   promise: Promise<boolean>;
@@ -413,6 +414,7 @@ export class NavigationTransitions {
       | 'currentRawUrl'
       | 'rawUrl'
       | 'extras'
+      | 'hasUAVisualTransition'
       | 'resolve'
       | 'reject'
       | 'promise'
@@ -776,6 +778,7 @@ export class NavigationTransitions {
               this.environmentInjector,
               currentSnapshot.root,
               targetSnapshot!.root,
+              overallTransitionState.hasUAVisualTransition,
             );
 
             // If view transitions are enabled, block the navigation until the view

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -317,7 +317,7 @@ export interface NavigationTransition {
   urlAfterRedirects?: UrlTree;
   rawUrl: UrlTree;
   extras: NavigationExtras;
-  hasUAVisualTransition: boolean;
+  hasUAVisualTransition?: boolean;
   resolve: (value: boolean | PromiseLike<boolean>) => void;
   reject: (reason?: any) => void;
   promise: Promise<boolean>;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -233,11 +233,18 @@ export class Router {
               ...opts,
             };
 
-            this.scheduleNavigation(mergedTree, IMPERATIVE_NAVIGATION, null, extras, {
-              resolve: currentTransition.resolve,
-              reject: currentTransition.reject,
-              promise: currentTransition.promise,
-            });
+            this.scheduleNavigation(
+              mergedTree,
+              IMPERATIVE_NAVIGATION,
+              null,
+              extras,
+              currentTransition.hasUAVisualTransition,
+              {
+                resolve: currentTransition.resolve,
+                reject: currentTransition.reject,
+                promise: currentTransition.promise,
+              },
+            );
           }
         }
 
@@ -288,8 +295,8 @@ export class Router {
     // run into ngZone
     this.nonRouterCurrentEntryChangeSubscription ??=
       this.stateManager.registerNonRouterCurrentEntryChangeListener(
-        (url, state, source, extras) => {
-          this.navigateToSyncWithBrowser(url, source, state, extras);
+        (url, state, source, extras, hasUAVisualTransition) => {
+          this.navigateToSyncWithBrowser(url, source, state, extras, hasUAVisualTransition);
         },
       );
   }
@@ -306,6 +313,7 @@ export class Router {
     source: NavigationTrigger,
     state: RestoredState | null | undefined,
     extras: NavigationExtras,
+    hasUAVisualTransition: boolean = false,
   ) {
     // TODO: restoredState should always include the entire state, regardless
     // of navigationId. This requires a breaking change to update the type on
@@ -338,12 +346,14 @@ export class Router {
     }
 
     const urlTree = this.parseUrl(routerUrl);
-    this.scheduleNavigation(urlTree, source, restoredState, extras).catch((e) => {
-      if (this.disposed) {
-        return;
-      }
-      this.injector.get(ɵINTERNAL_APPLICATION_ERROR_HANDLER)(e);
-    });
+    this.scheduleNavigation(urlTree, source, restoredState, extras, hasUAVisualTransition).catch(
+      (e) => {
+        if (this.disposed) {
+          return;
+        }
+        this.injector.get(ɵINTERNAL_APPLICATION_ERROR_HANDLER)(e);
+      },
+    );
   }
 
   /** The current URL. */
@@ -657,6 +667,7 @@ export class Router {
     source: NavigationTrigger,
     restoredState: RestoredState | null,
     extras: NavigationExtras,
+    hasUAVisualTransition: boolean = false,
     priorPromise?: {
       resolve: (result: boolean | PromiseLike<boolean>) => void;
       reject: (reason?: any) => void;
@@ -696,6 +707,7 @@ export class Router {
       currentRawUrl: this.currentUrlTree,
       rawUrl,
       extras,
+      hasUAVisualTransition,
       resolve: resolve!,
       reject: reject!,
       promise,

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -313,7 +313,7 @@ export class Router {
     source: NavigationTrigger,
     state: RestoredState | null | undefined,
     extras: NavigationExtras,
-    hasUAVisualTransition: boolean = false,
+    hasUAVisualTransition?: boolean,
   ) {
     // TODO: restoredState should always include the entire state, regardless
     // of navigationId. This requires a breaking change to update the type on
@@ -667,7 +667,7 @@ export class Router {
     source: NavigationTrigger,
     restoredState: RestoredState | null,
     extras: NavigationExtras,
-    hasUAVisualTransition: boolean = false,
+    hasUAVisualTransition?: boolean,
     priorPromise?: {
       resolve: (result: boolean | PromiseLike<boolean>) => void;
       reject: (reason?: any) => void;

--- a/packages/router/src/statemanager/navigation_state_manager.ts
+++ b/packages/router/src/statemanager/navigation_state_manager.ts
@@ -101,7 +101,7 @@ export class NavigationStateManager extends StateManager {
   private nonRouterCurrentEntryChangeSubject = new Subject<{
     path: string;
     state: RestoredState | null | undefined;
-    hasUAVisualTransition: boolean;
+    hasUAVisualTransition?: boolean;
   }>();
 
   nonRouterEntryChangeListener?: SubscriptionLike;
@@ -131,7 +131,7 @@ export class NavigationStateManager extends StateManager {
       state: RestoredState | null | undefined,
       trigger: NavigationTrigger,
       extras: NavigationExtras,
-      hasUAVisualTransition: boolean,
+      hasUAVisualTransition?: boolean,
     ) => void,
   ): SubscriptionLike {
     this.activeHistoryEntry = this.navigation.currentEntry!;
@@ -544,7 +544,7 @@ export class NavigationStateManager extends StateManager {
     this.nonRouterCurrentEntryChangeSubject.next({
       path,
       state,
-      hasUAVisualTransition: event.hasUAVisualTransition === true,
+      hasUAVisualTransition: event.hasUAVisualTransition,
     });
   }
 

--- a/packages/router/src/statemanager/navigation_state_manager.ts
+++ b/packages/router/src/statemanager/navigation_state_manager.ts
@@ -101,6 +101,7 @@ export class NavigationStateManager extends StateManager {
   private nonRouterCurrentEntryChangeSubject = new Subject<{
     path: string;
     state: RestoredState | null | undefined;
+    hasUAVisualTransition: boolean;
   }>();
 
   nonRouterEntryChangeListener?: SubscriptionLike;
@@ -130,16 +131,18 @@ export class NavigationStateManager extends StateManager {
       state: RestoredState | null | undefined,
       trigger: NavigationTrigger,
       extras: NavigationExtras,
+      hasUAVisualTransition: boolean,
     ) => void,
   ): SubscriptionLike {
     this.activeHistoryEntry = this.navigation.currentEntry!;
     this.nonRouterEntryChangeListener = this.nonRouterCurrentEntryChangeSubject.subscribe(
-      ({path, state}) => {
+      ({path, state, hasUAVisualTransition}) => {
         listener(
           path,
           state,
           'popstate',
           !this.precommitHandlerSupported ? {replaceUrl: true} : {},
+          hasUAVisualTransition,
         );
       },
     );
@@ -538,7 +541,11 @@ export class NavigationStateManager extends StateManager {
     // The url will always start with the appRootUrl because of the boundary check in handleNavigate.
     const path = event.destination.url.substring(this.appRootUrl.href.length - 1);
     const state = event.destination.getState() as RestoredState | null | undefined;
-    this.nonRouterCurrentEntryChangeSubject.next({path, state});
+    this.nonRouterCurrentEntryChangeSubject.next({
+      path,
+      state,
+      hasUAVisualTransition: event.hasUAVisualTransition === true,
+    });
   }
 
   private eventAndRouterDestinationsMatch(

--- a/packages/router/src/statemanager/state_manager.ts
+++ b/packages/router/src/statemanager/state_manager.ts
@@ -153,6 +153,7 @@ export abstract class StateManager {
       state: RestoredState | null | undefined,
       trigger: NavigationTrigger,
       extras: NavigationExtras,
+      hasUAVisualTransition: boolean,
     ) => void,
   ): SubscriptionLike;
 
@@ -194,17 +195,34 @@ export class HistoryStateManager extends StateManager {
       state: RestoredState | null | undefined,
       trigger: NavigationTrigger,
       extras: NavigationExtras,
+      hasUAVisualTransition: boolean,
     ) => void,
   ): SubscriptionLike {
     return this.location.subscribe((event) => {
       if (event['type'] === 'popstate') {
+        const hasUAVisualTransition = event.hasUAVisualTransition === true;
+        const invokeListener = () => {
+          listener(
+            event['url']!,
+            event.state as RestoredState | null | undefined,
+            'popstate',
+            {
+              replaceUrl: true,
+            },
+            hasUAVisualTransition,
+          );
+        };
+
+        if (hasUAVisualTransition) {
+          // A UA visual transition has already started. Schedule the navigation immediately so
+          // the browser can present the post-navigation DOM without an additional task.
+          invokeListener();
+          return;
+        }
+
         // The `setTimeout` was added in #12160 and is likely to support Angular/AngularJS
         // hybrid apps.
-        setTimeout(() => {
-          listener(event['url']!, event.state as RestoredState | null | undefined, 'popstate', {
-            replaceUrl: true,
-          });
-        });
+        setTimeout(invokeListener);
       }
     });
   }

--- a/packages/router/src/statemanager/state_manager.ts
+++ b/packages/router/src/statemanager/state_manager.ts
@@ -153,7 +153,7 @@ export abstract class StateManager {
       state: RestoredState | null | undefined,
       trigger: NavigationTrigger,
       extras: NavigationExtras,
-      hasUAVisualTransition: boolean,
+      hasUAVisualTransition?: boolean,
     ) => void,
   ): SubscriptionLike;
 
@@ -195,7 +195,7 @@ export class HistoryStateManager extends StateManager {
       state: RestoredState | null | undefined,
       trigger: NavigationTrigger,
       extras: NavigationExtras,
-      hasUAVisualTransition: boolean,
+      hasUAVisualTransition?: boolean,
     ) => void,
   ): SubscriptionLike {
     return this.location.subscribe((event) => {
@@ -210,7 +210,7 @@ export class HistoryStateManager extends StateManager {
             {
               replaceUrl: true,
             },
-            event.hasUAVisualTransition === true,
+            event.hasUAVisualTransition,
           );
         });
       }

--- a/packages/router/src/statemanager/state_manager.ts
+++ b/packages/router/src/statemanager/state_manager.ts
@@ -200,8 +200,9 @@ export class HistoryStateManager extends StateManager {
   ): SubscriptionLike {
     return this.location.subscribe((event) => {
       if (event['type'] === 'popstate') {
-        const hasUAVisualTransition = event.hasUAVisualTransition === true;
-        const invokeListener = () => {
+        // The `setTimeout` was added in #12160 and is likely to support Angular/AngularJS
+        // hybrid apps.
+        setTimeout(() => {
           listener(
             event['url']!,
             event.state as RestoredState | null | undefined,
@@ -209,20 +210,9 @@ export class HistoryStateManager extends StateManager {
             {
               replaceUrl: true,
             },
-            hasUAVisualTransition,
+            event.hasUAVisualTransition === true,
           );
-        };
-
-        if (hasUAVisualTransition) {
-          // A UA visual transition has already started. Schedule the navigation immediately so
-          // the browser can present the post-navigation DOM without an additional task.
-          invokeListener();
-          return;
-        }
-
-        // The `setTimeout` was added in #12160 and is likely to support Angular/AngularJS
-        // hybrid apps.
-        setTimeout(invokeListener);
+        });
       }
     });
   }

--- a/packages/router/src/utils/view_transition.ts
+++ b/packages/router/src/utils/view_transition.ts
@@ -72,7 +72,7 @@ export function createViewTransition(
   injector: Injector,
   from: ActivatedRouteSnapshot,
   to: ActivatedRouteSnapshot,
-  hasUAVisualTransition: boolean,
+  hasUAVisualTransition?: boolean,
 ): Promise<void> | undefined {
   const transitionOptions = injector.get(VIEW_TRANSITION_OPTIONS);
   const document = injector.get(DOCUMENT);

--- a/packages/router/src/utils/view_transition.ts
+++ b/packages/router/src/utils/view_transition.ts
@@ -63,17 +63,27 @@ export interface ViewTransitionInfo {
 
 /**
  * A helper function for using browser view transitions. This function skips the call to
- * `startViewTransition` if the browser does not support it.
+ * `startViewTransition` if the browser does not support it or has already provided a transition.
  *
- * @returns A Promise that resolves when the view transition callback begins.
+ * @returns A Promise that resolves when the view transition callback begins, or `undefined` when
+ * the user agent has already provided a transition and the navigation should continue immediately.
  */
 export function createViewTransition(
   injector: Injector,
   from: ActivatedRouteSnapshot,
   to: ActivatedRouteSnapshot,
-): Promise<void> {
+  hasUAVisualTransition: boolean,
+): Promise<void> | undefined {
   const transitionOptions = injector.get(VIEW_TRANSITION_OPTIONS);
   const document = injector.get(DOCUMENT);
+
+  if (hasUAVisualTransition) {
+    transitionOptions.skipNextTransition = false;
+    // The browser has already started presenting the navigation. Continuing synchronously gives it
+    // the earliest opportunity to display the post-navigation DOM.
+    return;
+  }
+
   if (!document.startViewTransition || transitionOptions.skipNextTransition) {
     transitionOptions.skipNextTransition = false;
     // The timing of `startViewTransition` is closer to a macrotask. It won't be called


### PR DESCRIPTION
Preserve hasUAVisualTransition through Location and the Router navigation pipeline. This prevents withViewTransitions from starting an author transition after the browser has already performed one, including across redirects and when using experimental platform navigation.

References:

* https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-popstateevent-hasuavisualtransition

* https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-hasuavisualtransition

* https://developer.chrome.com/docs/web-platform/view-transitions/same-document#integration_with_the_navigation_api_and_other_frameworks

Note:
> Note: By default Chrome on Android does not offer visual transitions for navigations invoked by a swipe gesture. This feature is in an experimental state and only available behind the chrome://flags/#back-forward-transitions feature flag.

Although the article mentions that swipe gestures are not a default behavior, this is not currently true in Chrome 150 on Android; the feature flag does not exist and it has become the default behavior.

## What is the current behavior?


https://github.com/user-attachments/assets/311b718d-35fd-4c8b-af80-f2cd2871c12a




## What is the new behavior?



https://github.com/user-attachments/assets/0ffdabc6-a68b-4f15-a201-7cdea66318de

