### PR TITLE
docs: release notes for the v20.3.29 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="20.3.29"></a>
+# 20.3.29 (2026-08-19)
+### platform-browser
+| Commit | Type | Description |
+| -- | -- | -- |
+| [7538744c10](https://github.com/angular/angular/commit/7538744c1048701d12e86e992704ea5fa13df4f4) | fix | disallow event handler attributes in Meta |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.2.21"></a>
 # 21.2.21 (2026-08-19)
 ### platform-browser


### PR DESCRIPTION
Cherry-picks the changelog from the "20.3.x" branch to the next branch (main).