### PR TITLE
fix(core): throw a descriptive error instead of crashing when a hydration node is missing

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -361,6 +361,18 @@ function locateOrCreateElementNodeImpl(
   }
 
   if (hydrationInfo) {
+    // `validateMatchingNode` above would normally catch a missing node too, but it's dev-mode
+    // only. Guard against it here so production throws a coded RuntimeError instead of a raw
+    // TypeError when dereferencing `native` below.
+    if (native == null) {
+      throw new RuntimeError(
+        RuntimeErrorCode.HYDRATION_MISSING_NODE,
+        ngDevMode
+          ? `During hydration Angular expected a "<${name}>" element at this location (tNode #${tNode.index}), but no matching DOM node was found. This usually means the client-rendered DOM no longer matches the server-rendered HTML.`
+          : `<${name}>`,
+      );
+    }
+
     // `hasSkipHydrationAttrOnRElement` below calls `.hasAttribute`, which needs `native` to be
     // an Element. `validateMatchingNode` above would normally catch a wrong node type, but it's
     // dev-mode only. Guard against it here too, cheaply, so production throws a coded

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -6326,6 +6326,73 @@ describe('platform-server full application hydration integration', () => {
         },
       );
 
+      it(
+        'should throw a coded RuntimeError, not a raw TypeError, when an element ' +
+          'instruction cannot locate a matching DOM node in production mode (ngDevMode off)',
+        async () => {
+          // Regression test. When the client-rendered DOM has fewer nodes than the
+          // server-rendered HTML (e.g. a node was removed before hydration runs),
+          // `locateNextRNode` returns `null`. The `validateMatchingNode` check that
+          // would normally catch this only runs in dev mode, so it's removed from
+          // production builds. Without a dedicated null guard, production would fall
+          // through to `native.nodeType`, which throws a raw TypeError instead of a
+          // coded RuntimeError.
+          @Component({
+            selector: 'app',
+            template: `
+              <div id="abc">
+                <p>This is an original content</p>
+                <b>Bold text</b>
+                <i>Italic text</i>
+              </div>
+            `,
+          })
+          class SimpleComponent {
+            private doc = inject(DOCUMENT);
+            private isServer = isPlatformServer(inject(PLATFORM_ID));
+            ngAfterViewInit() {
+              // Only change the DOM on the server, right before it gets serialized.
+              // `<i>` is the last child, so removing it means hydration's sibling walk
+              // runs off the end of the DOM (`nextSibling` is `null`) instead of landing
+              // on some other, wrongly-typed node — exercising the missing-node path
+              // rather than the node-mismatch path covered by the test above.
+              if (this.isServer) {
+                this.doc.querySelector('i')?.remove();
+              }
+            }
+          }
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain('<app ngh');
+
+          resetTViewsFor(SimpleComponent);
+
+          // Simulate a production build. `locateOrCreateElementNodeImpl` only calls
+          // `validateMatchingNode` when `ngDevMode` is truthy, so turning it off
+          // here means the full mismatch check is skipped, and only the new
+          // null guard runs.
+          const previousNgDevMode = (globalThis as any).ngDevMode;
+          (globalThis as any).ngDevMode = false;
+          try {
+            await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+              envProviders: [withNoopErrorHandler()],
+            });
+            fail('Expected the hydration process to throw.');
+          } catch (e: unknown) {
+            const error = e as Error;
+            // This is the fixed behavior: a coded NG0502 RuntimeError, not a raw
+            // TypeError.
+            expect(error instanceof TypeError).toBe(false);
+            expect(error.message).toBe('NG0502: <i>');
+            expect(error.message).not.toContain("reading 'nodeType'");
+          } finally {
+            (globalThis as any).ngDevMode = previousNgDevMode;
+          }
+        },
+      );
+
       it('should if there are any third-party scripts that manipulate the DOM', async () => {
         @Component({
           selector: 'app',


### PR DESCRIPTION
locateOrCreateElementNodeImpl looks up the DOM node for an element during hydration and immediately checks its nodeType. If the client-rendered DOM has fewer nodes than the server-rendered HTML, the lookup returns null, and in production that null flows straight into the nodeType check and crashes with a raw, uncoded "Cannot read properties of null (reading 'nodeType')" TypeError.

The dev-mode check that would normally catch this (validateMatchingNode) already handles a missing node, but it's compiled out of production builds, so the crash only shows up outside of dev mode.

Add a null check ahead of the nodeType check that throws a coded RuntimeError using the existing HYDRATION_MISSING_NODE (NG0502) code, with a descriptive message in dev mode and a cheap fallback in production. Also add a regression test that removes a server-rendered element before hydration runs and asserts a coded RuntimeError is thrown instead of a raw TypeError.