### PR TITLE
feat(core): support root: as a global @HostListener target

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -321,6 +321,7 @@ export class Identifiers {
   static resolveWindow: o.ExternalReference = {name: 'ɵɵresolveWindow', moduleName: CORE};
   static resolveDocument: o.ExternalReference = {name: 'ɵɵresolveDocument', moduleName: CORE};
   static resolveBody: o.ExternalReference = {name: 'ɵɵresolveBody', moduleName: CORE};
+  static resolveRoot: o.ExternalReference = {name: 'ɵɵresolveRoot', moduleName: CORE};
 
   static getComponentDepsFactory: o.ExternalReference = {
     name: 'ɵɵgetComponentDepsFactory',

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -27,6 +27,7 @@ const GLOBAL_TARGET_RESOLVERS = new Map<string, o.ExternalReference>([
   ['window', Identifiers.resolveWindow],
   ['document', Identifiers.resolveDocument],
   ['body', Identifiers.resolveBody],
+  ['root', Identifiers.resolveRoot],
 ]);
 
 /**

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -227,6 +227,7 @@ export {
   ɵɵresetView,
   ɵɵresolveBody,
   ɵɵresolveDocument,
+  ɵɵresolveRoot,
   ɵɵresolveWindow,
   ɵɵrestoreView,
   ɵɵsetComponentScope,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -207,7 +207,7 @@ export {
 } from './pure_function';
 export {ɵɵdisableBindings, ɵɵenableBindings, ɵɵresetView, ɵɵrestoreView} from './state';
 export {NO_CHANGE} from './tokens';
-export {ɵɵresolveBody, ɵɵresolveDocument, ɵɵresolveWindow} from './util/misc_utils';
+export {ɵɵresolveBody, ɵɵresolveDocument, ɵɵresolveRoot, ɵɵresolveWindow} from './util/misc_utils';
 export {ɵɵtemplateRefExtractor} from './view_engine_compatibility_prebound';
 export {ɵɵgetComponentDepsFactory} from './local_compilation';
 export {ɵsetClassDebugInfo} from './debug/set_debug_info';

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -165,6 +165,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵresolveWindow': r3.ɵɵresolveWindow,
   'ɵɵresolveDocument': r3.ɵɵresolveDocument,
   'ɵɵresolveBody': r3.ɵɵresolveBody,
+  'ɵɵresolveRoot': r3.ɵɵresolveRoot,
   'ɵɵsetComponentScope': r3.ɵɵsetComponentScope,
   'ɵɵsetNgModuleScope': r3.ɵɵsetNgModuleScope,
   'ɵɵregisterNgModuleType': registerNgModuleType,

--- a/packages/core/src/render3/util/misc_utils.ts
+++ b/packages/core/src/render3/util/misc_utils.ts
@@ -33,6 +33,17 @@ export function ɵɵresolveBody(element: RElement & {ownerDocument: Document}): 
 }
 
 /**
+ *
+ * @codeGenApi
+ */
+export function ɵɵresolveRoot(element: RElement & {ownerDocument: Document}): EventTarget {
+  // `getRootNode` isn't implemented by every renderer environment (e.g. server-side
+  // rendering), so fall back to the owner document, which matches the value `getRootNode`
+  // returns for elements that aren't inside a shadow tree.
+  return (element.getRootNode?.() as unknown as EventTarget) ?? element.ownerDocument;
+}
+
+/**
  * The special delimiter we use to separate property names, prefixes, and suffixes
  * in property binding metadata. See storeBindingMetadata().
  *

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -823,6 +823,34 @@ describe('event listeners', () => {
       expect(events).toEqual(['click!', 'click!']);
     });
 
+    it('should support root:-prefixed host listeners resolved via getRootNode()', () => {
+      const events: string[] = [];
+
+      @Component({
+        template: ``,
+        standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class MyComp {
+        @HostListener('root:click')
+        onClick() {
+          events.push('root click!');
+        }
+      }
+
+      const fixture = TestBed.createComponent(MyComp);
+      fixture.detectChanges();
+
+      const host = fixture.nativeElement;
+
+      host.click();
+      expect(events).toEqual(['root click!']);
+
+      host.click();
+      expect(events).toEqual(['root click!', 'root click!']);
+    });
+
     it('should support global host listeners on directives', () => {
       const events: string[] = [];
 


### PR DESCRIPTION
## Summary
- Addresses #70150.
- Adds `root:` as a fourth global event-listener target alongside the existing `window:`, `document:`, `body:` prefixes, resolved via `element.getRootNode()`:

  ```ts
  @HostListener('root:click')
  onRootClick() { /* ... */ }
  ```

- `getRootNode()` returns the document for elements outside a shadow tree, or the enclosing shadow root otherwise — useful for components that need to attach a listener without knowing in advance whether they're rendered inside a shadow DOM.
- Falls back to `element.ownerDocument` when `getRootNode` isn't implemented by the renderer environment (e.g. some SSR DOM shims), matching what `getRootNode()` itself would return outside a shadow tree.
- Wired through the same path as `window`/`document`/`body`: `GLOBAL_TARGET_RESOLVERS` (`packages/compiler/src/template/pipeline/src/phases/reify.ts`), `Identifiers.resolveRoot` (`packages/compiler/src/render3/r3_identifiers.ts`), the `ɵɵresolveRoot` runtime function (`packages/core/src/render3/util/misc_utils.ts`), and the JIT/export surfaces (`core_render3_private_export.ts`, `render3/index.ts`, `render3/jit/environment.ts`).

Scoped to just the target-resolution piece requested in the issue; the separate suggestion there about additional global targets (`visualViewport`, `screen.orientation`) is left out as a distinct follow-up.

## Test plan
- [x] Added `should support root:-prefixed host listeners resolved via getRootNode()` to `packages/core/test/acceptance/listener_spec.ts`.
- [x] `bazel test //packages/core/test/acceptance:acceptance` and `//packages/compiler/test/...` — passing (one pre-existing, unrelated Firefox flake in `shadow_css/nesting_spec.ts` reproduces without this change).