### PR TITLE
refactor(language-service): adapt strict template suggestion

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -8,18 +8,18 @@
 
 import {AST, TmplAstNode} from '@angular/compiler';
 import {
-  AbsoluteFsPath,
   absoluteFrom,
+  AbsoluteFsPath,
   CompilerOptions,
   ConfigurationHost,
   ErrorCode,
   FileUpdate,
+  InliningMode,
   isExternalResource,
   isFatalDiagnosticError,
   isNamedClassDeclaration,
-  ngErrorCode,
   NgCompiler,
-  InliningMode,
+  ngErrorCode,
   OptimizeFor,
   PerfPhase,
   ProgramDriver,
@@ -991,6 +991,17 @@ function parseNgCompilerOptions(
     const detectedVersion = detectAngularCoreVersion(project, host);
     if (detectedVersion !== null) {
       options['_angularCoreVersion'] = detectedVersion;
+    }
+  }
+
+  // Prior to v22, strictTemplates was set to false by default
+  if (options.strictTemplates === undefined && typeof options['_angularCoreVersion'] === 'string') {
+    const version = options['_angularCoreVersion'];
+    if (version !== `0.0.0-${'PLACEHOLDER'}`) {
+      const major = parseInt(version.split('.')[0], 10);
+      if (!Number.isNaN(major) && major < 22) {
+        options.strictTemplates = false;
+      }
     }
   }
 

--- a/packages/language-service/test/version_detection_spec.ts
+++ b/packages/language-service/test/version_detection_spec.ts
@@ -17,32 +17,63 @@ describe('Angular version detection', () => {
 
   it('should detect Angular version per project', () => {
     // Project 1: Angular v16
-    const project1 = env.addProject('project1', {
-      'tsconfig.json': '{}',
-      'app.ts': 'export class App {}',
-      'node_modules/@angular/core/package.json': JSON.stringify({
-        name: '@angular/core',
-        version: '16.0.0',
-      }),
-    });
+    const project1 = env.addProject(
+      'project1',
+      {
+        'tsconfig.json': '{}',
+        'app.ts': 'export class App {}',
+        'node_modules/@angular/core/package.json': JSON.stringify({
+          name: '@angular/core',
+          version: '16.0.0',
+        }),
+      },
+      // By default our testing env sets strictTemplates to true, we unset it here.
+      {strictTemplates: undefined},
+    );
 
     // Project 2: Angular v17
-    const project2 = env.addProject('project2', {
-      'tsconfig.json': '{}',
-      'app.ts': 'export class App {}',
-      'node_modules/@angular/core/package.json': JSON.stringify({
-        name: '@angular/core',
-        version: '17.0.0',
-      }),
-    });
+    const project2 = env.addProject(
+      'project2',
+      {
+        'tsconfig.json': '{}',
+        'app.ts': 'export class App {}',
+        'node_modules/@angular/core/package.json': JSON.stringify({
+          name: '@angular/core',
+          version: '17.0.0',
+        }),
+      },
+      // By default our testing env sets strictTemplates to true, we unset it here.
+      {strictTemplates: undefined},
+    );
+
+    // Project 3: Angular v22
+    const project3 = env.addProject(
+      'project3',
+      {
+        'tsconfig.json': '{}',
+        'app.ts': 'export class App {}',
+        'node_modules/@angular/core/package.json': JSON.stringify({
+          name: '@angular/core',
+          version: '22.0.0',
+        }),
+      },
+      // By default our testing env sets strictTemplates to true, we unset it here.
+      {strictTemplates: undefined},
+    );
 
     // We need to access the internal options to verify detection
     // Project wrapper in testing exposes ngLS
     const options1 = project1.ngLS.getCompilerOptions();
     expect(options1['_angularCoreVersion']).toBe('16.0.0');
+    expect(options1.strictTemplates).toBeFalse();
 
     const options2 = project2.ngLS.getCompilerOptions();
     expect(options2['_angularCoreVersion']).toBe('17.0.0');
+    expect(options2.strictTemplates).toBeFalse();
+
+    const options3 = project3.ngLS.getCompilerOptions();
+    expect(options3['_angularCoreVersion']).toBe('22.0.0');
+    expect(options3.strictTemplates).toBeUndefined();
   });
 
   it('should fallback to default if detection fails', () => {


### PR DESCRIPTION
In v22, `strictTemplates` is true by default. We need to adapte the LS to online report the suggestion when the option is explicitly `false`
