### PR TITLE
fix(core): handle event types that shadow Object.prototype members

### DIFF
--- a/packages/core/primitives/event-dispatch/src/action_resolver.ts
+++ b/packages/core/primitives/event-dispatch/src/action_resolver.ts
@@ -18,8 +18,13 @@ import * as eventLib from './event';
 /**
  * Since maps from event to action are immutable we can use a single map
  * to represent the empty map.
+ *
+ * Null-prototype because it is indexed by DOM event type, and an event type
+ * that collides with an `Object.prototype` member (`constructor`, `toString`,
+ * `valueOf`, ...) would otherwise resolve to the inherited value instead of
+ * `undefined`.
  */
-const EMPTY_ACTION_MAP: {[key: string]: string} = {};
+const EMPTY_ACTION_MAP: {[key: string]: string} = Object.create(null);
 
 /**
  * This regular expression matches a semicolon.
@@ -258,7 +263,7 @@ export class ActionResolver {
       } else {
         actionMap = cache.getParsed(jsactionAttribute);
         if (!actionMap) {
-          actionMap = {};
+          actionMap = Object.create(null) as {[key: string]: string | undefined};
           const values = jsactionAttribute.split(REGEXP_SEMICOLON);
           for (let idx = 0; idx < values.length; idx++) {
             const value = values[idx];

--- a/packages/core/primitives/event-dispatch/src/cache.ts
+++ b/packages/core/primitives/event-dispatch/src/cache.ts
@@ -10,8 +10,12 @@ import {Property} from './property';
 
 /**
  * Map from jsaction annotation to a parsed map from event name to action name.
+ *
+ * Null-prototype because it is indexed by the raw attribute value, so an
+ * attribute that is exactly an `Object.prototype` member name would otherwise
+ * read back the inherited value as if it were a cache hit.
  */
-const parseCache: {[key: string]: {[key: string]: string | undefined}} = {};
+const parseCache: {[key: string]: {[key: string]: string | undefined}} = Object.create(null);
 
 /**
  * Reads the jsaction parser cache from the given DOM Element.
@@ -25,7 +29,7 @@ export function get(element: Element): {[key: string]: string | undefined} | und
  * creates an empty one.
  */
 export function getDefaulted(element: Element): {[key: string]: string | undefined} {
-  const cache = get(element) ?? {};
+  const cache: {[key: string]: string | undefined} = get(element) ?? Object.create(null);
   set(element, cache);
   return cache;
 }

--- a/packages/core/primitives/event-dispatch/src/eventcontract.ts
+++ b/packages/core/primitives/event-dispatch/src/eventcontract.ts
@@ -85,10 +85,14 @@ export class EventContract implements UnrenamedEventContract {
    * internally created DOM event handler function that handles the
    * DOM events. See addEvent().
    *
+   * Null-prototype because it is keyed by event type. With a normal object
+   * literal the `eventType in this.eventHandlers` guard in `addEvent()` is
+   * satisfied by every `Object.prototype` member, so an event type such as
+   * `constructor` is treated as already registered and never gets a listener.
    */
-  private eventHandlers: {[key: string]: EventHandler} = {};
+  private eventHandlers: {[key: string]: EventHandler} = Object.create(null);
 
-  private browserEventTypeToExtraEventTypes: {[key: string]: string[]} = {};
+  private browserEventTypeToExtraEventTypes: {[key: string]: string[]} = Object.create(null);
 
   /**
    * The dispatcher function. Events are passed to this function for
@@ -252,8 +256,8 @@ export class EventContract implements UnrenamedEventContract {
   cleanUp() {
     this.containerManager?.cleanUp();
     this.containerManager = null;
-    this.eventHandlers = {};
-    this.browserEventTypeToExtraEventTypes = {};
+    this.eventHandlers = Object.create(null);
+    this.browserEventTypeToExtraEventTypes = Object.create(null);
     this.dispatcher = null;
     this.queuedEventInfos = [];
   }

--- a/packages/core/primitives/event-dispatch/test/dispatcher_test.ts
+++ b/packages/core/primitives/event-dispatch/test/dispatcher_test.ts
@@ -143,6 +143,16 @@ const domContent = `
     <div id="pointerleave-target-element"></div>
   </div>
 </div>
+
+<div id="prototype-event-type-container">
+  <div id="prototype-event-type-action-element" jsaction="constructor:handleConstructor">
+    <div id="prototype-event-type-target-element"></div>
+  </div>
+</div>
+
+<div id="prototype-action-name-container">
+  <div id="prototype-action-name-target-element" jsaction="constructor"></div>
+</div>
 `;
 
 function getRequiredElementById(id: string) {
@@ -256,6 +266,12 @@ function dispatchKeyboardEvent(
   // `initKeyboardEvent`.
   Object.defineProperty(event, 'key', {value: key});
   spyOn(event, 'preventDefault').and.callThrough();
+  target.dispatchEvent(event);
+  return event;
+}
+
+function dispatchCustomEvent(target: Element, type: string) {
+  const event = new Event(type, {bubbles: true, cancelable: true});
   target.dispatchEvent(event);
   return event;
 }
@@ -614,6 +630,67 @@ describe('Dispatcher', () => {
     expect(eventInfoWrapper.getEvent()).toBe(clickEvent);
     expect(eventInfoWrapper.getTargetElement()).toBe(targetElement);
     expect(eventInfoWrapper.getAction()).toBeUndefined();
+  });
+
+  it('dispatches event for an event type that shadows an Object.prototype member', () => {
+    const container = getRequiredElementById('prototype-event-type-container');
+    const actionElement = getRequiredElementById('prototype-event-type-action-element');
+    const targetElement = getRequiredElementById('prototype-event-type-target-element');
+
+    const eventContract = createEventContract({
+      container,
+      eventTypes: ['constructor'],
+    });
+    const dispatchDelegate = createDispatchDelegateSpy();
+    createDispatcher({dispatchDelegate, eventContract});
+
+    const customEvent = dispatchCustomEvent(targetElement, 'constructor');
+
+    expect(dispatchDelegate).toHaveBeenCalledTimes(1);
+    const eventInfoWrapper = dispatchDelegate.calls.mostRecent().args[0];
+    expect(eventInfoWrapper.getEventType()).toBe('constructor');
+    expect(eventInfoWrapper.getEvent()).toBe(customEvent);
+    expect(eventInfoWrapper.getTargetElement()).toBe(targetElement);
+    expect(eventInfoWrapper.getAction()?.name).toBe('handleConstructor');
+    expect(eventInfoWrapper.getAction()?.element).toBe(actionElement);
+  });
+
+  it('does not resolve an action for an event type the jsaction does not name', () => {
+    const container = getRequiredElementById('click-container');
+    const targetElement = getRequiredElementById('click-target-element');
+
+    const eventContract = createEventContract({
+      container,
+      eventTypes: ['toString'],
+    });
+    const dispatchDelegate = createDispatchDelegateSpy();
+    createDispatcher({dispatchDelegate, eventContract});
+
+    dispatchCustomEvent(targetElement, 'toString');
+
+    expect(dispatchDelegate).toHaveBeenCalledTimes(1);
+    const eventInfoWrapper = dispatchDelegate.calls.mostRecent().args[0];
+    expect(eventInfoWrapper.getEventType()).toBe('toString');
+    expect(eventInfoWrapper.getAction()).toBeUndefined();
+  });
+
+  it('dispatches event for a jsaction attribute that is an Object.prototype member name', () => {
+    const container = getRequiredElementById('prototype-action-name-container');
+    const targetElement = getRequiredElementById('prototype-action-name-target-element');
+
+    const eventContract = createEventContract({
+      container,
+      eventTypes: ['click'],
+    });
+    const dispatchDelegate = createDispatchDelegateSpy();
+    createDispatcher({dispatchDelegate, eventContract});
+
+    dispatchMouseEvent(targetElement);
+
+    expect(dispatchDelegate).toHaveBeenCalledTimes(1);
+    const eventInfoWrapper = dispatchDelegate.calls.mostRecent().args[0];
+    expect(eventInfoWrapper.getAction()?.name).toBe('constructor');
+    expect(eventInfoWrapper.getAction()?.element).toBe(targetElement);
   });
 
   it('dispatches event from shadow dom', () => {

--- a/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
+++ b/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
@@ -179,6 +179,32 @@ describe('EventContract', () => {
     expect(registeredEventTypes).toEqual(['click']);
   });
 
+  it('adds event listener for an event type that shadows an Object.prototype member', () => {
+    const container = getRequiredElementById('container');
+    const addEventListenerSpy = spyOn(container, 'addEventListener');
+
+    const eventContractContainerManager = new EventContractContainer(container);
+    const eventContract = createEventContract({eventContractContainerManager, eventTypes: []});
+
+    eventContract.addEvent('constructor');
+
+    const registeredEventTypes = addEventListenerSpy.calls
+      .allArgs()
+      .map(([eventType]) => eventType);
+    expect(registeredEventTypes).toEqual(['constructor']);
+  });
+
+  it('has no event handlers with `handler()` for an unregistered Object.prototype member name', () => {
+    const container = getRequiredElementById('click-container');
+
+    const eventContract = createEventContract({
+      eventContractContainerManager: new EventContractContainer(container),
+      eventTypes: [],
+    });
+
+    expect(eventContract.handler('constructor')).toBeUndefined();
+  });
+
   it('adds event listener for aliased event', () => {
     const container = getRequiredElementById('container');
     const addEventListenerSpy = spyOn(container, 'addEventListener');


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: N/A

The maps that jsaction event dispatch keys by names coming from the page are plain object literals, so a lookup that misses falls through to `Object.prototype`. An event type or a jsaction attribute whose text is a member of `Object.prototype` (`constructor`, `toString`, `valueOf`, `hasOwnProperty`, and so on) goes wrong in three separate places.

**1. The listener is never registered.** `addEvent()` guards with `eventType in this.eventHandlers` (`eventcontract.ts:153`), and `in` walks the prototype chain, so the guard is satisfied for every prototype member and the method returns before it reaches `addEventListener`. `handler('constructor')` afterwards returns the inherited `Object`, so the contract reports the type as registered while nothing is listening.

**2. The wrong element is picked, and the walk stops there.** `ActionResolver` reads `actionMap[getEventType(eventInfo)]` (`action_resolver.ts:233`). For an element with no jsaction attribute the map is `EMPTY_ACTION_MAP`; for an element whose jsaction does not name the event it is the parsed map. Either way the inherited member comes back, `actionName !== undefined` holds, and a function is set as the action name. `populateAction` reads that as a match and breaks out of the ancestor walk, so the element that really carried the jsaction is never reached.

**3. The attribute is never parsed.** `getParsed()` (`cache.ts:47`) is keyed by the raw attribute value, so `jsaction="constructor"` reads back as a cache hit and the element ends up with the `Object` constructor as its action map. The handler never fires.

## What is the new behavior?

Those maps get a null prototype, so a lookup can only return something that was actually stored. Nothing else changes: the guards, the walk and the cache keep the same shape.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**Tests.** Five specs across the two existing suites, written so they fail on `main` for the right reason:

| spec | failure on `main` |
| --- | --- |
| adds event listener for an event type that shadows an `Object.prototype` member | `Expected $.length = 0 to equal 1.` |
| has no event handlers with `handler()` for an unregistered `Object.prototype` member name | `Expected Function 'Object' to be undefined.` |
| dispatches event for an event type that shadows an `Object.prototype` member | `Expected spy dispatchDelegate to have been called once. It was called 0 times.` |
| does not resolve an action for an event type the jsaction does not name | `Expected spy dispatchDelegate to have been called once. It was called 0 times.` |
| dispatches event for a jsaction attribute that is an `Object.prototype` member name | `Expected undefined to be 'constructor'.` |

The two dispatcher suites go from 52 specs / 5 failures to 52 specs / 0 failures. The 47 pre-existing specs pass on both sides.

**Two things I checked rather than assumed.**

The `no-toplevel-property-access` rule is scoped to `packages/animations/src/`, `packages/common/src/`, `packages/core/src/` and a few others in `tslint.json`, and does not cover `packages/core/primitives/`, so the top level `Object.create(null)` here does not need the suppression comment that `format_date.ts` carries.

The parsed action map needs an explicit type on the assignment. `Object.create(null)` is typed `any`, and assigning `any` to a `T | undefined` local does not narrow it the way `= {}` did, so `actionMap` stayed nullable and `tsc` failed on the three uses below it. The cast keeps the narrowing that was there before.

**Left alone on purpose.** `dataContainer._ejsas` in `bootstrap_app_scoped.ts` is the same object literal shape, but it is keyed by app id, which is application configuration rather than a name arriving from the DOM. Happy to include it if you would rather have the package uniform.

**How it was run.** `pnpm test //packages/core/primitives/event-dispatch/...` needs Bazel with MSYS2, which I do not have working on this machine, so I ran the two suites unmodified under jsdom with jasmine, plus `tsc` with the compiler options from `packages/tsconfig-build.json` and `prettier --check`. Both the typecheck and the pre-existing specs were run against clean `main` as a control. If CI disagrees with any of this I will fix it.
