### PR TITLE
docs: note SafeResourceUrl audio src change

### DIFF
--- a/adev/src/app/features/update/recommendations.ts
+++ b/adev/src/app/features/update/recommendations.ts
@@ -2780,6 +2780,14 @@ export const RECOMMENDATIONS: Step[] = [
     possibleIn: 2100,
     step: '21.0.0_ng_update',
   },
+  {
+    possibleIn: 2100,
+    necessaryAsOf: 2100,
+    level: ApplicationComplexity.Advanced,
+    step: '21.0.0-safe-resource-url-audio-src',
+    action:
+      'If you use `SafeResourceUrl` values with `audio[src]` bindings, be aware that `audio[src]` is no longer sanitized in Angular v21. Existing uses of `bypassSecurityTrustResourceUrl` may therefore produce the `SafeValue must use [property]=binding` message. Remove the unnecessary sanitization and bind the URL directly instead.',
+  },
 
   {
     possibleIn: 2100,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (not applicable — documentation-only change)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The Angular 20 → 21 Update Guide does not mention the `SafeResourceUrl` compatibility issue affecting `audio[src]` bindings after the sanitization change.

Issue Number: #70183

## What is the new behavior?

The Angular 20 → 21 Update Guide now documents that `audio[src]` is no longer sanitized in Angular v21 and explains that existing `SafeResourceUrl`/`bypassSecurityTrustResourceUrl` usage may produce the `SafeValue must use [property]=binding` message.

The guidance recommends removing unnecessary sanitization and binding the URL directly.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This change is documentation-only and addresses #70183.
