### PR TITLE
fix(forms): use Object.hasOwn for stale-field diff in signal forms

### DIFF
--- a/packages/forms/signals/src/field/structure.ts
+++ b/packages/forms/signals/src/field/structure.ts
@@ -674,7 +674,7 @@ function maybeRemoveStaleObjectFields(
   // For objects, we diff a bit differently, and use the value to check whether an old
   // property still exists on the object value.
   for (const key of prevData.byPropertyKey.keys()) {
-    if (!value.hasOwnProperty(key)) {
+    if (!Object.hasOwn(value, key)) {
       data ??= {...(prevData as MutableChildrenData)};
       data.byPropertyKey.delete(key);
     }

--- a/packages/forms/signals/test/node/api/structure.spec.ts
+++ b/packages/forms/signals/test/node/api/structure.spec.ts
@@ -131,23 +131,21 @@ describe('structure APIs', () => {
     });
   });
 
-  describe('object models with shadowing keys', () => {
-    it('should not throw when the model has an own `hasOwnProperty` field', () => {
-      // A model value that mirrors untrusted JSON may carry a field literally named
-      // `hasOwnProperty`, which shadows the method used by the stale-field diff.
-      const data = signal<Record<string, unknown>>({a: '', hasOwnProperty: ''});
-      const f = form(data, {injector: TestBed.inject(Injector)}) as any;
+  it('should not throw when the model has an own `hasOwnProperty` field', () => {
+    // A model value that mirrors untrusted JSON may carry a field literally named
+    // `hasOwnProperty`, which shadows the method used by the stale-field diff.
+    const data = signal({a: '', hasOwnProperty: ''});
+    const f = form(data, {injector: TestBed.inject(Injector)});
 
-      // Materialize the root's children so the structural cache is populated.
-      expect(f.a).toBeDefined();
+    // Materialize the root's children so the structural cache is populated.
+    expect(f.a).toBeDefined();
 
-      // Update to another object that still carries the shadowing key. Re-reading a
-      // child recomputes the children map and runs the stale-field diff against this
-      // value.
-      data.set({a: 'updated', hasOwnProperty: ''});
+    // Update to another object that still carries the shadowing key. Re-reading a
+    // child recomputes the children map and runs the stale-field diff against this
+    // value.
+    data.set({a: 'updated', hasOwnProperty: ''});
 
-      expect(() => f.a().value()).not.toThrow();
-      expect(f.a().value()).toBe('updated');
-    });
+    expect(() => f.a().value()).not.toThrow();
+    expect(f.a().value()).toBe('updated');
   });
 });

--- a/packages/forms/signals/test/node/api/structure.spec.ts
+++ b/packages/forms/signals/test/node/api/structure.spec.ts
@@ -130,4 +130,24 @@ describe('structure APIs', () => {
       expect((f.a() as any).structure._areChildrenMaterialized()).toBeTrue();
     });
   });
+
+  describe('object models with shadowing keys', () => {
+    it('should not throw when the model has an own `hasOwnProperty` field', () => {
+      // A model value that mirrors untrusted JSON may carry a field literally named
+      // `hasOwnProperty`, which shadows the method used by the stale-field diff.
+      const data = signal<Record<string, unknown>>({a: '', hasOwnProperty: ''});
+      const f = form(data, {injector: TestBed.inject(Injector)}) as any;
+
+      // Materialize the root's children so the structural cache is populated.
+      expect(f.a).toBeDefined();
+
+      // Update to another object that still carries the shadowing key. Re-reading a
+      // child recomputes the children map and runs the stale-field diff against this
+      // value.
+      data.set({a: 'updated', hasOwnProperty: ''});
+
+      expect(() => f.a().value()).not.toThrow();
+      expect(f.a().value()).toBe('updated');
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`maybeRemoveStaleObjectFields` in `packages/forms/signals/src/field/structure.ts` diffs the previously materialized child keys against the current object model with `value.hasOwnProperty(key)`. When a form model mirrors untrusted JSON that carries an own field literally named `hasOwnProperty`, that data value shadows the method, so the call throws `TypeError: value.hasOwnProperty is not a function` and the structural diff crashes inside the reactive children computation. The sibling `maybeRemoveStaleArrayFields` in the same file already avoids this by using `Object.hasOwn`, so only the object path is affected.

## What is the new behavior?

The object path now uses `Object.hasOwn(value, key)`, matching the array sibling. Models without a `hasOwnProperty` field diff exactly as before; a model that happens to carry that key no longer crashes the diff. Added a regression test in `structure.spec.ts` that materializes an object form, then updates it to a value carrying a `hasOwnProperty` key and asserts the recompute does not throw.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information