### PR TITLE
release: bump Angular DevTools version to 1.20.0

### DIFF
--- a/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
@@ -3,7 +3,7 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Chrome DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "minimum_chrome_version": "102",
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
@@ -3,7 +3,7 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Firefox DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "icons": {
     "16": "assets/icon16.png",


### PR DESCRIPTION
- fix(devtools): breadcrumbs missing nav arrows
- fix(devtools): clarify disabled View Source tooltip and update demo app
- fix(devtools): prevent duplicate highlightComponent listener in injector tree
- feat(devtools): implement persistent breakpoints on signal consumers using CDP