### PR TITLE
fix(core): preserve per-tool argument type inference in provideExperimentalWebMcpTools

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1502,7 +1502,7 @@ export function provideCheckNoChangesConfig(options: {
 export function provideEnvironmentInitializer(initializerFn: () => void): EnvironmentProviders;
 
 // @public
-export function provideExperimentalWebMcpTools<const InputSchema extends JsonSchemaForInference>(tools: WebMcpToolDescriptor<InputSchema>[]): EnvironmentProviders;
+export function provideExperimentalWebMcpTools<const InputSchemas extends readonly JsonSchemaForInference[]>(tools: { [K in keyof InputSchemas]: WebMcpToolDescriptor<InputSchemas[K]>; }): EnvironmentProviders;
 
 // @public
 export function provideIdleServiceWith(useExisting: AbstractType<IdleService> | InjectionToken<IdleService>): EnvironmentProviders;

--- a/packages/core/src/webmcp/provide_tools.ts
+++ b/packages/core/src/webmcp/provide_tools.ts
@@ -26,8 +26,10 @@ import type {ToolDescriptor} from './types';
  *     or route providers.
  * @experimental
  */
-export function provideExperimentalWebMcpTools<const InputSchema extends JsonSchemaForInference>(
-  tools: ToolDescriptor<InputSchema>[],
+export function provideExperimentalWebMcpTools<
+  const InputSchemas extends readonly JsonSchemaForInference[],
+>(
+  tools: {[K in keyof InputSchemas]: ToolDescriptor<InputSchemas[K]>},
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
     provideEnvironmentInitializer(() => {

--- a/packages/core/test/strict_types/mcp_tools_spec.ts
+++ b/packages/core/test/strict_types/mcp_tools_spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {provideExperimentalWebMcpTools} from '../../src/webmcp/provide_tools';
+
+describe('provideExperimentalWebMcpTools', () => {
+  // Regression test for https://github.com/angular/angular/issues/70125
+  //
+  // Each tool passed to `provideExperimentalWebMcpTools` must infer its own
+  // argument types from its own `inputSchema`. Previously the function inferred
+  // a single shared `InputSchema` for the whole array, so heterogeneous tools
+  // lost their `execute` argument types (each `args` was widened to
+  // `Record<string, unknown>`), making the `arg1`/`arg2` accesses below type
+  // errors. This file intentionally fails to compile on the unfixed signature.
+  it('should preserve per-tool argument types for heterogeneous input schemas', () => {
+    provideExperimentalWebMcpTools([
+      {
+        name: 'tool1',
+        description: 'Tool #1',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            arg1: {type: 'number'},
+          },
+          required: ['arg1'],
+        },
+        execute: (args) => {
+          const arg1 = args.arg1; // must be inferred as `number`
+          return `arg1 number value is ${arg1.toFixed()}`;
+        },
+      },
+      {
+        name: 'tool2',
+        description: 'Tool #2',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            arg2: {type: 'string'},
+          },
+          required: ['arg2'],
+        },
+        execute: (args) => {
+          const arg2 = args.arg2; // must be inferred as `string`
+          return `arg2 string value is ${arg2.trim()}`;
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Fixes #70125

## What is the current behavior?

`provideExperimentalWebMcpTools` declares a single generic `InputSchema` for the whole `ToolDescriptor<InputSchema>[]` array. Because the entire array shares one `InputSchema`, TypeScript unifies the `inputSchema` types when multiple tools with heterogeneous inputs are provided, and the `execute` callback arguments degrade to `unknown` / `Record<string, unknown>` (the reporter observed `number | { [x: string]: unknown }`), breaking type safety inside `execute`.

This is the well-known TS limitation from microsoft/TypeScript#14466: a single generic cannot be inferred independently per array element.

## What is the new behavior?

Each tool now infers its own `InputSchema` from its own `inputSchema` property. The parameter type is a tuple-mapped type (`{ [K in keyof InputSchemas]: ToolDescriptor<InputSchemas[K]> }` over `const InputSchemas extends readonly JsonSchemaForInference[]`) so every `execute` callback receives precisely-typed arguments: `args.arg1` is `number` for a `{ type: 'number' }` schema, `args.arg2` is `string`, etc. The function body is unchanged (it only iterates the tools), and the existing call shape `provideExperimentalWebMcpTools([...])` is preserved.

Existing call sites remain backward compatible. Verified against the patterns used in the current runtime spec (`packages/core/test/webmcp/provide_tools_spec.ts`), pre-typed `ToolDescriptor<JsonSchemaForInference>[]` arrays, and the `provideExperimentalWebMcpTools<any>(...)` workaround from the issue.

The public API golden (`goldens/public-api/core/index.api.md`) was updated to the new signature.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (type-level change only; all existing homogeneous call sites compile unchanged)

## Verification

- Added a compile-time regression spec at `packages/core/test/strict_types/mcp_tools_spec.ts` (the repo's strict-types test target, which compiles under `strict: true`). With the old signature the spec fails to compile (`arg1` / `arg2` resolve to `unknown`); with the fix it compiles and the jasmine test passes.
- `pnpm bazel test //packages/core/test/strict_types:strict_types` passes with the fix applied.

## Notes

- This is a type-level fix with no runtime behavior change; WebMCP remains experimental.
- There are no other open pull requests from this author in `angular/angular`.
- If the API golden needs regenerating, `pnpm public-api:update` produces it deterministically.