### PR TITLE
fix(devtools): prevent duplicate highlightComponent listener in injector tree

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -10,6 +10,7 @@ import {
   afterRenderEffect,
   Component,
   computed,
+  DestroyRef,
   inject,
   input,
   signal,
@@ -142,6 +143,8 @@ export class InjectorTreeComponent {
   };
 
   constructor() {
+    this.subscribeToBackendEvents();
+
     afterRenderEffect({
       write: () => {
         const view = this.componentExplorerView();
@@ -149,7 +152,6 @@ export class InjectorTreeComponent {
           return;
         }
 
-        this.init();
         this.rawDirectiveForest = view.forest;
         untracked(() => this.updateInjectorTreeVisualization(view.forest));
       },
@@ -199,8 +201,8 @@ export class InjectorTreeComponent {
     }
   }
 
-  private init() {
-    this.messageBus.on('highlightComponent', (id: number) => {
+  private subscribeToBackendEvents(): void {
+    const unregisterHighlight = this.messageBus.on('highlightComponent', (id: number) => {
       const elementTree = this.elementTree();
       if (!elementTree) {
         return;
@@ -211,6 +213,10 @@ export class InjectorTreeComponent {
       }
 
       this.selectInjectorByNode(injectorNode);
+    });
+
+    inject(DestroyRef).onDestroy(() => {
+      unregisterHighlight();
     });
   }
 


### PR DESCRIPTION
The listener subscription for highlightComponent was getting recreated on every render of the injector tree component.

Moves the message bus subscription out of afterRenderEffect into constructor initialization and clean up the listener on destroy using DestroyRef.
