### PR TITLE
refactor(core): show bounded paths in hydration errors

### DIFF
--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -16,7 +16,9 @@ import {
   HOST,
   LView,
   T_HOST,
+  TVIEW,
 } from '../render3/interfaces/view';
+import {getParentRElement} from '../render3/node_manipulation';
 import {getComponent} from '../render3/util/discovery_utils';
 import {unwrapRNode} from '../render3/util/view_utils';
 
@@ -25,6 +27,7 @@ import {markRNodeAsHavingHydrationMismatch} from './utils';
 import {DOC_PAGE_BASE_URL} from '../../../core/src/error_details_base_url';
 
 const AT_THIS_LOCATION = '<-- AT THIS LOCATION';
+const MAX_DOM_PATH_NODES = 4;
 
 const THIRD_PARTY_SCRIPTS_URL = `/guide/hydration#third-party-scripts-with-dom-manipulation`;
 
@@ -83,7 +86,9 @@ export function validateMatchingNode(
     const componentClassName = hostComponentDef?.type?.name;
 
     const componentHostElement = getDeclarationComponentHostElement(lView);
-    const expectedDom = describeExpectedDom(lView, tNode, isViewContainerAnchor);
+    const expectedDom = describeExpectedDom(lView, tNode, isViewContainerAnchor, {
+      includePath: true,
+    });
     const expected = `Angular expected this DOM:\n\n${expectedDom}\n\n`;
 
     let actual = '';
@@ -104,7 +109,10 @@ export function validateMatchingNode(
 
       header += `found ${actualNode}.\n\n`;
       const actualComponentHostElement = getClosestComponentHostElement(node);
-      const actualDom = describeDomFromNode(node, actualComponentHostElement);
+      const actualDom = describeDomFromNode(node, {
+        ancestorBoundary: actualComponentHostElement,
+        includePath: true,
+      });
       actual = `Actual DOM is:\n\n${actualDom}\n\n`;
 
       // DevTools only report hydration issues on the component level, so we attach extra debug
@@ -326,6 +334,16 @@ function describeTNode(tNode: TNode, innerContent: string = '…'): string {
   }
 }
 
+function describeTNodeForPath(tNode: TNode): string {
+  if (tNode.type !== TNodeType.Element) {
+    return describeTNode(tNode);
+  }
+
+  const attrs = stringifyTNodeAttrs(tNode);
+  const tag = tNode.value.toLowerCase();
+  return `<${tag}${attrs ? ' ' + attrs : ''}>`;
+}
+
 /**
  * Converts an RNode to a helpful readable string value for use in error messages
  *
@@ -350,6 +368,17 @@ function describeRNode(rNode: RNode, innerContent: string = '…'): string {
   }
 }
 
+function describeRNodeForPath(rNode: RNode): string {
+  const node = rNode as HTMLElement;
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return describeRNode(rNode);
+  }
+
+  const tag = node.tagName.toLowerCase();
+  const attrs = stringifyRNodeAttrs(node);
+  return `<${tag}${attrs ? ' ' + attrs : ''}>`;
+}
+
 /**
  * Builds the string containing the expected DOM present given the LView and TNode
  * values for a readable error message
@@ -359,7 +388,12 @@ function describeRNode(rNode: RNode, innerContent: string = '…'): string {
  * @param isViewContainerAnchor boolean
  * @returns string
  */
-function describeExpectedDom(lView: LView, tNode: TNode, isViewContainerAnchor: boolean): string {
+function describeExpectedDom(
+  lView: LView,
+  tNode: TNode,
+  isViewContainerAnchor: boolean,
+  options: {includePath?: boolean} = {},
+): string {
   const lines: string[] = [];
   if (tNode.prev) {
     lines.push('…', describeTNode(tNode.prev));
@@ -373,7 +407,7 @@ function describeExpectedDom(lView: LView, tNode: TNode, isViewContainerAnchor: 
   }
   lines.push('…');
 
-  let content = lines.join('\n');
+  const ancestors: TNode[] = [];
   const declarationComponentLView = lView[DECLARATION_COMPONENT_VIEW];
   let currentLView: LView | null = lView;
   let parentTNode = tNode.parent;
@@ -381,7 +415,7 @@ function describeExpectedDom(lView: LView, tNode: TNode, isViewContainerAnchor: 
   while (currentLView !== null) {
     for (let parent = parentTNode; parent !== null; parent = parent.parent) {
       if (parent.type === TNodeType.Element) {
-        content = describeTNode(parent, `\n${indent(content)}\n`);
+        ancestors.push(parent);
       }
     }
 
@@ -394,9 +428,22 @@ function describeExpectedDom(lView: LView, tNode: TNode, isViewContainerAnchor: 
   }
 
   const componentHostElement = getDeclarationComponentHostElement(lView);
-  return componentHostElement === null
-    ? content
-    : describeRNode(componentHostElement, `\n${indent(content)}\n`);
+  let content = lines.join('\n');
+  const parentRNode = tNode.type ? getParentRElement(lView[TVIEW], tNode, lView) : null;
+  if (parentRNode !== null) {
+    content = describeRNode(parentRNode as unknown as Node, `\n${indent(content)}\n`);
+  }
+
+  if (!options.includePath) {
+    return content;
+  }
+
+  const path = ancestors.reverse().map(describeTNodeForPath);
+  if (componentHostElement !== null) {
+    path.unshift(describeRNodeForPath(componentHostElement));
+  }
+  path.push(isViewContainerAnchor ? '<!-- container -->' : describeTNodeForPath(tNode));
+  return `DOM path: ${formatDomPath(path)}\n\n${content}`;
 }
 
 /**
@@ -404,10 +451,13 @@ function describeExpectedDom(lView: LView, tNode: TNode, isViewContainerAnchor: 
  * readable error message
  *
  * @param node the RNode
- * @param ancestorBoundary the last ancestor to include in the description
+ * @param options configuration for the DOM description
  * @returns string
  */
-function describeDomFromNode(node: RNode, ancestorBoundary: RNode | null = null): string {
+function describeDomFromNode(
+  node: RNode,
+  options: {ancestorBoundary?: RNode | null; includePath?: boolean} = {},
+): string {
   const lines: string[] = [];
   const currentNode = node as HTMLElement;
   if (currentNode.previousSibling) {
@@ -419,15 +469,36 @@ function describeDomFromNode(node: RNode, ancestorBoundary: RNode | null = null)
   }
 
   let content = lines.join('\n');
-  let parent = currentNode.parentNode;
-  while (parent?.nodeType === Node.ELEMENT_NODE) {
+  const parent = currentNode.parentNode;
+  if (parent?.nodeType === Node.ELEMENT_NODE) {
     content = describeRNode(parent, `\n${indent(content)}\n`);
-    if (ancestorBoundary === null || parent === ancestorBoundary) {
+  }
+
+  if (!options.includePath) {
+    return content;
+  }
+
+  const path: string[] = [];
+  let pathNode: Node | null = currentNode;
+  while (
+    pathNode !== null &&
+    (pathNode === currentNode || pathNode.nodeType === Node.ELEMENT_NODE)
+  ) {
+    path.unshift(describeRNodeForPath(pathNode));
+    if (pathNode === options.ancestorBoundary) {
       break;
     }
-    parent = parent.parentNode;
+    pathNode = pathNode.parentNode;
   }
-  return content;
+  return `DOM path: ${formatDomPath(path)}\n\n${content}`;
+}
+
+function formatDomPath(nodes: string[]): string {
+  if (nodes.length <= MAX_DOM_PATH_NODES) {
+    return nodes.join(' > ');
+  }
+
+  return [nodes[0], '...', ...nodes.slice(-(MAX_DOM_PATH_NODES - 1))].join(' > ');
 }
 
 function indent(value: string): string {

--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -443,7 +443,7 @@ function describeExpectedDom(
     path.unshift(describeRNodeForPath(componentHostElement));
   }
   path.push(isViewContainerAnchor ? '<!-- container -->' : describeTNodeForPath(tNode));
-  return `DOM path: ${formatDomPath(path)}\n\n${content}`;
+  return `DOM path:\n${formatDomPath(path)}\n\n${content}`;
 }
 
 /**
@@ -490,15 +490,18 @@ function describeDomFromNode(
     }
     pathNode = pathNode.parentNode;
   }
-  return `DOM path: ${formatDomPath(path)}\n\n${content}`;
+  return `DOM path:\n${formatDomPath(path)}\n\n${content}`;
 }
 
 function formatDomPath(nodes: string[]): string {
-  if (nodes.length <= MAX_DOM_PATH_NODES) {
-    return nodes.join(' > ');
-  }
+  const boundedNodes =
+    nodes.length <= MAX_DOM_PATH_NODES
+      ? nodes
+      : [nodes[0], '...', ...nodes.slice(-(MAX_DOM_PATH_NODES - 1))];
 
-  return [nodes[0], '...', ...nodes.slice(-(MAX_DOM_PATH_NODES - 1))].join(' > ');
+  return boundedNodes
+    .map((node, index) => (index === 0 ? node : `${'   '.repeat(index - 1)} └─ ${node}`))
+    .join('\n');
 }
 
 function indent(value: string): string {

--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -10,8 +10,14 @@ import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {getDeclarationComponentDef} from '../render3/instructions/element_validation';
 import {TNode, TNodeType} from '../render3/interfaces/node';
 import {RNode} from '../render3/interfaces/renderer_dom';
-import {HOST, LView, TVIEW} from '../render3/interfaces/view';
-import {getParentRElement} from '../render3/node_manipulation';
+import {
+  DECLARATION_COMPONENT_VIEW,
+  DECLARATION_VIEW,
+  HOST,
+  LView,
+  T_HOST,
+} from '../render3/interfaces/view';
+import {getComponent} from '../render3/util/discovery_utils';
 import {unwrapRNode} from '../render3/util/view_utils';
 
 import {readPatchedData} from '../render3/context_discovery';
@@ -76,17 +82,19 @@ export function validateMatchingNode(
     const hostComponentDef = getDeclarationComponentDef(lView);
     const componentClassName = hostComponentDef?.type?.name;
 
+    const componentHostElement = getDeclarationComponentHostElement(lView);
     const expectedDom = describeExpectedDom(lView, tNode, isViewContainerAnchor);
     const expected = `Angular expected this DOM:\n\n${expectedDom}\n\n`;
 
     let actual = '';
-    const componentHostElement = unwrapRNode(lView[HOST]!);
     if (!node) {
       // No node found during hydration.
       header += `the node was not found.\n\n`;
 
       // Since the node is missing, we use the closest node to attach the error to
-      markRNodeAsHavingHydrationMismatch(componentHostElement, expectedDom);
+      if (componentHostElement !== null) {
+        markRNodeAsHavingHydrationMismatch(componentHostElement, expectedDom);
+      }
     } else {
       const actualNode = shortRNodeDescription(
         (node as Node).nodeType,
@@ -95,12 +103,16 @@ export function validateMatchingNode(
       );
 
       header += `found ${actualNode}.\n\n`;
-      const actualDom = describeDomFromNode(node);
+      const actualComponentHostElement = getClosestComponentHostElement(node);
+      const actualDom = describeDomFromNode(node, actualComponentHostElement);
       actual = `Actual DOM is:\n\n${actualDom}\n\n`;
 
       // DevTools only report hydration issues on the component level, so we attach extra debug
       // info to a component host element to make it available to DevTools.
-      markRNodeAsHavingHydrationMismatch(componentHostElement, expectedDom, actualDom);
+      const mismatchHostElement = actualComponentHostElement ?? componentHostElement;
+      if (mismatchHostElement !== null) {
+        markRNodeAsHavingHydrationMismatch(mismatchHostElement, expectedDom, actualDom);
+      }
     }
 
     const footer = getHydrationErrorFooter(componentClassName);
@@ -244,7 +256,7 @@ export function invalidSkipHydrationHost(rNode: RNode): Error {
 function stringifyTNodeAttrs(tNode: TNode): string {
   const results = [];
   if (tNode.attrs) {
-    for (let i = 0; i < tNode.attrs.length; ) {
+    for (let i = 0; i < tNode.attrs.length;) {
       const attrName = tNode.attrs[i++];
       // Once we reach the first flag, we know that the list of
       // attributes is over.
@@ -254,6 +266,12 @@ function stringifyTNodeAttrs(tNode: TNode): string {
       const attrValue = tNode.attrs[i++];
       results.push(`${attrName}="${shorten(attrValue as string)}"`);
     }
+  }
+  if (tNode.classesWithoutHost !== null) {
+    results.push(`class="${shorten(tNode.classesWithoutHost)}"`);
+  }
+  if (tNode.stylesWithoutHost !== null) {
+    results.push(`style="${shorten(tNode.stylesWithoutHost)}"`);
   }
   return results.join(' ');
 }
@@ -342,27 +360,43 @@ function describeRNode(rNode: RNode, innerContent: string = '…'): string {
  * @returns string
  */
 function describeExpectedDom(lView: LView, tNode: TNode, isViewContainerAnchor: boolean): string {
-  const spacer = '  ';
-  let content = '';
+  const lines: string[] = [];
   if (tNode.prev) {
-    content += spacer + '…\n';
-    content += spacer + describeTNode(tNode.prev) + '\n';
+    lines.push('…', describeTNode(tNode.prev));
   } else if (tNode.type && tNode.type & TNodeType.AnyContainer) {
-    content += spacer + '…\n';
+    lines.push('…');
   }
   if (isViewContainerAnchor) {
-    content += spacer + describeTNode(tNode) + '\n';
-    content += spacer + `<!-- container -->  ${AT_THIS_LOCATION}\n`;
+    lines.push(describeTNode(tNode), `<!-- container -->  ${AT_THIS_LOCATION}`);
   } else {
-    content += spacer + describeTNode(tNode) + `  ${AT_THIS_LOCATION}\n`;
+    lines.push(describeTNode(tNode) + `  ${AT_THIS_LOCATION}`);
   }
-  content += spacer + '…\n';
+  lines.push('…');
 
-  const parentRNode = tNode.type ? getParentRElement(lView[TVIEW], tNode, lView) : null;
-  if (parentRNode) {
-    content = describeRNode(parentRNode as unknown as Node, '\n' + content);
+  let content = lines.join('\n');
+  const declarationComponentLView = lView[DECLARATION_COMPONENT_VIEW];
+  let currentLView: LView | null = lView;
+  let parentTNode = tNode.parent;
+
+  while (currentLView !== null) {
+    for (let parent = parentTNode; parent !== null; parent = parent.parent) {
+      if (parent.type === TNodeType.Element) {
+        content = describeTNode(parent, `\n${indent(content)}\n`);
+      }
+    }
+
+    if (currentLView === declarationComponentLView) {
+      break;
+    }
+
+    parentTNode = currentLView[T_HOST]?.parent ?? null;
+    currentLView = currentLView[DECLARATION_VIEW];
   }
-  return content;
+
+  const componentHostElement = getDeclarationComponentHostElement(lView);
+  return componentHostElement === null
+    ? content
+    : describeRNode(componentHostElement, `\n${indent(content)}\n`);
 }
 
 /**
@@ -370,24 +404,53 @@ function describeExpectedDom(lView: LView, tNode: TNode, isViewContainerAnchor: 
  * readable error message
  *
  * @param node the RNode
+ * @param ancestorBoundary the last ancestor to include in the description
  * @returns string
  */
-function describeDomFromNode(node: RNode): string {
-  const spacer = '  ';
-  let content = '';
+function describeDomFromNode(node: RNode, ancestorBoundary: RNode | null = null): string {
+  const lines: string[] = [];
   const currentNode = node as HTMLElement;
   if (currentNode.previousSibling) {
-    content += spacer + '…\n';
-    content += spacer + describeRNode(currentNode.previousSibling) + '\n';
+    lines.push('…', describeRNode(currentNode.previousSibling));
   }
-  content += spacer + describeRNode(currentNode) + `  ${AT_THIS_LOCATION}\n`;
+  lines.push(describeRNode(currentNode) + `  ${AT_THIS_LOCATION}`);
   if (node.nextSibling) {
-    content += spacer + '…\n';
+    lines.push('…');
   }
-  if (node.parentNode) {
-    content = describeRNode(currentNode.parentNode as Node, '\n' + content);
+
+  let content = lines.join('\n');
+  let parent = currentNode.parentNode;
+  while (parent?.nodeType === Node.ELEMENT_NODE) {
+    content = describeRNode(parent, `\n${indent(content)}\n`);
+    if (ancestorBoundary === null || parent === ancestorBoundary) {
+      break;
+    }
+    parent = parent.parentNode;
   }
   return content;
+}
+
+function indent(value: string): string {
+  return value.replace(/^/gm, '  ');
+}
+
+function getDeclarationComponentHostElement(lView: LView): RNode | null {
+  const hostElement = lView[DECLARATION_COMPONENT_VIEW][HOST];
+  return hostElement === null ? null : unwrapRNode(hostElement);
+}
+
+function getClosestComponentHostElement(node: RNode): RNode | null {
+  let currentNode: Node | null = node as Node;
+  while (currentNode !== null) {
+    if (
+      currentNode.nodeType === Node.ELEMENT_NODE &&
+      getComponent(currentNode as Element) !== null
+    ) {
+      return currentNode;
+    }
+    currentNode = currentNode.parentNode;
+  }
+  return null;
 }
 
 /**

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -6252,36 +6252,41 @@ describe('platform-server full application hydration integration', () => {
         });
       });
 
-      it('should show the full DOM ancestry for an element node mismatch', async () => {
+      it('should show a bounded DOM path for a mismatch in otherwise identical branches', async () => {
         @Component({
           selector: 'app',
           template: `
             <main id="content">
-              <section aria-label="Profile">
-                <div class="name"><b>Alice</b></div>
-              </section>
+              <div class="layout">
+                <section aria-label="Account">
+                  <div class="name"><b>Alice</b></div>
+                </section>
+                <section aria-label="Billing">
+                  <div class="name"><b>Bob</b></div>
+                </section>
+              </div>
             </main>
           `,
         })
-        class NestedElementMismatchComponent {
+        class AmbiguousBranchMismatchComponent {
           private doc = inject(DOCUMENT);
 
           ngAfterViewInit() {
-            const b = this.doc.querySelector('b');
+            const b = this.doc.querySelector('[aria-label="Billing"] b');
             const span = this.doc.createElement('span');
-            span.textContent = 'Alice';
+            span.textContent = 'Bob';
             b?.parentNode?.replaceChild(span, b);
           }
         }
 
-        const html = await ssr(NestedElementMismatchComponent);
+        const html = await ssr(AmbiguousBranchMismatchComponent);
 
-        resetTViewsFor(NestedElementMismatchComponent);
+        resetTViewsFor(AmbiguousBranchMismatchComponent);
 
         const result = await prepareEnvironmentAndHydrate(
           doc,
           html,
-          NestedElementMismatchComponent,
+          AmbiguousBranchMismatchComponent,
           {
             envProviders: [withNoopErrorHandler()],
           },
@@ -6292,70 +6297,51 @@ describe('platform-server full application hydration integration', () => {
 
         expect(result.message).toContain(
           'Angular expected this DOM:\n\n' +
-            '<app>\n' +
-            '  <main id="content">\n' +
-            '    <section aria-label="Profile">\n' +
-            '      <div class="name">\n' +
-            '        <b>…</b>  <-- AT THIS LOCATION',
+            'DOM path: <app> > ... > <section aria-label="Billing"> > <div class="name"> > <b>\n\n' +
+            '<div class="name">\n' +
+            '  <b>…</b>  <-- AT THIS LOCATION',
         );
         expect(result.message).toContain(
           'Actual DOM is:\n\n' +
-            '<app>\n' +
-            '  <main id="content">\n' +
-            '    <section aria-label="Profile">\n' +
-            '      <div class="name">\n' +
-            '        <span>…</span>  <-- AT THIS LOCATION',
+            'DOM path: <app> > ... > <section aria-label="Billing"> > <div class="name"> > <span>\n\n' +
+            '<div class="name">\n' +
+            '  <span>…</span>  <-- AT THIS LOCATION',
         );
         verifyNodeHasMismatchInfo(doc);
       });
 
-      it('should show the full DOM ancestry after browser HTML normalization', async () => {
+      it('should include a non-element mismatch in the actual DOM path', async () => {
         @Component({
           selector: 'app',
-          template: `
-            <main>
-              <table>
-                <tr>
-                  <td>Cell</td>
-                </tr>
-              </table>
-            </main>
-          `,
+          template: `<main>
+            <div class="content"><b>Bold</b></div>
+          </main>`,
         })
-        class BrowserNormalizedTableComponent {}
+        class CommentNodeMismatchComponent {
+          private doc = inject(DOCUMENT);
 
-        const html = await ssr(BrowserNormalizedTableComponent);
-        const normalizedHtml = html
-          .replace('<tr>', '<tbody><tr>')
-          .replace('</tr>', '</tr></tbody>');
+          ngAfterViewInit() {
+            const b = this.doc.querySelector('b');
+            b?.parentNode?.replaceChild(this.doc.createComment('mismatch'), b);
+          }
+        }
 
-        resetTViewsFor(BrowserNormalizedTableComponent);
+        const html = await ssr(CommentNodeMismatchComponent);
 
-        const result = await prepareEnvironmentAndHydrate(
-          doc,
-          normalizedHtml,
-          BrowserNormalizedTableComponent,
-          {
-            envProviders: [withNoopErrorHandler()],
-          },
-        ).catch((err: unknown) => err);
+        resetTViewsFor(CommentNodeMismatchComponent);
+
+        const result = await prepareEnvironmentAndHydrate(doc, html, CommentNodeMismatchComponent, {
+          envProviders: [withNoopErrorHandler()],
+        }).catch((err: unknown) => err);
 
         expect(result).toBeInstanceOf(Error);
         if (!(result instanceof Error)) return;
 
         expect(result.message).toContain(
-          'Angular expected this DOM:\n\n' +
-            '<app>\n' +
-            '  <main>\n' +
-            '    <table>\n' +
-            '      <tr>…</tr>  <-- AT THIS LOCATION',
-        );
-        expect(result.message).toContain(
           'Actual DOM is:\n\n' +
-            '<app>\n' +
-            '  <main>\n' +
-            '    <table>\n' +
-            '      <tbody>…</tbody>  <-- AT THIS LOCATION',
+            'DOM path: <app> > <main> > <div class="content"> > <!-- mismatch -->\n\n' +
+            '<div class="content">\n' +
+            '  <!-- mismatch -->  <-- AT THIS LOCATION',
         );
         verifyNodeHasMismatchInfo(doc);
       });

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -6297,13 +6297,23 @@ describe('platform-server full application hydration integration', () => {
 
         expect(result.message).toContain(
           'Angular expected this DOM:\n\n' +
-            'DOM path: <app> > ... > <section aria-label="Billing"> > <div class="name"> > <b>\n\n' +
+            'DOM path:\n' +
+            '<app>\n' +
+            ' └─ ...\n' +
+            '    └─ <section aria-label="Billing">\n' +
+            '       └─ <div class="name">\n' +
+            '          └─ <b>\n\n' +
             '<div class="name">\n' +
             '  <b>…</b>  <-- AT THIS LOCATION',
         );
         expect(result.message).toContain(
           'Actual DOM is:\n\n' +
-            'DOM path: <app> > ... > <section aria-label="Billing"> > <div class="name"> > <span>\n\n' +
+            'DOM path:\n' +
+            '<app>\n' +
+            ' └─ ...\n' +
+            '    └─ <section aria-label="Billing">\n' +
+            '       └─ <div class="name">\n' +
+            '          └─ <span>\n\n' +
             '<div class="name">\n' +
             '  <span>…</span>  <-- AT THIS LOCATION',
         );
@@ -6339,7 +6349,11 @@ describe('platform-server full application hydration integration', () => {
 
         expect(result.message).toContain(
           'Actual DOM is:\n\n' +
-            'DOM path: <app> > <main> > <div class="content"> > <!-- mismatch -->\n\n' +
+            'DOM path:\n' +
+            '<app>\n' +
+            ' └─ <main>\n' +
+            '    └─ <div class="content">\n' +
+            '       └─ <!-- mismatch -->\n\n' +
             '<div class="content">\n' +
             '  <!-- mismatch -->  <-- AT THIS LOCATION',
         );

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -6252,6 +6252,114 @@ describe('platform-server full application hydration integration', () => {
         });
       });
 
+      it('should show the full DOM ancestry for an element node mismatch', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            <main id="content">
+              <section aria-label="Profile">
+                <div class="name"><b>Alice</b></div>
+              </section>
+            </main>
+          `,
+        })
+        class NestedElementMismatchComponent {
+          private doc = inject(DOCUMENT);
+
+          ngAfterViewInit() {
+            const b = this.doc.querySelector('b');
+            const span = this.doc.createElement('span');
+            span.textContent = 'Alice';
+            b?.parentNode?.replaceChild(span, b);
+          }
+        }
+
+        const html = await ssr(NestedElementMismatchComponent);
+
+        resetTViewsFor(NestedElementMismatchComponent);
+
+        const result = await prepareEnvironmentAndHydrate(
+          doc,
+          html,
+          NestedElementMismatchComponent,
+          {
+            envProviders: [withNoopErrorHandler()],
+          },
+        ).catch((err: unknown) => err);
+
+        expect(result).toBeInstanceOf(Error);
+        if (!(result instanceof Error)) return;
+
+        expect(result.message).toContain(
+          'Angular expected this DOM:\n\n' +
+            '<app>\n' +
+            '  <main id="content">\n' +
+            '    <section aria-label="Profile">\n' +
+            '      <div class="name">\n' +
+            '        <b>…</b>  <-- AT THIS LOCATION',
+        );
+        expect(result.message).toContain(
+          'Actual DOM is:\n\n' +
+            '<app>\n' +
+            '  <main id="content">\n' +
+            '    <section aria-label="Profile">\n' +
+            '      <div class="name">\n' +
+            '        <span>…</span>  <-- AT THIS LOCATION',
+        );
+        verifyNodeHasMismatchInfo(doc);
+      });
+
+      it('should show the full DOM ancestry after browser HTML normalization', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            <main>
+              <table>
+                <tr>
+                  <td>Cell</td>
+                </tr>
+              </table>
+            </main>
+          `,
+        })
+        class BrowserNormalizedTableComponent {}
+
+        const html = await ssr(BrowserNormalizedTableComponent);
+        const normalizedHtml = html
+          .replace('<tr>', '<tbody><tr>')
+          .replace('</tr>', '</tr></tbody>');
+
+        resetTViewsFor(BrowserNormalizedTableComponent);
+
+        const result = await prepareEnvironmentAndHydrate(
+          doc,
+          normalizedHtml,
+          BrowserNormalizedTableComponent,
+          {
+            envProviders: [withNoopErrorHandler()],
+          },
+        ).catch((err: unknown) => err);
+
+        expect(result).toBeInstanceOf(Error);
+        if (!(result instanceof Error)) return;
+
+        expect(result.message).toContain(
+          'Angular expected this DOM:\n\n' +
+            '<app>\n' +
+            '  <main>\n' +
+            '    <table>\n' +
+            '      <tr>…</tr>  <-- AT THIS LOCATION',
+        );
+        expect(result.message).toContain(
+          'Actual DOM is:\n\n' +
+            '<app>\n' +
+            '  <main>\n' +
+            '    <table>\n' +
+            '      <tbody>…</tbody>  <-- AT THIS LOCATION',
+        );
+        verifyNodeHasMismatchInfo(doc);
+      });
+
       it(
         'should throw a coded RuntimeError, not a raw TypeError, when an element ' +
           'instruction locates a Text node in production mode (ngDevMode off)',


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Hydration mismatch errors describe the mismatched node and its immediate parent. When multiple branches have the same local structure, that snippet does not identify which branch in the component template contains the mismatch.

Issue Number: #56392

## What is the new behavior?

Hydration mismatch errors retain the compact local expected and actual DOM snippets and add a bounded `DOM path`:

- at most four real nodes are shown: the component host and the three nodes closest to the mismatch;
- omitted middle ancestors are represented by `...`;
- the expected path follows template declaration ancestry, while the actual path follows the physical DOM to the nearest component host;
- element, text, and comment mismatch locations are represented in the path.

The integration test uses two otherwise-identical nested branches, `Account` and `Billing`. The local snippets are the same, while the bounded path identifies the `Billing` branch without rendering the full ancestry tree.

The change only improves development-mode diagnostics. It does not add DOM validation, recognize specific mismatch patterns, or change when hydration reports a mismatch.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No documentation update is needed because this change does not introduce or modify a public API.

Tested with:

`pnpm bazel test //packages/platform-server/test:test`
