### PR TITLE
test(platform-server): clean up viewport hydration observer

### DIFF
--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -1376,6 +1376,12 @@ describe('platform-server partial hydration integration', () => {
 
           expect(activeObservers.length).toBe(1);
           expect(activeObservers[0].options).toEqual({rootMargin: '123px', threshold: 0.5});
+
+          const article = doc.getElementsByTagName('article')[0];
+          MockIntersectionObserver.invokeCallbacksForElement(article, true);
+          await appRef.whenStable();
+
+          expect(activeObservers[0].observedElements.size).toBe(0);
         });
       });
 


### PR DESCRIPTION
Trigger routed viewport hydration so its cached observer is removed before later randomized specs run.
 
This fixes the flaky test we're having in https://github.com/angular/angular/pull/69722  & https://github.com/angular/angular/actions/runs/31479796502/job/93742697101?pr=70148


> Failures: 
> 1\) platform-server partial hydration integration core functionality triggers viewport should create IntersectionObserver 
> with the options from the \`hydrate on viewport\` trigger 
>  Message: 
>    Expected 0 to be 1. 
>  Stack: 
>        at \<Jasmine> 
>        at UserContext.\<anonymous> (./packages/platform-server/test/incremental\_hydration\_spec.ts:1318:42) 
>  Message: 
>    TypeError: Cannot read properties of undefined (reading 'options') 
>  Stack: 
>        at UserContext.\<anonymous> (./packages/platform-server/test/incremental\_hydration\_spec.ts:1319:37) 
> 387 specs, 1 failure 
> Finished in 10.91 seconds 
> Randomized with seed 90995 (jasmine --random=true --seed=90995) 