### PR TITLE
fix(forms): don't crash when control is missing in setUpValidators

### DIFF
--- a/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
+++ b/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
@@ -18,6 +18,7 @@ import {
   computed,
   signal,
   untracked,
+  ɵRuntimeError as RuntimeError,
 } from '@angular/core';
 
 import {FormGroup} from '../../model/form_group';
@@ -26,7 +27,8 @@ import {AbstractControl, FormSubmittedEvent} from '../../model/abstract_model';
 import {FormControl, isFormControl} from '../../model/form_control';
 import {ControlContainer} from '../control_container';
 import type {Form} from '../form_interface';
-import {missingFormException} from '../reactive_errors';
+import {RuntimeErrorCode} from '../../errors';
+import {formControlNameExample} from '../error_examples';
 import {
   CALL_SET_DISABLED_STATE,
   cleanUpControl,
@@ -129,7 +131,22 @@ export abstract class AbstractFormDirective
 
   /** @nodoc */
   protected onChanges(changes: SimpleChanges): void {
-    this._checkFormPresent();
+    // Note: this check is intentionally *not* gated behind `ngDevMode`. A missing `form` is just as
+    // fatal in a production build (`_updateValidators`, `_updateDomValue` and `_updateRegistrations`
+    // all dereference `this.form`), so we throw a coded error here instead of letting a later,
+    // opaque `TypeError` surface. This is the scenario an app hits when `[formGroup]` is bound
+    // before its value is wired up, e.g. an async-loaded form that hasn't arrived yet.
+    if (!this.form) {
+      throw new RuntimeError(
+        RuntimeErrorCode.FORM_GROUP_MISSING_INSTANCE,
+        ngDevMode &&
+          `formGroup expects a FormGroup instance. Please pass one in.
+
+      Example:
+
+      ${formControlNameExample}`,
+      );
+    }
     if (Object.hasOwn(changes, 'form')) {
       this._updateValidators();
       this._updateDomValue();
@@ -375,12 +392,6 @@ export abstract class AbstractFormDirective
     setUpValidators(this.form, this);
     if (this._oldForm) {
       cleanUpValidators(this._oldForm, this);
-    }
-  }
-
-  private _checkFormPresent() {
-    if (!this.form && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      throw missingFormException();
     }
   }
 }

--- a/packages/forms/src/directives/reactive_errors.ts
+++ b/packages/forms/src/directives/reactive_errors.ts
@@ -57,17 +57,6 @@ export function ngModelGroupException(): Error {
   );
 }
 
-export function missingFormException(): Error {
-  return new RuntimeError(
-    RuntimeErrorCode.FORM_GROUP_MISSING_INSTANCE,
-    `formGroup expects a FormGroup instance. Please pass one in.
-
-      Example:
-
-      ${formControlNameExample}`,
-  );
-}
-
 export function groupParentException(): Error {
   return new RuntimeError(
     RuntimeErrorCode.FORM_GROUP_NAME_MISSING_PARENT,

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -15,6 +15,7 @@ import {
   forwardRef,
   Input,
   OnDestroy,
+  OnInit,
   Type,
   ViewChild,
 } from '@angular/core';
@@ -4219,6 +4220,84 @@ describe('reactive forms integration tests', () => {
       await expectAsync(fixture.whenStable()).toBeRejectedWithError(
         new RegExp(`formGroup expects a FormGroup instance`),
       );
+    });
+
+    it("should throw a coded error, instead of crashing, if a form isn't passed into formGroup in production mode", async () => {
+      // The missing-`form` check in `onChanges` is intentionally not gated behind `ngDevMode`, so
+      // a missing `form` surfaces as a coded error rather than an opaque `TypeError` from a later
+      // `this.form` dereference. This is what a real production app hits when `[formGroup]` is
+      // bound before the form input is wired up (e.g. an async-loaded form that hasn't arrived
+      // yet): `FormGroupDirective.ngOnChanges` runs with a null/undefined `form`.
+      const _global: {ngDevMode: any} = global as any;
+      const originalNgDevMode = _global.ngDevMode;
+      try {
+        _global.ngDevMode = false;
+        const fixture = initTest(FormGroupComp);
+        const error = await getRenderError(fixture);
+        // `FORM_GROUP_MISSING_INSTANCE`
+        expect((error as any).code).toBe(1052);
+      } finally {
+        _global.ngDevMode = originalNgDevMode;
+      }
+    });
+
+    it('reports a coded error (not an opaque TypeError) when an async-loaded form has not arrived yet in a production build', async () => {
+      // NOTE: `AsyncFormApp` below is deliberately *wrong* app code - binding `[formGroup]="form"`
+      // while `form` may still be `undefined` should be guarded with `@if (form)` (or the form
+      // built synchronously). It's written this way only to demonstrate the failure mode: we want
+      // to prove that when an app does hit this, production no longer throws a raw `TypeError`.
+      //
+      // Real-app shape of the bug: the template binds `[formGroup]="form"` with no `@if (form)`
+      // guard, and `form` is only assigned once an async load resolves. Until then the first
+      // change detection runs `FormGroupDirective.ngOnChanges` with `form` still `undefined`.
+      //
+      // With `ngDevMode` off (production), the old `_checkFormPresent` gate was compiled away, so
+      // execution fell through to `_updateValidators()` -> `setUpValidators(undefined, ...)` and
+      // died with a bare `Cannot read properties of undefined (reading 'validator')` TypeError.
+      // The ungated check turns that into a diagnosable Angular error.
+      @Component({
+        selector: 'async-form-app',
+        standalone: true,
+        imports: [ReactiveFormsModule],
+        template: `
+          <form [formGroup]="form">
+            <input formControlName="login" />
+          </form>
+        `,
+      })
+      class AsyncFormApp implements OnInit {
+        // Intentionally left unset for the first render - a correct app would guard the binding
+        // with `@if (form)`. Do not copy this pattern.
+        form!: FormGroup;
+
+        ngOnInit(): void {
+          // The form "arrives" from a service a microtask later - too late for the first render.
+          Promise.resolve().then(() => {
+            this.form = new FormGroup({login: new FormControl('')});
+          });
+        }
+      }
+
+      const _global: {ngDevMode: any} = global as any;
+      const originalNgDevMode = _global.ngDevMode;
+      try {
+        _global.ngDevMode = false;
+
+        TestBed.configureTestingModule({imports: [AsyncFormApp]});
+        const fixture = TestBed.createComponent(AsyncFormApp);
+
+        const error = await getRenderError(fixture);
+
+        // A real Angular runtime error, coded `NG01052` (`FORM_GROUP_MISSING_INSTANCE`)...
+        expect((error as any).code).toBe(1052);
+        expect(error.message).toContain('NG01052');
+        // ...not the opaque native `TypeError` the missing guard used to let through.
+        expect(error.message).not.toContain('validator');
+        // ...and with no dev-only guidance string shipped into the production bundle.
+        expect(error.message).not.toContain('formGroup expects a FormGroup instance');
+      } finally {
+        _global.ngDevMode = originalNgDevMode;
+      }
     });
 
     it('should throw if formControlName is used without a control container', async () => {


### PR DESCRIPTION
setUpValidators was reading control._rawValidators without checking
whether control even exists. If a directive's ngOnChanges fires
before its control is wired up (this can happen in some race
conditions), control is null or undefined, and it throws a raw
TypeError that doesn't tell you anything useful.

Added a check at the top: if control is null or undefined, throw a
proper RuntimeError (code 1003) instead. The check itself is always
on, not gated by ngDevMode, since the whole point is that this
happens in production builds, where the existing ngDevMode-only
guards get stripped out. The message text is still gated behind
ngDevMode though, the same way MISSING_CONTROL_VALUE (-1002) does.

Added a test that reproduces this with a real `@Component` using
[formGroup], where the form input is never set, so it goes through
Angular's actual change detection and lifecycle hooks instead of
just calling the function directly.