### PR TITLE
fix(vscode-extension): prevent command URI injection in TSDK approval

### DIFF
--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -666,7 +666,7 @@ export class AngularLanguageClient implements vscode.Disposable {
 
         if (isApproved === undefined) {
           // Prompt the user asynchronously, without blocking current server initialization
-          this.promptForTsdkApproval(workspaceTsdk, stateKey);
+          this.promptForTsdkApproval(stateKey);
         }
 
         // Fall back to globalValue (or bundled) while waiting for approval or if rejected
@@ -676,12 +676,12 @@ export class AngularLanguageClient implements vscode.Disposable {
     return jsTsTsdkInspect?.globalValue?.trim() ?? tsTsdkInspect?.globalValue?.trim() ?? '';
   }
 
-  private async promptForTsdkApproval(workspaceTsdk: string, stateKey: string): Promise<void> {
+  private async promptForTsdkApproval(stateKey: string): Promise<void> {
     const allowOption = 'Allow';
     const disallowOption = 'Disallow';
 
     const choice = await vscode.window.showWarningMessage(
-      `This workspace configures a custom TypeScript compiler path (${workspaceTsdk}) via 'js/ts.tsdk.path' or 'typescript.tsdk'. ` +
+      `This workspace configures a custom TypeScript compiler path via 'js/ts.tsdk.path' or 'typescript.tsdk'. ` +
         `Do you want to allow the Angular Language Service to load the TypeScript compiler from this path?`,
       allowOption,
       disallowOption,


### PR DESCRIPTION
VS Code notifications parse linked text from string messages, including `command:` URIs. 

The TSDK approval prompt interpolates `workspaceTsdk`, which is controlled by workspace settings, so a malicious path can introduce a command link into the approval prompt.

Remove the workspace-controlled path from the notification instead of attempting to sanitize or escape it. 
This keeps the prompt static, avoids relying on VS Code's linked-text escaping rules, and matches the built-in TypeScript extension's workspace-version approval flow.

Fixes #70176