### PR TITLE
release: bump Angular DevTools version to 1.19.1

### DIFF
--- a/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
@@ -3,7 +3,7 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Chrome DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "minimum_chrome_version": "102",
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
@@ -3,7 +3,7 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Firefox DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "icons": {
     "16": "assets/icon16.png",


### PR DESCRIPTION
- fix(devtools): fix regression for node serialization.
- fix(devtools): Extension name for non googlers.
- fix(devtools): invoke selectedNode signal in directive tree keyboard guard