### PR TITLE
ci: update github nick

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -497,7 +497,7 @@ groups:
         - iteriani # Thomas Nguyen
         - tbondwilkinson # Tom Wilkinson
         - rahatarmanahmed # Rahat Ahmed
-        - ENAML # Ethan Cline
+        - e-cline # Ethan Cline
 
   ####################################################################################
   # Override managed result groups


### PR DESCRIPTION
ethan changed his nick, this was causing some pullapproves errors when a pr hit the primitives-shared scope.

See: https://github.com/angular/angular/pull/70187