### PR TITLE
fix(animations): detect object trigger values with Object.hasOwn

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -112,7 +112,7 @@ class StateValue {
     input: any,
     public namespaceId: string = '',
   ) {
-    const isObj = input && input.hasOwnProperty('value');
+    const isObj = input && Object.hasOwn(input, 'value');
     const value = isObj ? input['value'] : input;
     this.value = normalizeTriggerValue(value);
     if (isObj) {
@@ -246,7 +246,7 @@ class AnimationTransitionNamespace {
 
     let fromState = triggersWithStates.get(triggerName);
     const toState = new StateValue(value, this.id);
-    const isObj = value && value.hasOwnProperty('value');
+    const isObj = value && Object.hasOwn(value, 'value');
     if (!isObj && fromState) {
       toState.absorbOptions(fromState.options);
     }

--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -118,6 +118,25 @@ const DEFAULT_NAMESPACE_ID = 'id';
         expect(engine.players.length).toEqual(1);
       });
 
+      it('should read the value from a trigger object whose own key shadows hasOwnProperty', () => {
+        const engine = makeEngine();
+
+        const trig = trigger('myTrigger', [
+          transition('* => *', [style({height: '0px'}), animate(1000, style({height: '100px'}))]),
+        ]);
+
+        registerTrigger(element, engine, trig);
+
+        // A bound trigger value in the `{value, params}` object form can come from
+        // untrusted data (e.g. a parsed JSON payload) and carry an own `hasOwnProperty`
+        // key that shadows the method. Detecting the object form must not depend on it.
+        const value = JSON.parse('{"value": "matched", "hasOwnProperty": "x"}');
+        expect(() => setProperty(element, engine, 'myTrigger', value)).not.toThrow();
+
+        engine.flush();
+        expect(engine.players.length).toEqual(1);
+      });
+
       it('should throw an error if an animation property without a matching trigger is changed', () => {
         const engine = makeEngine();
         expect(() => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`StateValue` (and `AnimationTransitionNamespace.trigger`) figure out whether a trigger binding is in the `{value, params}` object form by calling `input.hasOwnProperty('value')` on the bound value. When an app binds a trigger to an object that comes from untrusted data and happens to carry an own `hasOwnProperty` key, for example `[@state]="JSON.parse('{\"value\":\"open\",\"hasOwnProperty\":\"x\"}')"`, that own property shadows the method, so the call throws `TypeError: input.hasOwnProperty is not a function` and the whole animation flush fails during change detection.

## What is the new behavior?

Both checks use `Object.hasOwn(value, 'value')`, which does not go through the value's own members, so a shadowing key no longer matters. Primitive values and normal `{value, params}` objects are detected exactly as before.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The added spec fails on `main` with the `TypeError` and passes with this change.
