### PR TITLE
fix(router): support multiple matrix parameter values

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -1067,14 +1067,10 @@ export type UrlMatchResult = {
 export class UrlSegment {
     constructor(
     path: string,
-    parameters: {
-        [name: string]: string;
-    });
+    parameters: Params);
     // (undocumented)
     get parameterMap(): ParamMap;
-    parameters: {
-        [name: string]: string;
-    };
+    parameters: Params;
     path: string;
     toString(): string;
 }

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -1067,10 +1067,14 @@ export type UrlMatchResult = {
 export class UrlSegment {
     constructor(
     path: string,
-    parameters: Params);
+    parameters: {
+        [name: string]: string | string[];
+    });
     // (undocumented)
     get parameterMap(): ParamMap;
-    parameters: Params;
+    parameters: {
+        [name: string]: string | string[];
+    };
     path: string;
     toString(): string;
 }

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -560,8 +560,8 @@ function createNewSegmentChildren(outlets: {[name: string]: readonly unknown[] |
   return children;
 }
 
-function stringify(params: Params): Params {
-  const res: Params = {};
+function stringify(params: Params): {[key: string]: string | string[]} {
+  const res: {[key: string]: string | string[]} = {};
   for (const [key, value] of Object.entries(params)) {
     res[key] = Array.isArray(value) ? value.map((item) => `${item}`) : `${value}`;
   }

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -560,9 +560,11 @@ function createNewSegmentChildren(outlets: {[name: string]: readonly unknown[] |
   return children;
 }
 
-function stringify(params: {[key: string]: any}): {[key: string]: string} {
-  const res: {[key: string]: string} = {};
-  Object.entries(params).forEach(([k, v]) => (res[k] = `${v}`));
+function stringify(params: Params): Params {
+  const res: Params = {};
+  for (const [key, value] of Object.entries(params)) {
+    res[key] = Array.isArray(value) ? value.map((item) => `${item}`) : `${value}`;
+  }
   return res;
 }
 

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -383,7 +383,7 @@ export class UrlSegment {
     public path: string,
 
     /** The matrix parameters associated with a segment */
-    public parameters: Params,
+    public parameters: {[name: string]: string | string[]},
   ) {}
 
   get parameterMap(): ParamMap {
@@ -582,7 +582,7 @@ export function serializePath(path: UrlSegment): string {
   return `${encodeUriSegment(path.path)}${serializeMatrixParams(path.parameters)}`;
 }
 
-function serializeMatrixParams(params: Params): string {
+function serializeMatrixParams(params: {[key: string]: string | string[]}): string {
   return Object.entries(params)
     .map(([key, value]) => {
       return Array.isArray(value)
@@ -723,15 +723,15 @@ class UrlParser {
     return new UrlSegment(decode(path), this.parseMatrixParams());
   }
 
-  private parseMatrixParams(): Params {
-    const params: Params = {};
+  private parseMatrixParams(): {[key: string]: string | string[]} {
+    const params: {[key: string]: string | string[]} = {};
     while (this.consumeOptional(';')) {
       this.parseParam(params);
     }
     return params;
   }
 
-  private parseParam(params: Params): void {
+  private parseParam(params: {[key: string]: string | string[]}): void {
     const key = matchMatrixKeySegments(this.remaining);
     if (!key) {
       return;
@@ -746,19 +746,7 @@ class UrlParser {
       }
     }
 
-    const decodedKey = decode(key);
-    const decodedVal = decode(value);
-
-    if (Object.hasOwn(params, decodedKey)) {
-      let currentVal = params[decodedKey];
-      if (!Array.isArray(currentVal)) {
-        currentVal = [currentVal];
-        params[decodedKey] = currentVal;
-      }
-      currentVal.push(decodedVal);
-    } else {
-      params[decodedKey] = decodedVal;
-    }
+    appendParam(params, decode(key), decode(value));
   }
 
   // Parse a single query parameter `name[=value]`
@@ -777,21 +765,7 @@ class UrlParser {
       }
     }
 
-    const decodedKey = decodeQuery(key);
-    const decodedVal = decodeQuery(value);
-
-    if (Object.hasOwn(params, decodedKey)) {
-      // Append to existing values
-      let currentVal = params[decodedKey];
-      if (!Array.isArray(currentVal)) {
-        currentVal = [currentVal];
-        params[decodedKey] = currentVal;
-      }
-      currentVal.push(decodedVal);
-    } else {
-      // Create a new value
-      params[decodedKey] = decodedVal;
-    }
+    appendParam(params, decodeQuery(key), decodeQuery(value));
   }
 
   // parse `(a/b//outlet_name:c/d)`
@@ -857,6 +831,19 @@ class UrlParser {
         (typeof ngDevMode === 'undefined' || ngDevMode) && `Expected "${str}".`,
       );
     }
+  }
+}
+
+function appendParam(params: Params, key: string, value: string): void {
+  if (Object.hasOwn(params, key)) {
+    let currentVal = params[key];
+    if (!Array.isArray(currentVal)) {
+      currentVal = [currentVal];
+      params[key] = currentVal;
+    }
+    currentVal.push(value);
+  } else {
+    params[key] = value;
   }
 }
 

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -383,7 +383,7 @@ export class UrlSegment {
     public path: string,
 
     /** The matrix parameters associated with a segment */
-    public parameters: {[name: string]: string},
+    public parameters: Params,
   ) {}
 
   get parameterMap(): ParamMap {
@@ -582,9 +582,13 @@ export function serializePath(path: UrlSegment): string {
   return `${encodeUriSegment(path.path)}${serializeMatrixParams(path.parameters)}`;
 }
 
-function serializeMatrixParams(params: {[key: string]: string}): string {
+function serializeMatrixParams(params: Params): string {
   return Object.entries(params)
-    .map(([key, value]) => `;${encodeUriSegment(key)}=${encodeUriSegment(value)}`)
+    .map(([key, value]) => {
+      return Array.isArray(value)
+        ? value.map((item) => `;${encodeUriSegment(key)}=${encodeUriSegment(item)}`).join('')
+        : `;${encodeUriSegment(key)}=${encodeUriSegment(value)}`;
+    })
     .join('');
 }
 
@@ -719,15 +723,15 @@ class UrlParser {
     return new UrlSegment(decode(path), this.parseMatrixParams());
   }
 
-  private parseMatrixParams(): {[key: string]: string} {
-    const params: {[key: string]: string} = {};
+  private parseMatrixParams(): Params {
+    const params: Params = {};
     while (this.consumeOptional(';')) {
       this.parseParam(params);
     }
     return params;
   }
 
-  private parseParam(params: {[key: string]: string}): void {
+  private parseParam(params: Params): void {
     const key = matchMatrixKeySegments(this.remaining);
     if (!key) {
       return;
@@ -742,7 +746,19 @@ class UrlParser {
       }
     }
 
-    params[decode(key)] = decode(value);
+    const decodedKey = decode(key);
+    const decodedVal = decode(value);
+
+    if (Object.hasOwn(params, decodedKey)) {
+      let currentVal = params[decodedKey];
+      if (!Array.isArray(currentVal)) {
+        currentVal = [currentVal];
+        params[decodedKey] = currentVal;
+      }
+      currentVal.push(decodedVal);
+    } else {
+      params[decodedKey] = decodedVal;
+    }
   }
 
   // Parse a single query parameter `name[=value]`

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -13,7 +13,7 @@ import {map} from 'rxjs/operators';
 import {PartialMatchRouteSnapshot, Route} from '../models';
 import {runCanMatchGuards} from '../operators/check_guards';
 import {ActivatedRouteSnapshot} from '../router_state';
-import {defaultUrlMatcher, Params, PRIMARY_OUTLET} from '../shared';
+import {defaultUrlMatcher, PRIMARY_OUTLET} from '../shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer} from '../url_tree';
 
 import {getOrCreateRouteInjectorIfNeeded, getOutlet} from './config';
@@ -22,7 +22,7 @@ export interface MatchResult {
   matched: boolean;
   consumedSegments: UrlSegment[];
   remainingSegments: UrlSegment[];
-  parameters: Params;
+  parameters: {[k: string]: string | string[]};
   positionalParamSegments: {[k: string]: UrlSegment};
 }
 

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -13,7 +13,7 @@ import {map} from 'rxjs/operators';
 import {PartialMatchRouteSnapshot, Route} from '../models';
 import {runCanMatchGuards} from '../operators/check_guards';
 import {ActivatedRouteSnapshot} from '../router_state';
-import {defaultUrlMatcher, PRIMARY_OUTLET} from '../shared';
+import {defaultUrlMatcher, Params, PRIMARY_OUTLET} from '../shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer} from '../url_tree';
 
 import {getOrCreateRouteInjectorIfNeeded, getOutlet} from './config';
@@ -22,7 +22,7 @@ export interface MatchResult {
   matched: boolean;
   consumedSegments: UrlSegment[];
   remainingSegments: UrlSegment[];
-  parameters: {[k: string]: string};
+  parameters: Params;
   positionalParamSegments: {[k: string]: UrlSegment};
 }
 

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -452,6 +452,24 @@ describe('createUrlTree', () => {
     expect(serializer.serialize(t)).toEqual('/a/b;aa=22;bb=33');
   });
 
+  it('should support matrix parameters with multiple values', async () => {
+    const p = serializer.parse('/a');
+    const t = await createRoot(p, ['/a', {m: ['v1', 'v2']}]);
+    const segment = t.root.children[PRIMARY_OUTLET].segments[0];
+
+    expect(segment.parameters).toEqual({m: ['v1', 'v2']});
+    expect(segment.parameterMap.get('m')).toEqual('v1');
+    expect(segment.parameterMap.getAll('m')).toEqual(['v1', 'v2']);
+    expect(serializer.serialize(t)).toEqual('/a;m=v1;m=v2');
+  });
+
+  it('should omit matrix parameters with empty arrays as values', async () => {
+    const p = serializer.parse('/a');
+    const t = await createRoot(p, ['/a', {m: [], n: 1}]);
+
+    expect(serializer.serialize(t)).toEqual('/a;n=1');
+  });
+
   it('should stringify matrix parameters', async () => {
     await router.navigateByUrl('/a');
     const relative = create(router.routerState.root.children[0], [{pp: 22}]);

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -159,11 +159,12 @@ describe('recognize', () => {
         {path: 'a', component: ComponentA, children: [{path: 'b', component: ComponentB}]},
         {path: 'c', component: ComponentC, outlet: 'left'},
       ],
-      'a;a1=11;a2=22/b;b1=111;b2=222(left:c;c1=1111;c2=2222)',
+      'a;a1=11;a2=22;a2=33/b;b1=111;b2=222(left:c;c1=1111;c2=2222)',
       'emptyOnly',
     );
     const c = s.root.children;
-    checkActivatedRoute(c[0], 'a', {a1: '11', a2: '22'}, ComponentA);
+    checkActivatedRoute(c[0], 'a', {a1: '11', a2: ['22', '33']}, ComponentA);
+    expect(c[0].paramMap.getAll('a2')).toEqual(['22', '33']);
     checkActivatedRoute(c[0].firstChild!, 'b', {b1: '111', b2: '222'}, ComponentB);
     checkActivatedRoute(c[1], 'c', {c1: '1111', c2: '2222'}, ComponentC, 'left');
   });

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -169,6 +169,24 @@ describe('url serializer', () => {
     expect(url.serialize(tree)).toEqual('/one;a=');
   });
 
+  it('should handle multiple matrix params of the same name as an array', () => {
+    const tree = url.parse('/one;a=foo;a=bar;a=swaz');
+    const segment = tree.root.children[PRIMARY_OUTLET].segments[0];
+
+    expect(segment.parameters).toEqual({a: ['foo', 'bar', 'swaz']});
+    expect(segment.parameterMap.get('a')).toEqual('foo');
+    expect(segment.parameterMap.getAll('a')).toEqual(['foo', 'bar', 'swaz']);
+    expect(url.serialize(tree)).toEqual('/one;a=foo;a=bar;a=swaz');
+  });
+
+  it('should preserve commas in matrix param values', () => {
+    const tree = url.parse('/one;a=foo,bar');
+    const segment = tree.root.children[PRIMARY_OUTLET].segments[0];
+
+    expect(segment.parameterMap.getAll('a')).toEqual(['foo,bar']);
+    expect(url.serialize(tree)).toEqual('/one;a=foo,bar');
+  });
+
   it('should parse query params (root)', () => {
     const tree = url.parse('/?a=1&b=2');
     expect(tree.root.children).toEqual({});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (the public API golden reflects the widened matrix parameter type; existing `ParamMap#getAll` documentation already covers multiple values)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Matrix parameters cannot retain multiple values. Creating a URL tree with an array-valued matrix parameter coerces the array to a comma-separated string, while parsing repeated matrix keys overwrites earlier values. As a result, `ParamMap#getAll()` returns only one value.

Issue Number: #19179

## What is the new behavior?

Array-valued matrix parameters are preserved when URL trees are created and serialized as repeated keys, for example `;m=v1;m=v2`. Repeated matrix keys are accumulated while parsing, allowing `ParamMap#getAll()` to return every value. A literal comma remains part of a single value and is not treated as a separator.

The public `UrlSegment.parameters` type is widened to `Params` to represent the already-supported scalar values as well as multiple values.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## Other information

Regression coverage was added for URL creation, parsing/serialization, empty arrays, literal commas, and route recognition through `ActivatedRouteSnapshot.paramMap`.

