### PR TITLE
fix(compiler-cli): retain metadata for strict standalone errors

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -516,6 +516,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
       this.jitDeclarationRegistry.jitDeclarations.add(node);
       return {};
     }
+    diagnostics = directiveResult.diagnostics;
 
     // Next, read the `@Component`-specific fields.
     const {

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -253,6 +253,7 @@ export class DirectiveDecoratorHandler implements DecoratorHandler<
     }
 
     return {
+      diagnostics: directiveResult.diagnostics,
       analysis: {
         inputs: directiveResult.inputs,
         inputFieldNamesFromMetadataArray: directiveResult.inputFieldNamesFromMetadataArray,

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -40,7 +40,12 @@ import {
 } from '@angular/compiler';
 import ts from 'typescript';
 
-import {ErrorCode, FatalDiagnosticError, makeRelatedInformation} from '../../../diagnostics';
+import {
+  ErrorCode,
+  FatalDiagnosticError,
+  makeDiagnostic,
+  makeRelatedInformation,
+} from '../../../diagnostics';
 import {
   assertSuccessfulReferenceEmit,
   ImportedSymbolsTracker,
@@ -151,6 +156,7 @@ export function extractDirectiveMetadata(
       rawHostDirectives: ts.Expression | null;
       inputFieldNamesFromMetadataArray: Set<string>;
       hostBindingNodes: HostBindingNodes;
+      diagnostics: ts.Diagnostic[] | undefined;
     }
   | {jitForced: true} {
   let directive: Map<string, ts.Expression>;
@@ -372,6 +378,7 @@ export function extractDirectiveMetadata(
     );
 
   let isStandalone = implicitStandaloneValue;
+  let diagnostics: ts.Diagnostic[] | undefined;
   if (directive.has('standalone')) {
     const expr = directive.get('standalone')!;
     const resolved = evaluator.evaluate(expr);
@@ -381,11 +388,13 @@ export function extractDirectiveMetadata(
     isStandalone = resolved;
 
     if (!isStandalone && strictStandalone) {
-      throw new FatalDiagnosticError(
-        ErrorCode.NON_STANDALONE_NOT_ALLOWED,
-        expr,
-        `Only standalone components/directives are allowed when 'strictStandalone' is enabled.`,
-      );
+      diagnostics = [
+        makeDiagnostic(
+          ErrorCode.NON_STANDALONE_NOT_ALLOWED,
+          expr,
+          `Only standalone components/directives are allowed when 'strictStandalone' is enabled.`,
+        ),
+      ];
     }
   }
   let isSignal = false;
@@ -471,6 +480,7 @@ export function extractDirectiveMetadata(
     hostDirectives,
     rawHostDirectives,
     hostBindingNodes,
+    diagnostics,
     // Track inputs from class metadata. This is useful for migration efforts.
     inputFieldNamesFromMetadataArray: new Set(
       Object.values(inputsFromMeta).map((i) => i.classPropertyName),

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/compiler';
 import ts from 'typescript';
 
-import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
+import {ErrorCode, FatalDiagnosticError, makeDiagnostic} from '../../diagnostics';
 import {Reference} from '../../imports';
 import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {MetadataRegistry, MetaKind} from '../../metadata';
@@ -157,6 +157,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<
     let pipeNameExpr: ts.Expression | null = null;
     let pure = true;
     let isStandalone = this.implicitStandaloneValue;
+    let diagnostics: ts.Diagnostic[] | undefined;
 
     if (meta !== null) {
       if (!ts.isObjectLiteralExpression(meta)) {
@@ -204,16 +205,19 @@ export class PipeDecoratorHandler implements DecoratorHandler<
         isStandalone = resolved;
 
         if (!isStandalone && this.strictStandalone) {
-          throw new FatalDiagnosticError(
-            ErrorCode.NON_STANDALONE_NOT_ALLOWED,
-            expr,
-            `Only standalone pipes are allowed when 'strictStandalone' is enabled.`,
-          );
+          diagnostics = [
+            makeDiagnostic(
+              ErrorCode.NON_STANDALONE_NOT_ALLOWED,
+              expr,
+              `Only standalone pipes are allowed when 'strictStandalone' is enabled.`,
+            ),
+          ];
         }
       }
     }
 
     return {
+      diagnostics,
       analysis: {
         meta: {
           name,

--- a/packages/compiler-cli/test/ngtsc/standalone_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/standalone_spec.ts
@@ -1143,6 +1143,38 @@ runInEachFileSystem(() => {
       expect(diags[0].messageText).toContain('component');
     });
 
+    it('should retain metadata for non-standalone declarations', () => {
+      env.write(
+        'app.ts',
+        `
+        import {Component, NgModule, Pipe, PipeTransform} from '@angular/core';
+
+        @Component({selector: 'legacy-cmp', standalone: false, template: ''})
+        export class LegacyCmp {}
+
+        @Pipe({name: 'legacy', standalone: false})
+        export class LegacyPipe implements PipeTransform {
+          transform(value: unknown): unknown { return value; }
+        }
+
+        @NgModule({
+          declarations: [LegacyCmp, LegacyPipe],
+          exports: [LegacyCmp, LegacyPipe],
+        })
+        export class LegacyModule {}
+
+        @Component({imports: [LegacyModule], template: '<legacy-cmp />{{value | legacy}}'})
+        export class TestCmp { value = ''; }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.map((diag) => diag.code)).toEqual([
+        ngErrorCode(ErrorCode.NON_STANDALONE_NOT_ALLOWED),
+        ngErrorCode(ErrorCode.NON_STANDALONE_NOT_ALLOWED),
+      ]);
+    });
+
     it('should not allow a non-standalone directive', () => {
       env.write(
         'app.ts',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (not applicable: this does not change the public API or the documented `strictStandalone` semantics)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When `strictStandalone` encounters an explicit `standalone: false` component, directive, or pipe, analysis stops with a fatal diagnostic. The declaration's metadata is therefore not registered. This prevents the language service from resolving legacy declarations imported through an NgModule and also produces cascading diagnostics such as NG6001 and NG6003.

Issue Number: #60035

## What is the new behavior?

The required NG2023 error remains an error, but it is reported as a non-fatal analysis diagnostic. Angular can continue registering the declaration metadata, so imported legacy NgModules remain understandable to the language service and unrelated cascading diagnostics are avoided.

The same behavior is applied consistently to components, directives, and pipes. A regression test verifies that a standalone component can still resolve a legacy component and pipe through an NgModule while only the two expected NG2023 diagnostics are reported.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified against the issue reproduction with Angular 22.2.0-next.3. Before the fix, compilation reports NG2023 followed by NG6001 and NG6003; with the patched compiler it reports only NG2023. The complete standalone compiler test suite passes (160 specs across Angular's file-system variants).

