### PR TITLE
docs: warn against non-memoized function calls in templates in the angular-developer skill

### DIFF
--- a/skills/dev-skills/angular-developer/references/components.md
+++ b/skills/dev-skills/angular-developer/references/components.md
@@ -90,6 +90,8 @@ The `@for` block iterates over collections. The `track` expression is **required
 
 **Implicit Variables**: `$index`, `$count`, `$first`, `$last`, `$even`, `$odd`.
 
+**Avoid calling non-memoized methods in template expressions** (e.g. `@for (x of getItems())`, `{{ formatDate(item.date) }}`). These reevaluate on every change-detection run, which is wasteful when the computation is nontrivial. Prefer a `computed()` signal, or a pure pipe, so the result is cached and only recalculated when its dependencies change. A plain function call is fine when it's a trivial/pure lookup (e.g. reading a signal, indexing an object).
+
 ### Switching Content (`@switch`)
 
 The `@switch` block renders content based on a value. It uses strict equality (`===`) and has **no fallthrough**.


### PR DESCRIPTION
## Summary
- Addresses #70132: multiple reports of AI coding agents (using this repo's `angular-developer` skill) generating templates that call plain methods directly inside `@for`/`@if` expressions, re-executing on every change-detection run.
- Checked `skills/dev-skills/angular-developer/SKILL.md` and all `references/*.md` — no existing guidance covers this.
- Added a short, balanced note to `references/components.md` after the `@for` section: recommend `computed()`/a pure pipe for non-trivial work, but don't ban function calls outright — as discussed on the issue, there's no maintainer consensus that plain calls are always wrong (fine for cheap/pure lookups), so the note reflects that instead of a hard rule.

## Test plan
- N/A — Markdown-only change to skill guidance; no automated tests apply. Reviewed the added text for accuracy against the issue discussion.