### PR TITLE
docs: clarify dist/browser deployment impact in build migration guide

### DIFF
--- a/adev/src/content/tools/cli/build-system-migration.md
+++ b/adev/src/content/tools/cli/build-system-migration.md
@@ -578,7 +578,7 @@ If you'd rather keep your existing deploy path unchanged, you can flatten the ou
 "outputPath": {
   "base": "dist/<project-name>"
 }
-\`\`\` 
+\`\`\`
 ```
 
 ## Bug reports

--- a/adev/src/content/tools/cli/build-system-migration.md
+++ b/adev/src/content/tools/cli/build-system-migration.md
@@ -573,7 +573,7 @@ If you deploy via a CI/CD pipeline (for example Azure DevOps release tasks, IIS,
 
 If you'd rather keep your existing deploy path unchanged, you can flatten the output back to `dist/<project-name>` by setting `outputPath` in `angular.json`:
 
-```conf - angular.json
+```config - angular.json
  \`\`\`json
 "outputPath": {
   "base": "dist/<project-name>"

--- a/adev/src/content/tools/cli/build-system-migration.md
+++ b/adev/src/content/tools/cli/build-system-migration.md
@@ -569,6 +569,18 @@ IMPORTANT: Avoiding the use of modules with non-local side effects (outside of p
 By default, after a successful build by the application builder the bundle is located in a `dist/<project-name>/browser` directory (instead of `dist/<project-name>` for the browser builder).
 This might break some of the toolchains that rely the previous location. In this case, you can [configure the output path](reference/configs/workspace-config#output-path-configuration) to suit your needs.
 
+If you deploy via a CI/CD pipeline (for example Azure DevOps release tasks, IIS, or any script that copies from a fixed `dist/<project-name>` path), update the deploy step to point at `dist/<project-name>/browser` instead. Pipelines that copy `dist/<project-name>` directly will silently deploy an incomplete or empty site.
+
+If you'd rather keep your existing deploy path unchanged, you can flatten the output back to `dist/<project-name>` by setting `outputPath` in `angular.json`:
+
+```conf - angular.json
+ \`\`\`json
+"outputPath": {
+  "base": "dist/<project-name>"
+}
+\`\`\` 
+```
+
 ## Bug reports
 
 Report issues and feature requests on [GitHub](https://github.com/angular/angular-cli/issues).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## What

Adds a clarifying section to the application builder migration guide
explaining the practical deployment impact of the new `dist/<project-name>/browser`
output structure, and documents the `outputPath.base` workaround for
teams that want to keep the previous flat output location.

## Why

The current guide only says the new output location "might break some
of the toolchains that rely [on] the previous location," without naming
any specific toolchains or giving concrete remediation steps. In
practice this means CI/CD pipelines that copy from a fixed
`dist/<project-name>` path (e.g. Azure DevOps release tasks deploying
to IIS) silently deploy an incomplete or empty site, since the actual
build output now lives one level deeper at `dist/<project-name>/browser`.

There's no build-time warning from the CLI when this happens, so the
first signal most people get is a failed or broken deployment — which
is what happened in my own case. This change makes the guide explicit
about who is affected and what to do about it, rather than leaving it
as a vague caveat.

## Changes

- Added a paragraph naming CI/CD pipelines and deployment tools
  (Azure DevOps, IIS, and similar) as directly affected by the new
  output path, with the required path update.
- Documented the `outputPath.base` config option as a way to preserve
  the previous flat `dist/<project-name>` structure without changing
  deploy tooling.

Closes #57247
