### PR TITLE
feat(forms): introduce WebMCP tool support for Reactive Forms

### DIFF
--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -14,6 +14,7 @@ ng_project(
         ],
     ),
     deps = [
+        ":node_modules/@mcp-b/webmcp-types",
         "//:node_modules/rxjs",
         "//packages/common",
         "//packages/core",

--- a/packages/forms/src/directives.ts
+++ b/packages/forms/src/directives.ts
@@ -61,6 +61,7 @@ export {
 export {FormControlName} from './directives/reactive_directives/form_control_name';
 export {FormGroupDirective} from './directives/reactive_directives/form_group_directive';
 export {FormArrayName, FormGroupName} from './directives/reactive_directives/form_group_name';
+export {WebMcpFormDirective} from './directives/reactive_directives/webmcp_form_directive';
 export {
   NgSelectOption,
   SelectControlValueAccessor,

--- a/packages/forms/src/directives/reactive_directives/webmcp_form_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/webmcp_form_directive.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  declareExperimentalWebMcpTool,
+  Directive,
+  inject,
+  Injector,
+  input,
+  OnInit,
+} from '@angular/core';
+
+import {AbstractControl} from '../../model/abstract_model';
+import {FormArray} from '../../model/form_array';
+import {FormGroup} from '../../model/form_group';
+import {Validators} from '../../validators';
+
+import {FormGroupDirective} from './form_group_directive';
+
+function inferSchemaFromControl(control: AbstractControl): any {
+  if (control instanceof FormGroup) {
+    const properties: Record<string, any> = {};
+    const required: string[] = [];
+
+    Object.keys(control.controls).forEach((key) => {
+      const child = control.controls[key];
+      const childSchema = inferSchemaFromControl(child);
+      if (childSchema) {
+        properties[key] = childSchema;
+        if (child.hasValidator && child.hasValidator(Validators.required)) {
+          required.push(key);
+        }
+      }
+    });
+
+    return {
+      type: 'object',
+      properties,
+      required,
+      additionalProperties: false,
+    };
+  }
+
+  if (control instanceof FormArray) {
+    if (control.length > 0) {
+      const itemSchema = inferSchemaFromControl(control.at(0));
+      return {
+        type: 'array',
+        items: itemSchema,
+      };
+    }
+    return {
+      type: 'array',
+      items: {type: 'string'},
+    };
+  }
+
+  // FormControl
+  const val = control.value;
+  let type = 'string';
+  if (typeof val === 'number') {
+    type = 'number';
+  } else if (typeof val === 'boolean') {
+    type = 'boolean';
+  }
+  return {type};
+}
+
+function getControlErrors(control: AbstractControl, path: string[] = []): string[] {
+  const errors: string[] = [];
+
+  if (control.errors) {
+    errors.push(`${path.join('.') || 'form'}: ${JSON.stringify(control.errors)}`);
+  }
+
+  if (control instanceof FormGroup) {
+    Object.keys(control.controls).forEach((key) => {
+      const child = control.controls[key];
+      errors.push(...getControlErrors(child, [...path, key]));
+    });
+  } else if (control instanceof FormArray) {
+    control.controls.forEach((child, index) => {
+      errors.push(...getControlErrors(child, [...path, index.toString()]));
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * @description
+ *
+ * Directive that automatically exposes an existing `FormGroup` to WebMCP,
+ * allowing browser-side AI assistants to query the form schema, validate values,
+ * and submit the form programmatically.
+ *
+ * @usageNotes
+ *
+ * ```html
+ * <form [formGroup]="loginForm" webMcpForm="login" webMcpDescription="Submit login form">
+ *   ...
+ * </form>
+ * ```
+ *
+ * @publicApi
+ * @experimental
+ */
+@Directive({
+  selector: '[formGroup][webMcpForm]',
+  standalone: true,
+})
+export class WebMcpFormDirective implements OnInit {
+  /**
+   * The name of the WebMCP tool. This must be a unique, alphanumeric identifier.
+   */
+  readonly name = input.required<string>({alias: 'webMcpForm'});
+
+  /**
+   * The description of the WebMCP tool, explaining to the AI agent what the form does.
+   */
+  readonly webMcpDescription = input<string | undefined>(undefined);
+
+  private readonly formGroupDirective = inject(FormGroupDirective, {self: true});
+  private readonly injector = inject(Injector);
+
+  ngOnInit() {
+    if (!this.name()) {
+      throw new Error('WebMcpFormDirective: [webMcpForm] requires a non-empty name.');
+    }
+
+    const form = this.formGroupDirective.form;
+
+    declareExperimentalWebMcpTool(
+      {
+        name: this.name(),
+        description: this.webMcpDescription() ?? `Fills and submits the form: ${this.name()}`,
+        inputSchema: inferSchemaFromControl(form),
+        execute: async (args: Record<string, any>) => {
+          form.patchValue(args);
+          form.markAllAsTouched();
+
+          if (form.invalid) {
+            const errors = getControlErrors(form);
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `Form validation failed:\n${errors.join('\n')}`,
+                },
+              ],
+            };
+          }
+
+          // Emit ngSubmit event
+          this.formGroupDirective.onSubmit(new Event('submit'));
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Form submitted successfully.',
+              },
+            ],
+          };
+        },
+      },
+      this.injector,
+    );
+  }
+}

--- a/packages/forms/src/form_providers.ts
+++ b/packages/forms/src/form_providers.ts
@@ -13,6 +13,7 @@ import {
   NG_MODEL_WITH_FORM_CONTROL_WARNING,
   REACTIVE_DRIVEN_DIRECTIVES,
   TEMPLATE_DRIVEN_DIRECTIVES,
+  WebMcpFormDirective,
 } from './directives';
 import {
   CALL_SET_DISABLED_STATE,
@@ -68,7 +69,8 @@ export class FormsModule {
  */
 @NgModule({
   declarations: [REACTIVE_DRIVEN_DIRECTIVES],
-  exports: [InternalFormsSharedModule, REACTIVE_DRIVEN_DIRECTIVES],
+  imports: [WebMcpFormDirective],
+  exports: [InternalFormsSharedModule, REACTIVE_DRIVEN_DIRECTIVES, WebMcpFormDirective],
 })
 export class ReactiveFormsModule {
   /**

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -40,6 +40,7 @@ export {AbstractFormDirective} from './directives/reactive_directives/abstract_f
 export {FormArrayDirective} from './directives/reactive_directives/form_array_directive';
 export {FormGroupDirective} from './directives/reactive_directives/form_group_directive';
 export {FormArrayName, FormGroupName} from './directives/reactive_directives/form_group_name';
+export {WebMcpFormDirective} from './directives/reactive_directives/webmcp_form_directive';
 export {
   NgSelectOption,
   SelectControlValueAccessor,

--- a/packages/forms/test/BUILD.bazel
+++ b/packages/forms/test/BUILD.bazel
@@ -12,6 +12,8 @@ ts_project(
         "//packages/core",
         "//packages/core/testing",
         "//packages/forms",
+        "//packages/forms:node_modules/@mcp-b/webmcp-polyfill",
+        "//packages/forms:node_modules/@mcp-b/webmcp-types",
         "//packages/platform-browser",
         "//packages/platform-browser/animations",
         "//packages/platform-browser/testing",

--- a/packages/forms/test/webmcp_reactive_spec.ts
+++ b/packages/forms/test/webmcp_reactive_spec.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {cleanupWebMCPPolyfill, initializeWebMCPPolyfill} from '@mcp-b/webmcp-polyfill';
+
+@Component({
+  selector: 'reactive-form-comp',
+  template: `
+    <form [formGroup]="formGroup" webMcpForm="testForm" webMcpDescription="Test reactive form tool">
+      <input formControlName="name" />
+      <input formControlName="age" />
+    </form>
+  `,
+  standalone: false,
+})
+class ReactiveFormComp {
+  formGroup = new FormGroup({
+    name: new FormControl('', Validators.required),
+    age: new FormControl(0),
+  });
+}
+
+describe('Reactive Forms WebMCP Integration', () => {
+  beforeEach(() => {
+    initializeWebMCPPolyfill({installTestingShim: true});
+  });
+
+  afterEach(() => {
+    cleanupWebMCPPolyfill();
+  });
+
+  it('should infer schema and register form as a tool', async () => {
+    TestBed.configureTestingModule({
+      declarations: [ReactiveFormComp],
+      imports: [ReactiveFormsModule],
+    });
+
+    const fixture = TestBed.createComponent(ReactiveFormComp);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const registeredTools = globalThis.navigator.modelContextTesting!.listTools();
+    const testTool = registeredTools.find((t) => t.name === 'testForm');
+    expect(testTool).toBeDefined();
+    expect(testTool!.description).toBe('Test reactive form tool');
+    expect(JSON.parse(testTool!.inputSchema!)).toEqual({
+      type: 'object',
+      properties: {
+        name: {type: 'string'},
+        age: {type: 'number'},
+      },
+      required: ['name'],
+      additionalProperties: false,
+    });
+  });
+
+  it('should fill out and submit the form successfully when valid', async () => {
+    TestBed.configureTestingModule({
+      declarations: [ReactiveFormComp],
+      imports: [ReactiveFormsModule],
+    });
+
+    const fixture = TestBed.createComponent(ReactiveFormComp);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const submitSpy = jasmine.createSpy('submitSpy');
+    fixture.componentInstance.formGroup.valueChanges.subscribe(() => {
+      if (fixture.componentInstance.formGroup.valid) {
+        submitSpy();
+      }
+    });
+
+    const result = await globalThis.navigator.modelContextTesting!.executeTool(
+      'testForm',
+      JSON.stringify({
+        name: 'Alice',
+        age: 25,
+      }),
+    );
+
+    expect(fixture.componentInstance.formGroup.value).toEqual({
+      name: 'Alice',
+      age: 25,
+    });
+
+    expect(JSON.parse(result!)).toEqual({
+      content: [{type: 'text', text: 'Form submitted successfully.'}],
+    });
+  });
+
+  it('should return validation errors if invalid', async () => {
+    TestBed.configureTestingModule({
+      declarations: [ReactiveFormComp],
+      imports: [ReactiveFormsModule],
+    });
+
+    const fixture = TestBed.createComponent(ReactiveFormComp);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const result = await globalThis.navigator.modelContextTesting!.executeTool(
+      'testForm',
+      JSON.stringify({
+        name: '',
+        age: 30,
+      }),
+    );
+
+    expect(JSON.parse(result!)).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: jasmine.stringContaining('name: {"required":true}'),
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
# Proposal: WebMCP Integration for Angular Reactive Forms

## 1. Context & Existing Support
Angular recently introduced experimental support for the **Web Model Context Protocol (WebMCP)**, an emerging web standard that allows web applications to expose structured tools directly to browser-side AI agents.

Currently, this capability is only integrated into the next-generation **Signal Forms** package (`@angular/forms/signals`). However, the vast majority of existing Angular applications in the enterprise ecosystem rely on **Reactive Forms** (`@angular/forms`). 

This PR proposes bringing feature parity to the forms ecosystem by introducing a first-class, opt-in directive `[webMcpForm]` for traditional **Reactive Forms** (`FormGroup`).

### Feature Parity: Signal Forms vs Reactive Forms

Here is a side-by-side comparison of how both forms systems declare WebMCP tools under modern Angular standards:

| Feature | Signal Forms (Existing `@angular/forms/signals`) | Reactive Forms (This PR `@angular/forms`) |
| :--- | :--- | :--- |
| **API Paradigm** | Functional / Signal-based | Declarative Directive on `formGroup` |
| **Declaration** | `form(this.model, (f) => { ... }, { experimentalWebMcpTool: { name: 'auth_login' } })` | `<form [formGroup]="loginForm" webMcpForm="auth_login">` |
| **Schema Inference** | Automatic inference from the model's Signal value structure | Automatic inference from the `FormGroup`'s control structure |
| **Validators** | Detects Signal-based validation functions (e.g. `required(f.email)`) | Detects Reactive-based validators (e.g. `Validators.required`) |
| **HMR & Lifecycle** | Bound to the signal form effect lifecycle | Bound to the component injector lifecycle via `DestroyRef` |

---

## 2. The Problem: Brittle DOM-Agent Interactions
When generic browser-side AI agents (like MultiOn, Rabbit R1, or browser automation models) attempt to fill out forms using standard DOM scraping/interaction APIs (such as setting `.value` on HTML elements):

1. **Broken Angular Lifecycle**: Setting values directly on DOM elements bypasses Angular's change detection. Form controls remain `pristine` and `untouched`. If submit buttons are disabled until the form is `dirty` and `valid`, the agent gets stuck because the Angular model never updates.
2. **Blind to Validations**: The agent cannot see Angular's in-memory validations (such as `Validators.required`, custom regex patterns, or minimum lengths) in advance. It has to guess, submit, scrape visible DOM error text (which may not always be present or readable), and try to self-correct in a slow, token-heavy loop.
3. **Brittle Selectors**: The agent relies on DOM selectors (like `id` or classes). If a developer refactors the UI design, the agent's scripts immediately break.

---

## 3. The Proposal: `[webMcpForm]` Directive
We introduce the standalone directive `WebMcpFormDirective` with the selector `[formGroup][webMcpForm]`. By decorating an existing form, developers instantly turn their Angular form model into a structured WebMCP tool.

### Key Capabilities:
* **Zero-config Schema Inference**: The directive recursively traverses the `FormGroup` controls (supporting nested groups and `FormArray`s) to infer the JSON Schema types (string, number, boolean) based on control values.
* **Automatic Validator Mapping**: It queries the active validators via the public `control.hasValidator(Validators.required)` API to automatically mark JSON Schema fields as `required`.
* **Safe, Native Updates**: When called, the tool patches the `FormGroup` values, marks all controls as `dirty` and `touched` to trigger visual cues, runs the standard validation cycle, and triggers the component's `(ngSubmit)` event.
* **Structured Error Reporting**: If validation fails, it returns the exact, structured Angular validation errors directly to the agent as a JSON payload, avoiding DOM scraping.

---

## 4. Key Use Cases

### A. Advanced Accessibility (AI Screen Readers)
Users with motor or visual impairments can instruct their browser's AI agent: *"Fill this checkout form with my home address and default card."* The agent queries the form schema, collects the required fields, executes the tool, and completes the action instantly and securely.

### B. Robust E2E & QA Automation
Instead of writing and maintaining complex, fragile selector-based scripts (`cy.get('.input-class').type(...)`), AI-driven test runners can inspect the WebMCP tool registry, identify the schema, and automatically test boundary conditions (e.g. invalid emails, missing required values) directly via the framework.

### C. Robotic Process Automation (RPA)
Back-office assistants can automate repetitive data entry tasks from unstructured data (emails, PDFs) by passing structured data directly into the React/Angular forms.

---

## 5. Developer Guides & Examples

Here is how the exact same Login Form tool is declared using both forms systems under Angular's standards.

### Option A: Reactive Forms (This PR)
```typescript
import {Component, inject} from '@angular/core';
import {FormBuilder, ReactiveFormsModule, Validators} from '@angular/forms';

@Component({
  selector: 'app-login',
  standalone: true,
  imports: [ReactiveFormsModule], // WebMcpFormDirective is exported out-of-the-box
  template: `
    <form [formGroup]="loginForm" 
          webMcpForm="auth_login" 
          webMcpDescription="Allows the agent to log in the user"
          (ngSubmit)="handleLogin()">
      <input formControlName="email" type="email" placeholder="Email" />
      <input formControlName="password" type="password" placeholder="Password" />
      <button type="submit">Submit</button>
    </form>
  `
})
export class LoginComponent {
  private readonly fb = inject(FormBuilder);

  // Strongly typed form with non-nullable controls using FormBuilder
  readonly loginForm = this.fb.nonNullable.group({
    email: ['', [Validators.required, Validators.email]],
    password: ['', [Validators.required]],
  });

  handleLogin() {
    console.log('Logged in successfully:', this.loginForm.value);
  }
}
```

### Option B: Signal Forms (Existing `@angular/forms/signals`)
```typescript
import {Component, signal} from '@angular/core';
import {form, required, email} from '@angular/forms/signals';

@Component({
  selector: 'app-login',
  standalone: true,
  template: `
    <!-- Signal Forms bind directly to model fields using the [formField] directive -->
    <input [formField]="loginForm.email" type="email" placeholder="Email" />
    <input [formField]="loginForm.password" type="password" placeholder="Password" />
    <button (click)="loginForm.submit()">Submit</button>
  `
})
export class LoginComponent {
  private readonly model = signal({
    email: '',
    password: '',
  });

  readonly loginForm = form(
    this.model,
    (f) => {
      required(f.email);
      email(f.email);
      required(f.password);
    },
    {
      experimentalWebMcpTool: {
        name: 'auth_login',
        description: 'Allows the agent to log in the user',
      },
      submission: {
        action: async (val) => {
          console.log('Logged in successfully:', val);
        }
      }
    }
  );
}
```

### Auto-Generated WebMCP Schema (Inferred at Runtime)
```json
{
  "name": "auth_login",
  "description": "Allows the agent to log in the user",
  "inputSchema": {
    "type": "object",
    "properties": {
      "email": { "type": "string" },
      "password": { "type": "string" }
    },
    "required": ["email", "password"],
    "additionalProperties": false
  }
}
```

---

## 6. Execution Scenarios (Simulating an Agent)

### Scenario A: Agent submits invalid values
* **Agent Request**: `executeTool("auth_login", { "email": "not-an-email", "password": "" })`
* **Result**:
  ```
  Form validation failed:
  email: {"email":true}
  password: {"required":true}
  ```

### Scenario B: Agent submits valid values
* **Agent Request**: `executeTool("auth_login", { "email": "user@example.com", "password": "secure123" })`
* **Result**:
  ```
  Form submitted successfully.
  ```
  *(Triggers `(ngSubmit)` event and prints `Logged in successfully` in the console).*
