### PR TITLE
fix(core): namespace resource TransferState keys

### DIFF
--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -157,6 +157,8 @@ const userResource = resource({
 
 The `id` value must be unique within your application and identical on the server and the client so that Angular can match the cached entry to the resource that requested it.
 
+Angular creates a namespaced `TransferState` key for each resource `id`. Use `id` only to identify the resource. Do not pass it to `makeStateKey` or access the resource's `TransferState` entry directly.
+
 IMPORTANT: Because the cached value is serialized into the page's HTML, avoid setting `id` on resources that load data specific to the user who triggered the server-side render, especially if the rendered HTML can be cached or shared between users.
 
 ## Chaining resources
@@ -252,9 +254,7 @@ function withPreviousValue<T>(input: Resource<T>): Resource<T> {
   return resourceFromSnapshots(derived);
 }
 
-@Component({
-  /*... */
-})
+@Component({/*... */})
 export class AwesomeProfile {
   userId = input.required<number>();
   user = withPreviousValue(httpResource(() => `/user/${this.userId()}`));

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -16,6 +16,7 @@ import {
   PLATFORM_ID,
   TransferState,
   makeStateKey,
+  resource,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {useAutoTick, timeout, withBody} from '@angular/private/testing';
@@ -172,6 +173,38 @@ describe('TransferCache', () => {
 
       expect(firstNext).toHaveBeenCalledTimes(1);
       expect(secondNext).not.toHaveBeenCalled();
+    });
+
+    it('should isolate resource cache entries from HTTP transfer cache keys', async () => {
+      configureInterceptor();
+      const request = new HttpRequest('GET', '/api/policy');
+      const cacheKey = generateHash(['GET', 'json', '/api/policy', '', ''].join('\0'));
+      const forgedResponse = {
+        [BODY]: {allowed: true},
+        [HEADERS]: {},
+        [STATUS]: 200,
+        [STATUS_TEXT]: 'OK',
+        [REQ_URL]: '/api/policy',
+        [RESPONSE_TYPE]: 'json',
+      };
+      const next = jasmine
+        .createSpy('next')
+        .and.returnValue(of(new HttpResponse({body: {allowed: false}})));
+      const previousServerMode = globalThis['ngServerMode'];
+      globalThis['ngServerMode'] = true;
+
+      try {
+        const collidingResource = TestBed.runInInjectionContext(() =>
+          resource({id: cacheKey, loader: async () => forgedResponse}),
+        );
+        await TestBed.inject(ApplicationRef).whenStable();
+
+        expect(collidingResource.value()).toBe(forgedResponse);
+        expect(runInterceptor(request, next).body).toEqual({allowed: false});
+        expect(next).toHaveBeenCalledTimes(1);
+      } finally {
+        globalThis['ngServerMode'] = previousServerMode;
+      }
     });
 
     it('should not cache responses with Cache-Control: no-store', () => {

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -203,13 +203,13 @@ describe('rxResource()', () => {
     });
 
     it('should read from TransferState if a key is present', async () => {
-      const key = makeStateKey<number>('test-key');
+      const key = makeStateKey<number>('ng-resource:test-key');
       transferState.set(key, 123);
 
       const injector = TestBed.inject(Injector);
       const testResource = rxResource({
         stream: () => of(456),
-        id: key,
+        id: 'test-key',
         injector,
       });
 
@@ -239,7 +239,7 @@ describe('rxResource()', () => {
 
       expect(testResource.status()).toBe('resolved');
       expect(testResource.value()).toBe(789);
-      expect(transferState.get(key, null!)).toBe(789);
+      expect(transferState.get(makeStateKey<number>(`ng-resource:${key}`), null!)).toBe(789);
     });
 
     it('should write to TransferState on server when resolved (async)', async () => {
@@ -264,7 +264,7 @@ describe('rxResource()', () => {
       await waitFor(() => testResource.status() === 'resolved');
 
       expect(testResource.value()).toBe(101112);
-      expect(transferState.get(key, null!)).toBe(101112);
+      expect(transferState.get(makeStateKey<number>(`ng-resource:${key}`), null!)).toBe(101112);
     });
 
     it('should not write to TransferState on client when resolved', async () => {
@@ -282,7 +282,7 @@ describe('rxResource()', () => {
 
       expect(testResource.status()).toBe('resolved');
       expect(testResource.value()).toBe(131415);
-      expect(transferState.hasKey(key)).toBeFalse();
+      expect(transferState.hasKey(makeStateKey(`ng-resource:${key}`))).toBeFalse();
     });
   });
 

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -34,7 +34,7 @@ import {CACHE_ACTIVE} from '../hydration/cache';
 import {DestroyRef} from '../linker/destroy_ref';
 import {PendingTasks} from '../pending_tasks';
 import {linkedSignal} from '../render3/reactivity/linked_signal';
-import {StateKey, TransferState} from '../transfer_state';
+import {makeStateKey, StateKey, TransferState} from '../transfer_state';
 
 /**
  * Constructs a `Resource` that projects a reactive request to an asynchronous operation defined by
@@ -80,7 +80,7 @@ export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | 
     options.equal ? wrapEqualityFn(options.equal) : undefined,
     options.debugName,
     options.injector ?? inject(Injector),
-    options.id as StateKey<T>,
+    options.id ? makeStateKey<T>(`ng-resource:${options.id}`) : undefined,
   );
 }
 

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -1132,12 +1132,13 @@ describe('with TransferState', () => {
   });
 
   it('should read from TransferState if a key is present', async () => {
-    const key = makeStateKey<number>('test-key');
+    const key = makeStateKey<number>('ng-resource:test-key');
     transferState.set(key, 123);
+    transferState.set(makeStateKey<number>('test-key'), 999);
 
     const testResource = resource({
       loader: async () => 456,
-      id: key,
+      id: 'test-key',
       injector: TestBed.inject(Injector),
     });
 
@@ -1166,7 +1167,24 @@ describe('with TransferState', () => {
 
     expect(testResource.status()).toBe('resolved');
     expect(testResource.value()).toBe(789);
-    expect(transferState.get(makeStateKey<number>(key), null!)).toBe(789);
+    expect(transferState.get(makeStateKey<number>(`ng-resource:${key}`), null!)).toBe(789);
+    (globalThis as any).ngServerMode = undefined;
+  });
+
+  it('should namespace IDs that name Object prototype properties', async () => {
+    (globalThis as any).ngServerMode = true;
+
+    const testResource = resource({
+      loader: async () => 123,
+      id: '__proto__',
+      injector: TestBed.inject(Injector),
+    });
+
+    await flushMicrotasks();
+
+    expect(testResource.value()).toBe(123);
+    expect(transferState.get(makeStateKey<number>('ng-resource:__proto__'), null!)).toBe(123);
+    expect(transferState.hasKey(makeStateKey('__proto__'))).toBeFalse();
     (globalThis as any).ngServerMode = undefined;
   });
 
@@ -1183,6 +1201,6 @@ describe('with TransferState', () => {
 
     expect(testResource.status()).toBe('resolved');
     expect(testResource.value()).toBe(101112);
-    expect(transferState.hasKey(makeStateKey(key))).toBeFalse();
+    expect(transferState.hasKey(makeStateKey(`ng-resource:${key}`))).toBeFalse();
   });
 });


### PR DESCRIPTION
Prefix resource and rxResource TransferState keys so user-controlled IDs cannot overlap deterministic HttpTransferCache hashes.
 