### PR TITLE
Update README for housing service instructions

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/09-services/README.md
+++ b/adev/src/content/tutorials/first-app/steps/09-services/README.md
@@ -52,9 +52,9 @@ For now, your app's new service uses the data that has, so far, been created loc
 In the **Edit** pane of your IDE:
 
 1. In `src/app/home/home.ts`, from `Home`, copy the `housingLocationList` variable and its array value.
-1. In `src/app/housing.service.ts`:
-   1. Inside the `HousingService` class, paste the variable that you copied from `Home` in the previous step.
-   1. Inside the `HousingService` class, paste these functions after the data you just copied.
+1. In `src/app/housing.ts`:
+   1. Inside the `Housing` class, paste the variable that you copied from `Home` in the previous step.
+   1. Inside the `Housing` class, paste these functions after the data you just copied.
       These functions allow dependencies to access the service's data.
 
       <docs-code header="Service functions in src/app/housing.service.ts" path="adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing.service.ts" visibleLines="[112,118]"/>
@@ -79,11 +79,11 @@ In the **Edit** pane of your IDE, in `src/app/home/home.ts`:
 
       <docs-code language="angular-ts" header="Update to src/app/home/home.ts" path="adev/src/content/tutorials/first-app/steps/10-routing/src/app/home/home.ts" visibleLines="[1]"/>
 
-1.  Add a new file level import for the `HousingService`:
+1.  Add a new file level import for the `Housing` service:
 
       <docs-code language="angular-ts" header="Add import to src/app/home/home.ts" path="adev/src/content/tutorials/first-app/steps/10-routing/src/app/home/home.ts" visibleLines="[4]"/>
 
-1.  From `Home`, delete the `housingLocationList` array entries and assign `housingLocationList` the value of empty array (`[]`). In a few steps you will update the code to pull the data from the `HousingService`.
+1.  From `Home`, delete the `housingLocationList` array entries and assign `housingLocationList` the value of empty array (`[]`). In a few steps you will update the code to pull the data from the `Housing` service.
 
 1.  In `Home`, add the following code to inject the new service and initialize the data for the app. The `constructor` is the first function that runs when this component is created. The code in the `constructor` will assign the `housingLocationList` the value returned from the call to `getAllHousingLocations`.
 


### PR DESCRIPTION
Reflect correct naming when running the tutorial in Angular 22.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The tutorial uses the name "HousingService" for the generated class and "housing.service.ts" as the filename.

Issue Number: N/A

## What is the new behavior?

The tutorial uses the name "Housing" for the generated class and "housing.ts" as the filename, which matches the behavior when running `ng generate service housing --skip-tests`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

In Angular 22, `Services` have been updated to no longer have (or require) `.service` to be included in the filename. Additionally, when generating services via `ng`, services are named without "Service" appended to the class name.