### PR TITLE
fix(core): default the Component decorator to OnPush change detection in JIT

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -679,7 +679,7 @@ export interface Component extends Directive {
  */
 export const Component: ComponentDecorator = makeDecorator(
   'Component',
-  (c: Component = {}) => ({changeDetection: ChangeDetectionStrategy.Eager, ...c}),
+  (c: Component = {}) => ({changeDetection: ChangeDetectionStrategy.OnPush, ...c}),
   Directive,
   undefined,
   (type: Type<any>, meta: Component) => compileComponent(type, meta),

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -40,6 +40,7 @@ import {
   ViewChildren,
   ViewContainerRef,
 } from '../../src/core';
+import {getComponentDef} from '../../src/render3/def_getters';
 import {ComponentFixture, ComponentFixtureAutoDetect, TestBed} from '../../testing';
 
 describe('change detection', () => {
@@ -55,6 +56,21 @@ describe('change detection', () => {
       });
       TestBed.inject(ApplicationRef);
     }).not.toThrow();
+  });
+  it('defaults an unspecified changeDetection strategy to OnPush, matching the AOT compiler default', () => {
+    // The `@Component` decorator itself must default to OnPush, the same way the AOT
+    // compiler does (see `compileComponentFromMetadata` in
+    // packages/compiler/src/render3/view/compiler.ts). Before this fix, the JIT decorator
+    // in this file still defaulted to `ChangeDetectionStrategy.Eager`, so a component
+    // without an explicit `changeDetection` behaved differently under TestBed/JIT than in
+    // a production AOT build.
+    @Component({
+      selector: 'default-cd-comp',
+      template: '',
+    })
+    class DefaultCdComponent {}
+
+    expect(getComponentDef(DefaultCdComponent)!.onPush).toBe(true);
   });
   describe('embedded views', () => {
     @Directive({


### PR DESCRIPTION
## What's the problem

`@Component()` compiled in JIT (TestBed, Jest, etc.) still defaults `changeDetection` to `Eager`. The AOT compiler already defaults to `OnPush` — that changed in #67687. So a component with no `changeDetection` set behaves as `OnPush` in a real build but as `Eager` under TestBed. Tests don't exercise the same strategy the app ships with.

Found this while removing "redundant" explicit `OnPush` from a bunch of components after upgrading to v22 — one test broke, and only in JIT.

## Why it's still there

`packages/core/src/metadata/directives.ts` line 682 was never touched by #67687. It still hardcodes:

```ts
(c: Component = {}) => ({changeDetection: ChangeDetectionStrategy.Eager, ...c}),
```

There's actually a paper trail for this. The very TODO that anticipated the fix:

```diff
-  // TODO(jeanmeche): remove the ts-ignore when OnPush is the default
-  // @ts-ignore
```

was removed in `cf3b7fe489`, the same day #67687 merged — but only the comment/ts-ignore was removed, not the value it was pointing at. It's been `Eager` ever since (checked `main` and the latest published `22.1.2`).

## The fix

One line: `Eager` → `OnPush` in the decorator default, plus a regression test asserting `getComponentDef(...).onPush` for a component with no explicit `changeDetection`.

I couldn't run the full internal test suite here (no Bazel setup on my end), so this may well surface spec files elsewhere in the repo that quietly relied on the old JIT default — happy to help track those down if CI turns anything up.