### PR TITLE
docs: add practical DOM XSS resource to security guide

### DIFF
--- a/adev/src/content/guide/security.md
+++ b/adev/src/content/guide/security.md
@@ -254,6 +254,8 @@ To learn more about troubleshooting Trusted Type configurations, the following r
 
 [Prevent DOM-based cross-site scripting vulnerabilities with Trusted Types](https://web.dev/trusted-types/#how-to-use-trusted-types)
 
+For a worked example that traces attacker-controlled sources to unsafe DOM sinks, see [DOM XSS prevention in JavaScript](https://frontendatlas.com/javascript/trivia/js-xss-dom-sinks).
+
 </docs-callout>
 
 ### Use the AOT template compiler


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the Angular guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Documentation content changes

## What is the current behavior?

The Community contributions callout links to a Trusted Types configuration guide but does not include an applied source-to-sink walkthrough.

Issue Number: N/A

## What is the new behavior?

Adds one public companion resource covering attacker-controlled sources, unsafe DOM sinks, safe DOM APIs, URL validation, sanitization, CSP, and Trusted Types.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Disclosure: I maintain FrontendAtlas and am proposing my own public resource.

Tests were not run; this is a one-line documentation-only link addition.