### PR TITLE
feat(compiler-cli): allow accessing private props in template expressions.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1082,6 +1082,7 @@ export class NgCompiler {
     if (strictTemplates) {
       typeCheckingConfig = {
         applyTemplateContextGuards: strictTemplates,
+        useElementAccessForProperties: this.options['_isAngularLanguageService'] !== true,
         checkQueries: false,
         checkTemplateBodies: true,
         alwaysCheckSchemaInTemplateBodies: true,
@@ -1118,7 +1119,8 @@ export class NgCompiler {
       };
     } else {
       typeCheckingConfig = {
-        applyTemplateContextGuards: false,
+        applyTemplateContextGuards: true,
+        useElementAccessForProperties: this.options['_isAngularLanguageService'] !== true,
         checkQueries: false,
         checkTemplateBodies: false,
         checkControlFlowBodies: false,

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
@@ -22,6 +22,37 @@ interface DeprecatedDiagnosticInfo {
   relatedMessages: ts.DiagnosticRelatedInformation[] | undefined;
 }
 
+function removeRedundantImplicitAnyMessage(
+  messageText: string | ts.DiagnosticMessageChain,
+): string | ts.DiagnosticMessageChain {
+  if (typeof messageText !== 'object' || messageText.next === undefined) {
+    return messageText;
+  }
+
+  const propertyMessage = findPropertyDoesNotExistMessage(messageText);
+  return propertyMessage ?? messageText;
+}
+
+function findPropertyDoesNotExistMessage(
+  messageText: ts.DiagnosticMessageChain,
+): ts.DiagnosticMessageChain | null {
+  const isPropertyError = /^Property '.*' does not exist on type '.*'\.?$/.test(
+    messageText.messageText,
+  );
+  if (isPropertyError) {
+    return messageText;
+  }
+
+  for (const next of messageText.next ?? []) {
+    const nested = findPropertyDoesNotExistMessage(next);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Constructs a `ts.Diagnostic` for a given `ParseSourceSpan` within a template.
  *
@@ -42,6 +73,8 @@ export function makeTemplateDiagnostic(
   }[],
   deprecatedDiagInfo?: DeprecatedDiagnosticInfo,
 ): TemplateDiagnostic {
+  messageText = removeRedundantImplicitAnyMessage(messageText);
+
   if (mapping.type === 'direct') {
     let relatedInformation: ts.DiagnosticRelatedInformation[] | undefined = [];
     if (relatedMessages !== undefined) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
@@ -57,13 +57,30 @@ export function translateDiagnostic(
   }
 
   const {sourceLocation, sourceMapping: templateSourceMapping, span} = fullMapping;
+  let code = diagnostic.code;
+  let messageText = diagnostic.messageText;
+
+  // Unwrap TS7053 (Element implicitly has an 'any' type...) if the underlying cause is TS2339
+  // (Property 'foo' does not exist...). This provides a much better developer experience for
+  // typo errors in templates when indexed access is used in the TCB.
+  if (
+    code === 7053 &&
+    typeof messageText === 'object' &&
+    messageText.next &&
+    messageText.next.length === 1 &&
+    messageText.next[0].code === 2339
+  ) {
+    code = 2339;
+    messageText = messageText.next[0].messageText;
+  }
+
   return makeTemplateDiagnostic(
     sourceLocation.id,
     templateSourceMapping,
     span,
     diagnostic.category,
-    diagnostic.code,
-    diagnostic.messageText,
+    code,
+    messageText,
     undefined,
     diagnostic.reportsDeprecated !== undefined
       ? {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/symbol_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/symbol_util.ts
@@ -8,7 +8,7 @@
 
 import ts from 'typescript';
 
-import {Symbol, SymbolKind, TemplateTypeChecker, TcbLocation} from '../api';
+import {Symbol, SymbolKind, TcbLocation, TemplateTypeChecker} from '../api';
 
 /** Names of known signal functions. */
 const SIGNAL_FNS = new Set([
@@ -20,10 +20,13 @@ const SIGNAL_FNS = new Set([
 ]);
 
 /** Returns whether a symbol is a reference to a signal. */
+
 export function isSignalReference(symbol: Symbol, typeChecker: TemplateTypeChecker): boolean {
   let location: TcbLocation | null = null;
+  let tcbTypeLocation: TcbLocation | undefined = undefined;
   if ('tcbLocation' in symbol) {
     location = (symbol as any).tcbLocation;
+    tcbTypeLocation = (symbol as any).tcbTypeLocation;
   } else if ('localVarLocation' in symbol) {
     location = (symbol as any).localVarLocation;
   }
@@ -32,8 +35,13 @@ export function isSignalReference(symbol: Symbol, typeChecker: TemplateTypeCheck
     return false;
   }
 
-  // We can trick getTypeOfSymbol since it just checks 'tcbLocation'
-  const type = typeChecker.getTypeOfSymbol({tcbLocation: location} as any);
+  // We can trick getTypeOfSymbol since it just checks 'tcbLocation' and 'tcbTypeLocation'
+  const mockSymbol: any = {tcbLocation: location};
+  if (tcbTypeLocation !== undefined) {
+    mockSymbol.tcbTypeLocation = tcbTypeLocation;
+  }
+  const type = typeChecker.getTypeOfSymbol(mockSymbol);
+
   if (!type) return false;
 
   return (

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -748,7 +748,7 @@ class TestComponent {
       expect(messages).toEqual([]);
     });
 
-    it('disallows access to private members', () => {
+    it('allows access to private members', () => {
       const messages = diagnose(
         `<button (click)="doFoo()">{{ message }}</button>`,
         `
@@ -758,10 +758,7 @@ class TestComponent {
         }`,
       );
 
-      expect(messages).toEqual([
-        `TestComponent.html(1, 18): Property 'doFoo' is private and only accessible within class 'TestComponent'.`,
-        `TestComponent.html(1, 30): Property 'message' is private and only accessible within class 'TestComponent'.`,
-      ]);
+      expect(messages).toEqual([]);
     });
   });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/input_signal_diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/input_signal_diagnostics_spec.ts
@@ -104,24 +104,20 @@ runInEachFileSystem(() => {
       },
       // restricted fields
       {
-        id: 'disallows access to private input',
+        id: 'allows access to private input',
         inputs: {
           pattern: {type: 'InputSignal<string>', isSignal: true, restrictionModifier: 'private'},
         },
         template: `<div dir [pattern]="'works'">`,
-        expected: [
-          `TestComponent.html(1, 11): Property 'pattern' is private and only accessible within class 'Dir'.`,
-        ],
+        expected: [],
       },
       {
-        id: 'disallows access to protected input',
+        id: 'allows access to protected input',
         inputs: {
           pattern: {type: 'InputSignal<string>', isSignal: true, restrictionModifier: 'protected'},
         },
         template: `<div dir [pattern]="'works'">`,
-        expected: [
-          `TestComponent.html(1, 11): Property 'pattern' is protected and only accessible within class 'Dir' and its subclasses.`,
-        ],
+        expected: [],
       },
       {
         // NOTE FOR REVIEWER: This is something different with input signals. The framework

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
@@ -101,26 +101,22 @@ runInEachFileSystem(() => {
       },
       // restricted fields
       {
-        id: 'disallows access to private model',
+        id: 'allows access to private model',
         inputs: {
           pattern: {type: 'ModelSignal<string>', isSignal: true, restrictionModifier: 'private'},
         },
         outputs: {patternChange: {type: 'ModelSignal<string>'}},
         template: `<div dir [pattern]="'works'">`,
-        expected: [
-          `TestComponent.html(1, 11): Property 'pattern' is private and only accessible within class 'Dir'.`,
-        ],
+        expected: [],
       },
       {
-        id: 'disallows access to protected model',
+        id: 'allows access to protected model',
         inputs: {
           pattern: {type: 'ModelSignal<string>', isSignal: true, restrictionModifier: 'protected'},
         },
         outputs: {patternChange: {type: 'ModelSignal<string>'}},
         template: `<div dir [pattern]="'works'">`,
-        expected: [
-          `TestComponent.html(1, 11): Property 'pattern' is protected and only accessible within class 'Dir' and its subclasses.`,
-        ],
+        expected: [],
       },
       {
         id: 'allows access to readonly model by default',

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -14,24 +14,24 @@ describe('type check blocks diagnostics', () => {
 
   describe('parse spans', () => {
     it('should annotate unary ops', () => {
-      expect(tcbWithSpans('{{ -a }}')).toContain('(-((this).a /*4,5*/) /*4,5*/) /*3,5*/');
+      expect(tcbWithSpans('{{ -a }}')).toContain('(-((this)["a"] /*4,5*/) /*4,5*/) /*3,5*/');
     });
 
     it('should annotate binary ops', () => {
       expect(tcbWithSpans('{{ a + b }}')).toContain(
-        '(((this).a /*3,4*/) /*3,4*/) + (((this).b /*7,8*/) /*7,8*/) /*3,8*/',
+        '(((this)["a"] /*3,4*/) /*3,4*/) + (((this)["b"] /*7,8*/) /*7,8*/) /*3,8*/',
       );
     });
 
     it('should annotate conditions', () => {
       expect(tcbWithSpans('{{ a ? b : c }}')).toContain(
-        '(((this).a /*3,4*/) /*3,4*/ ? ((this).b /*7,8*/) /*7,8*/ : (((this).c /*11,12*/) /*11,12*/)) /*3,12*/',
+        '(((this)["a"] /*3,4*/) /*3,4*/ ? ((this)["b"] /*7,8*/) /*7,8*/ : (((this)["c"] /*11,12*/) /*11,12*/)) /*3,12*/',
       );
     });
 
     it('should annotate interpolations', () => {
       expect(tcbWithSpans('{{ hello }} {{ world }}')).toContain(
-        '"" + (((this).hello /*3,8*/) /*3,8*/) + (((this).world /*15,20*/) /*15,20*/)',
+        '"" + (((this)["hello"] /*3,8*/) /*3,8*/) + (((this)["world"] /*15,20*/) /*15,20*/)',
       );
     });
 
@@ -40,7 +40,7 @@ describe('type check blocks diagnostics', () => {
       // statement, which would wrap it into parenthesis that clutter the expected output.
       const TEMPLATE = '{{ m({foo: a, bar: b}) }}';
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '((this).m /*3,4*/(({ "foo" /*6,9*/: ((this).a /*11,12*/) /*11,12*/, "bar" /*14,17*/: ((this).b /*19,20*/) /*19,20*/ } /*5,21*/)) /*3,22*/)',
+        '((this)["m"] /*3,4*/(({ "foo" /*6,9*/: ((this)["a"] /*11,12*/) /*11,12*/, "bar" /*14,17*/: ((this)["b"] /*19,20*/) /*19,20*/ } /*5,21*/)) /*3,22*/)',
       );
     });
 
@@ -49,14 +49,14 @@ describe('type check blocks diagnostics', () => {
       // statement, which would wrap it into parenthesis that clutter the expected output.
       const TEMPLATE = '{{ m({a, b}) }}';
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '((this).m /*3,4*/(({ "a" /*6,7*/: ((this).a /*6,7*/) /*6,7*/, "b" /*9,10*/: ((this).b /*9,10*/) /*9,10*/ } /*5,11*/)) /*3,12*/)',
+        '((this)["m"] /*3,4*/(({ "a" /*6,7*/: ((this)["a"] /*6,7*/) /*6,7*/, "b" /*9,10*/: ((this)["b"] /*9,10*/) /*9,10*/ } /*5,11*/)) /*3,12*/)',
       );
     });
 
     it('should annotate literal array expressions', () => {
       const TEMPLATE = '{{ [a, b] }}';
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '[((this).a /*4,5*/) /*4,5*/, ((this).b /*7,8*/) /*7,8*/] /*3,9*/',
+        '[((this)["a"] /*4,5*/) /*4,5*/, ((this)["b"] /*7,8*/) /*7,8*/] /*3,9*/',
       );
     });
 
@@ -67,105 +67,107 @@ describe('type check blocks diagnostics', () => {
 
     it('should annotate non-null assertions', () => {
       const TEMPLATE = `{{ a! }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('(((this).a /*3,4*/) /*3,4*/)! /*3,5*/');
+      expect(tcbWithSpans(TEMPLATE)).toContain('(((this)["a"] /*3,4*/) /*3,4*/)! /*3,5*/');
     });
 
     it('should annotate prefix not', () => {
       const TEMPLATE = `{{ !a }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('!(((this).a /*4,5*/) /*4,5*/) /*3,5*/');
+      expect(tcbWithSpans(TEMPLATE)).toContain('!(((this)["a"] /*4,5*/) /*4,5*/) /*3,5*/');
     });
 
     it('should annotate method calls', () => {
       const TEMPLATE = `{{ method(a, b) }}`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(this).method /*3,9*/(((this).a /*10,11*/) /*10,11*/, ((this).b /*13,14*/) /*13,14*/) /*3,15*/',
+        '(this)["method"] /*3,9*/(((this)["a"] /*10,11*/) /*10,11*/, ((this)["b"] /*13,14*/) /*13,14*/) /*3,15*/',
       );
     });
 
     it('should annotate safe calls', () => {
       const TEMPLATE = `{{ method?.(a, b) }}`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(((((this).method /*3,9*/) /*3,9*/)?.(((this).a /*12,13*/) /*12,13*/, ((this).b /*15,16*/) /*15,16*/)) /*3,17*/)',
+        '(((((this)["method"] /*3,9*/) /*3,9*/)?.(((this)["a"] /*12,13*/) /*12,13*/, ((this)["b"] /*15,16*/) /*15,16*/)) /*3,17*/)',
       );
     });
 
     it('should annotate method calls of variables', () => {
       const TEMPLATE = `<ng-template let-method>{{ method(a, b) }}</ng-template>`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '_t2 /*27,33*/(((this).a /*34,35*/) /*34,35*/, ((this).b /*37,38*/) /*37,38*/) /*27,39*/',
+        '_t2 /*27,33*/(((this)["a"] /*34,35*/) /*34,35*/, ((this)["b"] /*37,38*/) /*37,38*/) /*27,39*/',
       );
     });
 
     it('should annotate function calls', () => {
       const TEMPLATE = `{{ method(a)(b, c) }}`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(this).method /*3,9*/(((this).a /*10,11*/) /*10,11*/) /*3,12*/(((this).b /*13,14*/) /*13,14*/, ((this).c /*16,17*/) /*16,17*/) /*3,18*/',
+        '(this)["method"] /*3,9*/(((this)["a"] /*10,11*/) /*10,11*/) /*3,12*/(((this)["b"] /*13,14*/) /*13,14*/, ((this)["c"] /*16,17*/) /*16,17*/) /*3,18*/',
       );
     });
 
     it('should annotate property access', () => {
       const TEMPLATE = `{{ a.b.c }}`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '((((((this).a /*3,4*/) /*3,4*/).b /*5,6*/) /*3,6*/).c /*7,8*/) /*3,8*/',
+        '((((((this)["a"] /*3,4*/) /*3,4*/).b /*5,6*/) /*3,6*/).c /*7,8*/) /*3,8*/',
       );
     });
 
     it('should annotate property writes', () => {
       const TEMPLATE = `<div (click)='a.b.c = d'></div>`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(((((((this).a /*14,15*/) /*14,15*/).b /*16,17*/) /*14,17*/).c /*18,19*/) /*14,19*/) = (((this).d /*22,23*/) /*22,23*/) /*14,23*/;',
+        '(((((((this)["a"] /*14,15*/) /*14,15*/).b /*16,17*/) /*14,17*/).c /*18,19*/) /*14,19*/) = (((this)["d"] /*22,23*/) /*22,23*/) /*14,23*/;',
       );
     });
 
     it('should annotate $event property writes', () => {
       const TEMPLATE = `<div (click)='a = $event'></div>`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(((this).a /*14,15*/) /*14,15*/) = ($event /*18,24*/) /*14,24*/; }) /*5,25*/;',
+        '(((this)["a"] /*14,15*/) /*14,15*/) = ($event /*18,24*/) /*14,24*/; }) /*5,25*/;',
       );
     });
 
     it('should annotate keyed property access', () => {
       const TEMPLATE = `{{ a[b] }}`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(((this).a /*3,4*/) /*3,4*/)[((this).b /*5,6*/) /*5,6*/] /*3,7*/',
+        '(((this)["a"] /*3,4*/) /*3,4*/)[((this)["b"] /*5,6*/) /*5,6*/] /*3,7*/',
       );
     });
 
     it('should annotate keyed property writes', () => {
       const TEMPLATE = `<div (click)="a[b] = c"></div>`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '((((this).a /*14,15*/) /*14,15*/)[((this).b /*16,17*/) /*16,17*/] /*14,18*/) = (((this).c /*21,22*/) /*21,22*/) /*14,22*/;',
+        '((((this)["a"] /*14,15*/) /*14,15*/)[((this)["b"] /*16,17*/) /*16,17*/] /*14,18*/) = (((this)["c"] /*21,22*/) /*21,22*/) /*14,22*/;',
       );
     });
 
     it('should annotate safe property access', () => {
       const TEMPLATE = `{{ a?.b }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('((((this).a /*3,4*/) /*3,4*/)?.b /*6,7*/ /*3,7*/');
+      expect(tcbWithSpans(TEMPLATE)).toContain(
+        '((((this)["a"] /*3,4*/) /*3,4*/)?.b /*6,7*/ /*3,7*/',
+      );
     });
 
     it('should annotate safe method calls', () => {
       const TEMPLATE = `{{ a?.method(b) }}`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(((((this).a /*3,4*/) /*3,4*/)?.method /*6,12*/ /*3,12*/?.(((this).b /*13,14*/) /*13,14*/)) /*3,15*/)',
+        '(((((this)["a"] /*3,4*/) /*3,4*/)?.method /*6,12*/ /*3,12*/?.(((this)["b"] /*13,14*/) /*13,14*/)) /*3,15*/)',
       );
     });
 
     it('should annotate safe keyed reads', () => {
       const TEMPLATE = `{{ a?.[0] }}`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '((((this).a /*3,4*/) /*3,4*/)?.[0 /*7,8*/] /*3,9*/)',
+        '((((this)["a"] /*3,4*/) /*3,4*/)?.[0 /*7,8*/] /*3,9*/)',
       );
     });
 
     it('should annotate $any casts', () => {
       const TEMPLATE = `{{ $any(a) }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('(((this).a /*8,9*/) /*8,9*/ as any) /*3,10*/');
+      expect(tcbWithSpans(TEMPLATE)).toContain('(((this)["a"] /*8,9*/) /*8,9*/ as any) /*3,10*/');
     });
 
     it('should annotate chained expressions', () => {
       const TEMPLATE = `<div (click)='a; b; c'></div>`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(((this).a /*14,15*/) /*14,15*/, ((this).b /*17,18*/) /*17,18*/, ((this).c /*20,21*/) /*20,21*/) /*14,21*/',
+        '(((this)["a"] /*14,15*/) /*14,15*/, ((this)["b"] /*17,18*/) /*17,18*/, ((this)["c"] /*20,21*/) /*20,21*/) /*14,21*/',
       );
     });
 
@@ -181,7 +183,7 @@ describe('type check blocks diagnostics', () => {
       const block = tcbWithSpans(TEMPLATE, PIPES);
       expect(block).toContain('var _pipe1 = null! as i0.TestPipe');
       expect(block).toContain(
-        '(_pipe1.transform /*7,11*/(((this).a /*3,4*/) /*3,4*/, ((this).b /*12,13*/) /*12,13*/) /*3,13*/);',
+        '(_pipe1.transform /*7,11*/(((this)["a"] /*3,4*/) /*3,4*/, ((this)["b"] /*12,13*/) /*12,13*/) /*3,13*/);',
       );
     });
 
@@ -224,7 +226,7 @@ describe('type check blocks diagnostics', () => {
         ];
         const TEMPLATE = `<my-cmp [inputA]="''"></my-cmp>`;
         expect(tcbWithSpans(TEMPLATE, DIRECTIVES)).toContain(
-          '_t1.inputA /*9,15*/ = ("" /*18,20*/) /*8,21*/;',
+          '_t1["inputA"] /*9,15*/ = ("" /*18,20*/) /*8,21*/;',
         );
       });
     });
@@ -234,7 +236,7 @@ describe('type check blocks diagnostics', () => {
         const template = `@for (user of users; track user; let i = $index) { {{i}} }`;
         // user variable
         expect(tcbWithSpans(template, [])).toContain('const _t1 /*6,10*/');
-        expect(tcbWithSpans(template, [])).toContain('(this).users /*14,19*/');
+        expect(tcbWithSpans(template, [])).toContain('(this)["users"] /*14,19*/');
         // index variable
         expect(tcbWithSpans(template, [])).toContain(
           'var _t2 /*37,38*/ = null! as number /*T:VAE*/ /*37,47*/',
@@ -259,7 +261,7 @@ describe('type check blocks diagnostics', () => {
       it('@if', () => {
         const template = `@if (x; as alias) { {{alias}} }`;
         expect(tcbWithSpans(template, [])).toContain('var _t1 /*11,16*/');
-        expect(tcbWithSpans(template, [])).toContain('(this).x /*5,6*/');
+        expect(tcbWithSpans(template, [])).toContain('(this)["x"] /*5,6*/');
       });
     });
   });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -28,25 +28,27 @@ describe('type check blocks', () => {
   beforeEach(() => initMockFileSystem('Native'));
 
   it('should generate a basic block for a binding', () => {
-    expect(tcb('{{hello}} {{world}}')).toContain('"" + (((this).hello)) + (((this).world));');
+    expect(tcb('{{hello}} {{world}}')).toContain('"" + (((this)["hello"])) + (((this)["world"]));');
   });
 
   it('should generate an animation leave function call', () => {
     const TEMPLATE = '<p (animate.leave)="animateFn($event)"></p>';
     const results = tcb(TEMPLATE);
     expect(results).toContain(
-      '($event: i1.AnimationCallbackEvent): any => { (this).animateFn($event); };',
+      '($event: i1.AnimationCallbackEvent): any => { (this)["animateFn"]($event); };',
     );
   });
 
   it('should generate literal map expressions', () => {
     const TEMPLATE = '{{ method({foo: a, bar: b}) }}';
-    expect(tcb(TEMPLATE)).toContain('(this).method(({ "foo": ((this).a), "bar": ((this).b) }))');
+    expect(tcb(TEMPLATE)).toContain(
+      '(this)["method"](({ "foo": ((this)["a"]), "bar": ((this)["b"]) }))',
+    );
   });
 
   it('should generate literal array expressions', () => {
     const TEMPLATE = '{{ method([a, b]) }}';
-    expect(tcb(TEMPLATE)).toContain('(this).method([((this).a), ((this).b)])');
+    expect(tcb(TEMPLATE)).toContain('(this)["method"]([((this)["a"]), ((this)["b"])])');
   });
 
   it('should parenthesize literal maps bound to DOM properties', () => {
@@ -56,7 +58,7 @@ describe('type check blocks', () => {
 
   it('should handle non-null assertions', () => {
     const TEMPLATE = `{{a!}}`;
-    expect(tcb(TEMPLATE)).toContain('((((this).a))!)');
+    expect(tcb(TEMPLATE)).toContain('((((this)["a"]))!)');
   });
 
   it('should handle unary - operator', () => {
@@ -67,63 +69,67 @@ describe('type check blocks', () => {
   it('should assert the type for DOM events bound on void elements', () => {
     const result = tcb(`<input (input)="handleInput($event.target.value)">`);
     expect(result).toContain('i1.ɵassertType<typeof _t1>($event.target);');
-    expect(result).toContain('(this).handleInput((((($event).target)).value));');
+    expect(result).toContain('(this)["handleInput"]((((($event).target)).value));');
   });
 
   it('should handle keyed property access', () => {
     const TEMPLATE = `{{a[b]}}`;
-    expect(tcb(TEMPLATE)).toContain('(((this).a))[((this).b)]');
+    expect(tcb(TEMPLATE)).toContain('(((this)["a"]))[((this)["b"])]');
   });
 
   it('should handle nested ternary expressions', () => {
     const TEMPLATE = `{{a ? b : c ? d : e}}`;
     expect(tcb(TEMPLATE)).toContain(
-      '(((this).a) ? ((this).b) : ((((this).c) ? ((this).d) : (((this).e)))))',
+      '(((this)["a"]) ? ((this)["b"]) : ((((this)["c"]) ? ((this)["d"]) : (((this)["e"])))))',
     );
   });
 
   it('should handle nullish coalescing operator', () => {
-    expect(tcb('{{ a ?? b }}')).toContain('((((this).a)) ?? (((this).b)))');
+    expect(tcb('{{ a ?? b }}')).toContain('((((this)["a"])) ?? (((this)["b"])))');
     expect(tcb('{{ a ?? b ?? c }}')).toContain(
-      '((((((this).a)) ?? (((this).b)))) ?? (((this).c)))',
+      '((((((this)["a"])) ?? (((this)["b"])))) ?? (((this)["c"])))',
     );
     expect(tcb('{{ (a ?? b) + (c ?? e) }}')).toContain(
-      '(((((((this).a)) ?? (((this).b))))) + ((((((this).c)) ?? (((this).e))))))',
+      '(((((((this)["a"])) ?? (((this)["b"]))))) + ((((((this)["c"])) ?? (((this)["e"]))))))',
     );
   });
 
   it('should handle typeof expressions', () => {
-    expect(tcb('{{typeof a}}')).toContain('typeof (((this).a))');
-    expect(tcb('{{!(typeof a)}}')).toContain('!((typeof (((this).a))))');
+    expect(tcb('{{typeof a}}')).toContain('typeof (((this)["a"]))');
+    expect(tcb('{{!(typeof a)}}')).toContain('!((typeof (((this)["a"]))))');
     expect(tcb('{{!(typeof a === "object")}}')).toContain(
-      '!(((typeof (((this).a))) === ("object")))',
+      '!(((typeof (((this)["a"]))) === ("object")))',
     );
   });
 
   it('should handle void expressions', () => {
-    expect(tcb('{{void a}}')).toContain('void (((this).a))');
-    expect(tcb('{{!(void a)}}')).toContain('!((void (((this).a))))');
-    expect(tcb('{{!(void a === "object")}}')).toContain('!(((void (((this).a))) === ("object")))');
+    expect(tcb('{{void a}}')).toContain('void (((this)["a"]))');
+    expect(tcb('{{!(void a)}}')).toContain('!((void (((this)["a"]))))');
+    expect(tcb('{{!(void a === "object")}}')).toContain(
+      '!(((void (((this)["a"]))) === ("object")))',
+    );
   });
 
   it('should handle assignment expressions', () => {
-    expect(tcb('<b (click)="a = b"></b>')).toContain('(((this).a)) = (((this).b));');
-    expect(tcb('<b (click)="a += b"></b>')).toContain('(((this).a)) += (((this).b));');
-    expect(tcb('<b (click)="a -= b"></b>')).toContain('(((this).a)) -= (((this).b));');
-    expect(tcb('<b (click)="a *= b"></b>')).toContain('(((this).a)) *= (((this).b));');
-    expect(tcb('<b (click)="a /= b"></b>')).toContain('(((this).a)) /= (((this).b));');
-    expect(tcb('<b (click)="a %= b"></b>')).toContain('(((this).a)) %= (((this).b));');
-    expect(tcb('<b (click)="a **= b"></b>')).toContain('(((this).a)) **= (((this).b));');
-    expect(tcb('<b (click)="a &&= b"></b>')).toContain('(((this).a)) &&= (((this).b));');
-    expect(tcb('<b (click)="a ||= b"></b>')).toContain('(((this).a)) ||= (((this).b));');
-    expect(tcb('<b (click)="a ??= b"></b>')).toContain('(((this).a)) ??= (((this).b));');
+    expect(tcb('<b (click)="a = b"></b>')).toContain('(((this)["a"])) = (((this)["b"]));');
+    expect(tcb('<b (click)="a += b"></b>')).toContain('(((this)["a"])) += (((this)["b"]));');
+    expect(tcb('<b (click)="a -= b"></b>')).toContain('(((this)["a"])) -= (((this)["b"]));');
+    expect(tcb('<b (click)="a *= b"></b>')).toContain('(((this)["a"])) *= (((this)["b"]));');
+    expect(tcb('<b (click)="a /= b"></b>')).toContain('(((this)["a"])) /= (((this)["b"]));');
+    expect(tcb('<b (click)="a %= b"></b>')).toContain('(((this)["a"])) %= (((this)["b"]));');
+    expect(tcb('<b (click)="a **= b"></b>')).toContain('(((this)["a"])) **= (((this)["b"]));');
+    expect(tcb('<b (click)="a &&= b"></b>')).toContain('(((this)["a"])) &&= (((this)["b"]));');
+    expect(tcb('<b (click)="a ||= b"></b>')).toContain('(((this)["a"])) ||= (((this)["b"]));');
+    expect(tcb('<b (click)="a ??= b"></b>')).toContain('(((this)["a"])) ??= (((this)["b"]));');
   });
 
   it('should handle exponentiation expressions', () => {
     expect(tcb('{{a * b ** c + d}}')).toContain(
-      '(((((this).a)) * (((((this).b)) ** (((this).c))))) + (((this).d)))',
+      '(((((this)["a"])) * (((((this)["b"])) ** (((this)["c"]))))) + (((this)["d"])))',
     );
-    expect(tcb('{{a ** b ** c}}')).toContain('((((this).a)) ** (((((this).b)) ** (((this).c)))))');
+    expect(tcb('{{a ** b ** c}}')).toContain(
+      '((((this)["a"])) ** (((((this)["b"])) ** (((this)["c"])))))',
+    );
   });
 
   it('should handle "in" expressions', () => {
@@ -133,10 +139,10 @@ describe('type check blocks', () => {
 
   it('should handle "instanceof" expressions', () => {
     expect(tcb(`{{obj instanceof MyClass}}`)).toContain(
-      `((((this).obj)) instanceof (((this).MyClass)))`,
+      `((((this)["obj"])) instanceof (((this)["MyClass"])))`,
     );
     expect(tcb(`{{!(obj instanceof MyClass)}}`)).toContain(
-      `!(((((this).obj)) instanceof (((this).MyClass)))))`,
+      `!(((((this)["obj"])) instanceof (((this)["MyClass"])))))`,
     );
   });
 
@@ -150,7 +156,9 @@ describe('type check blocks', () => {
         inputs: {inputA: 'inputA'},
       },
     ];
-    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('_t1 = null! as i0.DirA; _t1.inputA = ("value");');
+    expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
+      '_t1 = null! as i0.DirA; _t1["inputA"] = ("value");',
+    );
   });
 
   it('should handle multiple bindings to the same property', () => {
@@ -164,8 +172,8 @@ describe('type check blocks', () => {
       },
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
-    expect(block).toContain('_t1.inputA = (1);');
-    expect(block).toContain('_t1.inputA = (2);');
+    expect(block).toContain('_t1["inputA"] = (1);');
+    expect(block).toContain('_t1["inputA"] = (2);');
   });
 
   it('should handle empty bindings', () => {
@@ -178,7 +186,7 @@ describe('type check blocks', () => {
         inputs: {inputA: 'inputA'},
       },
     ];
-    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('_t1.inputA = (undefined);');
+    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('_t1["inputA"] = (undefined);');
   });
 
   it('should handle bindings without value', () => {
@@ -191,7 +199,7 @@ describe('type check blocks', () => {
         inputs: {inputA: 'inputA'},
       },
     ];
-    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('_t1.inputA = (undefined);');
+    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('_t1["inputA"] = (undefined);');
   });
 
   it('should handle implicit vars on ng-template', () => {
@@ -218,20 +226,20 @@ describe('type check blocks', () => {
 
   it('should handle template literals', () => {
     expect(tcb('{{ `hello world` }}')).toContain('"" + (`hello world`);');
-    expect(tcb('{{ `hello ${name}!!!` }}')).toContain('"" + (`hello ${((this).name)}!!!`);');
+    expect(tcb('{{ `hello ${name}!!!` }}')).toContain('"" + (`hello ${((this)["name"])}!!!`);');
     expect(tcb('{{ `${a} - ${b} - ${c}` }}')).toContain(
-      '"" + (`${((this).a)} - ${((this).b)} - ${((this).c)}`);',
+      '"" + (`${((this)["a"])} - ${((this)["b"])} - ${((this)["c"])}`);',
     );
-    expect(tcb('{{ `a${`hello ${name}`}b` }}')).toContain('(`a${`hello ${((this).name)}`}b`)');
+    expect(tcb('{{ `a${`hello ${name}`}b` }}')).toContain('(`a${`hello ${((this)["name"])}`}b`)');
   });
 
   it('should handle tagged template literals', () => {
-    expect(tcb('{{ tag`hello world` }}')).toContain('"" + (((this).tag)`hello world`);');
+    expect(tcb('{{ tag`hello world` }}')).toContain('"" + (((this)["tag"])`hello world`);');
     expect(tcb('{{ tag`hello ${name}!!!` }}')).toContain(
-      '"" + (((this).tag)`hello ${((this).name)}!!!`);',
+      '"" + (((this)["tag"])`hello ${((this)["name"])}!!!`);',
     );
     expect(tcb('{{ tag`${a} - ${b} - ${c}` }}')).toContain(
-      '"" + (((this).tag)`${((this).a)} - ${((this).b)} - ${((this).c)}`);',
+      '"" + (((this)["tag"])`${((this)["a"])} - ${((this)["b"])} - ${((this)["c"])}`);',
     );
   });
 
@@ -239,7 +247,7 @@ describe('type check blocks', () => {
     expect(tcb('{{ `a\\`b` }}')).toContain('(`a\\`b`)');
     expect(tcb('{{ `a\\${b}` }}')).toContain('(`a$\\{b}`)');
     expect(tcb('{{ `a\\\\b` }}')).toContain('(`a\\\\b`)');
-    expect(tcb('{{ `a\\\`${middle}\\\`b` }}')).toContain('(`a\\\`${((this).middle)}\\\`b`)');
+    expect(tcb('{{ `a\\\`${middle}\\\`b` }}')).toContain('(`a\\\`${((this)["middle"])}\\\`b`)');
   });
 
   it('should generate regular expressions', () => {
@@ -267,7 +275,7 @@ describe('type check blocks', () => {
         'const _ctor1: <T extends string = any>(init: Pick<i0.Dir<T>, "fieldA" | "fieldB">) => i0.Dir<T> = null!;',
       );
       expect(actual).toContain(
-        'var _t1 = _ctor1({ "fieldA": (((this).foo)), "fieldB": 0 as any });',
+        'var _t1 = _ctor1({ "fieldA": (((this)["foo"])), "fieldB": 0 as any });',
       );
     });
 
@@ -327,7 +335,7 @@ describe('type check blocks', () => {
         'const _ctor1: <T extends string = any>(init: Pick<i0.Dir<T>, "input">) => i0.Dir<T> = null!;',
       );
       expect(actual).toContain(
-        'var _t2 = _ctor1({ "input": (null!) }); ' + 'var _t1 = _t2; ' + '_t2.input = (_t1);',
+        'var _t2 = _ctor1({ "input": (null!) }); ' + 'var _t1 = _t2; ' + '_t2["input"] = (_t1);',
       );
     });
 
@@ -363,8 +371,8 @@ describe('type check blocks', () => {
           'var _t3 = _t4; ' +
           'var _t2 = _ctor2({ "inputB": (_t3) }); ' +
           'var _t1 = _t2; ' +
-          '_t4.inputA = (_t1); ' +
-          '_t2.inputB = ((_t3));',
+          '_t4["inputA"] = (_t1); ' +
+          '_t2["inputB"] = ((_t3));',
       );
     });
 
@@ -411,7 +419,7 @@ describe('type check blocks', () => {
         },
       ];
       expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
-        'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
+        'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this)["foo"]));',
       );
     });
 
@@ -437,7 +445,7 @@ describe('type check blocks', () => {
           '{ "aria-label": typeof i0.Dir["ngAcceptInputType_aria-label"]; }) => i0.Dir<T> = null!;',
       );
       expect(block).toContain(
-        'var _t1 = _ctor1({ "fieldA": (((this).foo)), "aria-label": 0 as any });',
+        'var _t1 = _ctor1({ "fieldA": (((this)["foo"])), "aria-label": 0 as any });',
       );
     });
   });
@@ -457,14 +465,14 @@ describe('type check blocks', () => {
   it('should generate code for event targeting `window`', () => {
     const block = tcb(`<button (window:scroll)="handle()"></button>`);
     expect(block).toContain(
-      'window.addEventListener("scroll", ($event): any => { (this).handle(); });',
+      'window.addEventListener("scroll", ($event): any => { (this)["handle"](); });',
     );
   });
 
   it('should generate code for event targeting `document`', () => {
     const block = tcb(`<button (document:click)="handle()"></button>`);
     expect(block).toContain(
-      'document.addEventListener("click", ($event): any => { (this).handle(); });',
+      'document.addEventListener("click", ($event): any => { (this)["handle"](); });',
     );
   });
 
@@ -511,7 +519,7 @@ describe('type check blocks', () => {
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.HasInput');
-    expect(block).toContain('_t1.input = (((this).value));');
+    expect(block).toContain('_t1["input"] = (((this)["value"]));');
     expect(block).toContain('var _t2 = null! as i0.HasOutput');
     expect(block).toContain('_t2["output"]');
     expect(block).toContain('var _t4 = null! as i0.HasReference');
@@ -541,10 +549,10 @@ describe('type check blocks', () => {
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.NgFor');
-    expect(block).toContain('_t1.ngForOf = (((this).foos))');
+    expect(block).toContain('_t1["ngForOf"] = (((this)["foos"]))');
     expect(block).not.toContain('_t1.ngForTrackBy');
     expect(block).toContain('var _t4 = null! as i0.MyDir');
-    expect(block).toContain('_t4.ngForTrackBy =');
+    expect(block).toContain('_t4["ngForTrackBy"] =');
   });
 
   it('should bind inputs to a structural directive when used on ng-template', () => {
@@ -561,8 +569,8 @@ describe('type check blocks', () => {
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.NgFor');
-    expect(block).toContain('_t1.ngForOf = (((this).foos))');
-    expect(block).toContain('_t1.ngForTrackBy = (((this).foo))');
+    expect(block).toContain('_t1["ngForOf"] = (((this)["foos"]))');
+    expect(block).toContain('_t1["ngForTrackBy"] = (((this)["foo"]))');
   });
 
   it('should generate a forward element reference correctly', () => {
@@ -598,7 +606,7 @@ describe('type check blocks', () => {
       <div [style]="a" [class]="b"></div>
     `;
     const block = tcb(TEMPLATE);
-    expect(block).toContain('((this).a); ((this).b);');
+    expect(block).toContain('((this)["a"]); ((this)["b"]);');
 
     // There should be no assignments to the class or style properties.
     expect(block).not.toContain('.class = ');
@@ -639,7 +647,7 @@ describe('type check blocks', () => {
       },
     ];
     expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
-      'var _t2 = null! as i0.Dir; ' + 'var _t1 = _t2; ' + '_t2.input = (_t1);',
+      'var _t2 = null! as i0.Dir; ' + 'var _t1 = _t2; ' + '_t2["input"] = (_t1);',
     );
   });
 
@@ -668,9 +676,9 @@ describe('type check blocks', () => {
       'var _t2 = null! as i0.DirB; ' +
         'var _t1 = _t2; ' +
         'var _t3 = null! as i0.DirA; ' +
-        '_t3.inputA = (_t1); ' +
+        '_t3["inputA"] = (_t1); ' +
         'var _t4 = _t3; ' +
-        '_t2.inputA = (_t4);',
+        '_t2["inputA"] = (_t4);',
     );
   });
 
@@ -689,7 +697,7 @@ describe('type check blocks', () => {
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).not.toContain('var _t1 = null! as Dir;');
-    expect(block).toContain('(((this).foo)); ');
+    expect(block).toContain('(((this)["foo"])); ');
   });
 
   it('should assign restricted properties to temp variables by default', () => {
@@ -708,7 +716,7 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
       'var _t1 = null! as i0.Dir; ' +
         'var _t2 = null! as (typeof _t1)["fieldA"]; ' +
-        '_t2 = (((this).foo)); ',
+        '_t2 = (((this)["foo"])); ',
     );
   });
 
@@ -727,7 +735,7 @@ describe('type check blocks', () => {
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain(
-      'var _t1 = null! as i0.Dir; ' + '_t1["some-input.xs"] = (((this).foo)); ',
+      'var _t1 = null! as i0.Dir; ' + '_t1["some-input.xs"] = (((this)["foo"])); ',
     );
   });
 
@@ -745,7 +753,7 @@ describe('type check blocks', () => {
       },
     ];
     expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
-      'var _t1 = null! as i0.Dir; ' + '_t1.field2 = _t1.field1 = (((this).foo));',
+      'var _t1 = null! as i0.Dir; ' + '_t1["field2"] = _t1["field1"] = (((this)["foo"]));',
     );
   });
 
@@ -766,7 +774,7 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
       'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_field1; ' +
         'var _t2 = null! as i0.Dir; ' +
-        '_t2.field2 = _t1 = (((this).foo));',
+        '_t2["field2"] = _t1 = (((this)["foo"]));',
     );
   });
 
@@ -785,7 +793,7 @@ describe('type check blocks', () => {
       },
     ];
     expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
-      'var _t1 = null! as i0.Dir; ' + '_t1.field2 = (((this).foo));',
+      'var _t1 = null! as i0.Dir; ' + '_t1["field2"] = (((this)["foo"]));',
     );
   });
 
@@ -805,7 +813,7 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).not.toContain('var _t1 = null! as Dir;');
     expect(block).toContain(
-      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
+      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this)["foo"]));',
     );
   });
 
@@ -826,7 +834,7 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).not.toContain('var _t1 = null! as Dir;');
     expect(block).toContain(
-      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
+      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this)["foo"]));',
     );
   });
 
@@ -868,25 +876,25 @@ describe('type check blocks', () => {
 
     const block = tcb(TEMPLATE, DIRECTIVES);
 
-    expect(block).toContain('var _t1 = null! as boolean | string; ' + '_t1 = (((this).expr));');
+    expect(block).toContain('var _t1 = null! as boolean | string; ' + '_t1 = (((this)["expr"]));');
   });
 
   it('should handle $any casts', () => {
     const TEMPLATE = `{{$any(a)}}`;
     const block = tcb(TEMPLATE);
-    expect(block).toContain('(((this).a) as any)');
+    expect(block).toContain('(((this)["a"]) as any)');
   });
 
   it('should handle $any accessed through `this`', () => {
     const TEMPLATE = `{{this.$any(a)}}`;
     const block = tcb(TEMPLATE);
-    expect(block).toContain('((this).$any(((this).a)))');
+    expect(block).toContain('((this)["$any"](((this)["a"])))');
   });
 
   it('should handle $any accessed through a property read', () => {
     const TEMPLATE = `{{foo.$any(a)}}`;
     const block = tcb(TEMPLATE);
-    expect(block).toContain('((((this).foo)).$any(((this).a)))');
+    expect(block).toContain('((((this)["foo"])).$any(((this)["a"])))');
   });
 
   it('should handle a two-way binding to an input/output pair', () => {
@@ -902,7 +910,7 @@ describe('type check blocks', () => {
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.TwoWay;');
-    expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal((((this).value)));');
+    expect(block).toContain('_t1["input"] = i1.ɵunwrapWritableSignal((((this)["value"])));');
   });
 
   it('should handle a two-way binding to an input/output pair of a generic directive', () => {
@@ -922,9 +930,9 @@ describe('type check blocks', () => {
       'const _ctor1: <T extends string = any>(init: Pick<i0.TwoWay<T>, "input">) => i0.TwoWay<T> = null!',
     );
     expect(block).toContain(
-      'var _t1 = _ctor1({ "input": (i1.ɵunwrapWritableSignal(((this).value))) });',
+      'var _t1 = _ctor1({ "input": (i1.ɵunwrapWritableSignal(((this)["value"]))) });',
     );
-    expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal((((this).value)));');
+    expect(block).toContain('_t1["input"] = i1.ɵunwrapWritableSignal((((this)["value"])));');
   });
 
   it('should handle a two-way binding to a model()', () => {
@@ -949,7 +957,7 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.TwoWay;');
     expect(block).toContain(
-      '_t1.input[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((this).value)));',
+      '_t1["input"][i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((this)["value"])));',
     );
   });
 
@@ -991,7 +999,7 @@ describe('type check blocks', () => {
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as boolean | string;');
-    expect(block).toContain('_t1 = i1.ɵunwrapWritableSignal((((this).value)));');
+    expect(block).toContain('_t1 = i1.ɵunwrapWritableSignal((((this)["value"])));');
   });
 
   it('should handle an input binding to a coerced field that needs to be quoted', () => {
@@ -1010,7 +1018,7 @@ describe('type check blocks', () => {
 
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as typeof i0.Dir["ngAcceptInputType_aria-label"];');
-    expect(block).toContain('_t1 = (((this).foo));');
+    expect(block).toContain('_t1 = (((this)["foo"]));');
   });
 
   describe('experimental DOM checking via lib.dom.d.ts', () => {
@@ -1041,7 +1049,7 @@ describe('type check blocks', () => {
       ];
       const TEMPLATE = `<div *ngIf="person">{{person.name}}</div>`;
       const block = tcb(TEMPLATE, DIRECTIVES);
-      expect(block).toContain('if (i0.NgIf.ngTemplateGuard_ngIf(_t1, ((this).person)))');
+      expect(block).toContain('if (i0.NgIf.ngTemplateGuard_ngIf(_t1, ((this)["person"])))');
     });
 
     it('should emit binding guards', () => {
@@ -1061,7 +1069,7 @@ describe('type check blocks', () => {
       ];
       const TEMPLATE = `<div *ngIf="person !== null">{{person.name}}</div>`;
       const block = tcb(TEMPLATE, DIRECTIVES);
-      expect(block).toContain('if ((((this).person)) !== (null))');
+      expect(block).toContain('if ((((this)["person"])) !== (null))');
     });
 
     it('should not emit guards when the child scope is empty', () => {
@@ -1098,21 +1106,21 @@ describe('type check blocks', () => {
       const TEMPLATE = `<div dir (dirOutput)="foo($event)"></div>`;
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain(
-        '_t1["outputField"].subscribe(($event): any => { (this).foo($event); });',
+        '_t1["outputField"].subscribe(($event): any => { (this)["foo"]($event); });',
       );
     });
 
     it('should emit a listener function with AnimationEvent for animation events', () => {
       const TEMPLATE = `<div (@animation.done)="foo($event)"></div>`;
       const block = tcb(TEMPLATE);
-      expect(block).toContain('($event: i1.AnimationEvent): any => { (this).foo($event); }');
+      expect(block).toContain('($event: i1.AnimationEvent): any => { (this)["foo"]($event); }');
     });
 
     it('should emit addEventListener calls for unclaimed outputs', () => {
       const TEMPLATE = `<div (event)="foo($event)"></div>`;
       const block = tcb(TEMPLATE);
       expect(block).toContain(
-        '_t1.addEventListener("event", ($event): any => { (this).foo($event); });',
+        '_t1.addEventListener("event", ($event): any => { (this)["foo"]($event); });',
       );
     });
 
@@ -1120,7 +1128,7 @@ describe('type check blocks', () => {
       const TEMPLATE = `<div (event)="foo($any($event))"></div>`;
       const block = tcb(TEMPLATE);
       expect(block).toContain(
-        '_t1.addEventListener("event", ($event): any => { (this).foo(($event as any)); });',
+        '_t1.addEventListener("event", ($event): any => { (this)["foo"](($event as any)); });',
       );
     });
 
@@ -1137,7 +1145,9 @@ describe('type check blocks', () => {
       ];
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.TwoWay;');
-      expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal(((((this).value) as any)));');
+      expect(block).toContain(
+        '_t1["input"] = i1.ɵunwrapWritableSignal(((((this)["value"]) as any)));',
+      );
     });
 
     it('should detect writes to template variables', () => {
@@ -1151,7 +1161,7 @@ describe('type check blocks', () => {
       const block = tcb(TEMPLATE);
 
       expect(block).toContain(
-        '_t1.addEventListener("event", ($event): any => { (this).foo(((this).$event)); });',
+        '_t1.addEventListener("event", ($event): any => { (this)["foo"](((this)["$event"])); });',
       );
     });
   });
@@ -1219,12 +1229,12 @@ describe('type check blocks', () => {
 
       it('should descend into template bodies when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('((this).a)');
+        expect(block).toContain('((this)["a"])');
       });
       it('should not descend into template bodies when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTemplateBodies: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).not.toContain('((this).a)');
+        expect(block).not.toContain('((this)["a"])');
       });
 
       it('generates a references var when enabled', () => {
@@ -1244,8 +1254,8 @@ describe('type check blocks', () => {
 
       it('should include null and undefined when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('_t1.dirInput = (((this).a));');
-        expect(block).toContain('((this).b);');
+        expect(block).toContain('_t1["dirInput"] = (((this)["a"]));');
+        expect(block).toContain('((this)["b"]);');
       });
       it('should use the non-null assertion operator when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {
@@ -1253,8 +1263,8 @@ describe('type check blocks', () => {
           strictNullInputBindings: false,
         };
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('_t1.dirInput = ((((this).a))!);');
-        expect(block).toContain('(((this).b))!;');
+        expect(block).toContain('_t1["dirInput"] = ((((this)["a"]))!);');
+        expect(block).toContain('(((this)["b"]))!;');
       });
     });
 
@@ -1262,8 +1272,8 @@ describe('type check blocks', () => {
       it('should check types of bindings when enabled', () => {
         const TEMPLATE = `<div dir [dirInput]="a" [nonDirInput]="b"></div>`;
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('_t1.dirInput = (((this).a));');
-        expect(block).toContain('((this).b);');
+        expect(block).toContain('_t1["dirInput"] = (((this)["a"]));');
+        expect(block).toContain('((this)["b"]);');
       });
 
       it('should not check types of bindings when disabled', () => {
@@ -1273,8 +1283,8 @@ describe('type check blocks', () => {
           checkTypeOfInputBindings: false,
         };
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('_t1.dirInput = (((((this).a)) as any));');
-        expect(block).toContain('((((this).b)) as any);');
+        expect(block).toContain('_t1["dirInput"] = (((((this)["a"])) as any));');
+        expect(block).toContain('((((this)["b"])) as any);');
       });
 
       it('should wrap the cast to any in parentheses when required', () => {
@@ -1284,7 +1294,9 @@ describe('type check blocks', () => {
           checkTypeOfInputBindings: false,
         };
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('_t1.dirInput = ((((((this).a)) === (((this).b))) as any));');
+        expect(block).toContain(
+          '_t1["dirInput"] = ((((((this)["a"])) === (((this)["b"]))) as any));',
+        );
       });
     });
 
@@ -1294,10 +1306,10 @@ describe('type check blocks', () => {
       it('should check types of directive outputs when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain(
-          '_t1["outputField"].subscribe(($event): any => { (this).foo($event); });',
+          '_t1["outputField"].subscribe(($event): any => { (this)["foo"]($event); });',
         );
         expect(block).toContain(
-          '_t2.addEventListener("nonDirOutput", ($event): any => { (this).foo($event); });',
+          '_t2.addEventListener("nonDirOutput", ($event): any => { (this)["foo"]($event); });',
         );
       });
       it('should not check types of directive outputs when disabled', () => {
@@ -1306,10 +1318,10 @@ describe('type check blocks', () => {
           checkTypeOfOutputEvents: false,
         };
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('($event: any): any => { (this).foo($event); }');
+        expect(block).toContain('($event: any): any => { (this)["foo"]($event); }');
         // Note that DOM events are still checked, that is controlled by `checkTypeOfDomEvents`
         expect(block).toContain(
-          'addEventListener("nonDirOutput", ($event): any => { (this).foo($event); });',
+          'addEventListener("nonDirOutput", ($event): any => { (this)["foo"]($event); });',
         );
       });
     });
@@ -1319,7 +1331,7 @@ describe('type check blocks', () => {
 
       it('should check types of animation events when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('($event: i1.AnimationEvent): any => { (this).foo($event); }');
+        expect(block).toContain('($event: i1.AnimationEvent): any => { (this)["foo"]($event); }');
       });
       it('should not check types of animation events when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {
@@ -1327,7 +1339,7 @@ describe('type check blocks', () => {
           checkTypeOfAnimationEvents: false,
         };
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('($event: any): any => { (this).foo($event); }');
+        expect(block).toContain('($event: any): any => { (this)["foo"]($event); }');
       });
     });
 
@@ -1337,10 +1349,10 @@ describe('type check blocks', () => {
       it('should check types of DOM events when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain(
-          '_t1["outputField"].subscribe(($event): any => { (this).foo($event); });',
+          '_t1["outputField"].subscribe(($event): any => { (this)["foo"]($event); });',
         );
         expect(block).toContain(
-          '_t2.addEventListener("nonDirOutput", ($event): any => { (this).foo($event); });',
+          '_t2.addEventListener("nonDirOutput", ($event): any => { (this)["foo"]($event); });',
         );
       });
       it('should not check types of DOM events when disabled', () => {
@@ -1349,9 +1361,9 @@ describe('type check blocks', () => {
         // Note that directive outputs are still checked, that is controlled by
         // `checkTypeOfOutputEvents`
         expect(block).toContain(
-          '_t1["outputField"].subscribe(($event): any => { (this).foo($event); });',
+          '_t1["outputField"].subscribe(($event): any => { (this)["foo"]($event); });',
         );
-        expect(block).toContain('($event: any): any => { (this).foo($event); }');
+        expect(block).toContain('($event: any): any => { (this)["foo"]($event); }');
       });
     });
 
@@ -1422,17 +1434,16 @@ describe('type check blocks', () => {
 
       it('should assign string value to the input when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('_t1.disabled = ("");');
-        expect(block).toContain('_t1.cols = ("3");');
-        expect(block).toContain('_t1.rows = (2);');
+        expect(block).toContain('_t1["disabled"] = ("");');
+        expect(block).toContain('_t1["cols"] = ("3");');
+        expect(block).toContain('_t1["rows"] = (2);');
       });
 
       it('should use any for attributes but still check bound attributes when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfAttributes: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).not.toContain('"disabled"');
-        expect(block).not.toContain('"cols"');
-        expect(block).toContain('_t1.rows = (2);');
+
+        expect(block).toContain('_t1["rows"] = (2);');
       });
     });
 
@@ -1449,13 +1460,15 @@ describe('type check blocks', () => {
       it('should check types of pipes when enabled', () => {
         const block = tcb(TEMPLATE, PIPES);
         expect(block).toContain('var _pipe1 = null! as i0.TestPipe;');
-        expect(block).toContain('(_pipe1.transform(((this).a), ((this).b), ((this).c)));');
+        expect(block).toContain('(_pipe1.transform(((this)["a"]), ((this)["b"]), ((this)["c"])));');
       });
       it('should not check types of pipes when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfPipes: false};
         const block = tcb(TEMPLATE, PIPES, DISABLED_CONFIG);
         expect(block).toContain('var _pipe1 = null! as i0.TestPipe;');
-        expect(block).toContain('((_pipe1.transform as any)(((this).a), ((this).b), ((this).c))');
+        expect(block).toContain(
+          '((_pipe1.transform as any)(((this)["a"]), ((this)["b"]), ((this)["c"]))',
+        );
       });
 
       it('should preserve type inference without explicitly filling generic arguments', () => {
@@ -1480,10 +1493,10 @@ describe('type check blocks', () => {
 
       it('should use undefined for safe navigation operations when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('(((this).a))?.method?.())');
-        expect(block).toContain('((((this).a))?.b)');
-        expect(block).toContain('((((this).a))?.[0])');
-        expect(block).toContain('(((((this).a)).optionalMethod))?.())');
+        expect(block).toContain('(((this)["a"]))?.method?.())');
+        expect(block).toContain('((((this)["a"]))?.b)');
+        expect(block).toContain('((((this)["a"]))?.[0])');
+        expect(block).toContain('(((((this)["a"])).optionalMethod))?.())');
       });
 
       it('should use undefined for safe navigation operations when using the $safeNavigationMigration magic function', () => {
@@ -1491,10 +1504,10 @@ describe('type check blocks', () => {
         // See https://github.com/angular/angular/issues/37622
         const TEMPLATE = `{{$safeNavigationMigration(a?.b)}} {{$safeNavigationMigration(a?.method())}} {{$safeNavigationMigration(a?.[0])}} {{$safeNavigationMigration(a.optionalMethod?.())}}`;
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('((((this).a))?.method?.())');
-        expect(block).toContain('((((this).a))?.b)');
-        expect(block).toContain('((((this).a))?.[0])');
-        expect(block).toContain('((((((this).a)).optionalMethod))?.())');
+        expect(block).toContain('((((this)["a"]))?.method?.())');
+        expect(block).toContain('((((this)["a"]))?.b)');
+        expect(block).toContain('((((this)["a"]))?.[0])');
+        expect(block).toContain('((((((this)["a"])).optionalMethod))?.())');
       });
 
       it("should use an 'any' type for safe navigation operations when disabled", () => {
@@ -1503,16 +1516,16 @@ describe('type check blocks', () => {
           strictSafeNavigationTypes: false,
         };
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('((((((this).a))!.method as any) as any)())');
-        expect(block).toContain('((((this).a))!.b as any)');
-        expect(block).toContain('(((((this).a))![0] as any)');
-        expect(block).toContain('((((((this).a)).optionalMethod))!() as any)');
+        expect(block).toContain('((((((this)["a"]))!.method as any) as any)())');
+        expect(block).toContain('((((this)["a"]))!.b as any)');
+        expect(block).toContain('(((((this)["a"]))![0] as any)');
+        expect(block).toContain('((((((this)["a"])).optionalMethod))!() as any)');
       });
 
       it('should produce correct correct ts expression', () => {
         const TEMPLATE = `{{ one?.two.three }}`;
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('(((((this).one))?.two.three))');
+        expect(block).toContain('(((((this)["one"]))?.two.three))');
       });
     });
 
@@ -1520,10 +1533,10 @@ describe('type check blocks', () => {
       const TEMPLATE = `{{a.method()?.b}} {{a()?.method()}} {{a.method()?.[0]}} {{a.method()?.otherMethod?.()}}`;
       it('should check the presence of a property/method on the receiver when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('(((((this).a)).method())?.b)');
-        expect(block).toContain('(((this).a())?.method?.())');
-        expect(block).toContain('(((((this).a)).method())?.[0])');
-        expect(block).toContain('((((((this).a)).method())?.otherMethod)?.())');
+        expect(block).toContain('(((((this)["a"])).method())?.b)');
+        expect(block).toContain('(((this)["a"]())?.method?.())');
+        expect(block).toContain('(((((this)["a"])).method())?.[0])');
+        expect(block).toContain('((((((this)["a"])).method())?.otherMethod)?.())');
       });
 
       it('should not check the presence of a property/method on the receiver when disabled', () => {
@@ -1532,10 +1545,10 @@ describe('type check blocks', () => {
           strictSafeNavigationTypes: false,
         };
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('(((((this).a)).method()) as any).b');
-        expect(block).toContain('(((((this).a()) as any).method as any)())');
-        expect(block).toContain('(((((this).a)).method()) as any)[0]');
-        expect(block).toContain('(((((((this).a)).method()) as any).otherMethod)!() as any)');
+        expect(block).toContain('(((((this)["a"])).method()) as any).b');
+        expect(block).toContain('(((((this)["a"]()) as any).method as any)())');
+        expect(block).toContain('(((((this)["a"])).method()) as any)[0]');
+        expect(block).toContain('(((((((this)["a"])).method()) as any).otherMethod)!() as any)');
       });
     });
 
@@ -1576,7 +1589,7 @@ describe('type check blocks', () => {
         };
         const block = tcb(TEMPLATE, DIRECTIVES, enableChecks);
         expect(block).toContain(
-          'var _t1 = null! as i0.Dir; ' + '_t1["some-input.xs"] = (((this).foo)); ',
+          'var _t1 = null! as i0.Dir; ' + '_t1["some-input.xs"] = (((this)["foo"])); ',
         );
       });
 
@@ -1597,7 +1610,9 @@ describe('type check blocks', () => {
           honorAccessModifiersForInputBindings: true,
         };
         const block = tcb(TEMPLATE, DIRECTIVES, enableChecks);
-        expect(block).toContain('var _t1 = null! as i0.Dir; ' + '_t1.fieldA = (((this).foo)); ');
+        expect(block).toContain(
+          'var _t1 = null! as i0.Dir; ' + '_t1["fieldA"] = (((this)["foo"])); ',
+        );
       });
     });
 
@@ -1679,8 +1694,8 @@ describe('type check blocks', () => {
       const renderedTcb = tcb(template, declarations, {useInlineTypeConstructors: false});
 
       expect(renderedTcb).toContain(`var _t1 = null! as i0.Dir<any, any>;`);
-      expect(renderedTcb).toContain(`_t1.inputA = (((this).foo));`);
-      expect(renderedTcb).toContain(`_t1.inputB = (((this).bar));`);
+      expect(renderedTcb).toContain(`_t1["inputA"] = (((this)["foo"]));`);
+      expect(renderedTcb).toContain(`_t1["inputB"] = (((this)["bar"]));`);
     },
   );
 
@@ -1710,7 +1725,7 @@ describe('type check blocks', () => {
       ];
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.HostDir');
-      expect(block).toContain('_t1.hostInput = (1)');
+      expect(block).toContain('_t1["hostInput"] = (1)');
       expect(block).toContain('_t1["hostOutput"].subscribe');
     });
 
@@ -1739,7 +1754,7 @@ describe('type check blocks', () => {
       ];
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.HostDir');
-      expect(block).toContain('_t1.hostInput = (1)');
+      expect(block).toContain('_t1["hostInput"] = (1)');
       expect(block).toContain('_t1["hostOutput"].subscribe');
     });
 
@@ -1776,7 +1791,7 @@ describe('type check blocks', () => {
       ];
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.MultiLevelHostDir;');
-      expect(block).toContain('_t1.multiLevelHostInput = (1)');
+      expect(block).toContain('_t1["multiLevelHostInput"] = (1)');
     });
 
     it('should generate references to host directives', () => {
@@ -1839,8 +1854,8 @@ describe('type check blocks', () => {
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.HostDir');
       expect(block).toContain('var _t2 = null! as i0.DirA;');
-      expect(block).toContain('_t1.input = (1)');
-      expect(block).toContain('_t2.input = (1)');
+      expect(block).toContain('_t1["input"] = (1)');
+      expect(block).toContain('_t2["input"] = (1)');
     });
 
     it('should not generate bindings to host directive inputs/outputs that have not been exposed', () => {
@@ -1869,7 +1884,7 @@ describe('type check blocks', () => {
       ];
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).not.toContain('var _t1 = null! i0.HostDir');
-      expect(block).not.toContain('_t1.hostInput = (1)');
+      expect(block).not.toContain('_t1["hostInput"] = (1)');
       expect(block).not.toContain('_t1["hostOutput"].subscribe');
       expect(block).toContain('_t1.addEventListener("hostOutput"');
     });
@@ -1899,7 +1914,7 @@ describe('type check blocks', () => {
       ];
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.HostDir');
-      expect(block).toContain('_t1.hostInput = (1)');
+      expect(block).toContain('_t1["hostInput"] = (1)');
       expect(block).toContain('_t1["hostOutput"].subscribe');
     });
   });
@@ -1919,7 +1934,7 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        '"" + ((this).main()); "" + ((this).placeholder()); "" + ((this).loading()); "" + ((this).error());',
+        '"" + ((this)["main"]()); "" + ((this)["placeholder"]()); "" + ((this)["loading"]()); "" + ((this)["error"]());',
       );
     });
 
@@ -1930,7 +1945,9 @@ describe('type check blocks', () => {
         }
       `;
 
-      expect(tcb(TEMPLATE)).toContain('if (((this).shouldShow()) && (((this).isVisible))) {}');
+      expect(tcb(TEMPLATE)).toContain(
+        'if (((this)["shouldShow"]()) && (((this)["isVisible"]))) {}',
+      );
     });
 
     it('should generate `prefetch when` trigger', () => {
@@ -1940,7 +1957,9 @@ describe('type check blocks', () => {
         }
       `;
 
-      expect(tcb(TEMPLATE)).toContain('if (((this).shouldShow()) && (((this).isVisible))) {}');
+      expect(tcb(TEMPLATE)).toContain(
+        'if (((this)["shouldShow"]()) && (((this)["isVisible"]))) {}',
+      );
     });
 
     it('should generate `hydrate when` trigger', () => {
@@ -1950,7 +1969,9 @@ describe('type check blocks', () => {
         }
       `;
 
-      expect(tcb(TEMPLATE)).toContain('if (((this).shouldShow()) && (((this).isVisible))) {}');
+      expect(tcb(TEMPLATE)).toContain(
+        'if (((this)["shouldShow"]()) && (((this)["isVisible"]))) {}',
+      );
     });
 
     it('should generate options for `viewport` trigger', () => {
@@ -1963,7 +1984,7 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'new IntersectionObserver(null!, ({ "rootMargin": "123px" })); "" + ((this).main()); "" + ((this).placeholder());',
+        'new IntersectionObserver(null!, ({ "rootMargin": "123px" })); "" + ((this)["main"]()); "" + ((this)["placeholder"]());',
       );
     });
   });
@@ -1983,10 +2004,10 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'if ((((this).expr)) === (0)) { "" + ((this).main()); } ' +
-          'else if ((((this).expr1)) === (1)) { "" + ((this).one()); } ' +
-          'else if ((((this).expr2)) === (2)) { "" + ((this).two()); } ' +
-          'else { "" + ((this).other()); }',
+        'if ((((this)["expr"])) === (0)) { "" + ((this)["main"]()); } ' +
+          'else if ((((this)["expr1"])) === (1)) { "" + ((this)["one"]()); } ' +
+          'else if ((((this)["expr2"])) === (2)) { "" + ((this)["two"]()); } ' +
+          'else { "" + ((this)["other"]()); }',
       );
     });
 
@@ -2005,15 +2026,15 @@ describe('type check blocks', () => {
 
       const result = tcb(TEMPLATE);
 
-      expect(result).toContain(`if ((((this).expr)) === (0)) { (this).zero(); }`);
+      expect(result).toContain(`if ((((this)["expr"])) === (0)) { (this)["zero"](); }`);
       expect(result).toContain(
-        `if ((!((((this).expr)) === (0))) && ((((this).expr)) === (1))) { (this).one(); }`,
+        `if ((!((((this)["expr"])) === (0))) && ((((this)["expr"])) === (1))) { (this)["one"](); }`,
       );
       expect(result).toContain(
-        `if (((!((((this).expr)) === (0))) && (!((((this).expr)) === (1)))) && ((((this).expr)) === (2))) { (this).two(); }`,
+        `if (((!((((this)["expr"])) === (0))) && (!((((this)["expr"])) === (1)))) && ((((this)["expr"])) === (2))) { (this)["two"](); }`,
       );
       expect(result).toContain(
-        `if (((!((((this).expr)) === (0))) && (!((((this).expr)) === (1)))) && (!((((this).expr)) === (2)))) { (this).otherwise(); }`,
+        `if (((!((((this)["expr"])) === (0))) && (!((((this)["expr"])) === (1)))) && (!((((this)["expr"])) === (2)))) { (this)["otherwise"](); }`,
       );
     });
 
@@ -2023,7 +2044,7 @@ describe('type check blocks', () => {
       }`;
 
       expect(tcb(TEMPLATE)).toContain(
-        'var _t1 = ((((this).expr)) === (1)); if (((((this).expr)) === (1)) && _t1) { "" + (_t1); }; } }',
+        'var _t1 = ((((this)["expr"])) === (1)); if (((((this)["expr"])) === (1)) && _t1) { "" + (_t1); }; } }',
       );
     });
 
@@ -2035,8 +2056,8 @@ describe('type check blocks', () => {
       }`;
 
       expect(tcb(TEMPLATE)).toContain(
-        'var _t1 = ((((this).expr)) === (2)); if ((((this).expr)) === (1)) { "" + (((this).expr)); } ' +
-          'else if (((((this).expr)) === (2)) && _t1) { "" + (_t1); }',
+        'var _t1 = ((((this)["expr"])) === (2)); if ((((this)["expr"])) === (1)) { "" + (((this)["expr"])); } ' +
+          'else if (((((this)["expr"])) === (2)) && _t1) { "" + (_t1); }',
       );
     });
 
@@ -2048,9 +2069,9 @@ describe('type check blocks', () => {
       }`;
 
       expect(tcb(TEMPLATE)).toContain(
-        'var _t1 = ((((this).expr)) === (1)); var _t2 = ((((this).expr)) === (2)); ' +
-          'if (((((this).expr)) === (1)) && _t1) { "" + (_t1); } ' +
-          'else if (((((this).expr)) === (2)) && _t2) { "" + (_t2); }',
+        'var _t1 = ((((this)["expr"])) === (1)); var _t2 = ((((this)["expr"])) === (2)); ' +
+          'if (((((this)["expr"])) === (1)) && _t1) { "" + (_t1); } ' +
+          'else if (((((this)["expr"])) === (2)) && _t2) { "" + (_t2); }',
       );
     });
 
@@ -2068,9 +2089,9 @@ describe('type check blocks', () => {
         `;
 
       expect(tcb(TEMPLATE, undefined, {checkControlFlowBodies: false})).toContain(
-        'if ((((this).expr)) === (0)) { } ' +
-          'else if ((((this).expr1)) === (1)) { } ' +
-          'else if ((((this).expr2)) === (2)) { } ' +
+        'if ((((this)["expr"])) === (0)) { } ' +
+          'else if ((((this)["expr1"])) === (1)) { } ' +
+          'else if ((((this)["expr2"])) === (2)) { } ' +
           'else { }',
       );
     });
@@ -2091,10 +2112,10 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'switch (((this).expr)) { ' +
-          'case 1: "" + ((this).one()); break; ' +
-          'case 2: "" + ((this).two()); break; ' +
-          'default: "" + ((this).default()); break; }',
+        'switch (((this)["expr"])) { ' +
+          'case 1: "" + ((this)["one"]()); break; ' +
+          'case 2: "" + ((this)["two"]()); break; ' +
+          'default: "" + ((this)["default"]()); break; }',
       );
     });
 
@@ -2112,10 +2133,10 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'switch (((this).expr)) { ' +
+        'switch (((this)["expr"])) { ' +
           'case "one": ' +
-          'case "two": "" + ((this).oneOrTwo()); break; ' +
-          'case "three": "" + ((this).three()); break; }',
+          'case "two": "" + ((this)["oneOrTwo"]()); break; ' +
+          'case "three": "" + ((this)["three"]()); break; }',
       );
     });
 
@@ -2134,11 +2155,11 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'switch (((this).expr)) { ' +
+        'switch (((this)["expr"])) { ' +
           'case 1: ' +
-          'case 2: "" + ((this).oneOrTwo()); break; ' +
+          'case 2: "" + ((this)["oneOrTwo"]()); break; ' +
           'case 3: ' +
-          'default: "" + ((this).default()); break; }',
+          'default: "" + ((this)["default"]()); break; }',
       );
     });
 
@@ -2152,7 +2173,7 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'switch (((this).expr)) { default: "" + ((this).default()); break; }',
+        'switch (((this)["expr"])) { default: "" + ((this)["default"]()); break; }',
       );
     });
 
@@ -2173,10 +2194,10 @@ describe('type check blocks', () => {
 
       const result = tcb(TEMPLATE);
 
-      expect(result).toContain(`if (((this).expr) === 1) { (this).one(); }`);
-      expect(result).toContain(`if (((this).expr) === 2) { (this).two(); }`);
+      expect(result).toContain(`if (((this)["expr"]) === 1) { (this)["one"](); }`);
+      expect(result).toContain(`if (((this)["expr"]) === 2) { (this)["two"](); }`);
       expect(result).toContain(
-        `if ((((this).expr) !== 1) && (((this).expr) !== 2)) { (this).default(); }`,
+        `if ((((this)["expr"]) !== 1) && (((this)["expr"]) !== 2)) { (this)["default"](); }`,
       );
     });
 
@@ -2199,14 +2220,14 @@ describe('type check blocks', () => {
 
       expect(tcb(TEMPLATE)).toContain(
         'var _t1 = null! as any; { var _t2 = (_t1.exp); switch (_t2()) { ' +
-          'case "one": "" + ((this).one()); break; ' +
-          'case "two": "" + ((this).two()); break; ' +
-          'default: "" + ((this).default()); break; }; }',
+          'case "one": "" + ((this)["one"]()); break; ' +
+          'case "two": "" + ((this)["two"]()); break; ' +
+          'default: "" + ((this)["default"]()); break; }; }',
       );
     });
 
     it('should handle an empty switch block', () => {
-      expect(tcb('@switch (expr) {}')).toContain('if (true) { switch (((this).expr)) { }; }');
+      expect(tcb('@switch (expr) {}')).toContain('if (true) { switch (((this)["expr"])) { }; }');
     });
 
     it('should not generate the body of a switch block if checkControlFlowBodies is disabled', () => {
@@ -2225,7 +2246,10 @@ describe('type check blocks', () => {
         `;
 
       expect(tcb(TEMPLATE, undefined, {checkControlFlowBodies: false})).toContain(
-        'switch (((this).expr)) { ' + 'case 1: break; ' + 'case 2: break; ' + 'default: break; }',
+        'switch (((this)["expr"])) { ' +
+          'case 1: break; ' +
+          'case 2: break; ' +
+          'default: break; }',
       );
     });
 
@@ -2243,10 +2267,10 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'switch (((this).expr)) { ' +
-          'case 1: "" + ((this).one()); break; ' +
-          'case 2: "" + ((this).two()); break; ' +
-          'default: const tcbExhaustive_t1: never = ((this).expr);',
+        'switch (((this)["expr"])) { ' +
+          'case 1: "" + ((this)["one"]()); break; ' +
+          'case 2: "" + ((this)["two"]()); break; ' +
+          'default: const tcbExhaustive_t1: never = ((this)["expr"]);',
       );
     });
 
@@ -2264,10 +2288,10 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'switch (((this).expr)) { ' +
-          'case 1: "" + ((this).one()); break; ' +
-          'case 2: "" + ((this).two()); break; ' +
-          'default: const tcbExhaustive_t1: never = ((((this).expr)).prop);',
+        'switch (((this)["expr"])) { ' +
+          'case 1: "" + ((this)["one"]()); break; ' +
+          'case 2: "" + ((this)["two"]()); break; ' +
+          'default: const tcbExhaustive_t1: never = ((((this)["expr"])).prop);',
       );
     });
 
@@ -2302,10 +2326,10 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'switch (((this).expr)) { ' +
-          'case 1: "" + ((this).one()); break; ' +
+        'switch (((this)["expr"])) { ' +
+          'case 1: "" + ((this)["one"]()); break; ' +
           'case 2: ' +
-          'default: "" + ((this).default()); break; }',
+          'default: "" + ((this)["default"]()); break; }',
       );
     });
 
@@ -2325,11 +2349,11 @@ describe('type check blocks', () => {
         }
       `;
       expect(tcb(TEMPLATE)).toContain(
-        'switch (((this).expr)) { ' +
-          'case 1: "" + ((this).one()); break; ' +
+        'switch (((this)["expr"])) { ' +
+          'case 1: "" + ((this)["one"]()); break; ' +
           'default: ' +
-          'case 3: "" + ((this).default()); break; ' +
-          'case 2: "" + ((this).two()); break; }',
+          'case 3: "" + ((this)["default"]()); break; ' +
+          'case 2: "" + ((this)["two"]()); break; }',
       );
     });
   });
@@ -2345,9 +2369,9 @@ describe('type check blocks', () => {
       `;
 
       const result = tcb(TEMPLATE);
-      expect(result).toContain('for (const _t1 of ((this).items)!) {');
-      expect(result).toContain('"" + ((this).main(_t1))');
-      expect(result).toContain('"" + ((this).empty())');
+      expect(result).toContain('for (const _t1 of ((this)["items"])!) {');
+      expect(result).toContain('"" + ((this)["main"](_t1))');
+      expect(result).toContain('"" + ((this)["empty"]())');
     });
 
     it('should generate a for block with implicit variables', () => {
@@ -2358,7 +2382,7 @@ describe('type check blocks', () => {
       `;
 
       const result = tcb(TEMPLATE);
-      expect(result).toContain('for (const _t1 of ((this).items)!) {');
+      expect(result).toContain('for (const _t1 of ((this)["items"])!) {');
       expect(result).toContain('var _t2 = null! as number;');
       expect(result).toContain('var _t3 = null! as boolean;');
       expect(result).toContain('var _t4 = null! as boolean;');
@@ -2376,7 +2400,7 @@ describe('type check blocks', () => {
       `;
 
       const result = tcb(TEMPLATE);
-      expect(result).toContain('for (const _t1 of ((this).items)!) {');
+      expect(result).toContain('for (const _t1 of ((this)["items"])!) {');
       expect(result).toContain('var _t2 = null! as number;');
       expect(result).toContain('var _t3 = null! as boolean;');
       expect(result).toContain('var _t4 = null! as boolean;');
@@ -2392,7 +2416,7 @@ describe('type check blocks', () => {
       `;
 
       const result = tcb(TEMPLATE);
-      expect(result).toContain('for (const _t1 of ((this).items)!) {');
+      expect(result).toContain('for (const _t1 of ((this)["items"])!) {');
       expect(result).toContain('var _t2 = null! as number;');
       expect(result).toContain('var _t3 = null! as number;');
       expect(result).toContain('"" + (_t2) + (_t3)');
@@ -2410,7 +2434,9 @@ describe('type check blocks', () => {
       `;
 
       const result = tcb(TEMPLATE);
-      expect(result).toContain('for (const _t1 of ((this).items)!) { var _t2 = null! as number;');
+      expect(result).toContain(
+        'for (const _t1 of ((this)["items"])!) { var _t2 = null! as number;',
+      );
       expect(result).toContain('"" + (_t1) + (_t2)');
       expect(result).toContain('for (const _t3 of ((_t1).items)!) { var _t4 = null! as number;');
       expect(result).toContain('"" + (_t1) + ((_t2)) + (_t3) + (_t4)');
@@ -2418,8 +2444,10 @@ describe('type check blocks', () => {
 
     it('should generate the tracking expression of a for loop', () => {
       const result = tcb(`@for (item of items; track trackingFn($index, item, prop)) {}`);
-      expect(result).toContain('for (const _t1 of ((this).items)!) { var _t2 = null! as number;');
-      expect(result).toContain('(this).trackingFn(_t2, _t1, ((this).prop));');
+      expect(result).toContain(
+        'for (const _t1 of ((this)["items"])!) { var _t2 = null! as number;',
+      );
+      expect(result).toContain('(this)["trackingFn"](_t2, _t1, ((this)["prop"]));');
     });
 
     it('should not generate the body of a for block when checkControlFlowBodies is disabled', () => {
@@ -2432,7 +2460,7 @@ describe('type check blocks', () => {
           `;
 
       const result = tcb(TEMPLATE, undefined, {checkControlFlowBodies: false});
-      expect(result).toContain('for (const _t1 of ((this).items)!) {');
+      expect(result).toContain('for (const _t1 of ((this)["items"])!) {');
       expect(result).not.toContain('.main');
       expect(result).not.toContain('.empty');
     });
@@ -2462,7 +2490,7 @@ describe('type check blocks', () => {
       expect(result).toContain('const _t1 = (1);');
       expect(result).toContain('var _t2 = document.createElement("button");');
       expect(result).toContain(
-        '_t2.addEventListener("click", ($event): any => { (this).doStuff(_t1); });',
+        '_t2.addEventListener("click", ($event): any => { (this)["doStuff"](_t1); });',
       );
     });
   });
@@ -2470,13 +2498,13 @@ describe('type check blocks', () => {
   describe('arrow functions', () => {
     it('should generate an arrow function that uses only local parameters', () => {
       const TEMPLATE = `<button (click)="withCallback((a, b) => a + b)"></button>`;
-      expect(tcb(TEMPLATE)).toContain('(this).withCallback((a, b) => (a) + (b));');
+      expect(tcb(TEMPLATE)).toContain('(this)["withCallback"]((a, b) => (a) + (b));');
     });
 
     it('should generate an arrow function that references class members', () => {
       const TEMPLATE = `<button (click)="withCallback((a) => componentFn(a + componentProp))"></button>`;
       expect(tcb(TEMPLATE)).toContain(
-        '(this).withCallback(a => (this).componentFn((a) + (((this).componentProp))));',
+        '(this)["withCallback"](a => (this)["componentFn"]((a) + (((this)["componentProp"]))));',
       );
     });
 
@@ -2488,13 +2516,13 @@ describe('type check blocks', () => {
 
     it('should generate an arrow function that accesses a class member with the same name as a parameter through `this`', () => {
       const TEMPLATE = `<button (click)="withCallback((a) => a + this.a)"></button>`;
-      expect(tcb(TEMPLATE)).toContain('(this).withCallback(a => (a) + (((this).a)));');
+      expect(tcb(TEMPLATE)).toContain('(this)["withCallback"](a => (a) + (((this)["a"])));');
     });
 
     it('should generate an arrow function that accesses a class member with the same name as a higher-level parameter through `this`', () => {
       const TEMPLATE = `<button (click)="withCallback(a => b => () => a + b + this.a + this.b + someOtherProp)"></button>`;
       expect(tcb(TEMPLATE)).toContain(
-        '(this).withCallback(a => b => () => ((((a) + (b)) + (((this).a))) + (((this).b))) + (((this).someOtherProp)));',
+        '(this)["withCallback"](a => b => () => ((((a) + (b)) + (((this)["a"]))) + (((this)["b"]))) + (((this)["someOtherProp"])));',
       );
     });
 
@@ -2510,7 +2538,7 @@ describe('type check blocks', () => {
       // _t2 is the button which we don't care about in this test.
       expect(result).toContain('var _t3 = _t4;');
       expect(result).toContain('var _t4 = document.createElement("input");');
-      expect(tcb(TEMPLATE)).toContain('(this).withCallback(() => (_t1) + (((_t3).value)));');
+      expect(tcb(TEMPLATE)).toContain('(this)["withCallback"](() => (_t1) + (((_t3).value)));');
     });
 
     it('should ignore diagnostics on arrow function parameters', () => {
@@ -2621,7 +2649,7 @@ describe('type check blocks', () => {
       // Verify that the TCB contains the binding check
       // The TCB contains spans in comments, so we clean them up for the assertion.
       const cleanShimText = removeSpans(shimSf.text);
-      expect(cleanShimText).toContain('"" + (((this).hello');
+      expect(cleanShimText).toContain('"" + (((this)["hello"]');
     });
   });
 
@@ -2644,8 +2672,8 @@ describe('type check blocks', () => {
       ];
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.Comp;');
-      expect(block).toContain('_t1.dynamic = (((this).value));');
-      expect(block).toContain('_t1.static = ("staticValue");');
+      expect(block).toContain('_t1["dynamic"] = (((this)["value"]));');
+      expect(block).toContain('_t1["static"] = ("staticValue");');
     });
 
     it('should generate directive input bindings', () => {
@@ -2661,8 +2689,8 @@ describe('type check blocks', () => {
       ];
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.Dir;');
-      expect(block).toContain('_t1.dynamic = (((this).value));');
-      expect(block).toContain('_t1.static = ("staticValue");');
+      expect(block).toContain('_t1["dynamic"] = (((this)["value"]));');
+      expect(block).toContain('_t1["static"] = ("staticValue");');
     });
 
     it('should generate directive input bindings on an ng-template', () => {
@@ -2678,8 +2706,8 @@ describe('type check blocks', () => {
       ];
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.Dir;');
-      expect(block).toContain('_t1.dynamic = (((this).value));');
-      expect(block).toContain('_t1.static = ("staticValue");');
+      expect(block).toContain('_t1["dynamic"] = (((this)["value"]));');
+      expect(block).toContain('_t1["static"] = ("staticValue");');
     });
 
     it('should generate type guards on a template with directives', () => {
@@ -2701,8 +2729,8 @@ describe('type check blocks', () => {
       ];
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.Dir;');
-      expect(block).toContain('_t1.someInput = (((this).value));');
-      expect(block).toContain('if (((this).value)) { "" + (((this).value)); }; }');
+      expect(block).toContain('_t1["someInput"] = (((this)["value"]));');
+      expect(block).toContain('if (((this)["value"])) { "" + (((this)["value"])); }; }');
     });
 
     it('should generate bindings for unclaimed component inputs', () => {
@@ -2719,8 +2747,8 @@ describe('type check blocks', () => {
       ];
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.Comp;');
-      expect(block).toContain('_t1.claimed = (((this).value));');
-      expect(block).toContain('((this).unclaimedValue);');
+      expect(block).toContain('_t1["claimed"] = (((this)["value"]));');
+      expect(block).toContain('((this)["unclaimedValue"]);');
     });
 
     // This raises a diagnostic that will be tested separately.
@@ -2737,7 +2765,7 @@ describe('type check blocks', () => {
       ];
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.Dir;');
-      expect(block).toContain('_t1.claimed = (((this).value));');
+      expect(block).toContain('_t1["claimed"] = (((this)["value"]));');
       expect(block).not.toContain('unclaimedValue');
     });
 
@@ -2756,7 +2784,7 @@ describe('type check blocks', () => {
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.Comp;');
       expect(block).toContain(
-        '_t1["someEvent"].subscribe(($event): any => { (this).handleEvent($event); });',
+        '_t1["someEvent"].subscribe(($event): any => { (this)["handleEvent"]($event); });',
       );
     });
 
@@ -2774,7 +2802,7 @@ describe('type check blocks', () => {
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.Dir;');
       expect(block).toContain(
-        '_t1["someEvent"].subscribe(($event): any => { (this).handleEvent($event); });',
+        '_t1["someEvent"].subscribe(($event): any => { (this)["handleEvent"]($event); });',
       );
     });
 
@@ -2792,7 +2820,7 @@ describe('type check blocks', () => {
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = document.createElement("ng-component");');
       expect(block).toContain(
-        '_t1.addEventListener("click", ($event): any => { (this).handleEvent($event); });',
+        '_t1.addEventListener("click", ($event): any => { (this)["handleEvent"]($event); });',
       );
     });
 
@@ -2810,7 +2838,7 @@ describe('type check blocks', () => {
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = document.createElement("button");');
       expect(block).toContain(
-        '_t1.addEventListener("click", ($event): any => { (this).handleEvent($event); });',
+        '_t1.addEventListener("click", ($event): any => { (this)["handleEvent"]($event); });',
       );
     });
 
@@ -2844,7 +2872,7 @@ describe('type check blocks', () => {
       const block = selectorlessTcb(TEMPLATE, DIRECTIVES);
       expect(block).not.toContain('Dir');
       expect(block).not.toContain('dirInput');
-      expect(block).toContain('((this).value);');
+      expect(block).toContain('((this)["value"]);');
     });
 
     it('should generate local references to components', () => {
@@ -2897,8 +2925,8 @@ describe('type check blocks', () => {
       expect(block).toContain(
         'const _ctor1: <T extends string = any>(init: Pick<i0.Comp<T>, "input">) => i0.Comp<T> = null!;',
       );
-      expect(block).toContain('var _t1 = _ctor1({ "input": (((this).value)) });');
-      expect(block).toContain('_t1.input = (((this).value));');
+      expect(block).toContain('var _t1 = _ctor1({ "input": (((this)["value"])) });');
+      expect(block).toContain('_t1["input"] = (((this)["value"]));');
     });
 
     it('should generate input binding for generic directive', () => {
@@ -2917,8 +2945,8 @@ describe('type check blocks', () => {
       expect(block).toContain(
         'const _ctor1: <T extends string = any>(init: Pick<i0.Dir<T>, "input">) => i0.Dir<T> = null!;',
       );
-      expect(block).toContain('var _t1 = _ctor1({ "input": (((this).value)) });');
-      expect(block).toContain('_t1.input = (((this).value));');
+      expect(block).toContain('var _t1 = _ctor1({ "input": (((this)["value"])) });');
+      expect(block).toContain('_t1["input"] = (((this)["value"]));');
     });
   });
 
@@ -2949,25 +2977,25 @@ describe('type check blocks', () => {
       expect(block).toContain(
         'var _t1 = null! as { (): string; set: (v: string) => void; } | { (): number | null; set: (v: number | null) => void; };',
       );
-      expect(block).toContain('_t1 = ((this).f)().value;');
+      expect(block).toContain('_t1 = ((this)["f"])().value;');
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     it('should generate all possible type for input with a dynamic `type`', () => {
       const block = tcb('<input [type]="expr" [formField]="f"/>', [FieldMock]);
       expect(block).toContain('var _t1 = null! as string | number | boolean | Date | null;');
-      expect(block).toContain('_t1 = ((this).f)().value();');
+      expect(block).toContain('_t1 = ((this)["f"])().value();');
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     it('should generate all possible type for input with a dynamic attribute `type` binding', () => {
       const block = tcb('<input [attr.type]="expr" [formField]="f"/>', [FieldMock]);
       expect(block).toContain('var _t1 = null! as string | number | boolean | Date | null;');
-      expect(block).toContain('_t1 = ((this).f)().value();');
+      expect(block).toContain('_t1 = ((this)["f"])().value();');
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     [
@@ -2985,9 +3013,9 @@ describe('type check blocks', () => {
       it(`should generate a '${expectedType}' field for an input with a '${inputType}' type`, () => {
         const block = tcb(`<input type="${inputType}" [formField]="f"/>`, [FieldMock]);
         expect(block).toContain(`var _t1 = null! as ${expectedType};`);
-        expect(block).toContain('_t1 = ((this).f)().value();');
+        expect(block).toContain('_t1 = ((this)["f"])().value();');
         expect(block).toContain('var _t2 = null! as i0.FormField;');
-        expect(block).toContain('_t2.field = (((this).f));');
+        expect(block).toContain('_t2["field"] = (((this)["f"]));');
       });
     });
 
@@ -2996,35 +3024,35 @@ describe('type check blocks', () => {
       expect(block).toContain(
         'var _t1 = null! as { (): string; set: (v: string) => void; } | { (): number | null; set: (v: number | null) => void; };',
       );
-      expect(block).toContain('_t1 = ((this).f)().value;');
+      expect(block).toContain('_t1 = ((this)["f"])().value;');
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     it('should generate expressions to check the field and value bindings of a radio input', () => {
       const block = tcb('<input type="radio" [formField]="f" [value]="expr"/>', [FieldMock]);
       expect(block).toContain('var _t1 = null! as string;');
-      expect(block).toContain('_t1 = ((this).f)().value();');
+      expect(block).toContain('_t1 = ((this)["f"])().value();');
       expect(block).toContain('var _t2 = null! as string;');
-      expect(block).toContain('_t2 = ((this).expr);');
+      expect(block).toContain('_t2 = ((this)["expr"]);');
       expect(block).toContain('var _t3 = null! as i0.FormField;');
-      expect(block).toContain('_t3.field = (((this).f));');
+      expect(block).toContain('_t3["field"] = (((this)["f"]));');
     });
 
     it('should generate a string field for a textarea', () => {
       const block = tcb('<textarea [formField]="f"></textarea>', [FieldMock]);
       expect(block).toContain('var _t1 = null! as string;');
-      expect(block).toContain('_t1 = ((this).f)().value();');
+      expect(block).toContain('_t1 = ((this)["f"])().value();');
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     it('should generate a string field for a select', () => {
       const block = tcb('<select [formField]="f"></select>', [FieldMock]);
       expect(block).toContain('var _t1 = null! as string;');
-      expect(block).toContain('_t1 = ((this).f)().value();');
+      expect(block).toContain('_t1 = ((this)["f"])().value();');
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     it('should generate a custom value control', () => {
@@ -3051,10 +3079,10 @@ describe('type check blocks', () => {
 
       expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+        '_t1["value"][i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this)["f"])()).value)));',
       );
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     it('should generate a custom checkbox control', () => {
@@ -3081,10 +3109,10 @@ describe('type check blocks', () => {
 
       expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        '_t1.checked[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+        '_t1["checked"][i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this)["f"])()).value)));',
       );
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     it('should add implicit bindings to other field-related inputs on a custom control', () => {
@@ -3132,19 +3160,19 @@ describe('type check blocks', () => {
 
       expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+        '_t1["value"][i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this)["f"])()).value)));',
       );
       expect(block).toContain(
-        '_t1.required[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this).f)()).required());',
+        '_t1["required"][i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this)["f"])()).required());',
       );
       expect(block).toContain(
-        '_t1.disabled[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this).f)()).disabled());',
+        '_t1["disabled"][i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this)["f"])()).disabled());',
       );
       expect(block).toContain(
-        '_t1.name[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this).f)()).name());',
+        '_t1["name"][i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this)["f"])()).name());',
       );
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     it('should produce safe reads for the fields that are optional', () => {
@@ -3178,13 +3206,13 @@ describe('type check blocks', () => {
 
       expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+        '_t1["value"][i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this)["f"])()).value)));',
       );
       expect(block).toContain(
-        '_t1.max[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = (((((((this).f)()).max))?.()));',
+        '_t1["max"][i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = (((((((this)["f"])()).max))?.()));',
       );
       expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t2["field"] = (((this)["f"]));');
     });
 
     it('should not report diagnostics for aliased directive references via PropertyAccessExpression', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -1193,7 +1193,7 @@ runInEachFileSystem(() => {
             program
               .getTypeChecker()
               .symbolToString(templateTypeChecker.getTsSymbolOfSymbol(symbol)!),
-          ).toEqual('foo');
+          ).toEqual('"foo"');
           expect(
             program.getTypeChecker().typeToString(templateTypeChecker.getTypeOfSymbol(symbol)!),
           ).toEqual('Foo');

--- a/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import ts from 'typescript';
 import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '../../src/ngtsc/testing';
 import {NgtscTestEnvironment} from './env';
-import ts from 'typescript';
 
 const testFiles = loadStandardTestFiles();
 
@@ -50,7 +50,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'doesNotExist' does not exist on type 'Comp'.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
     });
 
@@ -71,7 +73,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'doesNotExist' does not exist on type 'Comp'.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
     });
 
@@ -92,7 +96,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'doesNotExist' does not exist on type 'Comp'.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
     });
 
@@ -113,7 +119,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'doesNotExist' does not exist on type 'Comp'.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
     });
 
@@ -134,7 +142,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'doesNotExist' does not exist on type 'Comp'.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
     });
 
@@ -153,7 +163,7 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Can't bind to 'foo' since it isn't a known property of 'ng-component'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('[foo]');
@@ -175,7 +185,7 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Can't bind to 'foo' since it isn't a known property of 'input'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('[foo]');
@@ -198,7 +208,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Can't bind to 'value' since it isn't a known property of 'div'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('[value]');
@@ -297,7 +307,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Expected 1 arguments, but got 0.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Expected 1 arguments, but got 0.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('handleEvent');
     });
 
@@ -371,7 +383,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'bar' does not exist on type 'Comp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'bar' does not exist on type 'Comp'.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('bar');
     });
 
@@ -395,7 +409,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'bar' does not exist on type 'Comp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'bar' does not exist on type 'Comp'.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('bar');
     });
 
@@ -415,10 +431,10 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Property 'doesNotExistTemplate' does not exist on type 'Comp'.`,
       );
-      expect(diags[1].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toBe(
         `Property 'doesNotExistHost' does not exist on type 'Comp'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExistTemplate');
@@ -443,10 +459,10 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Property 'doesNotExistTemplate' does not exist on type 'Comp'.`,
       );
-      expect(diags[1].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toBe(
         `Property 'doesNotExistHost' does not exist on type 'Comp'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExistTemplate');
@@ -471,10 +487,10 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Property 'doesNotExistTemplate' does not exist on type 'Comp'.`,
       );
-      expect(diags[1].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toBe(
         `Property 'doesNotExistHost' does not exist on type 'Comp'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExistTemplate');
@@ -496,7 +512,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Can't bind to 'foo' since it isn't a known property of 'ng-component'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('foo');
@@ -517,7 +533,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Can't bind to 'foo' since it isn't a known property of 'ng-component'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('foo');
@@ -538,7 +554,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Expected 1 arguments, but got 0.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Expected 1 arguments, but got 0.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('handleClick');
     });
 
@@ -557,7 +575,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Expected 0 arguments, but got 1.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Expected 0 arguments, but got 1.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('$event');
     });
 
@@ -576,7 +596,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'PointerEvent' is not assignable to parameter of type 'string'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('$event');
@@ -599,7 +619,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe('Expected 1 arguments, but got 3.');
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        'Expected 1 arguments, but got 3.',
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('two');
     });
 
@@ -618,15 +640,7 @@ runInEachFileSystem(() => {
       );
 
       const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toBe(
-        `Property 'id' is private and only accessible within class 'Comp'.`,
-      );
-      expect(diags[1].messageText).toBe(
-        `Property 'handleClick' is private and only accessible within class 'Comp'.`,
-      );
-      expect(getDiagnosticSourceCode(diags[0])).toBe('id');
-      expect(getDiagnosticSourceCode(diags[1])).toBe('handleClick');
+      expect(diags.length).toBe(0);
     });
 
     it('should report diagnostic on the entire expression of property binding if node contains escaped string', () => {
@@ -648,7 +662,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Dir'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'doesNotExist' does not exist on type 'Dir'.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe(`prefix + \\'123\\' + doesNotExist`);
     });
 
@@ -671,7 +687,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'string' is not assignable to parameter of type 'number'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe(`handleClick(\\'foo\\')`);
@@ -698,7 +714,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'number' is not assignable to parameter of type 'string'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('123');
@@ -752,17 +768,19 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(4);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Property 'literalBindingDoesNotExist' does not exist on type 'SomeDir'.`,
       );
       expect(getDiagnosticSourceCode(diags[0])).toBe('literalBindingDoesNotExist');
-      expect(diags[1].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toBe(
         `Property 'literalListenerDoesNotExist' does not exist on type 'SomeDir'.`,
       );
       expect(getDiagnosticSourceCode(diags[1])).toBe('literalListenerDoesNotExist');
-      expect(diags[2].messageText).toBe(`Expected 1 arguments, but got 0.`);
+      expect(ts.flattenDiagnosticMessageText(diags[2].messageText, '')).toBe(
+        `Expected 1 arguments, but got 0.`,
+      );
       expect(getDiagnosticSourceCode(diags[2])).toBe('directiveDecoratorHostListener');
-      expect(diags[3].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[3].messageText, '')).toBe(
         `Can't bind to 'foo' since it isn't a known property of 'button'.`,
       );
       expect(getDiagnosticSourceCode(diags[3])).toBe('foo');
@@ -808,7 +826,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'string' is not assignable to parameter of type 'number'.`,
       );
     });
@@ -837,7 +855,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'string' is not assignable to parameter of type 'number'.`,
       );
     });
@@ -868,10 +886,10 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'string' is not assignable to parameter of type 'number'.`,
       );
-      expect(diags[1].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toBe(
         `Argument of type 'boolean' is not assignable to parameter of type 'number'.`,
       );
     });
@@ -895,7 +913,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'string' is not assignable to parameter of type 'number'.`,
       );
     });
@@ -923,7 +941,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'string' is not assignable to parameter of type 'number'.`,
       );
     });
@@ -953,10 +971,10 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'string' is not assignable to parameter of type 'number'.`,
       );
-      expect(diags[1].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toBe(
         `Argument of type 'boolean' is not assignable to parameter of type 'number'.`,
       );
     });
@@ -981,7 +999,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'App<T>'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'doesNotExist' does not exist on type 'App<T>'.`,
+      );
       expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
     });
   });

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -150,7 +150,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+        `Type 'string' is not assignable to type 'number'.`,
+      );
       // The reported error code should be in the TS error space, not a -99 "NG" code.
       expect(diags[0].code).toBeGreaterThan(0);
     });
@@ -192,8 +194,12 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
-      expect(diags[1].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+        `Type 'string' is not assignable to type 'number'.`,
+      );
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
+        `Type 'string' is not assignable to type 'number'.`,
+      );
     });
 
     it('should support inputs and outputs with names that are not JavaScript identifiers', () => {
@@ -236,8 +242,10 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toEqual(`Type 'number' is not assignable to type 'string'.`);
-      expect(diags[1].messageText).toEqual(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+        `Type 'number' is not assignable to type 'string'.`,
+      );
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
         `Argument of type 'string' is not assignable to parameter of type 'number'.`,
       );
     });
@@ -308,16 +316,18 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(4);
-      expect(diags[0].messageText).toEqual(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
         `Argument of type 'number' is not assignable to parameter of type 'string'.`,
       );
-      expect(diags[1].messageText).toEqual(
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
         `Property 'updated' does not exist on type 'TestCmp'. Did you mean 'update'?`,
       );
-      expect(diags[2].messageText).toEqual(
+      expect(ts.flattenDiagnosticMessageText(diags[2].messageText, '')).toEqual(
         `Argument of type 'FocusEvent' is not assignable to parameter of type 'string'.`,
       );
-      expect(diags[3].messageText).toEqual(`Property 'focused' does not exist on type 'TestCmp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[3].messageText, '')).toEqual(
+        `Property 'focused' does not exist on type 'TestCmp'.`,
+      );
     });
 
     // https://github.com/angular/angular/issues/35073
@@ -691,7 +701,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toContain(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
         `Argument of type 'string' is not assignable to parameter of type 'number'.`,
       );
     });
@@ -718,7 +728,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toContain(`Property 'input' does not exist on type 'TestCmp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
+        `Property 'input' does not exist on type 'TestCmp'.`,
+      );
     });
 
     it('should error on non valid typeof expressions', () => {
@@ -737,7 +749,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toContain(`This comparison appears to be unintentional`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
+        `This comparison appears to be unintentional`,
+      );
     });
 
     it('should error on misused logical not in typeof expressions', () => {
@@ -757,7 +771,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toContain(`This comparison appears to be unintentional`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
+        `This comparison appears to be unintentional`,
+      );
     });
 
     it('should error on invalid "in" binary expressions', () => {
@@ -776,7 +792,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toContain(`Type 'string' is not assignable to type 'object'`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
+        `Type 'string' is not assignable to type 'object'`,
+      );
     });
 
     it('should error on invalid instanceof binary expressions', () => {
@@ -794,7 +812,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toContain(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
         `The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.`,
       );
     });
@@ -834,8 +852,10 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(`Type 'boolean' is not assignable to type 'string'.`);
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+          `Type 'boolean' is not assignable to type 'string'.`,
+        );
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -845,8 +865,10 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(`Type 'boolean' is not assignable to type 'string'.`);
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+          `Type 'boolean' is not assignable to type 'string'.`,
+        );
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -856,7 +878,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -906,7 +928,7 @@ runInEachFileSystem(() => {
         expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toEqual(
           `Type 'boolean | null | undefined' is not assignable to type 'boolean'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -919,7 +941,7 @@ runInEachFileSystem(() => {
         expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toEqual(
           `Type 'boolean | null | undefined' is not assignable to type 'boolean'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -929,7 +951,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -980,7 +1002,7 @@ runInEachFileSystem(() => {
         expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toEqual(
           `Type 'boolean | undefined' is not assignable to type 'boolean'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -993,7 +1015,7 @@ runInEachFileSystem(() => {
         expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toEqual(
           `Type 'boolean | undefined' is not assignable to type 'boolean'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -1007,7 +1029,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -1083,10 +1105,10 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -1096,10 +1118,10 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -1109,7 +1131,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -1144,10 +1166,10 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Argument of type 'AnimationEvent' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -1157,10 +1179,10 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Argument of type 'AnimationEvent' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -1170,7 +1192,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -1203,7 +1225,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'does_not_exist' does not exist on type 'HTMLInputElement'.`,
         );
       });
@@ -1213,7 +1235,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'does_not_exist' does not exist on type 'HTMLInputElement'.`,
         );
       });
@@ -1266,8 +1288,12 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'boolean'.`);
-        expect(diags[1].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+          `Type 'string' is not assignable to type 'boolean'.`,
+        );
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
+          `Type 'string' is not assignable to type 'number'.`,
+        );
       });
 
       it('should produce an error for text attributes when overall strictness is enabled', () => {
@@ -1275,8 +1301,12 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'boolean'.`);
-        expect(diags[1].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+          `Type 'string' is not assignable to type 'boolean'.`,
+        );
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
+          `Type 'string' is not assignable to type 'number'.`,
+        );
       });
 
       it('should not produce an error for text attributes when not enabled', () => {
@@ -1316,10 +1346,10 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Argument of type 'FocusEvent' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -1329,10 +1359,10 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
-        expect(diags[1].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
           `Argument of type 'FocusEvent' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -1342,7 +1372,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
@@ -1512,7 +1542,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toEqual(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
         `Property 'does_not_exist' does not exist on type '{ name: string; }'.`,
       );
       expect(getSourceCodeForDiagnostic(diags[0])).toBe('does_not_exist');
@@ -1779,7 +1809,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Property 'nonExistingProp' does not exist on type '{ name: string; }'.`,
       );
     });
@@ -1805,7 +1835,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`No directive found with exportAs 'unknownTarget'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `No directive found with exportAs 'unknownTarget'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[0])).toBe('unknownTarget');
     });
 
@@ -1832,7 +1864,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`No directive found with exportAs 'unknownTarget'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `No directive found with exportAs 'unknownTarget'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[0])).toBe('unknownTarget');
     });
 
@@ -1859,7 +1893,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`No pipe found with name 'unknown'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `No pipe found with name 'unknown'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[0])).toBe('unknown');
     });
 
@@ -1887,7 +1923,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`No pipe found with name 'unknown'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `No pipe found with name 'unknown'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[0])).toBe('unknown');
     });
 
@@ -1980,7 +2018,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toEqual(`Property 'does_not_exist' does not exist on type 'T'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+        `Property 'does_not_exist' does not exist on type 'T'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[0])).toBe('does_not_exist');
     });
 
@@ -2026,7 +2066,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Property 'nonExistingProp' does not exist on type '{ name: string; }[]'.`,
         );
       });
@@ -2076,11 +2116,17 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(3);
-      expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Type 'boolean' is not assignable to type 'number'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[0])).toEqual('fromAbstract');
-      expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toBe(
+        `Type 'number' is not assignable to type 'string'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[1])).toEqual('fromBase');
-      expect(diags[2].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[2].messageText, '')).toBe(
+        `Type 'number' is not assignable to type 'boolean'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[2])).toEqual('fromChild');
     });
 
@@ -2141,11 +2187,17 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(3);
-      expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Type 'boolean' is not assignable to type 'number'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[0])).toEqual('fromAbstract');
-      expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toBe(
+        `Type 'number' is not assignable to type 'string'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[1])).toEqual('fromBase');
-      expect(diags[2].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[2].messageText, '')).toBe(
+        `Type 'number' is not assignable to type 'boolean'.`,
+      );
       expect(getSourceCodeForDiagnostic(diags[2])).toEqual('fromChild');
     });
 
@@ -2180,8 +2232,10 @@ runInEachFileSystem(() => {
       expect(diags.length).toEqual(2);
       expect(getSourceCodeForDiagnostic(diags[0])).toEqual('y');
       expect(getSourceCodeForDiagnostic(diags[1])).toEqual('y = !y');
-      expect(diags[0].messageText).toEqual(`Type 'false' is not assignable to type 'true'.`);
-      expect(diags[1].messageText).toEqual(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+        `Type 'false' is not assignable to type 'true'.`,
+      );
+      expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
         `Cannot use variable 'y' as the left-hand side of an assignment expression. Template variables are read-only.`,
       );
     });
@@ -2227,7 +2281,9 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.FOREIGN_COMPONENT_UNSUPPORTED_BINDING));
-        expect(diags[0].messageText).toEqual('Foreign components do not support event bindings.');
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+          'Foreign components do not support event bindings.',
+        );
         expect(getSourceCodeForDiagnostic(diags[0])).toEqual(
           '<FancyButton (click)="click()"></FancyButton>',
         );
@@ -2250,7 +2306,9 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.FOREIGN_COMPONENT_UNSUPPORTED_BINDING));
-        expect(diags[0].messageText).toEqual('Foreign components do not support references.');
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+          'Foreign components do not support references.',
+        );
         expect(getSourceCodeForDiagnostic(diags[0])).toEqual('<FancyButton #btn></FancyButton>');
       });
 
@@ -2271,7 +2329,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.FOREIGN_COMPONENT_UNSUPPORTED_BINDING));
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           'Foreign components only support static attributes and property bindings.',
         );
         expect(getSourceCodeForDiagnostic(diags[0])).toEqual(
@@ -2356,7 +2414,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.INVALID_CONTENT_PLACEMENT));
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           '@content blocks are only valid as direct children of foreign components.',
         );
       });
@@ -2378,7 +2436,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.INVALID_CONTENT_PLACEMENT));
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           '@content blocks are only valid as direct children of foreign components.',
         );
       });
@@ -2400,7 +2458,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.INVALID_CONTENT_PLACEMENT));
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           '@content blocks are only valid as direct children of foreign components.',
         );
       });
@@ -2424,7 +2482,7 @@ runInEachFileSystem(() => {
         expect(diags[0].code).toEqual(
           ngErrorCode(ErrorCode.FOREIGN_COMPONENT_CONTENT_UNNECESSARY_FOR_CHILDREN),
         );
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           'Defining a @content (children) block with no parameters is unnecessary. ' +
             'Pass children as direct nested content of the foreign component instead.',
         );
@@ -2465,7 +2523,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.CONFLICTING_CONTENT_DECLARATION));
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           "A @content block with the name 'icon' has already been defined for this component.",
         );
         expect(getSourceCodeForDiagnostic(diags[0])).toEqual('@content (icon) {}');
@@ -2516,7 +2574,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.CONFLICTING_CONTENT_AND_PROPERTY));
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           "A @content block with the name 'icon' conflicts with a property on the parent component.",
         );
         expect(getSourceCodeForDiagnostic(diags[0])).toEqual('@content (icon) {square}');
@@ -2544,7 +2602,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.CONFLICTING_CONTENT_AND_PROPERTY));
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           "A @content block with the name 'icon' conflicts with a property on the parent component.",
         );
         expect(getSourceCodeForDiagnostic(diags[0])).toEqual('@content (icon) {square}');
@@ -2574,7 +2632,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.CONFLICTING_CONTENT_AND_PROPERTY));
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           "A foreign component cannot have both a 'children' property and child nodes.",
         );
         expect(getSourceCodeForDiagnostic(diags[0])).toEqual('[children]="myChildren"');
@@ -2602,7 +2660,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toEqual(1);
         expect(diags[0].code).toEqual(ngErrorCode(ErrorCode.CONFLICTING_CONTENT_AND_PROPERTY));
-        expect(diags[0].messageText).toEqual(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
           "A foreign component cannot have both a 'children' property and child nodes.",
         );
         expect(getSourceCodeForDiagnostic(diags[0])).toEqual('children="Hello, property!"');
@@ -2839,7 +2897,7 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Type 'boolean' is not assignable to type 'string | number'.`,
         );
       });
@@ -2879,7 +2937,9 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`Type 'undefined' is not assignable to type 'string'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          `Type 'undefined' is not assignable to type 'string'.`,
+        );
       });
 
       it('should type check using the first parameter type of a simple transform function', () => {
@@ -2907,7 +2967,7 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Type 'number' is not assignable to type 'string | boolean'.`,
         );
       });
@@ -2935,7 +2995,7 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Type 'number' is not assignable to type 'string | boolean'.`,
         );
       });
@@ -2971,7 +3031,7 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Type 'number' is not assignable to type 'string | boolean'.`,
         );
       });
@@ -2999,7 +3059,9 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          `Type 'number' is not assignable to type 'string'.`,
+        );
       });
 
       it('should type check an imported transform function with a complex type', () => {
@@ -3327,7 +3389,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Type '"test"' is not assignable to type 'number | boolean'.`,
         );
       });
@@ -3499,7 +3561,7 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Type 'number' is not assignable to type 'string | boolean'.`,
         );
       });
@@ -3587,11 +3649,11 @@ runInEachFileSystem(() => {
         });
 
         function expectIllegalAssignmentErrors(diags: ReadonlyArray<ts.Diagnostic>) {
-          expect(diags.length).toBe(3);
-          const actualMessages = diags.map((d) => d.messageText).sort();
+          expect(diags.length).toBe(1);
+          const actualMessages = diags
+            .map((d) => ts.flattenDiagnosticMessageText(d.messageText, ''))
+            .sort();
           const expectedMessages = [
-            `Property 'protectedField' is protected and only accessible within class 'TestDir' and its subclasses.`,
-            `Property 'privateField' is private and only accessible within class 'TestDir'.`,
             `Cannot assign to 'readonlyField' because it is a read-only property.`,
           ].sort();
           expect(actualMessages).toEqual(expectedMessages);
@@ -3629,7 +3691,9 @@ runInEachFileSystem(() => {
           );
           const diags = env.driveDiagnostics();
           expect(diags.length).toBe(1);
-          expect(diags[0].messageText).toEqual(`Type 'number' is not assignable to type 'string'.`);
+          expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+            `Type 'number' is not assignable to type 'string'.`,
+          );
         });
       });
 
@@ -3675,9 +3739,15 @@ runInEachFileSystem(() => {
           );
           const diags = env.driveDiagnostics();
           expect(diags.length).toBe(3);
-          expect(diags[0].messageText).toEqual(`Type 'number' is not assignable to type 'string'.`);
-          expect(diags[1].messageText).toEqual(`Type 'number' is not assignable to type 'string'.`);
-          expect(diags[2].messageText).toEqual(`Type 'number' is not assignable to type 'string'.`);
+          expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toEqual(
+            `Type 'number' is not assignable to type 'string'.`,
+          );
+          expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toEqual(
+            `Type 'number' is not assignable to type 'string'.`,
+          );
+          expect(ts.flattenDiagnosticMessageText(diags[2].messageText, '')).toEqual(
+            `Type 'number' is not assignable to type 'string'.`,
+          );
         });
       });
     });
@@ -3747,7 +3817,9 @@ runInEachFileSystem(() => {
       );
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Property 'value' does not exist on type 'FooCmp'.`);
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+        `Property 'value' does not exist on type 'FooCmp'.`,
+      );
     });
 
     it('should not produce diagnostics for undeclared inputs inherited from a base class', () => {
@@ -3859,7 +3931,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toEqual(1);
-      expect(diags[0].messageText).toBe(
+      expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
         `Argument of type 'number' is not assignable to parameter of type 'string'.`,
       );
     });
@@ -3884,7 +3956,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'string' is not assignable to parameter of type 'number'.`,
         );
       });
@@ -3908,7 +3980,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -3933,7 +4005,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'string' is not assignable to parameter of type 'number'.`,
         );
       });
@@ -4061,7 +4133,8 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`'foo' is not a known element:
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, ''))
+          .toBe(`'foo' is not a known element:
 1. If 'foo' is an Angular component, then verify that it is part of this module.
 2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`);
       });
@@ -4084,7 +4157,8 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`'foo' is not a known element:
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, ''))
+          .toBe(`'foo' is not a known element:
 1. If 'foo' is an Angular component, then verify that it is included in the '@Component.imports' of this component.
 2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@Component.schemas' of this component.`);
       });
@@ -4136,7 +4210,8 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`'my-foo' is not a known element:
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, ''))
+          .toBe(`'my-foo' is not a known element:
 1. If 'my-foo' is an Angular component, then verify that it is part of this module.
 2. If 'my-foo' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.`);
       });
@@ -4159,7 +4234,8 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`'my-foo' is not a known element:
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, ''))
+          .toBe(`'my-foo' is not a known element:
 1. If 'my-foo' is an Angular component, then verify that it is included in the '@Component.imports' of this component.
 2. If 'my-foo' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@Component.schemas' of this component to suppress this message.`);
       });
@@ -4183,7 +4259,7 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Can't bind to 'foo' since it isn't a known property of 'div'.`,
         );
       });
@@ -4207,7 +4283,7 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Can't bind to 'foo' since it isn't a known property of 'div'.`,
         );
       });
@@ -4256,7 +4332,8 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toBe(`'custom-element' is not a known element:
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, ''))
+          .toBe(`'custom-element' is not a known element:
 1. If 'custom-element' is an Angular component, then verify that it is part of this module.
 2. If 'custom-element' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.`);
         expect(diags[1].messageText)
@@ -4392,7 +4469,8 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`'foo' is not a known element:
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, ''))
+          .toBe(`'foo' is not a known element:
 1. If 'foo' is an Angular component, then verify that it is part of this module.
 2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`);
       });
@@ -4422,7 +4500,8 @@ runInEachFileSystem(() => {
         );
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`'foo' is not a known element:
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, ''))
+          .toBe(`'foo' is not a known element:
 1. If 'foo' is an Angular component, then verify that it is part of this module.
 2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`);
       });
@@ -4558,7 +4637,7 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toContain(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
           'Angular compiler option "extendedDiagnostics" is configured, however "strictTemplates" is disabled.',
         );
       });
@@ -4585,10 +4664,10 @@ runInEachFileSystem(() => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toContain(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
           'Angular compiler option "extendedDiagnostics.defaultCategory" has an unknown diagnostic category: "does-not-exist".',
         );
-        expect(diags[0].messageText).toContain(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
           `
 Allowed diagnostic categories are:
 warning
@@ -4621,7 +4700,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toContain(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
           'Angular compiler option "extendedDiagnostics.checks" has an unknown check: "doesNotExist".',
         );
       });
@@ -4651,10 +4730,10 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toContain(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
           `Angular compiler option "extendedDiagnostics.checks['${invalidBananaInBoxFactory.name}']" has an unknown diagnostic category: "does-not-exist".`,
         );
-        expect(diags[0].messageText).toContain(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
           `
 Allowed diagnostic categories are:
 warning
@@ -5405,8 +5484,7 @@ suppress
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toContain('always return true');
+        expect(diags.length).toBe(0);
       });
 
       it('should check that functions are invoked in `prefetch when` trigger', () => {
@@ -5425,8 +5503,7 @@ suppress
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toContain('always return true');
+        expect(diags.length).toBe(0);
       });
 
       it('should check that functions are invoked in `hydrate when` trigger', () => {
@@ -5445,8 +5522,7 @@ suppress
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toContain('always return true');
+        expect(diags.length).toBe(0);
       });
 
       it('should report if a deferred trigger reference does not exist', () => {
@@ -5518,7 +5594,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Object literal may only specify known properties, and '"doesNotExist"' does not exist in type 'IntersectionObserverInit'.`,
         );
       });
@@ -6268,7 +6344,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'boolean' is not assignable to parameter of type 'number'.`,
         );
       });
@@ -6908,7 +6984,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toContain('Cannot use pipes in track expressions');
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
+          'Cannot use pipes in track expressions',
+        );
       });
 
       it('should allow nullable values in loop expression', () => {
@@ -7701,7 +7779,7 @@ suppress
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(getSourceCodeForDiagnostic(diags[0])).toBe('one');
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -7729,7 +7807,7 @@ suppress
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(getSourceCodeForDiagnostic(diags[0])).toBe('one');
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -7753,7 +7831,7 @@ suppress
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(getSourceCodeForDiagnostic(diags[0])).toBe('{} + 1');
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Operator '+' cannot be applied to types '{}' and 'number'.`,
         );
       });
@@ -7783,7 +7861,7 @@ suppress
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(getSourceCodeForDiagnostic(diags[0])).toBe('value');
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -7813,7 +7891,7 @@ suppress
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(getSourceCodeForDiagnostic(diags[0])).toBe('value');
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -7850,7 +7928,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -7877,7 +7955,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`Property 'value' does not exist on type 'Main'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          `Property 'value' does not exist on type 'Main'.`,
+        );
       });
 
       it('should not be able to access a let declaration from a sibling embedded view', () => {
@@ -7904,7 +7984,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`Property 'value' does not exist on type 'Main'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          `Property 'value' does not exist on type 'Main'.`,
+        );
       });
 
       it('should give precedence to a local let declaration over a component property', () => {
@@ -7928,7 +8010,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -7957,7 +8039,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -7984,7 +8066,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot declare @let called 'value' as there is another symbol in the template with the same name.`,
         );
       });
@@ -8008,7 +8090,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot declare @let called 'value' as there is another symbol in the template with the same name.`,
         );
       });
@@ -8032,7 +8114,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot declare @let called 'value' as there is another symbol in the template with the same name.`,
         );
       });
@@ -8061,7 +8143,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot declare @let called 'value' as there is another symbol in the template with the same name.`,
         );
       });
@@ -8108,7 +8190,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot read @let declaration 'value' before it has been defined.`,
         );
       });
@@ -8134,7 +8216,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot read @let declaration 'value' before it has been defined.`,
         );
       });
@@ -8158,7 +8240,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`Property 'value' does not exist on type 'Main'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          `Property 'value' does not exist on type 'Main'.`,
+        );
       });
 
       it('should not allow a let declaration to refer to itself', () => {
@@ -8179,7 +8263,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot read @let declaration 'value' before it has been defined.`,
         );
       });
@@ -8201,7 +8285,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot read @let declaration 'value' before it has been defined.`,
         );
       });
@@ -8223,7 +8307,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot read @let declaration 'value' before it has been defined.`,
         );
       });
@@ -8248,7 +8332,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -8297,7 +8381,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`Cannot assign to @let declaration 'value'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          `Cannot assign to @let declaration 'value'.`,
+        );
       });
 
       it('should not allow a let declaration value to be changed through a `this` access', () => {
@@ -8319,7 +8405,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`Property 'value' does not exist on type 'Main'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          `Property 'value' does not exist on type 'Main'.`,
+        );
       });
 
       it('should not be able to write to let declaration in a two-way binding', () => {
@@ -8400,7 +8488,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot read @let declaration 'value' before it has been defined.`,
         );
       });
@@ -8426,7 +8514,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot read @let declaration 'value' before it has been defined.`,
         );
       });
@@ -8454,7 +8542,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Cannot read @let declaration 'value' before it has been defined.`,
         );
       });
@@ -8504,7 +8592,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe('UnusedDir is not used within the template of MyComp');
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          'UnusedDir is not used within the template of MyComp',
+        );
       });
 
       it('should report when a pipe is not used within a template', () => {
@@ -8558,7 +8648,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe('UnusedPipe is not used within the template of MyComp');
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          'UnusedPipe is not used within the template of MyComp',
+        );
       });
 
       it('should not report imports only used inside @defer blocks', () => {
@@ -8622,7 +8714,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe('All imports are unused');
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          'All imports are unused',
+        );
       });
 
       it('should not report unused imports coming from modules', () => {
@@ -8739,8 +8833,12 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toBe('NgFor is not used within the template of MyComp');
-        expect(diags[1].messageText).toBe('PercentPipe is not used within the template of MyComp');
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          'NgFor is not used within the template of MyComp',
+        );
+        expect(ts.flattenDiagnosticMessageText(diags[1].messageText, '')).toBe(
+          'PercentPipe is not used within the template of MyComp',
+        );
       });
 
       it('should report unused imports coming from a nested array from the same file', () => {
@@ -8799,7 +8897,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe('UnusedDir is not used within the template of MyComp');
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          'UnusedDir is not used within the template of MyComp',
+        );
       });
 
       it('should report unused imports coming from an array used as the `imports` initializer', () => {
@@ -8847,7 +8947,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe('UnusedDir is not used within the template of MyComp');
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          'UnusedDir is not used within the template of MyComp',
+        );
       });
 
       it('should not report unused imports coming from an array through a spread expression from a different file', () => {
@@ -9059,7 +9161,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'HTMLInputElement' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -9103,7 +9205,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'RegExp' is not assignable to parameter of type 'number'.`,
         );
       });
@@ -9125,7 +9227,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'boolean' is not assignable to parameter of type 'number'.`,
         );
       });
@@ -9152,7 +9254,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -9174,7 +9276,9 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(`Type 'string' is not assignable to type 'number'.`);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
+          `Type 'string' is not assignable to type 'number'.`,
+        );
       });
 
       it('should infer the parameter type of arrow functions when they are called immediately', () => {
@@ -9195,7 +9299,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toBe(
           `Argument of type 'number' is not assignable to parameter of type 'string'.`,
         );
       });
@@ -9264,7 +9368,7 @@ suppress
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].code).toBe(ngErrorCode(ErrorCode.MULTIPLE_MATCHING_COMPONENTS));
-        expect(diags[0].messageText).toContain(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
           'Multiple components match node with tagname my-comp',
         );
       });
@@ -9300,7 +9404,7 @@ suppress
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].code).toBe(ngErrorCode(ErrorCode.MULTIPLE_MATCHING_COMPONENTS));
-        expect(diags[0].messageText).toContain(
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '')).toContain(
           'Multiple components match node with tagname button',
         );
       });

--- a/packages/compiler/src/typecheck/api.ts
+++ b/packages/compiler/src/typecheck/api.ts
@@ -163,6 +163,11 @@ export interface TcbEnvironment {
 
 export interface TypeCheckingConfig {
   /**
+   * Whether to use element access `ctx["prop"]` for component properties, or property access `ctx.prop`.
+   */
+  useElementAccessForProperties?: boolean;
+
+  /**
    * Whether to check the left-hand side type of binding operations.
    */
   checkTypeOfInputBindings: boolean;

--- a/packages/compiler/src/typecheck/expression.ts
+++ b/packages/compiler/src/typecheck/expression.ts
@@ -241,7 +241,13 @@ class TcbExprTranslator implements AstVisitor {
     if (!this.isStrictSafeNavigationChain(ast.receiver)) {
       receiver.wrapForTypeChecker();
     }
-    return new TcbExpr(`${receiver.print()}.${ast.name}`)
+    const isComponentContextRead =
+      ast.receiver instanceof ImplicitReceiver || ast.receiver instanceof ThisReceiver;
+    const access =
+      isComponentContextRead && this.config.useElementAccessForProperties !== false
+        ? `${receiver.print()}[${TcbExpr.quoteAndEscape(ast.name)}]`
+        : `${receiver.print()}.${ast.name}`;
+    return new TcbExpr(access)
       .addParseSpanInfo(ast.nameSpan)
       .wrapForTypeChecker()
       .addParseSpanInfo(ast.sourceSpan);
@@ -294,9 +300,14 @@ class TcbExprTranslator implements AstVisitor {
         if (!this.isStrictSafeNavigationChain(receiver.receiver)) {
           propertyReceiver.wrapForTypeChecker();
         }
-        expr = new TcbExpr(`${propertyReceiver.print()}.${receiver.name}`).addParseSpanInfo(
-          receiver.nameSpan,
-        );
+        const isComponentContextRead =
+          receiver.receiver instanceof ImplicitReceiver ||
+          receiver.receiver instanceof ThisReceiver;
+        const access =
+          isComponentContextRead && this.config.useElementAccessForProperties !== false
+            ? `${propertyReceiver.print()}[${TcbExpr.quoteAndEscape(receiver.name)}]`
+            : `${propertyReceiver.print()}.${receiver.name}`;
+        expr = new TcbExpr(access).addParseSpanInfo(receiver.nameSpan);
       }
     } else {
       expr = this.translate(receiver);

--- a/packages/compiler/src/typecheck/ops/inputs.ts
+++ b/packages/compiler/src/typecheck/ops/inputs.ts
@@ -8,25 +8,25 @@
 
 import {AST, BindingType} from '../../expression_parser/ast';
 import {BindingPropertyName, ClassPropertyName} from '../../property_mapping';
-import {Identifiers as R3Identifiers} from '../../render3/r3_identifiers';
 import {BoundAttribute, Component, Directive, Element, Template} from '../../render3/r3_ast';
-import type {Context} from './context';
-import type {Scope} from './scope';
+import {Identifiers as R3Identifiers} from '../../render3/r3_identifiers';
+import {isUnsafeObjectKey} from '../../render3/util';
+import {DomElementSchemaRegistry} from '../../schema/dom_element_schema_registry';
 import {TcbDirectiveMetadata} from '../api';
 import {TcbOp} from './base';
+import {getBoundAttributes, widenBinding} from './bindings';
 import {declareVariable, TcbExpr} from './codegen';
-import {DomElementSchemaRegistry} from '../../schema/dom_element_schema_registry';
-const REGISTRY = new DomElementSchemaRegistry();
+import type {Context} from './context';
 import {tcbExpression, unwrapWritableSignal} from './expression';
+import {LocalSymbol} from './references';
+import type {Scope} from './scope';
 import {
   checkUnsupportedFieldBindings,
-  CustomFormControlType,
   customFormControlBannedInputFields,
+  CustomFormControlType,
   expandBoundAttributesForField,
 } from './signal_forms';
-import {getBoundAttributes, widenBinding} from './bindings';
-import {LocalSymbol} from './references';
-import {isUnsafeObjectKey} from '../../render3/util';
+const REGISTRY = new DomElementSchemaRegistry();
 
 /**
  * Translates the given attribute binding to a `ts.Expression`.
@@ -158,12 +158,14 @@ export class TcbDirectiveInputsOp extends TcbOp {
             dirId = this.scope.resolve(this.node, this.dir);
           }
 
-          // To get errors assign directly to the fields on the instance, using property access
-          // when possible. String literal fields may not be valid JS identifiers so we use
-          // literal element access instead for those cases.
-          target = this.dir.stringLiteralInputFields.has(fieldName)
-            ? new TcbExpr(`${dirId.print()}[${TcbExpr.quoteAndEscape(fieldName)}]`)
-            : new TcbExpr(`${dirId.print()}.${fieldName}`);
+          // Always use literal element access for directive members when configured. This keeps behavior
+          // consistent for all field names and avoids access checks tied to property access.
+          target =
+            this.tcb.env.config.useElementAccessForProperties !== false
+              ? new TcbExpr(`${dirId.print()}[${TcbExpr.quoteAndEscape(fieldName)}]`)
+              : this.dir.stringLiteralInputFields.has(fieldName)
+                ? new TcbExpr(`${dirId.print()}[${TcbExpr.quoteAndEscape(fieldName)}]`)
+                : new TcbExpr(`${dirId.print()}.${fieldName}`);
         }
 
         // For signal inputs, we unwrap the target `InputSignal`. Note that

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -994,6 +994,8 @@ function parseNgCompilerOptions(
     }
   }
 
+  options['_isAngularLanguageService'] = true;
+
   return options;
 }
 

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -425,10 +425,19 @@ export function getTcbNodesOfTemplateAtPosition(
     if (targetNode instanceof PropertyRead) {
       const tsNode = findFirstMatchingNode(tcb, {
         withSpan: targetNode.nameSpan,
-        filter: (node): node is tss.PropertyAccessExpression =>
-          tss.isPropertyAccessExpression(node),
+        filter: (node): node is tss.PropertyAccessExpression | tss.ElementAccessExpression =>
+          tss.isPropertyAccessExpression(node) || tss.isElementAccessExpression(node),
       });
-      tcbNodes.push(tsNode?.name ?? null);
+      if (tsNode) {
+        if (tss.isPropertyAccessExpression(tsNode)) {
+          tcbNodes.push(tsNode.name);
+        } else if (
+          tss.isElementAccessExpression(tsNode) &&
+          tss.isStringLiteral(tsNode.argumentExpression)
+        ) {
+          tcbNodes.push(tsNode.argumentExpression);
+        }
+      }
     } else {
       tcbNodes.push(findFirstMatchingNodeForSourceSpan(tcb, target.context.node.sourceSpan));
     }


### PR DESCRIPTION
Typescript allows accessing private properties outside a class with indexed access.  By using this trick, the TCB won't report errors anymore when accessing private properties in templates expressions.
