### PR TITLE
fix(platform-browser): reject event-handler attributes in Meta service

### DIFF
--- a/packages/platform-browser/src/browser/meta.ts
+++ b/packages/platform-browser/src/browser/meta.ts
@@ -177,7 +177,12 @@ function buildMetaSelector(attrSelector: string): string {
 }
 
 function setMetaElementAttributes(tag: MetaDefinition, el: HTMLMetaElement) {
-  Object.keys(tag).forEach((prop: string) => el.setAttribute(getMetaKeyMap(prop), tag[prop]));
+  Object.keys(tag)
+    // Event-handler attributes (e.g. `onerror`, `onsecuritypolicyviolation`) must never be
+    // written to the DOM: unlike template bindings, `MetaDefinition` keys aren't validated by
+    // Angular's compiler, so an attacker-controlled key could otherwise execute script.
+    .filter((prop: string) => !prop.toLowerCase().startsWith('on'))
+    .forEach((prop: string) => el.setAttribute(getMetaKeyMap(prop), tag[prop]));
 }
 
 function parseSelector(tag: MetaDefinition): string {

--- a/packages/platform-browser/test/browser/meta_spec.ts
+++ b/packages/platform-browser/test/browser/meta_spec.ts
@@ -156,6 +156,32 @@ describe('Meta service', () => {
     metaService.removeTagElement(actual);
   });
 
+  it('should not write event-handler attributes onto the meta element', () => {
+    const meta = metaService.addTag({
+      name: 'og:title',
+      content: 'Content Title',
+      onerror: 'alert(document.cookie)',
+      OnClick: 'alert(1)',
+    })!;
+
+    expect(meta.getAttribute('onerror')).toBeNull();
+    expect(meta.getAttribute('OnClick')).toBeNull();
+    expect(meta.getAttribute('onclick')).toBeNull();
+    expect(meta.getAttribute('content')).toEqual('Content Title');
+
+    // clean up
+    metaService.removeTagElement(meta);
+  });
+
+  it('should not add event-handler attributes when updating an existing meta tag', () => {
+    const selector = 'property="fb:app_id"';
+    metaService.updateTag({content: '4321', onsecuritypolicyviolation: 'alert(1)'}, selector);
+
+    const actual = metaService.getTag(selector)!;
+    expect(actual.getAttribute('onsecuritypolicyviolation')).toBeNull();
+    expect(actual.getAttribute('content')).toEqual('4321');
+  });
+
   it('should escape selector values when deriving the match selector', () => {
     // This payload attempts to prematurely close the attribute selector
     // and match another attribute.


### PR DESCRIPTION
## Summary
- Fixes #70126.
- `MetaDefinition` has an open index signature, so `addTag`/`addTags`/`updateTag` accept arbitrary keys, including `on*` event-handler attributes (e.g. `onsecuritypolicyviolation`, `oncontentvisibilityautostatechange`). `setMetaElementAttributes()` wrote every key straight onto the `<meta>` element via `setAttribute()` with no validation, so these execute without user interaction once the element updates (see repro in the issue).
- Skip keys starting with `on` (case-insensitive) before writing the attribute, matching the stance Angular already takes for property bindings in `validateAgainstEventProperties()` (`packages/core/src/sanitization/sanitization.ts`).

## Test plan
- [x] Added two cases to `packages/platform-browser/test/browser/meta_spec.ts`: `addTags` with an `onerror`/mixed-case `OnClick` key, and `updateTag` with `onsecuritypolicyviolation`, asserting the attribute is never written.
- [x] `bazel test //packages/platform-browser/test:test` — passing.