### PR TITLE
fix(core): detect static text hydration mismatches

### DIFF
--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -64,13 +64,17 @@ export function validateMatchingNode(
   tNode: TNode,
   isViewContainerAnchor = false,
 ): void {
+  const hasStaticTextContentMismatch = hasTextContentMismatch(node, tNode);
+
   if (
     !node ||
     (node as Node).nodeType !== nodeType ||
+    hasStaticTextContentMismatch ||
     ((node as Node).nodeType === Node.ELEMENT_NODE &&
       (node as HTMLElement).tagName.toLowerCase() !== tagName?.toLowerCase())
   ) {
-    const expectedNode = shortRNodeDescription(nodeType, tagName, null);
+    const expectedTextContent = hasStaticTextContentMismatch ? tNode.value : null;
+    const expectedNode = shortRNodeDescription(nodeType, tagName, expectedTextContent);
     let header = `During hydration Angular expected ${expectedNode} but `;
 
     const hostComponentDef = getDeclarationComponentDef(lView);
@@ -118,6 +122,16 @@ export function validateMatchingNode(
 
     throw new RuntimeError(RuntimeErrorCode.HYDRATION_NODE_MISMATCH, message);
   }
+}
+
+function hasTextContentMismatch(node: RNode | null, tNode: TNode): boolean {
+  return (
+    node !== null &&
+    (node as Node).nodeType === Node.TEXT_NODE &&
+    tNode.type === TNodeType.Text &&
+    tNode.value.length > 0 &&
+    (node as Node).textContent !== tNode.value
+  );
 }
 
 /**

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -6174,6 +6174,41 @@ describe('platform-server full application hydration integration', () => {
         });
       });
 
+      it('should detect static text content mismatch', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            <ul>
+              <li><span>Alice</span><button>Delete</button></li>
+            </ul>
+          `,
+        })
+        class SimpleComponent {
+          private doc = inject(DOCUMENT);
+          private isServer = isPlatformServer(inject(PLATFORM_ID));
+
+          ngAfterViewInit() {
+            if (this.isServer) {
+              const injectedItem = this.doc.createElement('li');
+              injectedItem.innerHTML = '<span>Sponsored</span><button>Visit ad</button>';
+              this.doc.querySelector('li')?.before(injectedItem);
+            }
+          }
+        }
+
+        const html = await ssr(SimpleComponent);
+
+        resetTViewsFor(SimpleComponent);
+
+        await expectAsync(
+          prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+            envProviders: [withNoopErrorHandler()],
+          }),
+        ).toBeRejectedWithError(
+          /During hydration Angular expected a text node \(with the "Alice" content\) but found a text node \(with the "Sponsored" content\)/,
+        );
+      });
+
       it('should not crash when a node can not be found during hydration', async () => {
         @Component({
           selector: 'app',


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Hydration validates text nodes by node type only. A third-party script or browser extension can insert same-shaped DOM with different static text and shift hydration claims without producing a mismatch error.

Issue Number: #56392

## What is the new behavior?

Hydration also validates non-empty static text content in development mode. When the DOM text differs from the template, Angular reports NG0500 with the expected and actual content and points to the mismatched location.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No documentation update is needed because this change does not introduce or modify a public API.

Tested with:

`pnpm bazel test //packages/platform-server/test:test --test_arg=--seed=15039`
