### PR TITLE
feat(router): introduce WebMCP router features

### DIFF
--- a/adev/src/app/routing/router_providers.ts
+++ b/adev/src/app/routing/router_providers.ts
@@ -23,6 +23,7 @@ import {
   withNavigationErrorHandler,
   withRouterConfig,
   isActive,
+  withExperimentalWebMcpRouterTools,
 } from '@angular/router';
 import {routes} from './routes';
 import {ADevTitleStrategy} from '../core/services/a-dev-title-strategy';
@@ -65,6 +66,7 @@ export const routerProviders = [
       },
     }),
     withComponentInputBinding(),
+    withExperimentalWebMcpRouterTools(),
   ),
   {
     provide: RouteReuseStrategy,

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -791,7 +791,7 @@ export interface RouterFeature<FeatureKind extends RouterFeatureKind> {
 }
 
 // @public
-export type RouterFeatures = PreloadingFeature | DebugTracingFeature | InitialNavigationFeature | InMemoryScrollingFeature | RouterConfigurationFeature | NavigationErrorHandlerFeature | ComponentInputBindingFeature | ViewTransitionsFeature | ExperimentalAutoCleanupInjectorsFeature | RouterHashLocationFeature | ExperimentalPlatformNavigationFeature;
+export type RouterFeatures = PreloadingFeature | DebugTracingFeature | InitialNavigationFeature | InMemoryScrollingFeature | RouterConfigurationFeature | NavigationErrorHandlerFeature | ComponentInputBindingFeature | ViewTransitionsFeature | ExperimentalAutoCleanupInjectorsFeature | RouterHashLocationFeature | ExperimentalPlatformNavigationFeature | WebMcpRouterToolsFeature;
 
 // @public
 export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHashLocationFeature>;
@@ -1137,6 +1137,9 @@ export interface ViewTransitionsFeatureOptions {
 }
 
 // @public
+export type WebMcpRouterToolsFeature = RouterFeature<RouterFeatureKind.WebMcpRouterToolsFeature>;
+
+// @public
 export function withComponentInputBinding(options?: ComponentInputBindingOptions): ComponentInputBindingFeature;
 
 // @public
@@ -1153,6 +1156,9 @@ export function withExperimentalAutoCleanupInjectors(): ExperimentalAutoCleanupI
 
 // @public
 export function withExperimentalPlatformNavigation(): ExperimentalPlatformNavigationFeature;
+
+// @public
+export function withExperimentalWebMcpRouterTools(): WebMcpRouterToolsFeature;
 
 // @public
 export function withHashLocation(): RouterHashLocationFeature;

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -1,6 +1,9 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "generate_api_docs", "ng_package", "ng_project", "ts_config")
 
 package(default_visibility = ["//visibility:public"])
+
+npm_link_all_packages(name = "node_modules")
 
 ts_config(
     name = "tsconfig_build",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -24,7 +24,9 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/dom-navigation": "^1.0.5"
+    "@types/dom-navigation": "^1.0.5",
+    "@mcp-b/webmcp-polyfill": "^4.0.0",
+    "@mcp-b/webmcp-types": "^4.0.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -100,6 +100,8 @@ export {
   withViewTransitions,
 } from './provide_router';
 
+export {withExperimentalWebMcpRouterTools, WebMcpRouterToolsFeature} from './webmcp';
+
 export {
   BaseRouteReuseStrategy,
   destroyDetachedRouteHandle,

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -54,6 +54,7 @@ import {ROUTER_SCROLLER, RouterScroller} from './router_scroller';
 
 import {getLoadedRoutes, getRouterInstance, navigateByUrl} from './router_devtools';
 import {ActivatedRoute} from './router_state';
+import type {WebMcpRouterToolsFeature} from './webmcp';
 import {NavigationStateManager} from './statemanager/navigation_state_manager';
 import {StateManager} from './statemanager/state_manager';
 import {afterNextNavigation} from './utils/navigations';
@@ -136,7 +137,7 @@ export interface RouterFeature<FeatureKind extends RouterFeatureKind> {
 /**
  * Helper function to create an object that represents a Router feature.
  */
-function routerFeature<FeatureKind extends RouterFeatureKind>(
+export function routerFeature<FeatureKind extends RouterFeatureKind>(
   kind: FeatureKind,
   providers: Array<Provider | EnvironmentProviders>,
 ): RouterFeature<FeatureKind> {
@@ -363,8 +364,7 @@ export type EnabledBlockingInitialNavigationFeature =
  * @publicApi
  */
 export type InitialNavigationFeature =
-  | EnabledBlockingInitialNavigationFeature
-  | DisabledInitialNavigationFeature;
+  EnabledBlockingInitialNavigationFeature | DisabledInitialNavigationFeature;
 
 /**
  * Configures initial navigation to start before the root component is created.
@@ -923,7 +923,8 @@ export type RouterFeatures =
   | ViewTransitionsFeature
   | ExperimentalAutoCleanupInjectorsFeature
   | RouterHashLocationFeature
-  | ExperimentalPlatformNavigationFeature;
+  | ExperimentalPlatformNavigationFeature
+  | WebMcpRouterToolsFeature;
 
 /**
  * The list of features as an enum to uniquely type each feature.
@@ -941,4 +942,5 @@ export const enum RouterFeatureKind {
   ViewTransitionsFeature,
   ExperimentalAutoCleanupInjectorsFeature,
   ExperimentalPlatformNavigationFeature,
+  WebMcpRouterToolsFeature,
 }

--- a/packages/router/src/webmcp.ts
+++ b/packages/router/src/webmcp.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {declareExperimentalWebMcpTool, inject, provideEnvironmentInitializer} from '@angular/core';
+import {Router} from './router';
+import {Routes} from './models';
+import {routerFeature, RouterFeature, RouterFeatureKind} from './provide_router';
+
+/**
+ * A Router feature that provides WebMCP routing tools to browser-side AI assistants.
+ *
+ * @experimental
+ */
+export type WebMcpRouterToolsFeature = RouterFeature<RouterFeatureKind.WebMcpRouterToolsFeature>;
+
+function getPaths(routes: Routes, parentPath = ''): string[] {
+  const paths: string[] = [];
+  for (const route of routes) {
+    let currentPath = parentPath;
+    if (route.path !== undefined) {
+      currentPath = parentPath ? `${parentPath}/${route.path}` : route.path;
+      if (route.path !== '**') {
+        let normalizedPath = currentPath.startsWith('/') ? currentPath : `/${currentPath}`;
+        // Replace multiple consecutive slashes with a single slash
+        normalizedPath = normalizedPath.replace(/\/+/g, '/');
+        // Strip trailing slash unless it is the root path "/"
+        if (normalizedPath.length > 1 && normalizedPath.endsWith('/')) {
+          normalizedPath = normalizedPath.slice(0, -1);
+        }
+        paths.push(normalizedPath);
+      }
+    }
+    if (route.children) {
+      paths.push(...getPaths(route.children, currentPath));
+    }
+    if (route._loadedRoutes) {
+      paths.push(...getPaths(route._loadedRoutes, currentPath));
+    }
+  }
+  return Array.from(new Set(paths)).sort();
+}
+
+/**
+ * Enables WebMCP tools for the Angular Router, allowing browser-side AI assistants
+ * to list available routes and navigate between them.
+ *
+ * @returns A router feature that registers the WebMCP routing tools.
+ * @experimental
+ */
+export function withExperimentalWebMcpRouterTools(): WebMcpRouterToolsFeature {
+  return routerFeature(RouterFeatureKind.WebMcpRouterToolsFeature, [
+    provideEnvironmentInitializer(() => {
+      const router = inject(Router);
+
+      // Tool to list loaded/configured routes
+      declareExperimentalWebMcpTool({
+        name: 'router.list_routes',
+        description: 'Lists all available routes/paths configured in the application.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+        execute: () => {
+          const paths = getPaths(router.config);
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Available paths:\n${paths.map((p) => `- ${p}`).join('\n')}`,
+              },
+            ],
+          };
+        },
+      });
+
+      // Tool to navigate to a path/URL
+      declareExperimentalWebMcpTool({
+        name: 'router.navigate',
+        description: 'Navigates the application to the specified path or URL.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            url: {
+              type: 'string',
+              description: 'The URL or path to navigate to, e.g., "/dashboard" or "/profile".',
+            },
+          },
+          required: ['url'],
+          additionalProperties: false,
+        },
+        execute: async ({url}) => {
+          if (typeof url !== 'string') {
+            throw new Error('Invalid URL provided.');
+          }
+          const success = await router.navigateByUrl(url);
+          return {
+            content: [
+              {
+                type: 'text',
+                text: success ? `Successfully navigated to ${url}` : `Failed to navigate to ${url}`,
+              },
+            ],
+          };
+        },
+      });
+    }),
+  ]);
+}

--- a/packages/router/test/BUILD.bazel
+++ b/packages/router/test/BUILD.bazel
@@ -26,6 +26,7 @@ ts_project(
         "//packages/platform-browser/testing",
         "//packages/private/testing",
         "//packages/router",
+        "//packages/router:node_modules/@mcp-b/webmcp-polyfill",
         "//packages/router/testing",
     ],
 )

--- a/packages/router/test/webmcp.spec.ts
+++ b/packages/router/test/webmcp.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {initializeWebMCPPolyfill, cleanupWebMCPPolyfill} from '@mcp-b/webmcp-polyfill';
+import {Router, RouterModule, provideRouter, withExperimentalWebMcpRouterTools} from '../index';
+
+@Component({
+  template: '<router-outlet/>',
+  imports: [RouterModule],
+})
+export class RootComponent {}
+
+@Component({template: '<div>Home</div>'})
+export class HomeComponent {}
+
+@Component({template: '<div>Dashboard</div>'})
+export class DashboardComponent {}
+
+@Component({template: '<div>Settings</div>'})
+export class SettingsComponent {}
+
+describe('withExperimentalWebMcpRouterTools', () => {
+  beforeEach(() => {
+    initializeWebMCPPolyfill({installTestingShim: true});
+    const modelContext = (globalThis.navigator as any).modelContext;
+    if (modelContext) {
+      modelContext.dispatchEvent = () => true;
+    }
+    const testingContext = (globalThis.navigator as any).modelContextTesting;
+    if (testingContext) {
+      testingContext.dispatchEvent = () => true;
+    }
+  });
+
+  afterEach(() => {
+    cleanupWebMCPPolyfill();
+  });
+
+  it('should register router.list_routes and router.navigate tools', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [
+            {path: 'home', component: HomeComponent},
+            {
+              path: 'admin',
+              children: [
+                {path: 'dashboard', component: DashboardComponent},
+                {path: 'settings', component: SettingsComponent},
+                {path: '', component: DashboardComponent},
+              ],
+            },
+          ],
+          withExperimentalWebMcpRouterTools(),
+        ),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(RootComponent);
+    await fixture.whenStable();
+
+    const testingContext = (globalThis.navigator as any).modelContextTesting!;
+    const tools = testingContext.listTools();
+    expect(tools).toContain(jasmine.objectContaining({name: 'router.list_routes'}));
+    expect(tools).toContain(jasmine.objectContaining({name: 'router.navigate'}));
+
+    // Test router.list_routes execution
+    const listResultJson = await testingContext.executeTool('router.list_routes', '{}');
+    const listResult = JSON.parse(listResultJson!);
+    expect(listResult.content[0].text).toContain('/home');
+    expect(listResult.content[0].text).toContain('/admin/dashboard');
+    expect(listResult.content[0].text).toContain('/admin/settings');
+    expect(listResult.content[0].text).toContain('/admin\n');
+    expect(listResult.content[0].text).not.toContain('/admin/\n');
+
+    // Test router.navigate execution
+    const router = TestBed.inject(Router);
+    expect(router.url).toEqual('/');
+
+    const navigateResultJson = await testingContext.executeTool(
+      'router.navigate',
+      '{"url": "/admin/dashboard"}',
+    );
+    const navigateResult = JSON.parse(navigateResultJson!);
+    expect(navigateResult.content[0].text).toContain('Successfully navigated to /admin/dashboard');
+
+    await fixture.whenStable();
+    expect(router.url).toEqual('/admin/dashboard');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1165,6 +1165,12 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
     devDependencies:
+      '@mcp-b/webmcp-polyfill':
+        specifier: ^4.0.0
+        version: 4.0.0
+      '@mcp-b/webmcp-types':
+        specifier: ^4.0.0
+        version: 4.0.0
       '@types/dom-navigation':
         specifier: ^1.0.5
         version: 1.0.7


### PR DESCRIPTION
This PR introduces a new Router feature, `withExperimentalWebMcpRouterTools()`, to `@angular/router`. This feature enables browser-side AI assistants (using the emerging WebMCP standard) to query available routes and trigger page navigations dynamically.

## Use Cases & Motivation

This feature enables web applications to expose structured routing APIs directly to browser-side AI assistants (via WebMCP), unlocking several critical modern use cases:

### 1. Hands-Free & Voice-Driven Navigation
* **Scenario:** Users interacting with applications in environments where they cannot physically touch the screen (e.g., cooking apps with messy hands, technicians following repair manuals, surgeons viewing medical protocols).
* **Benefit:** The AI assistant can programmatically request route listings and navigate directly to steps (e.g., "go to step 3") via `router.navigate`, keeping the user focused on their task without manual device interaction.

### 2. Next-Gen Accessibility (A11y)
* **Scenario:** Users with visual, motor, or cognitive impairments who find traversing deep nested navigation menus, accordions, or complex site maps using keyboards or screen readers tedious.
* **Benefit:** Users can ask the agent directly to "take me to my March invoice." The AI utilizes the routing tool to perform instant, direct transition, bypass complex DOM hierarchies, and improve autonomy.

### 3. AI-Assisted Journeys (Conversational E-Commerce)
* **Scenario:** Users configuring complex flows (like travel booking or custom checkouts) via a chat interface.
* **Benefit:** Upon completing a configuration dialog, the agent can seamlessly transition the user's viewport directly to the checkout page (`/checkout`) by invoking `router.navigate`, creating a smooth, unified user journey.

### 4. Design-Resilient AI Interactions (Zero Maintenance)
* **Scenario:** The development team completely changes the UI layout (e.g., hiding a settings button inside a dropdown).
* **Benefit:** The AI assistant does not break or require instruction updates because it relies on the stable Angular routing configuration (`/settings`) rather than fragile, visual-based DOM scraping.

## Proposed Changes

- **`packages/router/src/webmcp.ts`**: New module implementing `withExperimentalWebMcpRouterTools()` and registering the tools `router.list_routes` and `router.navigate`.
- **`packages/router/src/provide_router.ts` & `index.ts`**: Exported the new feature kind and creator function.
- **`packages/router/test/webmcp.spec.ts`**: Added web-based browser integration tests for both router tools (verifying that they pass on Chromium and Firefox).
