### PR TITLE
docs: add NG0991 error page and document rxResource's completion contract

### DIFF
--- a/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
+++ b/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
@@ -154,3 +154,5 @@ export class UserProfile {
 The `stream` property accepts a factory function for an RxJS `Observable`. This factory function is passed the resource's `params` value and returns an `Observable`. The resource calls this factory function every time the `params` computation produces a new value. See [Resource loaders](/guide/signals/resource#resource-loaders) for more details on the parameters passed to the factory function.
 
 In all other ways, `rxResource` behaves like and provides the same APIs as `resource` for specifying parameters, reading values, checking loading state, and examining errors.
+
+The `Observable` returned from `stream` must always emit a value or an error before it completes; see [`NG0991`](/errors/NG0991) for what happens otherwise and how to avoid it.

--- a/adev/src/content/reference/errors/NG0991.md
+++ b/adev/src/content/reference/errors/NG0991.md
@@ -1,0 +1,80 @@
+# Resource completed before producing a value
+
+This error happens when an `Observable`-backed resource — [`rxResource`](/ecosystem/rxjs-interop#using-rxresource-for-async-data) or [`httpResource`](/api/common/http/httpResource) — finishes (completes) without ever sending a value or an error.
+
+A resource always needs to end up with _something_: a value it loaded, or an error explaining what went wrong. An Observable that just completes silently doesn't give Angular either of those, so Angular doesn't know what to put in the resource — and it throws this error instead.
+
+## With `httpResource`
+
+`httpResource` doesn't give you an Observable to write yourself — it makes the HTTP call internally through `HttpClient` and completes once the response comes back. So if you're seeing this error from `httpResource`, the request itself isn't the problem; something sitting in front of it is swallowing the response before it gets there.
+
+The usual suspect is an `HttpInterceptor` that catches an error and doesn't re-emit anything, the same `EMPTY` mistake as below but living in an interceptor instead of your own code:
+
+```typescript
+@Injectable()
+class MyInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<unknown>, next: HttpHandler) {
+    return next.handle(req).pipe(
+      // BAD: same problem as `catchError(() => EMPTY)` in a `stream` —
+      // the request completes with no response and no error, and any
+      // httpResource depending on it hits NG0991.
+      catchError(() => EMPTY),
+    );
+  }
+}
+```
+
+Fix it the same way as you would in an interceptor pipeline generally: let the error propagate (drop the `catchError`), or replace it with something that actually resolves the request, like `of(new HttpResponse({body: fallbackValue}))`.
+
+## With `rxResource`
+
+The most common way to accidentally cause this is catching an error and swallowing it with `EMPTY`:
+
+```typescript
+import {EMPTY, catchError} from 'rxjs';
+
+const userResource = rxResource({
+  params: () => ({id: userId()}),
+  stream: ({params}) =>
+    this.http.get(`/users/${params.id}`).pipe(
+      // BAD: this hides the error completely. The Observable just
+      // completes with nothing, and the resource has no value and no
+      // error to show for it — this is what triggers NG0991.
+      catchError(() => EMPTY),
+    ),
+});
+```
+
+Another common way this happens: combining several Observables (with `merge`, `race`, and similar) where one of them can complete on its own before ever emitting, without a `startWith(...)` to guarantee an initial value. If none of the combined sources ever emits before they've all completed, the combined stream completes empty too.
+
+Pick whichever fix makes sense for your case:
+
+**Let the error through.** If you don't need to handle the error yourself, just remove the `catchError` — the resource will end up in its `error` state, which you can already check with `userResource.error()`.
+
+```typescript
+stream: ({params}) => this.http.get(`/users/${params.id}`),
+```
+
+**Recover with a fallback value.** If you'd rather show something instead of an error, use `catchError` to return an Observable that emits a value, such as `of(...)`:
+
+```typescript
+import {of, catchError} from 'rxjs';
+
+stream: ({params}) =>
+  this.http.get(`/users/${params.id}`).pipe(
+    catchError(() => of(null)), // resource resolves with `null` instead of erroring
+  ),
+```
+
+Either way, make sure the Observable you return from `stream` always emits at least one value or an error before it completes.
+
+## Where you'll actually see this error
+
+The error isn't thrown when the resource is created, and not necessarily where the request completes either. It's thrown the next time something reads the resource's value — for example `userResource.value()` in a template binding. That can make it look like the bug is somewhere else in your app, when the real cause is upstream (the `stream` completing empty, or an interceptor swallowing the response).
+
+If nothing in your code checks the resource's status before reading `.value()`, this error can bubble all the way up to Angular's global `ErrorHandler`, the same as any other uncaught error thrown while rendering a template.
+
+Two ways to reduce the impact of this, from most to least preferred:
+
+1. **Fix it at the root**, using one of the approaches above, so the resource never ends up in this state.
+2. **Guard reads of `.value()`** as defense in depth, in case something you don't fully control (a third-party interceptor or service, for example) ever completes empty unexpectedly. Check `.hasValue()` or `.status()` before reading `.value()`, for example with `@if (userResource.hasValue()) { {{ userResource.value() }} }`, instead of reading `.value()` unconditionally.

--- a/adev/src/content/reference/errors/overview.md
+++ b/adev/src/content/reference/errors/overview.md
@@ -37,6 +37,7 @@
 | `NG0951`  | [Child query result is required but no value is available](errors/NG0951)            |
 | `NG0955`  | [Track expression resulted in duplicated keys for a given collection](errors/NG0955) |
 | `NG0956`  | [Tracking expression caused re-creation of the DOM structure](errors/NG0956)         |
+| `NG0991`  | [Resource completed before producing a value](errors/NG0991)                         |
 | `NG01002` | [Missing Control Value](errors/NG01002)                                              |
 | `NG01101` | [Wrong Async Validator Return Type](errors/NG01101)                                  |
 | `NG01203` | [Missing value accessor](errors/NG01203)                                             |

--- a/goldens/public-api/core/errors.api.md
+++ b/goldens/public-api/core/errors.api.md
@@ -170,7 +170,7 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     REQUIRED_QUERY_NO_VALUE = -951,
     // (undocumented)
-    RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE = 991,
+    RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE = -991,
     // (undocumented)
     RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 980,
     // (undocumented)

--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -28,7 +28,6 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
 
 // @public
 export interface RxResourceOptions<T, R> extends BaseResourceOptions<T, R> {
-    // (undocumented)
     stream: (params: ResourceLoaderParams<R>) => Observable<T>;
 }
 

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -28,6 +28,15 @@ import {promiseWithResolvers} from '../../src/util/promise_with_resolvers';
  * @publicApi 22.0
  */
 export interface RxResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+  /**
+   * A function that returns the `Observable` to load the resource's value from.
+   *
+   * This Observable must eventually emit a value or an error before it completes — a resource
+   * needs one of those two things to know what to show. If the Observable completes without ever
+   * emitting anything (for example because of `catchError(() => EMPTY)`), Angular throws
+   * `RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE` (`NG0991`), since it has nothing to give the
+   * resource.
+   */
   stream: (params: ResourceLoaderParams<R>) => Observable<T>;
 }
 

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -10,6 +10,8 @@ import {timeout} from '@angular/private/testing';
 import {BehaviorSubject, EMPTY, Observable, of, Subscriber, throwError} from 'rxjs';
 import {
   ApplicationRef,
+  Component,
+  ErrorHandler,
   ɵCACHE_ACTIVE as CACHE_ACTIVE,
   Injector,
   makeStateKey,
@@ -176,6 +178,46 @@ describe('rxResource()', () => {
     expect(res.status()).toBe('error');
     expect(res.error()).toBeInstanceOf(Error);
     expect(() => res.value()).toThrowError(/Resource completed before producing a value/);
+  });
+
+  it('reports NG0991 to the ErrorHandler when a template reads value() after the stream completes immediately', async () => {
+    const handledErrors: unknown[] = [];
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ErrorHandler,
+          useClass: class extends ErrorHandler {
+            override handleError(error: unknown): void {
+              handledErrors.push(error);
+            }
+          },
+        },
+      ],
+    });
+
+    @Component({template: '{{res.value()}}'})
+    class TestComponent {
+      res = rxResource({stream: () => EMPTY});
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    // No manual `fixture.detectChanges()` here: that call would surface the
+    // error synchronously to the test itself. Reading an errored resource
+    // from a template during an app-triggered (scheduled) CD cycle is what
+    // routes the error to `ErrorHandler` instead, since nothing in user code
+    // is positioned to catch it — this is the actual failure mode reported
+    // in production.
+    //
+    // `TestBedApplicationErrorHandler` calls our `ErrorHandler` first and
+    // then still rejects the pending `whenStable()` promise with the same
+    // error (so tests don't silently swallow real bugs), so we expect the
+    // rejection here in addition to asserting our handler saw the error.
+    await expectAsync(fixture.whenStable()).toBeRejected();
+
+    expect(handledErrors.length).toBe(1);
+    expect((handledErrors[0] as Error).message).toContain(
+      'Resource completed before producing a value',
+    );
   });
 
   it('should report sync error synchronously (after tick) ', () => {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -154,7 +154,7 @@ export const enum RuntimeErrorCode {
 
   // resource() API errors
   MUST_PROVIDE_STREAM_OPTION = 990,
-  RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE = 991,
+  RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE = -991,
   INVALID_RESOURCE_CREATION_IN_PARAMS = 992,
 
   // Upper bounds for core runtime errors is 999


### PR DESCRIPTION
`RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE` had no guide, no JSDoc on `RxResourceOptions.stream`, and — since the code was positive rather than negative — could never get an auto-linked docs page even if one existed. Flip it to -991, add the NG0991 reference page, and document the "stream must emit a value or an error before completing" requirement on `stream`'s JSDoc and in the RxJS interop guide.

Also documents and tests that an unguarded template read of an errored resource's `.value()` propagates to the global `ErrorHandler`, and recommends guarding with `.hasValue()` as defense in depth.