### PR TITLE
ci: exclude markdown files from requiring dev-infra review

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -303,7 +303,8 @@ groups:
         contains_any_globs(files
             .exclude('.pullapprove.yml') 
             .exclude('tools/manual_api_docs/blocks/*.md')
-            .exclude('tools/manual_api_docs/elements/*.md'),
+            .exclude('tools/manual_api_docs/elements/*.md')
+            .exclude('.agent/**/*.md'),
         [
           '{*,.*}',
           '.agent/**/{*,.*}',


### PR DESCRIPTION
613c51e wasn't enough to exclude dev-infra
