### PR TITLE
fix(http): cancel oversized fetch response bodies

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -191,6 +191,7 @@ export class FetchBackend implements HttpBackend {
         Number.isFinite(contentLengthValue) &&
         contentLengthValue > this.maxResponseSize
       ) {
+        await response.body.cancel();
         throwBodyTooLargeError(this.maxResponseSize);
       }
 

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -708,6 +708,19 @@ describe('FetchBackend', () => {
       expect(infiniteStreamFactory.cancelCount).toBe(1);
     });
 
+    it('cancels an unread response stream when the declared size exceeds the limit', async () => {
+      infiniteStreamFactory.declaredContentLength = 2049;
+
+      const req = new HttpRequest('GET', '/test', {responseType: 'text'});
+      const events = await trackEvents(backend.handle(req));
+      const error = events[1] as HttpErrorResponse;
+
+      expect(events.length).toBe(2);
+      expect(error instanceof HttpErrorResponse).toBeTrue();
+      expect(error.error.code).toBe(RuntimeErrorCode.FETCH_RESPONSE_BODY_TOO_LARGE);
+      expect(infiniteStreamFactory.cancelCount).toBe(1);
+    });
+
     it('allows disabling the size limit via dependency injection', async () => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
@@ -854,6 +867,7 @@ class MockFetchRequest {
 
 class InfiniteStreamFetchFactory extends FetchFactory {
   public cancelCount = 0;
+  public declaredContentLength?: number;
 
   override fetch = async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
     const stream = new ReadableStream<Uint8Array>({
@@ -868,7 +882,12 @@ class InfiniteStreamFetchFactory extends FetchFactory {
     return new Response(stream, {
       status: HttpStatusCode.Ok,
       statusText: 'OK',
-      headers: {'Content-Type': 'text/plain'},
+      headers: {
+        'Content-Type': 'text/plain',
+        ...(this.declaredContentLength === undefined
+          ? {}
+          : {'Content-Length': `${this.declaredContentLength}`}),
+      },
     });
   };
 }
@@ -885,7 +904,7 @@ class FiniteChunkFetchFactory extends FetchFactory {
     return new Response(stream, {
       status: HttpStatusCode.Ok,
       statusText: 'OK',
-      headers: {'Content-Type': 'text/plain'},
+      headers: {'Content-Type': 'text/plain', 'Content-Length': '2'},
     });
   };
 }


### PR DESCRIPTION
Cancel the unread response body before reporting NG02825 when its declared Content-Length exceeds the configured buffer limit. Without cancellation, SSR can finish while the underlying connection remains open.

 ## What is the current behavior?

`FetchBackend` rejects a response when its declared `Content-Length` exceeds the configured buffer limit. This happens before Angular creates a body reader, and the response body is not cancelled on this rejection path.

In a local Angular 22.1.2 SSR application, five declared-length responses were rejected but all five connections remained open. The equivalent streamed-overrun case rejected all five responses and cancelled all five streams.

The smallest response used in the reproduction declared `Content-Length: 1048577`, sent no body bytes, and kept the socket open. Eight SSR requests left eight outbound connections open after two seconds.

Without cancellation, repeated requests can retain outbound connections after their Angular requests have already failed. The observed effect was socket and file-descriptor pressure rather than allocation of the declared response body.

A bounded availability test used one CPU, 256 MiB of memory, a healthy upstream with 250 ms latency, and approximately 192 open responses:

| FD limit and tested load | Clean worker | Worker with open responses |
| ------------------------ | -----------: | -------------------------: |
| 256 FDs, 20 renders      |     20/20 OK |    11 OK, 9 network errors |
| 512 FDs, 300 renders     |   300/300 OK |  260 OK, 40 network errors |
 