### PR TITLE
fix(forms): support generic form filling by listening to change events

### DIFF
--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -91,6 +91,7 @@ export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>(
   // selector: '[ngModel],[formControl],[formControlName]',
   host: {
     '(input)': '_handleInput($any($event.target).value)',
+    '(change)': '_handleInput($any($event.target).value)',
     '(blur)': 'onTouched()',
     '(compositionstart)': '_compositionStart()',
     '(compositionend)': '_compositionEnd($any($event.target).value)',

--- a/packages/forms/src/directives/number_value_accessor.ts
+++ b/packages/forms/src/directives/number_value_accessor.ts
@@ -47,7 +47,11 @@ const NUMBER_VALUE_ACCESSOR: Provider = {
 @Directive({
   selector:
     'input[type=number]:not([ngNoCva])[formControlName],input[type=number]:not([ngNoCva])[formControl],input[type=number]:not([ngNoCva])[ngModel]',
-  host: {'(input)': 'onChange($any($event.target).value)', '(blur)': 'onTouched()'},
+  host: {
+    '(change)': 'onChange($any($event.target).value)',
+    '(input)': 'onChange($any($event.target).value)',
+    '(blur)': 'onTouched()',
+  },
   providers: [NUMBER_VALUE_ACCESSOR],
   standalone: false,
 })

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -738,6 +738,35 @@ describe('reactive forms integration tests', () => {
         ],
       });
     });
+
+    it('should update the control value when change event is dispatched (generic form filling)', async () => {
+      const fixture = initTest(FormControlComp);
+      const control = new FormControl('old');
+      fixture.componentInstance.control = control;
+      await fixture.whenStable();
+
+      const input = fixture.debugElement.query(By.css('input'));
+      input.nativeElement.value = 'new';
+      dispatchEvent(input.nativeElement, 'change');
+      await fixture.whenStable();
+
+      expect(control.value).toEqual('new');
+    });
+
+    it('should update the number control value when change event is dispatched (generic form filling)', async () => {
+      const fixture = initTest(MinMaxFormControlComp);
+      const control = new FormControl(1);
+      fixture.componentInstance.control = control;
+      fixture.componentInstance.form = new FormGroup({'control': control});
+      await fixture.whenStable();
+
+      const input = fixture.debugElement.query(By.css('input'));
+      input.nativeElement.value = '42';
+      dispatchEvent(input.nativeElement, 'change');
+      await fixture.whenStable();
+
+      expect(control.value).toEqual(42);
+    });
   });
 
   describe('programmatic changes', () => {


### PR DESCRIPTION
This PR resolves a longstanding issue where AI agents (like WebMCP tools, Puppeteer, Playwright) and some browser autofill extensions fail to update Angular form models when interacting with text inputs.

### The Problem
When standard automation scripts or generic form filling tools write to a text input (e.g., `element.value = 'test'`), they often dispatch a `change` event instead of an `input` event (or dispatch both). Because Angular's `DefaultValueAccessor` only listened to `(input)` and `(compositionend)`, these programmatic `change` events were ignored. Consequently, the DOM would update but the internal `FormControl` or `ngModel` would remain empty, breaking change detection and form validation.

### The Solution
We have added a `(change)` event listener to `DefaultValueAccessor`, mapping it to the existing `_handleInput` method. This aligns `DefaultValueAccessor` with how `SelectControlValueAccessor` and `CheckboxControlValueAccessor` already behave (which both listen to `change`). 

This simple fix ensures that Angular forms remain robust and accessible to AI agents and standard web automation without requiring custom WebMCP features for Reactive Forms.

### Testing
- Added an integration test in `reactive_integration_spec.ts` that specifically verifies `dispatchEvent(input, 'change')` successfully updates the control value.
- All existing forms tests pass, confirming that this addition does not break `updateOn: 'blur'` semantics or cause unexpected double-emission side effects.
