### PR TITLE
fix(core): replace all hasOwnProperty usages with Object.hasOwn

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree/router-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree/router-tree.ts
@@ -189,7 +189,7 @@ function assignChildrenToParent(
  * @returns The formatted name: class name, function name with '()', or '[Function]' for anonymous/arrow functions
  */
 function getClassOrFunctionName(fn: Function, defaultName?: string) {
-  const isArrow = !fn.hasOwnProperty('prototype');
+  const isArrow = !Object.hasOwn(fn, 'prototype');
 
   const isEmptyName = fn.name === '';
 

--- a/devtools/projects/ng-devtools-backend/src/lib/shared/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/shared/state-serializer/serialized-descriptor-factory.ts
@@ -312,7 +312,7 @@ function getNestedDescriptorValue(
     case PropType.Object:
       return nodes.reduce(
         (accumulator, nestedProp) => {
-          if (prop.hasOwnProperty(nestedProp.name) && !ignoreList.has(nestedProp.name)) {
+          if (Object.hasOwn(prop, nestedProp.name) && !ignoreList.has(nestedProp.name)) {
             accumulator[nestedProp.name] = nestedSerializer(
               value,
               nestedProp.name,

--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -215,7 +215,7 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
         if (style instanceof Map) {
           style.forEach((value) => {
             extractStyleParams(value).forEach((sub) => {
-              if (!params.hasOwnProperty(sub)) {
+              if (!Object.hasOwn(params, sub)) {
                 missingSubs.add(sub);
               }
             });
@@ -650,7 +650,7 @@ function consumeOffset(styles: OffsetStyles | Array<OffsetStyles>): number | nul
 }
 
 function constructTimingAst(value: string | number | AnimateTimings, errors: Error[]) {
-  if (value.hasOwnProperty('duration')) {
+  if (typeof value === 'object' && value !== null && Object.hasOwn(value, 'duration')) {
     return value as AnimateTimings;
   }
 

--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -605,7 +605,7 @@ export class AnimationTimelineContext {
       }
 
       Object.keys(newParams).forEach((name) => {
-        if (!skipIfExists || !paramsToUpdate.hasOwnProperty(name)) {
+        if (!skipIfExists || !Object.hasOwn(paramsToUpdate, name)) {
           paramsToUpdate[name] = interpolateParams(newParams[name], paramsToUpdate, this.errors);
         }
       });

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -1918,7 +1918,7 @@ function objEquals(a: {[key: string]: any}, b: {[key: string]: any}): boolean {
   if (k1.length != k2.length) return false;
   for (let i = 0; i < k1.length; i++) {
     const prop = k1[i];
-    if (!b.hasOwnProperty(prop) || a[prop] !== b[prop]) return false;
+    if (!Object.hasOwn(b, prop) || a[prop] !== b[prop]) return false;
   }
   return true;
 }

--- a/packages/animations/browser/src/util.ts
+++ b/packages/animations/browser/src/util.ts
@@ -60,7 +60,7 @@ export function resolveTiming(
   errors: Error[],
   allowNegativeValues?: boolean,
 ) {
-  return timings.hasOwnProperty('duration')
+  return typeof timings === 'object' && timings !== null && Object.hasOwn(timings, 'duration')
     ? <AnimateTimings>timings
     : parseTimeExpression(<string | number>timings, errors, allowNegativeValues);
 }
@@ -168,7 +168,7 @@ export function validateStyleParams(
   const matches = extractStyleParams(value);
   if (matches.length) {
     matches.forEach((varName) => {
-      if (!params.hasOwnProperty(varName)) {
+      if (!Object.hasOwn(params, varName)) {
         errors.push(invalidStyleParams(varName));
       }
     });

--- a/packages/common/http/test/jsonp_mock.ts
+++ b/packages/common/http/test/jsonp_mock.ts
@@ -33,7 +33,7 @@ export class MockScriptElement {
   }
 
   getAttribute(name: string): string | null {
-    return this.attrs.hasOwnProperty(name) ? this.attrs[name] : null;
+    return Object.hasOwn(this.attrs, name) ? this.attrs[name] : null;
   }
 }
 

--- a/packages/common/locales/generate-locales-tool/locale-extra-file.ts
+++ b/packages/common/locales/generate-locales-tool/locale-extra-file.ts
@@ -49,7 +49,7 @@ export function generateLocaleExtraDataArrayCode(locale: string, localeData: Cld
   // TODO(gkalpak): If this turns out to be a bug and is fixed in CLDR, restore the previous logic
   //                of expecting the exact same keys in `dayPeriods` and `dayPeriodRules`.
   const dayPeriodKeys = Object.keys(dayPeriods.format.narrow).filter((key) =>
-    dayPeriodRules.hasOwnProperty(key),
+    Object.hasOwn(dayPeriodRules, key),
   );
 
   let dayPeriodsSupplemental: any[] = [];

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -747,7 +747,7 @@ export class NgOptimizedImage implements OnInit, OnChanges {
    * property `blur` within the optional configuration object `placeholderConfig`.
    */
   protected shouldBlurPlaceholder(placeholderConfig?: ImagePlaceholderConfig): boolean {
-    if (!placeholderConfig || !placeholderConfig.hasOwnProperty('blur')) {
+    if (!placeholderConfig || !Object.hasOwn(placeholderConfig, 'blur')) {
       return true;
     }
     return Boolean(placeholderConfig.blur);
@@ -1042,7 +1042,7 @@ function assertNoPostInitInputChange(
   inputs: string[],
 ) {
   inputs.forEach((input) => {
-    const isUpdated = changes.hasOwnProperty(input);
+    const isUpdated = Object.hasOwn(changes, input);
     if (isUpdated && !changes[input].isFirstChange()) {
       if (input === 'ngSrc') {
         // When the `ngSrc` input changes, we detect that only in the

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/diagnostics.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license
  * Copyright Google LLC All Rights Reserved.
  *
@@ -283,7 +283,7 @@ function validateHostDirectiveMappings(
   const exposedRequiredBindings = new Set<string>();
 
   for (const publicName in hostDirectiveMappings) {
-    if (hostDirectiveMappings.hasOwnProperty(publicName)) {
+    if (Object.hasOwn(hostDirectiveMappings, publicName)) {
       const bindings = existingBindings.getByBindingPropertyName(publicName);
 
       if (bindings === null) {

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -890,8 +890,7 @@ export function parseDirectiveStyles(
     let unresolvedNode: ts.Node | null = null;
     if (Array.isArray(value)) {
       const entry = value.find((e) => e instanceof DynamicValue && e.isFromUnknownIdentifier()) as
-        | DynamicValue
-        | undefined;
+        DynamicValue | undefined;
       unresolvedNode = entry?.node ?? null;
     } else if (value instanceof DynamicValue && value.isFromUnknownIdentifier()) {
       unresolvedNode = value.node;
@@ -1468,7 +1467,7 @@ function parseInputFields(
     }
 
     // Validate that signal inputs are not accidentally declared in the `inputs` metadata.
-    if (inputMapping.isSignal && inputsFromClassDecorator.hasOwnProperty(classPropertyName)) {
+    if (inputMapping.isSignal && Object.hasOwn(inputsFromClassDecorator, classPropertyName)) {
       throw new FatalDiagnosticError(
         ErrorCode.INITIALIZER_API_DECORATOR_METADATA_COLLISION,
         member.node ?? clazz,
@@ -1948,7 +1947,7 @@ function parseOutputFields(
     // in the `outputs` class metadata.
     if (
       (initializerOutput !== null || modelMapping !== null) &&
-      outputsFromMeta.hasOwnProperty(member.name)
+      Object.hasOwn(outputsFromMeta, member.name)
     ) {
       throw new FatalDiagnosticError(
         ErrorCode.INITIALIZER_API_DECORATOR_METADATA_COLLISION,

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/module_with_providers.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/module_with_providers.ts
@@ -161,7 +161,7 @@ export function isResolvedModuleWithProviders(
   return (
     typeof sv.value === 'object' &&
     sv.value != null &&
-    sv.value.hasOwnProperty('ngModule' as keyof ResolvedModuleWithProviders) &&
-    sv.value.hasOwnProperty('mwpCall' as keyof ResolvedModuleWithProviders)
+    Object.hasOwn(sv.value, 'ngModule' as keyof ResolvedModuleWithProviders) &&
+    Object.hasOwn(sv.value, 'mwpCall' as keyof ResolvedModuleWithProviders)
   );
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
@@ -89,7 +89,7 @@ export class HostDirectivesResolver {
 
     if (allowedProperties !== null) {
       for (const publicName in allowedProperties) {
-        if (allowedProperties.hasOwnProperty(publicName)) {
+        if (Object.hasOwn(allowedProperties, publicName)) {
           const bindings = source.getByBindingPropertyName(publicName);
 
           if (bindings !== null) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
@@ -178,8 +178,7 @@ export function makeTemplateDiagnostic(
 const TemplateSourceFile = Symbol('TemplateSourceFile');
 
 type TemplateSourceMappingWithSourceFile = (
-  | ExternalTemplateSourceMapping
-  | IndirectSourceMapping
+  ExternalTemplateSourceMapping | IndirectSourceMapping
 ) & {
   [TemplateSourceFile]?: ts.SourceFile;
 };
@@ -223,6 +222,6 @@ function parseTemplateAsSourceFile(fileName: string, template: string): ts.Sourc
 
 export function isTemplateDiagnostic(diagnostic: ts.Diagnostic): diagnostic is TemplateDiagnostic {
   return (
-    diagnostic.hasOwnProperty('componentFile') && ts.isSourceFile((diagnostic as any).componentFile)
+    Object.hasOwn(diagnostic, 'componentFile') && ts.isSourceFile((diagnostic as any).componentFile)
   );
 }

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -518,7 +518,7 @@ class _Visitor implements html.Visitor {
         return;
       }
 
-      if (attr.value && attr.value != '' && i18nParsedMessageMeta.hasOwnProperty(attr.name)) {
+      if (attr.value && attr.value != '' && Object.hasOwn(i18nParsedMessageMeta, attr.name)) {
         const {meaning, description, id} = i18nParsedMessageMeta[attr.name];
         const message: i18n.Message = this._createI18nMessage([attr], meaning, description, id);
         const nodes = this._translations.get(message);

--- a/packages/compiler/src/i18n/message_bundle.ts
+++ b/packages/compiler/src/i18n/message_bundle.ts
@@ -73,7 +73,7 @@ export class MessageBundle {
     // Deduplicate messages based on their ID
     this._messages.forEach((message) => {
       const id = serializer.digest(message);
-      if (!messages.hasOwnProperty(id)) {
+      if (!Object.hasOwn(messages, id)) {
         messages[id] = message;
       } else {
         messages[id].sources.push(...message.sources);

--- a/packages/compiler/src/i18n/serializers/placeholder.ts
+++ b/packages/compiler/src/i18n/serializers/placeholder.ts
@@ -149,7 +149,7 @@ export class PlaceholderRegistry {
   }
 
   private _generateUniqueName(base: string): string {
-    const seen = this._placeHolderNameCounts.hasOwnProperty(base);
+    const seen = Object.hasOwn(this._placeHolderNameCounts, base);
     if (!seen) {
       this._placeHolderNameCounts[base] = 1;
       return base;

--- a/packages/compiler/src/i18n/serializers/serializer.ts
+++ b/packages/compiler/src/i18n/serializers/serializer.ts
@@ -58,13 +58,13 @@ export class SimplePlaceholderMapper extends i18n.RecurseVisitor implements Plac
   }
 
   toPublicName(internalName: string): string | null {
-    return this.internalToPublic.hasOwnProperty(internalName)
+    return Object.hasOwn(this.internalToPublic, internalName)
       ? this.internalToPublic[internalName]
       : null;
   }
 
   toInternalName(publicName: string): string | null {
-    return this.publicToInternal.hasOwnProperty(publicName)
+    return Object.hasOwn(this.publicToInternal, publicName)
       ? this.publicToInternal[publicName]
       : null;
   }
@@ -95,13 +95,13 @@ export class SimplePlaceholderMapper extends i18n.RecurseVisitor implements Plac
 
   // XMB placeholders could only contains A-Z, 0-9 and _
   private visitPlaceholderName(internalName: string): void {
-    if (!internalName || this.internalToPublic.hasOwnProperty(internalName)) {
+    if (!internalName || Object.hasOwn(this.internalToPublic, internalName)) {
       return;
     }
 
     let publicName = this.mapName(internalName);
 
-    if (this.publicToInternal.hasOwnProperty(publicName)) {
+    if (Object.hasOwn(this.publicToInternal, publicName)) {
       // Create a new XMB when it has already been used
       const nextId = this.publicToNextId[publicName];
       this.publicToNextId[publicName] = nextId + 1;

--- a/packages/compiler/src/i18n/serializers/xliff.ts
+++ b/packages/compiler/src/i18n/serializers/xliff.ts
@@ -247,7 +247,7 @@ class XliffParser implements ml.Visitor {
           this._addError(element, `<${_UNIT_TAG}> misses the "id" attribute`);
         } else {
           const id = idAttr.value;
-          if (this._msgIdToHtml.hasOwnProperty(id)) {
+          if (Object.hasOwn(this._msgIdToHtml, id)) {
             this._addError(element, `Duplicated translations for msg ${id}`);
           } else {
             ml.visitAll(this, element.children, null);

--- a/packages/compiler/src/i18n/serializers/xliff2.ts
+++ b/packages/compiler/src/i18n/serializers/xliff2.ts
@@ -271,7 +271,7 @@ class Xliff2Parser implements ml.Visitor {
           this._addError(element, `<${_UNIT_TAG}> misses the "id" attribute`);
         } else {
           const id = idAttr.value;
-          if (this._msgIdToHtml.hasOwnProperty(id)) {
+          if (Object.hasOwn(this._msgIdToHtml, id)) {
             this._addError(element, `Duplicated translations for msg ${id}`);
           } else {
             ml.visitAll(this, element.children, null);

--- a/packages/compiler/src/i18n/serializers/xtb.ts
+++ b/packages/compiler/src/i18n/serializers/xtb.ts
@@ -127,7 +127,7 @@ class XtbParser implements ml.Visitor {
           this._addError(element, `<${_TRANSLATION_TAG}> misses the "id" attribute`);
         } else {
           const id = idAttr.value;
-          if (this._msgIdToHtml.hasOwnProperty(id)) {
+          if (Object.hasOwn(this._msgIdToHtml, id)) {
             this._addError(element, `Duplicated translations for msg ${id}`);
           } else {
             const innerTextStart = element.startSourceSpan.end.offset;

--- a/packages/compiler/src/i18n/translation_bundle.ts
+++ b/packages/compiler/src/i18n/translation_bundle.ts
@@ -125,7 +125,7 @@ class I18nToHtmlVisitor implements i18n.Visitor {
 
     // TODO(vicb): Once all format switch to using expression placeholders
     // we should throw when the placeholder is not in the source message
-    const exp = this._srcMsg.placeholders.hasOwnProperty(icu.expression)
+    const exp = Object.hasOwn(this._srcMsg.placeholders, icu.expression)
       ? this._srcMsg.placeholders[icu.expression].text
       : icu.expression;
 
@@ -134,11 +134,11 @@ class I18nToHtmlVisitor implements i18n.Visitor {
 
   visitPlaceholder(ph: i18n.Placeholder, context?: any): string {
     const phName = this._mapper(ph.name);
-    if (this._srcMsg.placeholders.hasOwnProperty(phName)) {
+    if (Object.hasOwn(this._srcMsg.placeholders, phName)) {
       return this._srcMsg.placeholders[phName].text;
     }
 
-    if (this._srcMsg.placeholderToMessage.hasOwnProperty(phName)) {
+    if (Object.hasOwn(this._srcMsg.placeholderToMessage, phName)) {
       return this._convertToText(this._srcMsg.placeholderToMessage[phName]);
     }
 
@@ -189,7 +189,7 @@ class I18nToHtmlVisitor implements i18n.Visitor {
     this._contextStack.push({msg: this._srcMsg, mapper: this._mapper});
     this._srcMsg = srcMsg;
 
-    if (this._i18nNodesByMsgId.hasOwnProperty(id)) {
+    if (Object.hasOwn(this._i18nNodesByMsgId, id)) {
       // When there is a translation use its nodes as the source
       // And create a mapper to convert serialized placeholder names to internal names
       nodes = this._i18nNodesByMsgId[id];

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -520,7 +520,7 @@ function convertDirectiveFacadeToMetadata(facade: R3DirectiveMetadataFacade): R3
   const inputsFromType: Record<string, R3InputMetadata> = {};
   const outputsFromType: Record<string, string> = {};
   for (const field in propMetadata) {
-    if (propMetadata.hasOwnProperty(field)) {
+    if (Object.hasOwn(propMetadata, field)) {
       propMetadata[field].forEach((ann) => {
         if (isInput(ann)) {
           inputsFromType[field] = {
@@ -820,7 +820,7 @@ function convertToProviderExpression(
   obj: any,
   property: string,
 ): MaybeForwardRefExpression | undefined {
-  if (obj.hasOwnProperty(property)) {
+  if (Object.hasOwn(obj, property)) {
     return createMayBeForwardRefExpression(
       new WrappedNodeExpr(obj[property]),
       ForwardRefHandling.None,
@@ -831,7 +831,7 @@ function convertToProviderExpression(
 }
 
 function wrapExpression(obj: any, property: string): WrappedNodeExpr<any> | undefined {
-  if (obj.hasOwnProperty(property)) {
+  if (Object.hasOwn(obj, property)) {
     return new WrappedNodeExpr(obj[property]);
   } else {
     return undefined;
@@ -926,7 +926,7 @@ function extractHostBindings(
 
   // Next, loop over the properties of the object, looking for @HostBinding and @HostListener.
   for (const field in propMetadata) {
-    if (propMetadata.hasOwnProperty(field)) {
+    if (Object.hasOwn(propMetadata, field)) {
       propMetadata[field].forEach((ann) => {
         if (isHostBinding(ann)) {
           // Since this is a decorator, we know that the value is a class member. Always access it

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -742,7 +742,7 @@ class _Tokenizer {
       } else {
         const name = this._cursor.getChars(nameStart);
         this._cursor.advance();
-        const char = NAMED_ENTITIES.hasOwnProperty(name) && NAMED_ENTITIES[name];
+        const char = Object.hasOwn(NAMED_ENTITIES, name) && NAMED_ENTITIES[name];
         if (!char) {
           throw this._createError(_unknownEntityErrorMsg(name), this._cursor.getSpan(start));
         }

--- a/packages/compiler/src/render3/r3_jit.ts
+++ b/packages/compiler/src/render3/r3_jit.ts
@@ -25,7 +25,7 @@ export class R3JitReflector implements ExternalReferenceResolver {
         `Cannot resolve external reference to ${ref.moduleName}, only references to @angular/core are supported.`,
       );
     }
-    if (!this.context.hasOwnProperty(ref.name!)) {
+    if (!Object.hasOwn(this.context, ref.name!)) {
       throw new Error(`No value provided for @angular/core symbol '${ref.name!}'.`);
     }
     return this.context[ref.name!];

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -735,7 +735,7 @@ export function createHostDirectivesMappingArray(
   const elements: o.LiteralExpr[] = [];
 
   for (const publicName in mapping) {
-    if (mapping.hasOwnProperty(publicName)) {
+    if (Object.hasOwn(mapping, publicName)) {
       elements.push(o.literal(publicName), o.literal(mapping[publicName]));
     }
   }

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -292,10 +292,10 @@ export function unparseWithSpan(ast: ASTWithSource): UnparsedWithSpan[] {
 
     override visit(ast: AST, unparsedList: UnparsedWithSpan[]) {
       this.recordUnparsed(ast, 'span', unparsedList);
-      if (ast.hasOwnProperty('nameSpan')) {
+      if (Object.hasOwn(ast, 'nameSpan')) {
         this.recordUnparsed(ast, 'nameSpan', unparsedList);
       }
-      if (ast.hasOwnProperty('argumentSpan')) {
+      if (Object.hasOwn(ast, 'argumentSpan')) {
         this.recordUnparsed(ast, 'argumentSpan', unparsedList);
       }
       ast.visit(this, unparsedList);

--- a/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
+++ b/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
@@ -918,11 +918,11 @@ function dispatchNavigateEvent({
     if (options.history === 'push' || options.history === 'replace') {
       event.navigationType = options.history;
     }
-    if (options.hasOwnProperty('state')) {
+    if (Object.hasOwn(options, 'state')) {
       event.destination.state = options.state;
     }
     event.destination.url = destinationUrl.href;
-    if (options.hasOwnProperty('info')) {
+    if (Object.hasOwn(options, 'info')) {
       event.info = options.info;
     }
   }

--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility.ts
@@ -63,7 +63,7 @@ export function isFieldIncompatibility(value: unknown): value is FieldIncompatib
   return (
     (value as Partial<FieldIncompatibility>).reason !== undefined &&
     (value as Partial<FieldIncompatibility>).context !== undefined &&
-    FieldIncompatibilityReason.hasOwnProperty((value as Partial<FieldIncompatibility>).reason!)
+    Object.hasOwn(FieldIncompatibilityReason, (value as Partial<FieldIncompatibility>).reason!)
   );
 }
 

--- a/packages/core/schematics/tsconfig.json
+++ b/packages/core/schematics/tsconfig.json
@@ -12,7 +12,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "target": "es2022",
-    "lib": ["es2019"],
+    "lib": ["es2022"],
     "types": ["node"],
     "paths": {
       "@angular/core": ["../"],

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -723,7 +723,7 @@ const NG_DEBUG_PROPERTY = '__ng_debug__';
  */
 export function getDebugNode(nativeNode: any): DebugNode | null {
   if (nativeNode instanceof Node) {
-    if (!nativeNode.hasOwnProperty(NG_DEBUG_PROPERTY)) {
+    if (!Object.hasOwn(nativeNode, NG_DEBUG_PROPERTY)) {
       (nativeNode as any)[NG_DEBUG_PROPERTY] =
         nativeNode.nodeType == Node.ELEMENT_NODE
           ? new DebugElement(nativeNode as Element)

--- a/packages/core/src/di/forward_ref.ts
+++ b/packages/core/src/di/forward_ref.ts
@@ -98,7 +98,7 @@ export function resolveForwardRef<T>(type: T): T {
 export function isForwardRef(fn: any): fn is () => any {
   return (
     typeof fn === 'function' &&
-    fn.hasOwnProperty(__forward_ref__) &&
+    Object.hasOwn(fn, __forward_ref__) &&
     fn.__forward_ref__ === forwardRef
   );
 }

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -218,7 +218,7 @@ export function isInjectable(type: any): boolean {
  */
 function getOwnDefinition<T>(type: any, field: string): ɵɵInjectableDeclaration<T> | null {
   // if the ɵprov prop exist but is undefined we still want to return null
-  return (type.hasOwnProperty(field) && type[field]) || null;
+  return (Object.hasOwn(type, field) && type[field]) || null;
 }
 
 /**
@@ -251,7 +251,7 @@ export function getInheritedInjectableDef<T>(type: any): ɵɵInjectableDeclarati
  * @param type type which may have an injector def (`ɵinj`)
  */
 export function getInjectorDef<T>(type: any): ɵɵInjectorDef<T> | null {
-  return type && type.hasOwnProperty(NG_INJ_DEF) ? (type as any)[NG_INJ_DEF] : null;
+  return type && Object.hasOwn(type, NG_INJ_DEF) ? (type as any)[NG_INJ_DEF] : null;
 }
 
 export const NG_PROV_DEF: string = getClosureSafeProperty({ɵprov: getClosureSafeProperty});

--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -36,7 +36,7 @@ export function compileInjectable(type: Type<any>, meta?: Injectable): void {
   let ngFactoryDef: any = null;
 
   // if NG_PROV_DEF is already defined on this class then don't overwrite it
-  if (!type.hasOwnProperty(NG_PROV_DEF)) {
+  if (!Object.hasOwn(type, NG_PROV_DEF)) {
     Object.defineProperty(type, NG_PROV_DEF, {
       get: () => {
         if (ngInjectableDef === null) {
@@ -57,7 +57,7 @@ export function compileInjectable(type: Type<any>, meta?: Injectable): void {
   }
 
   // if NG_FACTORY_DEF is already defined on this class then don't overwrite it
-  if (!type.hasOwnProperty(NG_FACTORY_DEF)) {
+  if (!Object.hasOwn(type, NG_FACTORY_DEF)) {
     Object.defineProperty(type, NG_FACTORY_DEF, {
       get: () => {
         if (ngFactoryDef === null) {

--- a/packages/core/src/di/jit/service.ts
+++ b/packages/core/src/di/jit/service.ts
@@ -27,7 +27,7 @@ export function compileService(type: Type<any>, meta?: Service): void {
   let factoryDef: any = null;
 
   // if NG_PROV_DEF is already defined on this class then don't overwrite it
-  if (!type.hasOwnProperty(NG_PROV_DEF)) {
+  if (!Object.hasOwn(type, NG_PROV_DEF)) {
     Object.defineProperty(type, NG_PROV_DEF, {
       get: () => {
         if (def === null) {
@@ -47,7 +47,7 @@ export function compileService(type: Type<any>, meta?: Service): void {
     });
   }
 
-  if (!type.hasOwnProperty(NG_FACTORY_DEF)) {
+  if (!Object.hasOwn(type, NG_FACTORY_DEF)) {
     Object.defineProperty(type, NG_FACTORY_DEF, {
       get: () => {
         if (factoryDef === null) {

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -327,7 +327,7 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
   ): T {
     assertNotDestroyed(this);
 
-    if (token.hasOwnProperty(NG_ENV_ID)) {
+    if (Object.hasOwn(token, NG_ENV_ID)) {
       return (token as any)[NG_ENV_ID](this);
     }
 

--- a/packages/core/src/metadata/resource_loading.ts
+++ b/packages/core/src/metadata/resource_loading.ts
@@ -130,7 +130,7 @@ export function isComponentDefPendingResolution(type: Type<any>): boolean {
 
 export function componentNeedsResolution(component: Component): boolean {
   return !!(
-    (component.templateUrl && !component.hasOwnProperty('template')) ||
+    (component.templateUrl && !Object.hasOwn(component, 'template')) ||
     component.styleUrls?.length ||
     component.styleUrl
   );

--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -149,7 +149,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     }
 
     // API for metadata created by invoking the decorators.
-    const paramAnnotations = type.hasOwnProperty(PARAMETERS) && (type as any)[PARAMETERS];
+    const paramAnnotations = Object.hasOwn(type, PARAMETERS) && (type as any)[PARAMETERS];
     const paramTypes =
       this._reflect &&
       this._reflect.getOwnMetadata &&
@@ -195,7 +195,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     }
 
     // API for metadata created by invoking the decorators.
-    if (typeOrFunc.hasOwnProperty(ANNOTATIONS)) {
+    if (Object.hasOwn(typeOrFunc, ANNOTATIONS)) {
       return (typeOrFunc as any)[ANNOTATIONS];
     }
     return null;
@@ -238,7 +238,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     }
 
     // API for metadata created by invoking the decorators.
-    if (typeOrFunc.hasOwnProperty(PROP_METADATA)) {
+    if (Object.hasOwn(typeOrFunc, PROP_METADATA)) {
       return (typeOrFunc as any)[PROP_METADATA];
     }
     return null;
@@ -260,7 +260,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     if (ownPropMetadata) {
       Object.keys(ownPropMetadata).forEach((propName) => {
         const decorators: any[] = [];
-        if (propMetadata.hasOwnProperty(propName)) {
+        if (Object.hasOwn(propMetadata, propName)) {
           decorators.push(...propMetadata[propName]);
         }
         decorators.push(...ownPropMetadata[propName]);

--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -62,7 +62,7 @@ export function assertTNodeForTView(tNode: TNode, tView: TView) {
 
 export function assertTNode(tNode: TNode) {
   assertDefined(tNode, 'TNode must be defined');
-  if (!(tNode && typeof tNode === 'object' && tNode.hasOwnProperty('directiveStylingLast'))) {
+  if (!(tNode && typeof tNode === 'object' && Object.hasOwn(tNode, 'directiveStylingLast'))) {
     throwError('Not of type TNode, got: ' + tNode);
   }
 }

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -508,7 +508,7 @@ function parseAndConvertInputsForDefinition<T>(
     [minifiedName: string, flags: InputFlags, transform: InputTransformFunction | null]
   > = {};
   for (const minifiedKey in obj) {
-    if (obj.hasOwnProperty(minifiedKey)) {
+    if (Object.hasOwn(obj, minifiedKey)) {
       const value = obj[minifiedKey]!;
       let publicName: string;
       let declaredName: string;
@@ -540,7 +540,7 @@ function parseAndConvertOutputsForDefinition<T>(
   if (obj == null) return EMPTY_OBJ as any;
   const newLookup: any = {};
   for (const minifiedKey in obj) {
-    if (obj.hasOwnProperty(minifiedKey)) {
+    if (Object.hasOwn(obj, minifiedKey)) {
       newLookup[obj[minifiedKey]!] = minifiedKey;
     }
   }

--- a/packages/core/src/render3/definition_factory.ts
+++ b/packages/core/src/render3/definition_factory.ts
@@ -29,7 +29,7 @@ export type FactoryFn<T> = {
 export function getFactoryDef<T>(type: any, throwNotFound: true): FactoryFn<T>;
 export function getFactoryDef<T>(type: any): FactoryFn<T> | null;
 export function getFactoryDef<T>(type: any, throwNotFound?: boolean): FactoryFn<T> | null {
-  const hasFactoryDef = type.hasOwnProperty(NG_FACTORY_DEF);
+  const hasFactoryDef = Object.hasOwn(type, NG_FACTORY_DEF);
   if (!hasFactoryDef && throwNotFound === true && ngDevMode) {
     throw new Error(`Type ${stringify(type)} does not have 'ɵfac' property.`);
   }

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -158,7 +158,7 @@ export function bloomAdd(
   let id: number | undefined;
   if (typeof type === 'string') {
     id = type.charCodeAt(0) || 0;
-  } else if (type.hasOwnProperty(NG_ELEMENT_ID)) {
+  } else if (Object.hasOwn(type, NG_ELEMENT_ID)) {
     id = (type as any)[NG_ELEMENT_ID];
   }
 
@@ -830,8 +830,8 @@ export function bloomHashBitOrFactory(
     return token.charCodeAt(0) || 0;
   }
   const tokenId: number | undefined =
-    // First check with `hasOwnProperty` so we don't get an inherited ID.
-    token.hasOwnProperty(NG_ELEMENT_ID) ? (token as any)[NG_ELEMENT_ID] : undefined;
+    // First check with `Object.hasOwn` so we don't get an inherited ID.
+    Object.hasOwn(token, NG_ELEMENT_ID) ? (token as any)[NG_ELEMENT_ID] : undefined;
   // Negative token IDs are used for special objects such as `Injector`
   if (typeof tokenId === 'number') {
     if (tokenId >= 0) {
@@ -884,10 +884,7 @@ export function getNodeInjectorTNode(
   nodeInjector: NodeInjector,
 ): TElementNode | TContainerNode | TElementContainerNode | null {
   return (nodeInjector as any)._tNode as
-    | TElementNode
-    | TContainerNode
-    | TElementContainerNode
-    | null;
+    TElementNode | TContainerNode | TElementContainerNode | null;
 }
 
 export class NodeInjector implements Injector {

--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -185,7 +185,7 @@ function mergeBindingMaps(
   Object.keys(newMap).forEach((publicName) => {
     const alias = newMap[publicName];
 
-    if (!targetMap.hasOwnProperty(publicName) || targetMap[publicName] === alias) {
+    if (!Object.hasOwn(targetMap, publicName) || targetMap[publicName] === alias) {
       targetMap[publicName] = alias;
     } else if (typeof ngDevMode === 'undefined' || ngDevMode) {
       const message =
@@ -248,7 +248,7 @@ function patchDeclaredInputs(
   exposedInputs: HostDirectiveBindingMap,
 ): void {
   for (const publicName in exposedInputs) {
-    if (exposedInputs.hasOwnProperty(publicName)) {
+    if (Object.hasOwn(exposedInputs, publicName)) {
       const remappedPublicName = exposedInputs[publicName];
       const privateName = declaredInputs[publicName];
 
@@ -258,7 +258,7 @@ function patchDeclaredInputs(
       // with the wrong name so we have a non-user-friendly assertion here just in case.
       if (
         (typeof ngDevMode === 'undefined' || ngDevMode) &&
-        declaredInputs.hasOwnProperty(remappedPublicName)
+        Object.hasOwn(declaredInputs, remappedPublicName)
       ) {
         assertEqual(
           declaredInputs[remappedPublicName],
@@ -324,8 +324,8 @@ function validateMappings<T>(
   const bindings = bindingType === 'input' ? def.inputs : def.outputs;
 
   for (const publicName in hostDirectiveBindings) {
-    if (hostDirectiveBindings.hasOwnProperty(publicName)) {
-      if (!bindings.hasOwnProperty(publicName)) {
+    if (Object.hasOwn(hostDirectiveBindings, publicName)) {
+      if (!Object.hasOwn(bindings, publicName)) {
         throw new RuntimeError(
           RuntimeErrorCode.HOST_DIRECTIVE_UNDEFINED_BINDING,
           `Directive ${className} does not have an ${bindingType} with a public name of ${publicName}.`,
@@ -334,7 +334,7 @@ function validateMappings<T>(
 
       const remappedPublicName = hostDirectiveBindings[publicName];
 
-      if (bindings.hasOwnProperty(remappedPublicName) && remappedPublicName !== publicName) {
+      if (Object.hasOwn(bindings, remappedPublicName) && remappedPublicName !== publicName) {
         throw new RuntimeError(
           RuntimeErrorCode.HOST_DIRECTIVE_CONFLICTING_ALIAS,
           `Cannot alias ${bindingType} ${publicName} of host directive ${className} to ${remappedPublicName}, because it already has a different ${bindingType} with the same public name.`,

--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -134,10 +134,10 @@ export function ɵɵInheritDefinitionFeature(
 
 function mergeInputsWithTransforms<T>(target: WritableDef, source: DirectiveDef<any>) {
   for (const key in source.inputs) {
-    if (!source.inputs.hasOwnProperty(key)) {
+    if (!Object.hasOwn(source.inputs, key)) {
       continue;
     }
-    if (target.inputs.hasOwnProperty(key)) {
+    if (Object.hasOwn(target.inputs, key)) {
       continue;
     }
 

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -808,7 +808,7 @@ function walkIcuTree(
       case Node.ELEMENT_NODE:
         const element = currentNode as Element;
         const tagName = element.tagName.toLowerCase();
-        if (VALID_ELEMENTS.hasOwnProperty(tagName)) {
+        if (Object.hasOwn(VALID_ELEMENTS, tagName)) {
           addCreateNodeAndAppend(create, ELEMENT_MARKER, tagName, parentIdx, newIndex);
           tView.data[newIndex] = tagName;
           const elAttrs = element.attributes;
@@ -821,7 +821,7 @@ function walkIcuTree(
             const tagNameWithNamespace = namespace ? `:${namespace}:${tagName}` : tagName;
 
             if (hasBinding) {
-              if (VALID_ATTRS.hasOwnProperty(lowerAttrName)) {
+              if (Object.hasOwn(VALID_ATTRS, lowerAttrName)) {
                 generateBindingUpdateOpCodes(
                   update,
                   attr.value,

--- a/packages/core/src/render3/i18n/i18n_postprocess.ts
+++ b/packages/core/src/render3/i18n/i18n_postprocess.ts
@@ -106,14 +106,14 @@ export function i18nPostprocess(
    * Step 2: replace all ICU vars (like "VAR_PLURAL")
    */
   result = result.replace(PP_ICU_VARS_REGEXP, (match, start, key, _type, _idx, end): string => {
-    return replacements.hasOwnProperty(key) ? `${start}${replacements[key]}${end}` : match;
+    return Object.hasOwn(replacements, key) ? `${start}${replacements[key]}${end}` : match;
   });
 
   /**
    * Step 3: replace all placeholders used inside ICUs in a form of {PLACEHOLDER}
    */
   result = result.replace(PP_ICU_PLACEHOLDERS_REGEXP, (match, key): string => {
-    return replacements.hasOwnProperty(key) ? (replacements[key] as string) : match;
+    return Object.hasOwn(replacements, key) ? (replacements[key] as string) : match;
   });
 
   /**
@@ -121,7 +121,7 @@ export function i18nPostprocess(
    * multiple ICUs have the same placeholder name
    */
   result = result.replace(PP_ICUS_REGEXP, (match, key): string => {
-    if (replacements.hasOwnProperty(key)) {
+    if (Object.hasOwn(replacements, key)) {
       const list = replacements[key] as string[];
       if (!list.length) {
         throw new Error(`i18n postprocess: unmatched ICU - ${match} with key: ${key}`);

--- a/packages/core/src/render3/i18n/i18n_util.ts
+++ b/packages/core/src/render3/i18n/i18n_util.ts
@@ -49,15 +49,15 @@ export function getTIcu(tView: TView, index: number): TIcu | null {
   if (value === null || typeof value === 'string') return null;
   if (
     ngDevMode &&
-    !(value.hasOwnProperty(TVIEW) || value.hasOwnProperty(CURRENT_CASE_LVIEW_INDEX))
+    !(Object.hasOwn(value, TVIEW) || Object.hasOwn(value, CURRENT_CASE_LVIEW_INDEX))
   ) {
     throwError("We expect to get 'null'|'TIcu'|'TIcuContainer', but got: " + value);
   }
-  // Here the `value.hasOwnProperty(CURRENT_CASE_LVIEW_INDEX)` is a polymorphic read as it can be
+  // Here the `Object.hasOwn(value, CURRENT_CASE_LVIEW_INDEX)` is a polymorphic read as it can be
   // either TIcu or TIcuContainerNode. This is not ideal, but we still think it is OK because it
   // will be just two cases which fits into the browser inline cache (inline cache can take up to
   // 4)
-  const tIcu = value.hasOwnProperty(CURRENT_CASE_LVIEW_INDEX)
+  const tIcu = Object.hasOwn(value, CURRENT_CASE_LVIEW_INDEX)
     ? (value as TIcu)
     : (value as TIcuContainerNode).value;
   ngDevMode && assertTIcu(tIcu);
@@ -82,7 +82,7 @@ export function setTIcu(tView: TView, index: number, tIcu: TIcu): void {
   const tNode = tView.data[index] as null | TIcuContainerNode;
   ngDevMode &&
     assertEqual(
-      tNode === null || tNode.hasOwnProperty(TVIEW),
+      tNode === null || Object.hasOwn(tNode, TVIEW),
       true,
       "We expect to get 'null'|'TIcuContainer'",
     );

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -799,7 +799,8 @@ export function setDirectiveInput(
   if (
     hostDirectivesStart !== null &&
     hostDirectivesEnd !== null &&
-    tNode.hostDirectiveInputs?.hasOwnProperty(publicName)
+    tNode.hostDirectiveInputs &&
+    Object.hasOwn(tNode.hostDirectiveInputs, publicName)
   ) {
     const hostDirectiveInputs = tNode.hostDirectiveInputs[publicName];
 
@@ -819,7 +820,7 @@ export function setDirectiveInput(
     }
   }
 
-  if (hostIndex !== null && target.inputs.hasOwnProperty(publicName)) {
+  if (hostIndex !== null && Object.hasOwn(target.inputs, publicName)) {
     ngDevMode && assertIndexInRange(lView, hostIndex);
     writeToDirectiveInput(target, lView[hostIndex], publicName, value);
     hasSet = true;

--- a/packages/core/src/render3/instructions/write_to_directive_input.ts
+++ b/packages/core/src/render3/instructions/write_to_directive_input.ts
@@ -24,7 +24,7 @@ export function writeToDirectiveInput<T>(
   const prevConsumer = setActiveConsumer(null);
   try {
     if (ngDevMode) {
-      if (!def.inputs.hasOwnProperty(publicName)) {
+      if (!Object.hasOwn(def.inputs, publicName)) {
         throw new Error(
           `ASSERTION ERROR: Directive ${def.type.name} does not have an input with a public name of "${publicName}"`,
         );

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -450,7 +450,7 @@ function extractQueriesMetadata(
   const signalQueriesMeta: R3QueryMetadataFacade[] = [];
   const decoratorQueriesMeta: R3QueryMetadataFacade[] = [];
   for (const field in propMetadata) {
-    if (propMetadata.hasOwnProperty(field)) {
+    if (Object.hasOwn(propMetadata, field)) {
       const annotations = propMetadata[field];
       annotations.forEach((ann) => {
         if (isQueryAnn(ann)) {

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -506,14 +506,14 @@ function setScopeOnDeclaredComponents(moduleType: Type<any>, ngModule: NgModule)
 
   declarations.forEach((declaration) => {
     declaration = resolveForwardRef(declaration);
-    if (declaration.hasOwnProperty(NG_COMP_DEF)) {
+    if (Object.hasOwn(declaration, NG_COMP_DEF)) {
       // A `ɵcmp` field exists - go ahead and patch the component directly.
       const component = declaration as Type<any> & {ɵcmp: ComponentDef<any>};
       const componentDef = getComponentDef(component)!;
       patchComponentDefWithScope(componentDef, transitiveScopes);
     } else if (
-      !declaration.hasOwnProperty(NG_DIR_DEF) &&
-      !declaration.hasOwnProperty(NG_PIPE_DEF)
+      !Object.hasOwn(declaration, NG_DIR_DEF) &&
+      !Object.hasOwn(declaration, NG_PIPE_DEF)
     ) {
       // Set `ngSelectorScope` for future reference when the component compilation finishes.
       (declaration as Type<any> & {ngSelectorScope?: any}).ngSelectorScope = moduleType;
@@ -532,7 +532,7 @@ export function patchComponentDefWithScope<C>(
   componentDef.directiveDefs = () =>
     Array.from(transitiveScopes.compilation.directives)
       .map((dir) =>
-        dir.hasOwnProperty(NG_COMP_DEF) ? getComponentDef(dir)! : getDirectiveDef(dir)!,
+        Object.hasOwn(dir, NG_COMP_DEF) ? getComponentDef(dir)! : getDirectiveDef(dir)!,
       )
       .filter((def) => !!def);
   componentDef.pipeDefs = () =>

--- a/packages/core/src/render3/metadata.ts
+++ b/packages/core/src/render3/metadata.ts
@@ -94,7 +94,7 @@ export function setClassMetadata(
     const clazz = type as TypeWithMetadata;
 
     if (decorators !== null) {
-      if (clazz.hasOwnProperty('decorators') && clazz.decorators !== undefined) {
+      if (Object.hasOwn(clazz, 'decorators') && clazz.decorators !== undefined) {
         clazz.decorators.push(...decorators);
       } else {
         clazz.decorators = decorators as any[];
@@ -111,7 +111,7 @@ export function setClassMetadata(
       // different decorator types. Decorators on individual fields are not merged, as it's
       // also incredibly unlikely that a field will be decorated both with an Angular
       // decorator and a non-Angular decorator that's also been downleveled.
-      if (clazz.hasOwnProperty('propDecorators') && clazz.propDecorators !== undefined) {
+      if (Object.hasOwn(clazz, 'propDecorators') && clazz.propDecorators !== undefined) {
         clazz.propDecorators = {...clazz.propDecorators, ...propDecorators};
       } else {
         clazz.propDecorators = propDecorators;

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -442,7 +442,7 @@ export function getListeners(element: Element): Listener[] {
   const tCleanup = tView.cleanup;
   const listeners: Listener[] = [];
   if (tCleanup && lCleanup) {
-    for (let i = 0; i < tCleanup.length; ) {
+    for (let i = 0; i < tCleanup.length;) {
       const firstParam = tCleanup[i++];
       const secondParam = tCleanup[i++];
       if (typeof firstParam === 'string') {
@@ -520,7 +520,7 @@ function extractInputDebugMetadata<T>(inputs: DirectiveDef<T>['inputs']) {
   const res: AngularDirectiveDebugMetadata['inputs'] = {};
 
   for (const key in inputs) {
-    if (inputs.hasOwnProperty(key)) {
+    if (Object.hasOwn(inputs, key)) {
       const value = inputs[key];
 
       if (value !== undefined) {

--- a/packages/core/src/render3/view/directive_outputs.ts
+++ b/packages/core/src/render3/view/directive_outputs.ts
@@ -69,7 +69,8 @@ export function listenToDirectiveOutput(
   if (
     hostDirectivesStart !== null &&
     hostDirectivesEnd !== null &&
-    tNode.hostDirectiveOutputs?.hasOwnProperty(eventName)
+    tNode.hostDirectiveOutputs &&
+    Object.hasOwn(tNode.hostDirectiveOutputs, eventName)
   ) {
     const hostDirectiveOutputs = tNode.hostDirectiveOutputs[eventName];
 
@@ -93,7 +94,7 @@ export function listenToDirectiveOutput(
     }
   }
 
-  if (target.outputs.hasOwnProperty(eventName)) {
+  if (Object.hasOwn(target.outputs, eventName)) {
     ngDevMode && assertIndexInRange(lView, hostIndex);
     hasOutput = true;
     listenToOutput(tNode, lView, hostIndex, eventName, eventName, listenerFn);

--- a/packages/core/src/render3/view/directives.ts
+++ b/packages/core/src/render3/view/directives.ts
@@ -296,7 +296,7 @@ function setupSelectorMatchedInputsOrOutputs<T>(
   const aliasMap = mode === BindingType.Inputs ? def.inputs : def.outputs;
 
   for (const publicName in aliasMap) {
-    if (aliasMap.hasOwnProperty(publicName)) {
+    if (Object.hasOwn(aliasMap, publicName)) {
       let bindings: NodeInputBindings | NodeOutputBindings;
       if (mode === BindingType.Inputs) {
         bindings = tNode.inputs ??= {};
@@ -326,7 +326,7 @@ function setupHostDirectiveInputsOrOutputs(
   const aliasMap = mode === BindingType.Inputs ? config.inputs : config.outputs;
 
   for (const initialName in aliasMap) {
-    if (aliasMap.hasOwnProperty(initialName)) {
+    if (Object.hasOwn(aliasMap, initialName)) {
       const publicName = aliasMap[initialName];
       let bindings: HostDirectiveInputs | HostDirectiveOutputs;
       if (mode === BindingType.Inputs) {
@@ -396,7 +396,7 @@ function setupInitialInputs(tNode: TNode, directiveIndex: number, isHostDirectiv
       break;
     }
 
-    if (!isHostDirective && inputs!.hasOwnProperty(attrName as string)) {
+    if (!isHostDirective && Object.hasOwn(inputs!, attrName as string)) {
       // Find the input's public name from the input store. Note that we can be found easier
       // through the directive def, but we want to do it using the inputs store so that it can
       // account for host directive aliases.
@@ -410,7 +410,7 @@ function setupInitialInputs(tNode: TNode, directiveIndex: number, isHostDirectiv
           break;
         }
       }
-    } else if (isHostDirective && hostDirectiveInputs!.hasOwnProperty(attrName as string)) {
+    } else if (isHostDirective && Object.hasOwn(hostDirectiveInputs!, attrName as string)) {
       const config = hostDirectiveInputs![attrName as string];
       for (let j = 0; j < config.length; j += 2) {
         if (config[j] === directiveIndex) {

--- a/packages/core/src/sanitization/html_sanitizer.ts
+++ b/packages/core/src/sanitization/html_sanitizer.ts
@@ -25,7 +25,7 @@ function merge(...sets: BooleanRecord[]): BooleanRecord {
   const res: BooleanRecord = {};
   for (const s of sets) {
     for (const v in s) {
-      if (s.hasOwnProperty(v)) res[v] = true;
+      if (Object.hasOwn(s, v)) res[v] = true;
     }
   }
   return res;
@@ -179,9 +179,9 @@ class SanitizingHtmlSerializer {
    */
   private startElement(element: Element): boolean {
     const tagName = getNodeName(element).toLowerCase();
-    if (!VALID_ELEMENTS.hasOwnProperty(tagName)) {
+    if (!Object.hasOwn(VALID_ELEMENTS, tagName)) {
       this.sanitizedSomething = true;
-      return !SKIP_TRAVERSING_CONTENT_IF_INVALID_ELEMENTS.hasOwnProperty(tagName);
+      return !Object.hasOwn(SKIP_TRAVERSING_CONTENT_IF_INVALID_ELEMENTS, tagName);
     }
     this.buf.push('<');
     this.buf.push(tagName);
@@ -190,7 +190,7 @@ class SanitizingHtmlSerializer {
       const elAttr = elAttrs.item(i);
       const attrName = elAttr!.name;
       const lower = attrName.toLowerCase();
-      if (!VALID_ATTRS.hasOwnProperty(lower)) {
+      if (!Object.hasOwn(VALID_ATTRS, lower)) {
         this.sanitizedSomething = true;
         continue;
       }
@@ -205,7 +205,7 @@ class SanitizingHtmlSerializer {
 
   private endElement(current: Element) {
     const tagName = getNodeName(current).toLowerCase();
-    if (VALID_ELEMENTS.hasOwnProperty(tagName) && !VOID_ELEMENTS.hasOwnProperty(tagName)) {
+    if (Object.hasOwn(VALID_ELEMENTS, tagName) && !Object.hasOwn(VOID_ELEMENTS, tagName)) {
       this.buf.push('</');
       this.buf.push(tagName);
       this.buf.push('>');

--- a/packages/core/src/transfer_state.ts
+++ b/packages/core/src/transfer_state.ts
@@ -108,7 +108,7 @@ export class TransferState {
    * Test whether a key exists in the store.
    */
   hasKey<T>(key: StateKey<T>): boolean {
-    return this.store.hasOwnProperty(key);
+    return Object.hasOwn(this.store, key);
   }
 
   /**
@@ -131,7 +131,7 @@ export class TransferState {
   toJson(): string {
     // Call the onSerialize callbacks and put those values into the store.
     for (const key in this.onSerializeCallbacks) {
-      if (this.onSerializeCallbacks.hasOwnProperty(key)) {
+      if (Object.hasOwn(this.onSerializeCallbacks, key)) {
         try {
           this.store[key] = this.onSerializeCallbacks[key]();
         } catch (e) {

--- a/packages/core/src/util/decorators.ts
+++ b/packages/core/src/util/decorators.ts
@@ -68,7 +68,7 @@ export function makeDecorator<T>(
         if (typeFn) typeFn(cls, ...args);
         // Use of Object.defineProperty is important since it creates non-enumerable property which
         // prevents the property is copied during subclassing.
-        const annotations = cls.hasOwnProperty(ANNOTATIONS)
+        const annotations = Object.hasOwn(cls, ANNOTATIONS)
           ? (cls as any)[ANNOTATIONS]
           : (Object.defineProperty(cls, ANNOTATIONS, {value: []}) as any)[ANNOTATIONS];
         annotations.push(annotationInstance);
@@ -123,7 +123,7 @@ export function makeParamDecorator(
       function ParamDecorator(cls: any, unusedKey: any, index: number): any {
         // Use of Object.defineProperty is important since it creates non-enumerable property which
         // prevents the property is copied during subclassing.
-        const parameters = cls.hasOwnProperty(PARAMETERS)
+        const parameters = Object.hasOwn(cls, PARAMETERS)
           ? (cls as any)[PARAMETERS]
           : Object.defineProperty(cls, PARAMETERS, {value: []})[PARAMETERS];
 
@@ -176,10 +176,10 @@ export function makePropDecorator(
         const constructor = target.constructor;
         // Use of Object.defineProperty is important because it creates a non-enumerable property
         // which prevents the property from being copied during subclassing.
-        const meta = constructor.hasOwnProperty(PROP_METADATA)
+        const meta = Object.hasOwn(constructor, PROP_METADATA)
           ? (constructor as any)[PROP_METADATA]
           : Object.defineProperty(constructor, PROP_METADATA, {value: {}})[PROP_METADATA];
-        meta[name] = (meta.hasOwnProperty(name) && meta[name]) || [];
+        meta[name] = (Object.hasOwn(meta, name) && meta[name]) || [];
         meta[name].unshift(decoratorInstance);
 
         if (additionalProcessing) additionalProcessing(target, name, ...args);

--- a/packages/core/src/util/property.ts
+++ b/packages/core/src/util/property.ts
@@ -29,7 +29,7 @@ export function getClosureSafeProperty<T>(objWithPropertyToExtract: T): string {
  */
 export function fillProperties(target: Record<string, unknown>, source: Record<string, unknown>) {
   for (const key in source) {
-    if (source.hasOwnProperty(key) && !target.hasOwnProperty(key)) {
+    if (Object.hasOwn(source, key) && !Object.hasOwn(target, key)) {
       target[key] = source[key];
     }
   }

--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -61,7 +61,7 @@ export type ShapeOf<T> = {
  */
 export function isShapeOf<T>(obj: any, shapeOf: ShapeOf<T>): obj is T {
   if (typeof obj === 'object' && obj) {
-    return Object.keys(shapeOf).every((key) => obj.hasOwnProperty(key));
+    return Object.keys(shapeOf).every((key) => Object.hasOwn(obj, key));
   }
   return false;
 }

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -82,7 +82,7 @@ describe('r3 jit environment', () => {
       )
       .forEach((sym) => {
         // Assert that angularCoreEnv has a reference to the runtime symbol.
-        expect(angularCoreEnv.hasOwnProperty(sym.name)).toBe(
+        expect(Object.hasOwn(angularCoreEnv, sym.name)).toBe(
           true,
           `Missing symbol ${sym.name} in render3/jit/environment`,
         );

--- a/packages/core/test/render3/matchers.ts
+++ b/packages/core/test/render3/matchers.ts
@@ -34,7 +34,7 @@ export function matchObjectShape<T>(
     _matcherUtils = matcherUtils;
     if (!shapePredicate(actual)) return false;
     for (const key in expected) {
-      if (expected.hasOwnProperty(key) && !matcherUtils.equals(actual[key], expected[key])) {
+      if (Object.hasOwn(expected, key) && !matcherUtils.equals(actual[key], expected[key])) {
         return false;
       }
     }
@@ -46,7 +46,7 @@ export function matchObjectShape<T>(
       return `Expecting ${pp(expect)} got ${pp(_actual)}`;
     }
     for (const key in expected) {
-      if (expected.hasOwnProperty(key) && !_matcherUtils.equals(_actual[key], expected[key]))
+      if (Object.hasOwn(expected, key) && !_matcherUtils.equals(_actual[key], expected[key]))
         errors.push(`\n  property obj.${key} to equal ${expected[key]} but got ${_actual[key]}`);
     }
     return errors.join('\n');
@@ -162,7 +162,7 @@ export function matchDomElement(
     }
     if (expectedAttrs) {
       for (const attrName in expectedAttrs) {
-        if (expectedAttrs.hasOwnProperty(attrName)) {
+        if (Object.hasOwn(expectedAttrs, attrName)) {
           const expectedAttrValue = expectedAttrs[attrName];
           const actualAttrValue = actual.getAttribute(attrName);
           if (expectedAttrValue !== actualAttrValue) {

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -2286,26 +2286,26 @@ describe('TestBed', () => {
       });
       TestBed.createComponent(ComponentWithNoAnnotations);
 
-      expect(ComponentWithNoAnnotations.hasOwnProperty('ɵcmp')).toBeTruthy();
-      expect(SomeComponent.hasOwnProperty('ɵcmp')).toBeTruthy();
+      expect(Object.hasOwn(ComponentWithNoAnnotations, 'ɵcmp')).toBeTruthy();
+      expect(Object.hasOwn(SomeComponent, 'ɵcmp')).toBeTruthy();
 
-      expect(DirectiveWithNoAnnotations.hasOwnProperty('ɵdir')).toBeTruthy();
-      expect(SomeDirective.hasOwnProperty('ɵdir')).toBeTruthy();
+      expect(Object.hasOwn(DirectiveWithNoAnnotations, 'ɵdir')).toBeTruthy();
+      expect(Object.hasOwn(SomeDirective, 'ɵdir')).toBeTruthy();
 
-      expect(PipeWithNoAnnotations.hasOwnProperty('ɵpipe')).toBeTruthy();
-      expect(SomePipe.hasOwnProperty('ɵpipe')).toBeTruthy();
+      expect(Object.hasOwn(PipeWithNoAnnotations, 'ɵpipe')).toBeTruthy();
+      expect(Object.hasOwn(SomePipe, 'ɵpipe')).toBeTruthy();
 
       TestBed.resetTestingModule();
 
       // ng defs should be removed from classes with no annotations
-      expect(ComponentWithNoAnnotations.hasOwnProperty('ɵcmp')).toBeFalsy();
-      expect(DirectiveWithNoAnnotations.hasOwnProperty('ɵdir')).toBeFalsy();
-      expect(PipeWithNoAnnotations.hasOwnProperty('ɵpipe')).toBeFalsy();
+      expect(Object.hasOwn(ComponentWithNoAnnotations, 'ɵcmp')).toBeFalsy();
+      expect(Object.hasOwn(DirectiveWithNoAnnotations, 'ɵdir')).toBeFalsy();
+      expect(Object.hasOwn(PipeWithNoAnnotations, 'ɵpipe')).toBeFalsy();
 
       // ng defs should be preserved on super types
-      expect(SomeComponent.hasOwnProperty('ɵcmp')).toBeTruthy();
-      expect(SomeDirective.hasOwnProperty('ɵdir')).toBeTruthy();
-      expect(SomePipe.hasOwnProperty('ɵpipe')).toBeTruthy();
+      expect(Object.hasOwn(SomeComponent, 'ɵcmp')).toBeTruthy();
+      expect(Object.hasOwn(SomeDirective, 'ɵdir')).toBeTruthy();
+      expect(Object.hasOwn(SomePipe, 'ɵpipe')).toBeTruthy();
     });
 
     it('should cleanup scopes (configured via `TestBed.configureTestingModule`) between tests', () => {

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -291,9 +291,9 @@ export class TestBedCompiler {
     override: MetadataOverride<Component | Directive | Pipe>,
   ) {
     if (
-      override.add?.hasOwnProperty('standalone') ||
-      override.set?.hasOwnProperty('standalone') ||
-      override.remove?.hasOwnProperty('standalone')
+      (override.add && Object.hasOwn(override.add, 'standalone')) ||
+      (override.set && Object.hasOwn(override.set, 'standalone')) ||
+      (override.remove && Object.hasOwn(override.remove, 'standalone'))
     ) {
       throw new Error(
         `An override for the ${type.name} class has the \`standalone\` flag. ` +
@@ -766,7 +766,7 @@ export class TestBedCompiler {
       // Check whether a give Type has respective NG def (ɵcmp) and compile if def is
       // missing. That might happen in case a class without any Angular decorators extends another
       // class where Component/Directive/Pipe decorator is defined.
-      if (ɵisComponentDefPendingResolution(type) || !type.hasOwnProperty(NG_COMP_DEF)) {
+      if (ɵisComponentDefPendingResolution(type) || !Object.hasOwn(type, NG_COMP_DEF)) {
         this.pendingComponents.add(type);
       }
       this.seenComponents.add(type);
@@ -797,7 +797,7 @@ export class TestBedCompiler {
 
     const directive = this.resolvers.directive.resolve(type);
     if (directive) {
-      if (!type.hasOwnProperty(NG_DIR_DEF)) {
+      if (!Object.hasOwn(type, NG_DIR_DEF)) {
         this.pendingDirectives.add(type);
       }
       this.seenDirectives.add(type);
@@ -805,7 +805,7 @@ export class TestBedCompiler {
     }
 
     const pipe = this.resolvers.pipe.resolve(type);
-    if (pipe && !type.hasOwnProperty(NG_PIPE_DEF)) {
+    if (pipe && !Object.hasOwn(type, NG_PIPE_DEF)) {
       this.pendingPipes.add(type);
       return;
     }
@@ -1170,7 +1170,7 @@ function getComponentDef(value: Type<unknown>): ComponentDef<unknown> | null {
 }
 
 function hasNgModuleDef<T>(value: Type<T>): value is NgModuleType<T> {
-  return value.hasOwnProperty('ɵmod');
+  return Object.hasOwn(value, 'ɵmod');
 }
 
 function isNgModule<T>(value: Type<T>): boolean {
@@ -1229,7 +1229,7 @@ function getProviderToken(provider: Provider) {
 }
 
 function isModuleWithProviders(value: any): value is ModuleWithProviders<any> {
-  return value.hasOwnProperty('ngModule');
+  return Object.hasOwn(value, 'ngModule');
 }
 
 function forEachRight<T>(values: T[], fn: (value: T, idx: number) => void): void {

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -157,7 +157,7 @@ export function createCustomElement<P>(
         // strategy.
         // TODO(alxhub): why are we doing this? this makes no sense.
         inputs.forEach(({propName, transform}) => {
-          if (!this.hasOwnProperty(propName)) {
+          if (!Object.hasOwn(this, propName)) {
             // No pre-existing value for `propName`.
             return;
           }

--- a/packages/forms/signals/src/field/structure.ts
+++ b/packages/forms/signals/src/field/structure.ts
@@ -674,7 +674,7 @@ function maybeRemoveStaleObjectFields(
   // For objects, we diff a bit differently, and use the value to check whether an old
   // property still exists on the object value.
   for (const key of prevData.byPropertyKey.keys()) {
-    if (!value.hasOwnProperty(key)) {
+    if (!Object.hasOwn(value, key)) {
       data ??= {...(prevData as MutableChildrenData)};
       data.byPropertyKey.delete(key);
     }

--- a/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
+++ b/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
@@ -130,7 +130,7 @@ export abstract class AbstractFormDirective
   /** @nodoc */
   protected onChanges(changes: SimpleChanges): void {
     this._checkFormPresent();
-    if (changes.hasOwnProperty('form')) {
+    if (Object.hasOwn(changes, 'form')) {
       this._updateValidators();
       this._updateDomValue();
       this._updateRegistrations();

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -216,7 +216,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
   }
 
   private _isControlChanged(changes: {[key: string]: any}): boolean {
-    return changes.hasOwnProperty('form');
+    return Object.hasOwn(changes, 'form');
   }
 
   /**

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -370,7 +370,7 @@ function _throwInvalidValueAccessorError(dir: AbstractControlDirective) {
 }
 
 export function isPropertyUpdated(changes: {[key: string]: any}, viewModel: any): boolean {
-  if (!changes.hasOwnProperty('model')) return false;
+  if (!Object.hasOwn(changes, 'model')) return false;
   const change = changes['model'];
 
   if (change.isFirstChange()) return true;

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -562,7 +562,7 @@ describe('value accessors', () => {
       };
 
       it('verify that native `selectedOptions` field is used while detecting the list of selected options', async () => {
-        if (isNode || !HTMLSelectElement.prototype.hasOwnProperty('selectedOptions')) return;
+        if (isNode || !Object.hasOwn(HTMLSelectElement.prototype, 'selectedOptions')) return;
         const spy = spyOnProperty(
           HTMLSelectElement.prototype,
           'selectedOptions',

--- a/packages/language-service/src/attribute_completions.ts
+++ b/packages/language-service/src/attribute_completions.ts
@@ -225,8 +225,7 @@ export function buildAttributeCompletionTable(
   // Use the `ElementSymbol` or `TemplateSymbol` to iterate over directives present on the node, and
   // their inputs/outputs. These have the highest priority of completion results.
   const symbol: ElementSymbol | TemplateSymbol = checker.getSymbolOfNode(element, component) as
-    | ElementSymbol
-    | TemplateSymbol;
+    ElementSymbol | TemplateSymbol;
   const presentDirectives = new Set<ts.ClassDeclaration>();
   if (symbol !== null) {
     // An `ElementSymbol` was available. This means inputs and outputs for directives on the
@@ -248,7 +247,10 @@ export function buildAttributeCompletionTable(
         let propertyName: string;
 
         if (dirSymbol.matchSource === MatchSource.HostDirective) {
-          if (!dirSymbol.exposedInputs?.hasOwnProperty(bindingPropertyName)) {
+          if (
+            !dirSymbol.exposedInputs ||
+            !Object.hasOwn(dirSymbol.exposedInputs, bindingPropertyName)
+          ) {
             continue;
           }
           propertyName = dirSymbol.exposedInputs[bindingPropertyName];
@@ -273,7 +275,10 @@ export function buildAttributeCompletionTable(
         let propertyName: string;
 
         if (dirSymbol.matchSource === MatchSource.HostDirective) {
-          if (!dirSymbol.exposedOutputs?.hasOwnProperty(bindingPropertyName)) {
+          if (
+            !dirSymbol.exposedOutputs ||
+            !Object.hasOwn(dirSymbol.exposedOutputs, bindingPropertyName)
+          ) {
             continue;
           }
           propertyName = dirSymbol.exposedOutputs[bindingPropertyName];

--- a/packages/language-service/src/utils/index.ts
+++ b/packages/language-service/src/utils/index.ts
@@ -77,7 +77,7 @@ interface NodeWithKeyAndValue extends TmplAstNode {
 export function isTemplateNodeWithKeyAndValue(
   node: TmplAstNode | AST,
 ): node is NodeWithKeyAndValue {
-  return isTemplateNode(node) && node.hasOwnProperty('keySpan');
+  return isTemplateNode(node) && Object.hasOwn(node, 'keySpan');
 }
 
 export function isWithinKey(position: number, node: NodeWithKeyAndValue): boolean {

--- a/packages/localize/test/translate_spec.ts
+++ b/packages/localize/test/translate_spec.ts
@@ -119,7 +119,7 @@ describe('$localize tag with translations', () => {
       // The malicious id must be stored as an own key rather than assigned through the inherited
       // `__proto__` setter, which would reparent the map (and drop the entry).
       expect(Object.getPrototypeOf(store)).toBe(null);
-      expect(Object.prototype.hasOwnProperty.call(store, '__proto__')).toBe(true);
+      expect(Object.hasOwn(store, '__proto__')).toBe(true);
       // A translation loaded alongside it still resolves.
       expect($localize`abc`).toEqual('abc');
     });

--- a/packages/localize/tools/src/extract/translation_files/legacy_message_id_migration_serializer.ts
+++ b/packages/localize/tools/src/extract/translation_files/legacy_message_id_migration_serializer.ts
@@ -23,7 +23,7 @@ export class LegacyMessageIdMigrationSerializer implements TranslationSerializer
       (output, message) => {
         if (shouldMigrate(message)) {
           for (const legacyId of message.legacyIds!) {
-            if (output.hasOwnProperty(legacyId)) {
+            if (Object.hasOwn(output, legacyId)) {
               this._diagnostics.warn(`Detected duplicate legacy ID ${legacyId}.`);
             }
 

--- a/packages/platform-server/init/test/shims_spec.ts
+++ b/packages/platform-server/init/test/shims_spec.ts
@@ -19,7 +19,7 @@ describe('applyShims()', () => {
         // These props are just a getter and cannot be changed
         continue;
       }
-      if (globalClone.hasOwnProperty(prop)) {
+      if (Object.hasOwn(globalClone, prop)) {
         (global as any)[prop] = (globalClone as any)[prop];
       } else {
         delete (global as any)[prop];

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -80,7 +80,7 @@ class ParamsAsMap implements ParamMap {
   }
 
   has(name: string): boolean {
-    return Object.prototype.hasOwnProperty.call(this.params, name);
+    return Object.hasOwn(this.params, name);
   }
 
   get(name: string): string | null {

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -417,7 +417,7 @@ export class Driver implements Debuggable, UpdateSource {
     }
     const desc = data.notification as {[key: string]: string | undefined};
     let options: {[key: string]: string | undefined} = {};
-    NOTIFICATION_OPTION_NAMES.filter((name) => desc.hasOwnProperty(name)).forEach(
+    NOTIFICATION_OPTION_NAMES.filter((name) => Object.hasOwn(desc, name)).forEach(
       (name) => (options[name] = desc[name]),
     );
     await this.scope.registration.showNotification(desc['title']!, options);
@@ -671,7 +671,7 @@ export class Driver implements Debuggable, UpdateSource {
 
       // Make sure latest manifest is correctly installed. If not (e.g. corrupted data),
       // it could stay locked in EXISTING_CLIENTS_ONLY or SAFE_MODE state.
-      if (!this.versions.has(latest.latest) && !manifests.hasOwnProperty(latest.latest)) {
+      if (!this.versions.has(latest.latest) && !Object.hasOwn(manifests, latest.latest)) {
         this.debugger.log(
           `Missing manifest for latest version hash ${latest.latest}`,
           'initialize: read from DB',

--- a/packages/upgrade/src/common/src/angular1.ts
+++ b/packages/upgrade/src/common/src/angular1.ts
@@ -275,7 +275,7 @@ let angular: {
 };
 
 try {
-  if (window.hasOwnProperty('angular')) {
+  if (Object.hasOwn(window, 'angular')) {
     angular = (<any>window).angular;
   }
 } catch {

--- a/packages/upgrade/src/common/src/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/src/downgrade_component_adapter.ts
@@ -139,7 +139,7 @@ export class DowngradeComponentAdapter {
       const inputBinding = new PropertyBinding(input.propName, input.templateName);
       let expr: string | null = null;
 
-      if (attrs.hasOwnProperty(inputBinding.attr)) {
+      if (Object.hasOwn(attrs, inputBinding.attr)) {
         const observeFn = ((prop, isSignal) => {
           let prevValue = INITIAL_VALUE;
           return (currValue: any) => {
@@ -164,13 +164,13 @@ export class DowngradeComponentAdapter {
           unwatch = null;
           observeFn(attrs[inputBinding.attr]);
         });
-      } else if (attrs.hasOwnProperty(inputBinding.bindAttr)) {
+      } else if (Object.hasOwn(attrs, inputBinding.bindAttr)) {
         expr = attrs[inputBinding.bindAttr];
-      } else if (attrs.hasOwnProperty(inputBinding.bracketAttr)) {
+      } else if (Object.hasOwn(attrs, inputBinding.bracketAttr)) {
         expr = attrs[inputBinding.bracketAttr];
-      } else if (attrs.hasOwnProperty(inputBinding.bindonAttr)) {
+      } else if (Object.hasOwn(attrs, inputBinding.bindonAttr)) {
         expr = attrs[inputBinding.bindonAttr];
-      } else if (attrs.hasOwnProperty(inputBinding.bracketParenAttr)) {
+      } else if (Object.hasOwn(attrs, inputBinding.bracketParenAttr)) {
         expr = attrs[inputBinding.bracketParenAttr];
       }
       if (expr != null) {
@@ -238,16 +238,16 @@ export class DowngradeComponentAdapter {
         outputBindings.bracketParenAttr.length - 8,
       )})]`;
       // order below is important - first update bindings then evaluate expressions
-      if (attrs.hasOwnProperty(bindonAttr)) {
+      if (Object.hasOwn(attrs, bindonAttr)) {
         this.subscribeToOutput(componentRef, outputBindings, attrs[bindonAttr], true);
       }
-      if (attrs.hasOwnProperty(bracketParenAttr)) {
+      if (Object.hasOwn(attrs, bracketParenAttr)) {
         this.subscribeToOutput(componentRef, outputBindings, attrs[bracketParenAttr], true);
       }
-      if (attrs.hasOwnProperty(outputBindings.onAttr)) {
+      if (Object.hasOwn(attrs, outputBindings.onAttr)) {
         this.subscribeToOutput(componentRef, outputBindings, attrs[outputBindings.onAttr]);
       }
-      if (attrs.hasOwnProperty(outputBindings.parenAttr)) {
+      if (Object.hasOwn(attrs, outputBindings.parenAttr)) {
         this.subscribeToOutput(componentRef, outputBindings, attrs[outputBindings.parenAttr]);
       }
     }

--- a/packages/upgrade/src/common/test/downgrade_injectable_spec.ts
+++ b/packages/upgrade/src/common/test/downgrade_injectable_spec.ts
@@ -16,7 +16,7 @@ describe('downgradeInjectable', () => {
   const setupMockInjectors = (downgradedModule = '') => {
     const mockNg1Injector = jasmine.createSpyObj<angular.IInjectorService>(['get', 'has']);
     mockNg1Injector.get.and.callFake((key: string) => mockDependencies[key]);
-    mockNg1Injector.has.and.callFake((key: string) => mockDependencies.hasOwnProperty(key));
+    mockNg1Injector.has.and.callFake((key: string) => Object.hasOwn(mockDependencies, key));
 
     const mockNg2Injector = jasmine.createSpyObj<Injector>(['get']);
     mockNg2Injector.get.and.returnValue('service value');

--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -151,7 +151,7 @@ export class UpgradeModule {
   /**
    * The AngularJS `$injector` for the upgrade application.
    */
-  public $injector: any /*angular.IInjectorService*/;
+  public $injector: any; /*angular.IInjectorService*/
   /** The Angular Injector **/
   public injector: Injector;
   private readonly applicationRef: ApplicationRef;
@@ -266,7 +266,7 @@ export class UpgradeModule {
                 );
 
                 // the `flush` method will be present when ngMocks is used
-                if (intervalDelegate.hasOwnProperty('flush')) {
+                if (Object.hasOwn(intervalDelegate, 'flush')) {
                   (wrappedInterval as any)['flush'] = () => {
                     (intervalDelegate as any)['flush']();
                     return wrappedInterval;

--- a/packages/zone.js/lib/browser/browser-util.ts
+++ b/packages/zone.js/lib/browser/browser-util.ts
@@ -31,7 +31,7 @@ export function patchCallbacks(
         // We don't want to stop the application rendering if we couldn't patch some
         // callback, e.g. `attributeChangedCallback`.
         try {
-          if (prototype.hasOwnProperty(callback)) {
+          if (Object.hasOwn(prototype, callback)) {
             const descriptor = api.ObjectGetOwnPropertyDescriptor(prototype, callback);
             if (descriptor && descriptor.value) {
               descriptor.value = api.wrapWithCurrentZone(descriptor.value, source);

--- a/packages/zone.js/lib/browser/shadydom.ts
+++ b/packages/zone.js/lib/browser/shadydom.ts
@@ -26,7 +26,7 @@ export function patchShadyDom(Zone: ZoneType): void {
       Document.prototype,
     ];
     prototypes.forEach(function (proto) {
-      if (proto && proto.hasOwnProperty('addEventListener')) {
+      if (proto && Object.hasOwn(proto, 'addEventListener')) {
         proto[Zone.__symbol__('addEventListener')] = null;
         proto[Zone.__symbol__('removeEventListener')] = null;
         api.patchEventTarget(global, api, [proto]);

--- a/packages/zone.js/lib/common/error-rewrite.ts
+++ b/packages/zone.js/lib/common/error-rewrite.ts
@@ -211,7 +211,7 @@ export function patchError(Zone: ZoneType): void {
       });
     }
 
-    if (NativeError.hasOwnProperty('stackTraceLimit')) {
+    if (Object.hasOwn(NativeError, 'stackTraceLimit')) {
       // Extend default stack limit as we will be removing few frames.
       NativeError.stackTraceLimit = Math.max(NativeError.stackTraceLimit, 15);
 
@@ -226,7 +226,7 @@ export function patchError(Zone: ZoneType): void {
       });
     }
 
-    if (NativeError.hasOwnProperty('captureStackTrace')) {
+    if (Object.hasOwn(NativeError, 'captureStackTrace')) {
       Object.defineProperty(ZoneAwareError, 'captureStackTrace', {
         // add named function here because we need to remove this
         // stack frame when prepareStackTrace below

--- a/packages/zone.js/lib/common/events.ts
+++ b/packages/zone.js/lib/common/events.ts
@@ -324,7 +324,7 @@ export function patchEventTarget(
     }
 
     let proto = obj;
-    while (proto && !proto.hasOwnProperty(ADD_EVENT_LISTENER)) {
+    while (proto && !Object.hasOwn(proto, ADD_EVENT_LISTENER)) {
       proto = ObjectGetPrototypeOf(proto);
     }
     if (!proto && obj[ADD_EVENT_LISTENER]) {

--- a/packages/zone.js/lib/common/promise.ts
+++ b/packages/zone.js/lib/common/promise.ts
@@ -160,8 +160,8 @@ export function patchPromise(Zone: ZoneType): void {
         if (
           state !== REJECTED &&
           value instanceof ZoneAwarePromise &&
-          value.hasOwnProperty(symbolState) &&
-          value.hasOwnProperty(symbolValue) &&
+          Object.hasOwn(value, symbolState) &&
+          Object.hasOwn(value, symbolValue) &&
           (value as any)[symbolState] !== UNRESOLVED
         ) {
           clearRejectedNoCatch(value);
@@ -212,7 +212,7 @@ export function patchPromise(Zone: ZoneType): void {
             }
           }
 
-          for (let i = 0; i < queue.length; ) {
+          for (let i = 0; i < queue.length;) {
             scheduleResolveOrReject(promise, queue[i++], queue[i++], queue[i++], queue[i++]);
           }
           if (queue.length == 0 && state == REJECTED) {

--- a/packages/zone.js/lib/common/utils.ts
+++ b/packages/zone.js/lib/common/utils.ts
@@ -210,7 +210,7 @@ export function patchProperty(obj: any, prop: string, prototype?: any) {
   }
 
   const onPropPatchedSymbol = zoneSymbol('on' + prop + 'patched');
-  if (obj.hasOwnProperty(onPropPatchedSymbol) && obj[onPropPatchedSymbol]) {
+  if (Object.hasOwn(obj, onPropPatchedSymbol) && obj[onPropPatchedSymbol]) {
     return;
   }
 
@@ -385,7 +385,7 @@ export function patchClass(className: string) {
   }
 
   for (prop in OriginalClass) {
-    if (prop !== 'prototype' && OriginalClass.hasOwnProperty(prop)) {
+    if (prop !== 'prototype' && Object.hasOwn(OriginalClass, prop)) {
       _global[className][prop] = OriginalClass[prop];
     }
   }
@@ -431,7 +431,7 @@ export function patchMethod(
   ) => (self: any, args: any[]) => any,
 ): Function | null {
   let proto = target;
-  while (proto && !proto.hasOwnProperty(name)) {
+  while (proto && !Object.hasOwn(proto, name)) {
     proto = ObjectGetPrototypeOf(proto);
   }
   if (!proto && target[name]) {
@@ -441,7 +441,7 @@ export function patchMethod(
 
   const delegateName = zoneSymbol(name);
   let delegate: Function | null = null;
-  if (proto && (!(delegate = proto[delegateName]) || !proto.hasOwnProperty(delegateName))) {
+  if (proto && (!(delegate = proto[delegateName]) || !Object.hasOwn(proto, delegateName))) {
     delegate = proto[delegateName] = proto[name];
     // check whether proto[name] is writable
     // some property is readonly in safari, such as HtmlCanvasElement.prototype.toBlob

--- a/packages/zone.js/lib/jasmine/jasmine.ts
+++ b/packages/zone.js/lib/jasmine/jasmine.ts
@@ -16,7 +16,7 @@ declare let jest: any;
 export function patchJasmine(Zone: ZoneType): void {
   Zone.__load_patch('jasmine', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
     const __extends = function (d: any, b: any) {
-      for (const p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+      for (const p in b) if (Object.hasOwn(b, p)) d[p] = b[p];
       function __(this: Object) {
         this.constructor = d;
       }

--- a/packages/zone.js/lib/zone-impl.ts
+++ b/packages/zone.js/lib/zone-impl.ts
@@ -628,12 +628,7 @@ export type TaskType = 'microTask' | 'macroTask' | 'eventTask';
  * Task type: `notScheduled`, `scheduling`, `scheduled`, `running`, `canceling`, 'unknown'.
  */
 export type TaskState =
-  | 'notScheduled'
-  | 'scheduling'
-  | 'scheduled'
-  | 'running'
-  | 'canceling'
-  | 'unknown';
+  'notScheduled' | 'scheduling' | 'scheduled' | 'running' | 'canceling' | 'unknown';
 
 /**
  */
@@ -862,7 +857,7 @@ export function initZone(): ZoneType {
     public getZoneWith(key: string): AmbientZone | null {
       let current: ZoneImpl | null = this;
       while (current) {
-        if (current._properties.hasOwnProperty(key)) {
+        if (Object.hasOwn(current._properties, key)) {
           return current;
         }
         current = current._parent;

--- a/packages/zone.js/lib/zone-spec/long-stack-trace.ts
+++ b/packages/zone.js/lib/zone-spec/long-stack-trace.ts
@@ -56,7 +56,7 @@ export function patchLongStackTrace(Zone: ZoneType): void {
     for (let i = 0; i < trace.length; i++) {
       const frame = trace[i];
       // Filter out the Frames which are part of stack capturing.
-      if (!IGNORE_FRAMES.hasOwnProperty(frame)) {
+      if (!Object.hasOwn(IGNORE_FRAMES, frame)) {
         lines.push(trace[i]);
       }
     }

--- a/packages/zone.js/lib/zone-spec/wtf.ts
+++ b/packages/zone.js/lib/zone-spec/wtf.ts
@@ -165,7 +165,7 @@ export function patchWtf(Zone: ZoneType): void {
     if (!obj || !depth) return null;
     const out: {[k: string]: any} = {};
     for (const key in obj) {
-      if (obj.hasOwnProperty(key)) {
+      if (Object.hasOwn(obj, key)) {
         // explicit : any due to https://github.com/microsoft/TypeScript/issues/33191
         let value: any = obj[key];
         switch (typeof value) {

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -434,7 +434,7 @@ describe('Zone Browser', function () {
             }
 
             const onPropPatchedSymbol = zoneSymbol('on' + prop + 'patched');
-            if (obj.hasOwnProperty(onPropPatchedSymbol) && obj[onPropPatchedSymbol]) {
+            if (Object.hasOwn(obj, onPropPatchedSymbol) && obj[onPropPatchedSymbol]) {
               return true;
             }
             return false;

--- a/packages/zone.js/test/closure/zone.closure.ts
+++ b/packages/zone.js/test/closure/zone.closure.ts
@@ -120,7 +120,7 @@ const testClosureFunction = () => {
         'cancelTask',
       ];
       zonePrototypeKeys.forEach((key) => {
-        if ((Zone as any).prototype.hasOwnProperty(key)) {
+        if (Object.hasOwn((Zone as any).prototype, key)) {
           logs.push(key);
         }
       });
@@ -138,7 +138,7 @@ const testClosureFunction = () => {
         'onHasTask',
       ];
       zoneSpecKeys.forEach((key) => {
-        if (testZoneSpec.hasOwnProperty(key)) {
+        if (Object.hasOwn(testZoneSpec, key)) {
           logs.push(key);
         }
       });
@@ -162,7 +162,7 @@ const testClosureFunction = () => {
         () => {},
       );
       zoneTaskKeys.forEach((key) => {
-        if (task.hasOwnProperty(key)) {
+        if (Object.hasOwn(task, key)) {
           logs.push(key);
         }
       });

--- a/packages/zone.js/test/common/Error.spec.ts
+++ b/packages/zone.js/test/common/Error.spec.ts
@@ -137,11 +137,11 @@ describe('ZoneAwareError', () => {
 
   it('should have browser specified property', () => {
     let myError = new Error('myError');
-    if (Object.prototype.hasOwnProperty.call(Error.prototype, 'description')) {
+    if (Object.hasOwn(Error.prototype, 'description')) {
       // in IE, error has description property
       expect((<any>myError).description).toEqual('myError');
     }
-    if (Object.prototype.hasOwnProperty.call(Error.prototype, 'fileName')) {
+    if (Object.hasOwn(Error.prototype, 'fileName')) {
       // in firefox, error has fileName property
       expect((<any>myError).fileName).toBeTruthy();
     }

--- a/packages/zone.js/test/test-env-setup-mocha.ts
+++ b/packages/zone.js/test/test-env-setup-mocha.ts
@@ -33,7 +33,7 @@ declare const global: any;
       let isEqual = true;
 
       for (let prop in a) {
-        if (a.hasOwnProperty(prop)) {
+        if (Object.hasOwn(a, prop)) {
           if (!eq(a[prop], b[prop])) {
             isEqual = false;
             break;
@@ -50,7 +50,7 @@ declare const global: any;
       let isEqual = true;
 
       for (let prop in a) {
-        if (a.hasOwnProperty(prop)) {
+        if (Object.hasOwn(a, prop)) {
           if (!eq(a[prop], b[prop])) {
             isEqual = false;
             break;

--- a/tslint.json
+++ b/tslint.json
@@ -74,6 +74,10 @@
       {
         "name": ["performance", "mark"],
         "message": "`performance` methods aren't not fully supported in all environments like JSDOM and Cloudflare workers. Use 'performanceMark' from '@angular/core' instead."
+      },
+      {
+        "name": ["*", "hasOwnProperty"],
+        "message": "Use `Object.hasOwn` instead."
       }
     ]
   },


### PR DESCRIPTION
We keep getting PRs that target single usages of `hasOwnProperty` and we have ~100 of them. These changes aim to address the issue centrally by swapping out all the instances and adding a lint rule against introducing new ones.
