### PR TITLE
fix(core): release the loader function on destroy() so it doesn't leak memory

### DIFF
--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -196,13 +196,37 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
   private destroyed = false;
   private unregisterOnDestroy: () => void;
 
+  // This used to be `readonly`, but now we clear it to `undefined` when the resource is
+  // destroyed. Same idea as `PromiseStrategy.createSubscription` in `async_pipe.ts` — read
+  // the comment there too if you want the full picture.
+  //
+  // According to the promise specification, promises are not cancellable. Once you start
+  // waiting on one — which is what the `await` in `loadEffect()` below does — there's no
+  // built-in way to say "never mind, stop." If the loader's promise never settles (a fetch
+  // that hangs forever, a third-party API that never calls back), that `await` just keeps
+  // waiting, potentially forever.
+  //
+  // While it's waiting, the JS engine has to keep everything that code needs alive in memory.
+  // For an `async` method like `loadEffect()`, that includes `this` — the whole resource
+  // object — for as long as the wait continues. We can't avoid that part; it's just how
+  // `await` works under the hood (if you're curious, Chrome lets you see this yourself with
+  // `--allow-natives-syntax --track-retaining-path` and `%DebugTrackRetainingPath()`, which
+  // prints how many references away from a GC root something is being kept alive by).
+  //
+  // What we CAN do is stop holding onto the loader function itself. It's just a normal
+  // reference stored on `this`, so setting it to `undefined` here takes effect immediately —
+  // it doesn't need to wait for anything. If your loader closes over data from the component
+  // that created it (e.g. `loader: () => fetch(this.userId())`), that data is now free to be
+  // garbage collected instead of being kept alive for as long as the abandoned load "waits."
+  private loaderFn: ResourceStreamingLoader<T, R> | undefined;
+
   override readonly status: Signal<ResourceStatus>;
   override readonly error: Signal<Error | undefined>;
   private readonly transferState: TransferState | undefined;
 
   constructor(
     request: (ctx: ResourceParamsContext) => R,
-    private readonly loaderFn: ResourceStreamingLoader<T, R>,
+    loaderFn: ResourceStreamingLoader<T, R>,
     defaultValue: T,
     private readonly equal: ValueEqualityFn<T> | undefined,
     private readonly debugName: string | undefined,
@@ -240,6 +264,8 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
       ),
       debugName,
     );
+
+    this.loaderFn = loaderFn;
 
     const cacheState = injector.get(CACHE_ACTIVE, undefined, {optional: true}) ?? {isActive: false};
 
@@ -399,6 +425,12 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
     this.effectRef.destroy();
     this.abortInProgressLoad();
 
+    // Per the promise spec, if a load is still happening in the background, we can't cancel
+    // it — so it might keep running (or hang) long after this resource is gone. We can't do
+    // anything about that. But we don't need to keep the loader function around anymore, so
+    // let it go here — see the comment on the `loaderFn` field above for the full reasoning.
+    this.loaderFn = undefined;
+
     // Destroyed resources enter Idle state.
     this.state.set({
       extRequest: {request: undefined, reload: 0},
@@ -445,7 +477,9 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
       // reactive. This avoids any confusion with signals tracking or not tracking depending on
       // which side of the `await` they are.
       const stream = untracked(() => {
-        return this.loaderFn({
+        // The only place `loaderFn` gets cleared is `destroy()`, and that also stops this function
+        // (`loadEffect`) from ever running again. So if we're here, it's always still set.
+        return this.loaderFn!({
           params: extRequest.request as Exclude<R, undefined>,
           abortSignal,
           previous: {

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -527,6 +527,32 @@ describe('resource', () => {
     expect(aborted).toEqual([{counter: 0}]);
   });
 
+  it('should release the loader closure once destroyed, even if the load never resolves', async () => {
+    // Regression test. `loadEffect` is an async method, so a still-pending `await` (waiting on
+    // the loader's promise) keeps `this` alive until that promise settles — which, since
+    // promises can't be cancelled, might be never. `destroy()` should still release the loader
+    // reference itself, so at least its closure (which may capture arbitrary caller state)
+    // isn't held onto for that long too.
+    const backend = new MockEchoBackend<{counter: number}>();
+    const echoResource = resource<{counter: number}, {counter: number}>({
+      params: () => ({counter: 0}),
+      loader: ({params}) => backend.fetch(params),
+      injector: TestBed.inject(Injector),
+    });
+
+    TestBed.tick();
+    await Promise.resolve();
+
+    // Destroy while the load is still pending — never call `backend.flush()`, simulating a
+    // loader whose promise never resolves.
+    echoResource.destroy();
+
+    // `loaderFn` is a private implementation field; reaching into it here is the only way to
+    // directly verify the reference was actually released, since calling it again after
+    // destroy was already impossible before this fix too (the effect is destroyed either way).
+    expect((echoResource as any).loaderFn).toBeUndefined();
+  });
+
   it('should not respond to reactive state changes in a loader', async () => {
     const unrelated = signal('a');
     const backend = new MockResponseCountingBackend();


### PR DESCRIPTION
Here's the problem: `resource()` takes a `loader` function you give it, and internally it does `await` on whatever promise that loader returns. If that promise never finishes — say, a fetch request that hangs, or a third-party library that just never calls back — the `await` sits there waiting forever. And because promises can't be cancelled once you've started waiting on them, there's nothing Angular can do to force it to stop.

The catch is: while it's waiting, JavaScript has to keep everything that code needs in memory. That includes the whole resource object, AND the loader function you originally passed in. If your loader function reads from a component (like `loader: () => fetch(this.userId())`), that whole component gets kept alive too, even after you call `.destroy()` on the resource. That's a memory leak.

We can't fix the "waiting forever" part - that's just how promises work. But we can at least stop holding onto the loader function itself once the resource is destroyed, so whatever it captured is free to be cleaned up sooner rather than never.

The fix: `loaderFn` is no longer `readonly`. When `destroy()` runs, we set it to `undefined`. The one place that calls it (`loadEffect`) is guaranteed to never run again after destroy anyway (because destroying the resource also destroys its internal effect), so this is safe.

This is the same fix, for the same reason, as an older one in `AsyncPipe` (`PromiseStrategy.createSubscription`) - nulling out a callback reference on cleanup so a promise that never resolves doesn't hold onto memory forever.

Added a test that destroys a resource while its load is still pending (never resolving it) and checks that the loader reference is actually gone. Confirmed it fails without the fix, passes with it.