### PR TITLE
fix(forms): implement `has` handler on FieldTree proxy for Symbol.iterator

### DIFF
--- a/packages/forms/signals/src/field/proxy.ts
+++ b/packages/forms/signals/src/field/proxy.ts
@@ -77,6 +77,31 @@ export const FIELD_PROXY_HANDLER: ProxyHandler<() => FieldNode> = {
     return undefined;
   },
 
+  has(getTgt: () => FieldNode, property: string | symbol): boolean {
+    if (property === FIELD_TREE) {
+      return true;
+    }
+
+    const tgt = getTgt();
+    if (tgt.structure.getChild(property) !== undefined) {
+      return true;
+    }
+
+    const value = untracked(tgt.value);
+
+    if (isArray(value)) {
+      if (property === 'length' || property === Symbol.iterator) {
+        return true;
+      }
+    } else if (isObject(value)) {
+      if (property === Symbol.iterator) {
+        return true;
+      }
+    }
+
+    return false;
+  },
+
   getOwnPropertyDescriptor(getTgt: () => FieldNode, prop: string | symbol) {
     const value = untracked(getTgt().value) as Object;
     const desc = Reflect.getOwnPropertyDescriptor(value, prop);

--- a/packages/forms/signals/test/node/field_proxy.spec.ts
+++ b/packages/forms/signals/test/node/field_proxy.spec.ts
@@ -141,4 +141,19 @@ describe('FieldTree proxy', () => {
       }
     }).toThrow();
   });
+
+  it('should return true for Symbol.iterator in the `has` handler for object field', () => {
+    const f = form(signal({x: 1, y: 2}), {injector: TestBed.inject(Injector)});
+    expect(Symbol.iterator in f).toBe(true);
+  });
+
+  it('should return true for Symbol.iterator in the `has` handler for array field', () => {
+    const f = form(signal([1, 2]), {injector: TestBed.inject(Injector)});
+    expect(Symbol.iterator in f).toBe(true);
+  });
+
+  it('should return false for Symbol.iterator in the `has` handler for primitive field', () => {
+    const f = form(signal(1), {injector: TestBed.inject(Injector)});
+    expect(Symbol.iterator in f).toBe(false);
+  });
 });


### PR DESCRIPTION
Fixes #70252.