### PR TITLE
feat(router): add containsTree as public API

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -206,6 +206,9 @@ export interface ComponentInputBindingOptions {
 }
 
 // @public
+export function containsTree(container: UrlTree, containee: UrlTree, options?: Partial<IsActiveMatchOptions>): boolean;
+
+// @public
 export function convertToParamMap(params: Params): ParamMap;
 
 // @public

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -140,6 +140,7 @@ export {
   UrlSegmentGroup,
   UrlSerializer,
   UrlTree,
+  containsTree,
 } from './url_tree';
 export {
   mapToCanActivate,

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -123,22 +123,41 @@ export function isActive(
 ): Signal<boolean> {
   const urlTree = url instanceof UrlTree ? url : router.parseUrl(url);
   return computed(() =>
-    containsTree(router.lastSuccessfulNavigation()?.finalUrl ?? new UrlTree(), urlTree, {
-      ...subsetMatchOptions,
-      ...matchOptions,
-    }),
+    containsTree(
+      router.lastSuccessfulNavigation()?.finalUrl ?? new UrlTree(),
+      urlTree,
+      matchOptions,
+    ),
   );
 }
 
+/**
+ * Determines if a `UrlTree` is contained within another `UrlTree` based on the provided matching options.
+ *
+ * @param container The outer or reference `UrlTree`.
+ * @param containee The target `UrlTree` to test against the container.
+ * @param options Optional, matching options:
+ * - `paths`: Defines how to compare URL segments ('exact' or 'subset'). Defaults to 'subset'.
+ * - `matrixParams`: Defines how to compare matrix parameters ('exact', 'subset', or 'ignored'). Defaults to 'ignored'.
+ * - `queryParams`: Defines how to compare query parameters ('exact', 'subset', or 'ignored'). Defaults to 'subset'.
+ * - `fragment`: Defines how to compare URL fragments ('exact' or 'ignored'). Defaults to 'ignored'.
+ *
+ * @publicApi
+ */
 export function containsTree(
   container: UrlTree,
   containee: UrlTree,
-  options: IsActiveMatchOptions,
+  options?: Partial<IsActiveMatchOptions>,
 ): boolean {
+  const matchOptions: IsActiveMatchOptions = {
+    ...subsetMatchOptions,
+    ...(options || {}),
+  };
+
   return (
-    pathCompareMap[options.paths](container.root, containee.root, options.matrixParams) &&
-    paramCompareMap[options.queryParams](container.queryParams, containee.queryParams) &&
-    !(options.fragment === 'exact' && container.fragment !== containee.fragment)
+    pathCompareMap[matchOptions.paths](container.root, containee.root, matchOptions.matrixParams) &&
+    paramCompareMap[matchOptions.queryParams](container.queryParams, containee.queryParams) &&
+    !(matchOptions.fragment === 'exact' && container.fragment !== containee.fragment)
   );
 }
 

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -371,6 +371,61 @@ describe('UrlTree', () => {
           },
         );
       });
+
+      describe('options', () => {
+        it('should default to subset matching when options are omitted', () => {
+          const t1 = serializer.parse('/one/two/three');
+          const t2 = serializer.parse('/one/two');
+          expect(containsTree(t1, t2)).toBe(true);
+        });
+
+        it('should perform exact matching when passing exactMatchOptions', () => {
+          const t1 = serializer.parse('/one/two/three');
+          const t2 = serializer.parse('/one/two');
+          expect(containsTree(t1, t2, exactMatchOptions)).toBe(false);
+
+          const t3 = serializer.parse('/one/two');
+          expect(containsTree(t3, t2, exactMatchOptions)).toBe(true);
+        });
+
+        it('should require exact query parameter matches when passing exactMatchOptions', () => {
+          const t1 = serializer.parse('/one/two?a=1&b=2');
+          const t2 = serializer.parse('/one/two?a=1');
+          expect(containsTree(t1, t2, exactMatchOptions)).toBe(false);
+        });
+
+        it('should default to subset matching when passed an empty options object', () => {
+          const t1 = serializer.parse('/one/two/three');
+          const t2 = serializer.parse('/one/two');
+          expect(containsTree(t1, t2, {})).toBe(true);
+        });
+
+        it('should handle undefined options without throwing', () => {
+          const t1 = serializer.parse('/one/two/three');
+          const t2 = serializer.parse('/one/two');
+          expect(containsTree(t1, t2, undefined)).toBe(true);
+        });
+
+        it('should handle null options gracefully', () => {
+          const t1 = serializer.parse('/one/two/three');
+          const t2 = serializer.parse('/one/two');
+          expect(containsTree(t1, t2, null as any)).toBe(true);
+        });
+      });
+
+      describe('partial options', () => {
+        it('should allow overriding specific options while applying subset defaults for the rest', () => {
+          const t1 = serializer.parse('/one/two/three?test=1&page=5');
+          const t2 = serializer.parse('/one/two?test=1');
+          expect(containsTree(t1, t2, {paths: 'subset'})).toBe(true);
+        });
+
+        it('should enforce exact paths when explicitly set while keeping subset queryParams default', () => {
+          const t1 = serializer.parse('/one/two/three?test=1&page=5');
+          const t2 = serializer.parse('/one/two?test=1');
+          expect(containsTree(t1, t2, {paths: 'exact'})).toBe(false);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Export containsTree from @angular/router to enable direct UrlTree subset matching.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

- `containsTree()` was not included in public API for comparing URLs

Issue Number: #53129 

## What is the new behavior?

- Re-exports `containsTree()` from @angular/router to allow developers to perform direct `UrlTree` subset matching

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
