### PR TITLE
feat(forms): add custom equality function for signal forms

### DIFF
--- a/adev/src/content/guide/forms/signals/form-logic.md
+++ b/adev/src/content/guide/forms/signals/form-logic.md
@@ -372,6 +372,26 @@ All three skip validation and prevent user editing while active. The key differe
 | Users can focus/select           | No         | No           | Yes          |
 | Included in HTML form submission | No         | No           | Yes          |
 
+## Custom equality
+
+Signal Forms use reference equality for object values by default. Use `equality()` to provide a
+custom comparator when two different object instances represent the same value. This is useful for
+types such as `Temporal.PlainDate`:
+
+```ts
+import {signal} from '@angular/core';
+import {form, equality} from '@angular/forms/signals';
+
+const model = signal({date: Temporal.Now.plainDateISO()});
+const profileForm = form(model, (schemaPath) => {
+  equality(schemaPath.date, (a, b) => a.equals(b));
+});
+```
+
+With this configuration, setting `profileForm.date().value` to another `PlainDate` with the same
+date does not replace the current value or notify dependent signals. Values that the comparator
+considers different are applied normally.
+
 ## Delay input operations with `debounce()`
 
 The `debounce()` rule delays updating the form model. This is useful for performance optimization and reducing unnecessary operations during rapid input.

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -129,6 +129,12 @@ export class EmailValidationError extends BaseNgValidationError {
 }
 
 // @public
+export const EQUALITY: MetadataKey<Signal<((a: any, b: any) => boolean) | undefined>, (a: any, b: any) => boolean, ((a: any, b: any) => boolean) | undefined>;
+
+// @public
+export function equality<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, logic: (a: TValue, b: TValue) => boolean): void;
+
+// @public
 export type Field<TValue, TKey extends string | number = string | number> = () => FieldState<TValue, TKey>;
 
 // @public

--- a/packages/forms/signals/src/api/rules/equality.ts
+++ b/packages/forms/signals/src/api/rules/equality.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {FieldPathNode} from '../../schema/path_node';
+import {assertPathIsCurrent} from '../../schema/schema';
+import type {PathKind, SchemaPath, SchemaPathRules} from '../types';
+
+/**
+ * Adds logic to a field to set a custom equality function for change detection.
+ *
+ * This is useful for types where reference equality doesn't work, such as immutable objects
+ * (e.g., `Temporal.PlainDate`). The equality function will be used by the field's value signal
+ * to determine if a new value is considered different from the previous value.
+ *
+ * @param path The target path to add the equality logic to.
+ * @param logic A function that takes two values and returns `true` if they are considered equal.
+ * @template TValue The type of value stored in the field the logic is bound to.
+ * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @see [Custom equality](guide/forms/signals/form-logic#custom-equality)
+ *
+ * @category logic
+ * @publicApi 22.0
+ */
+export function equality<TValue, TPathKind extends PathKind = PathKind.Root>(
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  logic: (a: TValue, b: TValue) => boolean,
+): void {
+  assertPathIsCurrent(path);
+
+  const pathNode = FieldPathNode.unwrapFieldPath(path);
+  pathNode.builder.addEqualityRule(() => logic);
+}

--- a/packages/forms/signals/src/api/rules/index.ts
+++ b/packages/forms/signals/src/api/rules/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './disabled';
+export * from './equality';
 export * from './hidden';
 export * from './metadata';
 export * from './readonly';

--- a/packages/forms/signals/src/api/rules/metadata.ts
+++ b/packages/forms/signals/src/api/rules/metadata.ts
@@ -7,9 +7,30 @@
  */
 
 import {type Signal} from '@angular/core';
+import {
+  createMetadataKey,
+  IS_ASYNC_VALIDATION_RESOURCE,
+  type LimitKey,
+  type LimitSelectionKey,
+  MetadataKey,
+  MetadataReducer,
+  type MetadataSetterType,
+} from '../../schema/metadata';
+import {EQUALITY} from '../../schema/logic_node';
 import {FieldPathNode} from '../../schema/path_node';
 import {assertPathIsCurrent} from '../../schema/schema';
 import type {FieldState, LogicFn, PathKind, SchemaPath, SchemaPathRules} from '../types';
+
+export {
+  createMetadataKey,
+  EQUALITY,
+  IS_ASYNC_VALIDATION_RESOURCE,
+  type LimitKey,
+  type LimitSelectionKey,
+  MetadataKey,
+  MetadataReducer,
+  type MetadataSetterType,
+};
 
 /**
  * Sets a value for the {@link MetadataKey} for this field.
@@ -50,211 +71,6 @@ export function metadata<
   const pathNode = FieldPathNode.unwrapFieldPath(path);
   pathNode.builder.addMetadataRule(key, logic);
   return key;
-}
-
-/**
- * A reducer that determines the accumulated value for a metadata key by reducing the individual
- * values contributed from `metadata()` rules.
- *
- * @template TAcc The accumulated type of the reduce operation.
- * @template TItem The type of the individual items that are reduced over.
- *
- * @see [Combining contributions with reducers](guide/forms/signals/field-metadata#combining-contributions-with-reducers)
- *
- * @publicApi 22.0
- */
-export interface MetadataReducer<TAcc, TItem> {
-  /** The reduce function. */
-  reduce: (acc: TAcc, item: TItem) => TAcc;
-  /** Gets the initial accumulated value. */
-  getInitial: () => TAcc;
-}
-export const MetadataReducer = {
-  /** Creates a reducer that accumulates a list of its individual item values. */
-  list<TItem>(): MetadataReducer<TItem[], TItem | undefined> {
-    return {
-      reduce: (acc, item) => (item === undefined ? acc : [...acc, item]),
-      getInitial: () => [],
-    };
-  },
-
-  /** Creates a reducer that accumulates the min of its individual item values. */
-  min<T extends Date | number>(): MetadataReducer<T | undefined, T | undefined> {
-    return {
-      reduce: (acc, item) => {
-        if (acc === undefined || item === undefined) {
-          return acc ?? item;
-        }
-        return item < acc ? item : acc;
-      },
-      getInitial: () => undefined,
-    };
-  },
-
-  /** Creates a reducer that accumulates a the max of its individual item values. */
-  max<T extends Date | number>(): MetadataReducer<T | undefined, T | undefined> {
-    return {
-      reduce: (acc, item) => {
-        if (acc === undefined || item === undefined) {
-          return acc ?? item;
-        }
-        return item > acc ? item : acc;
-      },
-      getInitial: () => undefined,
-    };
-  },
-
-  /** Creates a reducer that logically or's its accumulated value with each individual item value. */
-  or(): MetadataReducer<boolean, boolean> {
-    return {
-      reduce: (prev, next) => prev || next,
-      getInitial: () => false,
-    };
-  },
-
-  /** Creates a reducer that logically and's its accumulated value with each individual item value. */
-  and(): MetadataReducer<boolean, boolean> {
-    return {
-      reduce: (prev, next) => prev && next,
-      getInitial: () => true,
-    };
-  },
-
-  /** Creates a reducer that always takes the next individual item value as the accumulated value. */
-  override,
-} as const;
-
-function override<T>(): MetadataReducer<T | undefined, T>;
-function override<T>(getInitial: () => T): MetadataReducer<T, T>;
-function override<T>(getInitial?: () => T): MetadataReducer<T | undefined, T> {
-  return {
-    reduce: (_, item) => item,
-    getInitial: () => getInitial?.(),
-  };
-}
-
-/**
- * A symbol used to tag a `MetadataKey` as representing an asynchronous validation resource.
- *
- * @see [Async validation](guide/forms/signals/validation#async-validation)
- *
- * @category validation
- * @publicApi 22.0
- */
-export const IS_ASYNC_VALIDATION_RESOURCE: unique symbol = Symbol('IS_ASYNC_VALIDATION_RESOURCE');
-
-/**
- * Represents metadata that is aggregated from multiple parts according to the key's reducer
- * function. A value can be contributed to the aggregated value for a field using an
- * `metadata` rule in the schema. There may be multiple rules in a schema that contribute
- * values to the same `MetadataKey` of the same field.
- *
- * @template TRead The type read from the `FieldState` for this key
- * @template TWrite The type written to this key using the `metadata()` rule
- * @template TAcc The type of the reducer's accumulated value.
- *
- * @see [Field metadata](guide/forms/signals/field-metadata)
- *
- * @publicApi 22.0
- */
-export class MetadataKey<TRead, TWrite, TAcc> {
-  private brand!: (write: TWrite) => [TRead, TAcc];
-
-  /** @internal */
-  [IS_ASYNC_VALIDATION_RESOURCE]?: true;
-
-  /** Use {@link createMetadataKey}. */
-  protected constructor(
-    readonly reducer: MetadataReducer<TAcc, TWrite>,
-    readonly create: ((state: FieldState<unknown>, data: Signal<TAcc>) => TRead) | undefined,
-  ) {}
-}
-
-/**
- * Represents metadata that is used to define a valid limit for a field.
- *
- * @template TLimit The type the limit value.
- *
- * @see [Validation constraints](guide/forms/signals/custom-controls#validation-constraints)
- *
- * @publicApi 22.0
- */
-export type LimitKey<TLimit> = MetadataKey<
-  Signal<NonNullable<TLimit> | undefined>,
-  NonNullable<TLimit> | undefined,
-  NonNullable<TLimit> | undefined
->;
-
-/**
- * A symbol used to tag a `MetadataKey` as representing a limit selection key.
- */
-declare const LIMIT_SELECTION_KEY: unique symbol;
-
-/**
- * Used to select a {@link LimitKey}.
- *
- * This indirection allows rules to bind a {@link LimitKey} of a specific limit type (e.g. `number`
- * or `Date`) matching the field's type to a generic {@link MetadataKey}.
- *
- * @see [Validation constraints](guide/forms/signals/custom-controls#validation-constraints)
- *
- * @publicApi 22.0
- */
-export type LimitSelectionKey = MetadataKey<
-  Signal<LimitKey<unknown> | undefined>,
-  LimitKey<unknown>,
-  LimitKey<unknown> | undefined
-> & {
-  [LIMIT_SELECTION_KEY]: true;
-};
-
-/**
- * Extracts the the type that can be set into the given metadata key type using the `metadata()` rule.
- *
- * @template TKey The `MetadataKey` type
- *
- * @see [Field metadata](guide/forms/signals/field-metadata)
- *
- * @publicApi 22.0
- */
-export type MetadataSetterType<TKey> =
-  TKey extends MetadataKey<any, infer TWrite, any> ? TWrite : never;
-
-/**
- * Creates a metadata key used to contain a computed value.
- * The last value set on a given field tree node overrides any previously set values.
- *
- * @template TWrite The type written to this key using the `metadata()` rule
- *
- * @see [Creating a metadata key](guide/forms/signals/field-metadata#creating-a-metadata-key)
- *
- * @publicApi 22.0
- */
-export function createMetadataKey<TWrite>(): MetadataKey<
-  Signal<TWrite | undefined>,
-  TWrite,
-  TWrite | undefined
->;
-/**
- * Creates a metadata key used to contain a computed value.
- *
- * @param reducer The reducer used to combine individually set values into the final computed value.
- * @template TWrite The type written to this key using the `metadata()` rule
- * @template TAcc The type of the reducer's accumulated value.
- *
- * @see [Creating a metadata key](guide/forms/signals/field-metadata#creating-a-metadata-key)
- *
- * @publicApi 22.0
- */
-export function createMetadataKey<TWrite, TAcc>(
-  reducer: MetadataReducer<TAcc, TWrite>,
-): MetadataKey<Signal<TAcc>, TWrite, TAcc>;
-export function createMetadataKey<TWrite, TAcc>(
-  reducer?: MetadataReducer<TAcc, TWrite>,
-): MetadataKey<Signal<TAcc>, TWrite, TAcc> {
-  return new (MetadataKey as new (
-    reducer: MetadataReducer<TAcc, TWrite>,
-  ) => MetadataKey<Signal<TAcc>, TWrite, TAcc>)(reducer ?? MetadataReducer.override<any>());
 }
 
 /**
@@ -300,10 +116,12 @@ export function createManagedMetadataKey<TRead, TWrite, TAcc>(
   create: (state: FieldState<unknown>, data: Signal<TAcc>) => TRead,
   reducer?: MetadataReducer<TAcc, TWrite>,
 ): MetadataKey<TRead, TWrite, TAcc> {
-  return new (MetadataKey as new (
-    reducer: MetadataReducer<TAcc, TWrite>,
-    create: (state: FieldState<unknown>, data: Signal<TAcc>) => TRead,
-  ) => MetadataKey<TRead, TWrite, TAcc>)(reducer ?? MetadataReducer.override<any>(), create);
+  return new (
+    MetadataKey as new (
+      reducer: MetadataReducer<TAcc, TWrite>,
+      create: (state: FieldState<unknown>, data: Signal<TAcc>) => TRead,
+    ) => MetadataKey<TRead, TWrite, TAcc>
+  )(reducer ?? MetadataReducer.override<any>(), create);
 }
 
 /**

--- a/packages/forms/signals/src/field/structure.ts
+++ b/packages/forms/signals/src/field/structure.ts
@@ -23,6 +23,7 @@ import {LogicNode} from '../schema/logic_node';
 import type {FieldPathNode} from '../schema/path_node';
 import {deepSignal} from '../util/deep_signal';
 import {isArray, isObject} from '../util/type_guards';
+import {EQUALITY} from '../schema/logic_node';
 import type {FieldAdapter} from './field_adapter';
 import type {FormFieldManager} from './manager';
 import type {FieldNode, ParentFieldNode} from './node';
@@ -294,7 +295,18 @@ export abstract class FieldNodeStructure {
       computation: (
         value: unknown,
         previous: {source: unknown; value: ChildrenData | undefined} | undefined,
-      ): ChildrenData | undefined => this.computeChildrenMap(value, previous?.value, false),
+      ): ChildrenData | undefined => {
+        // Check if source changed using custom 'equality' function.
+        const equalityFn = this.node.metadata(EQUALITY)?.();
+        if (previous !== undefined && equalityFn) {
+          if (equalityFn(previous.source, value)) {
+            // Values are equal according to the 'equality' function, no update needed.
+            return previous.value;
+          }
+        }
+
+        return this.computeChildrenMap(value, previous?.value, false);
+      },
     });
   }
 
@@ -520,7 +532,11 @@ export class ChildFieldNodeStructure extends FieldNodeStructure {
 
     this.pathKeys = computed(() => [...parent.structure.pathKeys(), this.keyInParent()]);
 
-    this.value = deepSignal(this.parent.structure.value, this.keyInParent);
+    this.value = deepSignal(this.parent.structure.value, this.keyInParent, (a, b) => {
+      const equalityFn = this.node.metadata(EQUALITY)?.();
+      // Default signal equality when no custom comparator is configured.
+      return equalityFn ? equalityFn(a, b) : Object.is(a, b);
+    });
     this.childrenMap = this.createChildrenMap();
     this.fieldManager.structures.add(this);
   }

--- a/packages/forms/signals/src/schema/logic.ts
+++ b/packages/forms/signals/src/schema/logic.ts
@@ -7,12 +7,12 @@
  */
 
 import {untracked} from '@angular/core';
-import type {MetadataKey} from '../api/rules/metadata';
 import type {ValidationError} from '../api/rules/validation/validation_errors';
 import {DisabledReason, type FieldContext, type LogicFn, type SchemaPath} from '../api/types';
 import type {FieldNode} from '../field/node';
 import {cast} from '../field/util';
 import {isArray} from '../util/type_guards';
+import type {MetadataKey} from './metadata';
 
 /**
  * Special key which is used to represent a dynamic logic property in a `FieldPathNode` path.

--- a/packages/forms/signals/src/schema/logic_node.ts
+++ b/packages/forms/signals/src/schema/logic_node.ts
@@ -6,13 +6,27 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵRuntimeError as RuntimeError} from '@angular/core';
+import {ɵRuntimeError as RuntimeError, type Signal} from '@angular/core';
 import {RuntimeErrorCode} from '../errors';
-
-import type {MetadataKey, ValidationError} from '../api/rules';
+import type {ValidationError} from '../api/rules';
 import type {AsyncValidationResult, DisabledReason, LogicFn, ValidationResult} from '../api/types';
 import {setBoundPathDepthForResolution} from '../field/resolution';
 import {type BoundPredicate, DYNAMIC, LogicContainer, type Predicate} from './logic';
+import {createMetadataKey, type MetadataKey, MetadataReducer} from './metadata';
+
+/**
+ * A {@link MetadataKey} representing the custom equality function for the field.
+ *
+ * @see [Custom equality](guide/forms/signals/form-logic#custom-equality)
+ *
+ * @category logic
+ * @publicApi 22.0
+ */
+export const EQUALITY: MetadataKey<
+  Signal<((a: any, b: any) => boolean) | undefined>,
+  (a: any, b: any) => boolean,
+  ((a: any, b: any) => boolean) | undefined
+> = createMetadataKey(MetadataReducer.override());
 
 /**
  * Abstract base class for building a `LogicNode`.
@@ -46,6 +60,9 @@ export abstract class AbstractLogicNodeBuilder {
 
   /** Adds a rule to compute metadata for a field. */
   abstract addMetadataRule<M>(key: MetadataKey<unknown, M, unknown>, logic: LogicFn<any, M>): void;
+
+  /** Adds a rule to compute the equality function for a field. */
+  abstract addEqualityRule(logic: LogicFn<any, (a: any, b: any) => boolean>): void;
 
   /**
    * Gets a builder for a child node associated with the given property key.
@@ -136,6 +153,10 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
 
   override addMetadataRule<T>(key: MetadataKey<unknown, T, any>, logic: LogicFn<any, T>): void {
     this.getCurrent().addMetadataRule(key, logic);
+  }
+
+  override addEqualityRule(logic: LogicFn<any, (a: any, b: any) => boolean>): void {
+    this.getCurrent().addEqualityRule(logic);
   }
 
   override getChild(key: PropertyKey): LogicNodeBuilder {
@@ -274,6 +295,10 @@ class NonMergeableLogicNodeBuilder extends AbstractLogicNodeBuilder {
 
   override addMetadataRule<T>(key: MetadataKey<unknown, T, unknown>, logic: LogicFn<any, T>): void {
     this.logic.getMetadata(key).push(setBoundPathDepthForResolution(logic, this.depth));
+  }
+
+  override addEqualityRule(logic: LogicFn<any, (a: any, b: any) => boolean>): void {
+    this.logic.getMetadata(EQUALITY).push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
   override getChild(key: PropertyKey): LogicNodeBuilder {

--- a/packages/forms/signals/src/schema/metadata.ts
+++ b/packages/forms/signals/src/schema/metadata.ts
@@ -1,0 +1,217 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {type Signal} from '@angular/core';
+import type {FieldState} from '../api/types';
+
+/**
+ * A reducer that determines the accumulated value for a metadata key by reducing the individual
+ * values contributed from `metadata()` rules.
+ *
+ * @template TAcc The accumulated type of the reduce operation.
+ * @template TItem The type of the individual items that are reduced over.
+ *
+ * @see [Combining contributions with reducers](guide/forms/signals/field-metadata#combining-contributions-with-reducers)
+ *
+ * @publicApi 22.0
+ */
+export interface MetadataReducer<TAcc, TItem> {
+  /** The reduce function. */
+  reduce: (acc: TAcc, item: TItem) => TAcc;
+  /** Gets the initial accumulated value. */
+  getInitial: () => TAcc;
+}
+export const MetadataReducer = {
+  /** Creates a reducer that accumulates a list of its individual item values. */
+  list<TItem>(): MetadataReducer<TItem[], TItem | undefined> {
+    return {
+      reduce: (acc, item) => (item === undefined ? acc : [...acc, item]),
+      getInitial: () => [],
+    };
+  },
+
+  /** Creates a reducer that accumulates the min of its individual item values. */
+  min<T extends Date | number>(): MetadataReducer<T | undefined, T | undefined> {
+    return {
+      reduce: (acc, item) => {
+        if (acc === undefined || item === undefined) {
+          return acc ?? item;
+        }
+        return item < acc ? item : acc;
+      },
+      getInitial: () => undefined,
+    };
+  },
+
+  /** Creates a reducer that accumulates a the max of its individual item values. */
+  max<T extends Date | number>(): MetadataReducer<T | undefined, T | undefined> {
+    return {
+      reduce: (acc, item) => {
+        if (acc === undefined || item === undefined) {
+          return acc ?? item;
+        }
+        return item > acc ? item : acc;
+      },
+      getInitial: () => undefined,
+    };
+  },
+
+  /** Creates a reducer that logically or's its accumulated value with each individual item value. */
+  or(): MetadataReducer<boolean, boolean> {
+    return {
+      reduce: (prev, next) => prev || next,
+      getInitial: () => false,
+    };
+  },
+
+  /** Creates a reducer that logically and's its accumulated value with each individual item value. */
+  and(): MetadataReducer<boolean, boolean> {
+    return {
+      reduce: (prev, next) => prev && next,
+      getInitial: () => true,
+    };
+  },
+
+  /** Creates a reducer that always takes the next individual item value as the accumulated value. */
+  override,
+} as const;
+
+function override<T>(): MetadataReducer<T | undefined, T>;
+function override<T>(getInitial: () => T): MetadataReducer<T, T>;
+function override<T>(getInitial?: () => T): MetadataReducer<T | undefined, T> {
+  return {
+    reduce: (_, item) => item,
+    getInitial: () => getInitial?.(),
+  };
+}
+
+/**
+ * A symbol used to tag a `MetadataKey` as representing an asynchronous validation resource.
+ *
+ * @see [Async validation](guide/forms/signals/validation#async-validation)
+ *
+ * @category validation
+ * @publicApi 22.0
+ */
+export const IS_ASYNC_VALIDATION_RESOURCE: unique symbol = Symbol('IS_ASYNC_VALIDATION_RESOURCE');
+
+/**
+ * Represents metadata that is aggregated from multiple parts according to the key's reducer
+ * function. A value can be contributed to the aggregated value for a field using an
+ * `metadata` rule in the schema. There may be multiple rules in a schema that contribute
+ * values to the same `MetadataKey` of the same field.
+ *
+ * @template TRead The type read from the `FieldState` for this key
+ * @template TWrite The type written to this key using the `metadata()` rule
+ * @template TAcc The type of the reducer's accumulated value.
+ *
+ * @see [Field metadata](guide/forms/signals/field-metadata)
+ *
+ * @publicApi 22.0
+ */
+export class MetadataKey<TRead, TWrite, TAcc> {
+  private brand!: (write: TWrite) => [TRead, TAcc];
+
+  /** @internal */
+  [IS_ASYNC_VALIDATION_RESOURCE]?: true;
+
+  /** Use {@link createMetadataKey}. */
+  protected constructor(
+    readonly reducer: MetadataReducer<TAcc, TWrite>,
+    readonly create: ((state: FieldState<unknown>, data: Signal<TAcc>) => TRead) | undefined,
+  ) {}
+}
+
+/**
+ * Represents metadata that is used to define a valid limit for a field.
+ *
+ * @template TLimit The type the limit value.
+ *
+ * @see [Validation constraints](guide/forms/signals/custom-controls#validation-constraints)
+ *
+ * @publicApi 22.0
+ */
+export type LimitKey<TLimit> = MetadataKey<
+  Signal<NonNullable<TLimit> | undefined>,
+  NonNullable<TLimit> | undefined,
+  NonNullable<TLimit> | undefined
+>;
+
+/**
+ * A symbol used to tag a `MetadataKey` as representing a limit selection key.
+ */
+declare const LIMIT_SELECTION_KEY: unique symbol;
+
+/**
+ * Used to select a {@link LimitKey}.
+ *
+ * This indirection allows rules to bind a {@link LimitKey} of a specific limit type (e.g. `number`
+ * or `Date`) matching the field's type to a generic {@link MetadataKey}.
+ *
+ * @see [Validation constraints](guide/forms/signals/custom-controls#validation-constraints)
+ *
+ * @publicApi 22.0
+ */
+export type LimitSelectionKey = MetadataKey<
+  Signal<LimitKey<unknown> | undefined>,
+  LimitKey<unknown>,
+  LimitKey<unknown> | undefined
+> & {
+  [LIMIT_SELECTION_KEY]: true;
+};
+
+/**
+ * Extracts the the type that can be set into the given metadata key type using the `metadata()` rule.
+ *
+ * @template TKey The `MetadataKey` type
+ *
+ * @see [Field metadata](guide/forms/signals/field-metadata)
+ *
+ * @publicApi 22.0
+ */
+export type MetadataSetterType<TKey> =
+  TKey extends MetadataKey<any, infer TWrite, any> ? TWrite : never;
+
+/**
+ * Creates a metadata key used to contain a computed value.
+ * The last value set on a given field tree node overrides any previously set values.
+ *
+ * @template TWrite The type written to this key using the `metadata()` rule
+ *
+ * @see [Creating a metadata key](guide/forms/signals/field-metadata#creating-a-metadata-key)
+ *
+ * @publicApi 22.0
+ */
+export function createMetadataKey<TWrite>(): MetadataKey<
+  Signal<TWrite | undefined>,
+  TWrite,
+  TWrite | undefined
+>;
+/**
+ * Creates a metadata key used to contain a computed value.
+ *
+ * @param reducer The reducer used to combine individually set values into the final computed value.
+ * @template TWrite The type written to this key using the `metadata()` rule
+ * @template TAcc The type of the reducer's accumulated value.
+ *
+ * @see [Creating a metadata key](guide/forms/signals/field-metadata#creating-a-metadata-key)
+ *
+ * @publicApi 22.0
+ */
+export function createMetadataKey<TWrite, TAcc>(
+  reducer: MetadataReducer<TAcc, TWrite>,
+): MetadataKey<Signal<TAcc>, TWrite, TAcc>;
+export function createMetadataKey<TWrite, TAcc>(
+  reducer?: MetadataReducer<TAcc, TWrite>,
+): MetadataKey<Signal<TAcc>, TWrite, TAcc> {
+  return new (
+    MetadataKey as new (
+      reducer: MetadataReducer<TAcc, TWrite>,
+    ) => MetadataKey<Signal<TAcc>, TWrite, TAcc>
+  )(reducer ?? MetadataReducer.override<any>());
+}

--- a/packages/forms/signals/src/util/deep_signal.ts
+++ b/packages/forms/signals/src/util/deep_signal.ts
@@ -14,6 +14,8 @@ import {isArray} from './type_guards';
  * Creates a writable signal for a specific property on a source writeable signal.
  * @param source A writeable signal to derive from
  * @param prop A signal of a property key of the source value
+ * @param equal Optional, custom equality function used to determine whether the property's
+ *   value has changed
  * @returns A writeable signal for the given property of the source value.
  * @template S The source value type
  * @template K The key type for S
@@ -21,13 +23,15 @@ import {isArray} from './type_guards';
 export function deepSignal<S, K extends keyof S>(
   source: WritableSignal<S>,
   prop: Signal<K>,
+  equal?: (a: S[K], b: S[K]) => boolean,
 ): WritableSignal<S[K]> {
   // Memoize the property.
-  const read = computed(() => source()[prop()]) as WritableSignal<S[K]>;
+  const read = computed(() => source()[prop()], {equal}) as WritableSignal<S[K]>;
 
   read[SIGNAL] = source[SIGNAL];
   read.set = (value: S[K]) => {
-    if (Object.is(untracked(read), value)) {
+    // Avoid updating the parent signal when the values are equal.
+    if ((equal ?? Object.is)(untracked(read), value)) {
       return;
     }
     source.update((current) => valueForWrite(current, value, prop()) as S);

--- a/packages/forms/signals/test/node/api/equality.spec.ts
+++ b/packages/forms/signals/test/node/api/equality.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {applyEach, applyWhen, equality, form} from '../../../public_api';
+
+class PlainDate {
+  constructor(readonly iso: string) {}
+}
+
+describe('equality', () => {
+  it('does not update the value when the custom equality function considers it equal', () => {
+    const f = form(
+      signal({date: new PlainDate('2024-01-01')}),
+      (p) => {
+        equality(p.date, (a, b) => a.iso === b.iso);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const before = f.date().value();
+    // A new object instance representing the same logical value.
+    f.date().value.set(new PlainDate('2024-01-01'));
+
+    expect(f.date().value()).toBe(before);
+  });
+
+  it('updates the value when the custom equality function considers it different', () => {
+    const f = form(
+      signal({date: new PlainDate('2024-01-01')}),
+      (p) => {
+        equality(p.date, (a, b) => a.iso === b.iso);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const next = new PlainDate('2024-02-02');
+    f.date().value.set(next);
+
+    expect(f.date().value()).toBe(next);
+  });
+
+  it('falls back to default equality when no custom function is configured', () => {
+    const f = form(signal({date: new PlainDate('2024-01-01')}), () => {}, {
+      injector: TestBed.inject(Injector),
+    });
+
+    const next = new PlainDate('2024-01-01');
+    f.date().value.set(next);
+
+    expect(f.date().value()).toBe(next);
+  });
+
+  it('handles null values safely within the equality comparator', () => {
+    const f = form(
+      signal({date: null as PlainDate | null}),
+      (p) => {
+        equality(p.date, (a, b) => a?.iso === b?.iso);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    f.date().value.set(new PlainDate('2024-01-01'));
+    expect(f.date().value()).toEqual(new PlainDate('2024-01-01'));
+
+    // Setting to null
+    f.date().value.set(null);
+    expect(f.date().value()).toBeNull();
+  });
+
+  it('works with primitive value comparison customizations', () => {
+    const f = form(
+      signal({text: 'hello'}),
+      (p) => {
+        // Case-insensitive string equality
+        equality(p.text, (a, b) => a.toLowerCase() === b.toLowerCase());
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const initial = f.text().value();
+    f.text().value.set('HELLO');
+
+    expect(f.text().value()).toBe(initial);
+  });
+
+  it('applies custom equality check when updating value via update()', () => {
+    const f = form(
+      signal({date: new PlainDate('2024-01-01')}),
+      (p) => {
+        equality(p.date, (a, b) => a.iso === b.iso);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const before = f.date().value();
+    f.date().value.update(() => new PlainDate('2024-01-01'));
+
+    expect(f.date().value()).toBe(before);
+  });
+
+  it('respects equality setting when form is reset', () => {
+    const initialDate = new PlainDate('2024-01-01');
+    const f = form(
+      signal({date: initialDate}),
+      (p) => {
+        equality(p.date, (a, b) => a.iso === b.iso);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    f.date().value.set(new PlainDate('2024-05-05'));
+    expect(f.date().value().iso).toBe('2024-05-05');
+
+    // Resetting to a new object with identical value
+    const resetDate = new PlainDate('2024-01-01');
+    f().reset({date: resetDate});
+
+    // Asserts that the internal value updated correctly to the reset payload instance
+    expect(f.date().value()).toBe(resetDate);
+  });
+
+  it('supports custom equality on nested child fields', () => {
+    const f = form(
+      signal({
+        user: {
+          dob: new PlainDate('2000-01-01'),
+        },
+      }),
+      (p) => {
+        equality(p.user.dob, (a, b) => a.iso === b.iso);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const initial = f.user.dob().value();
+    f.user.dob().value.set(new PlainDate('2000-01-01'));
+
+    expect(f.user.dob().value()).toBe(initial);
+  });
+
+  it('applies custom equality when updating a parent object', () => {
+    const initial = new PlainDate('2024-01-01');
+    const f = form(
+      signal({date: initial}),
+      (p) => {
+        equality(p.date, (a, b) => a.iso === b.iso);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    expect(f.date().value()).toBe(initial);
+    f().value.set({date: new PlainDate('2024-01-01')});
+
+    expect(f.date().value()).toBe(initial);
+  });
+
+  it('supports custom equality on array items', () => {
+    const initial = new PlainDate('2024-01-01');
+    const f = form(
+      signal({dates: [initial]}),
+      (p) => {
+        applyEach(p.dates, (date) => {
+          equality(date, (a, b) => a.iso === b.iso);
+        });
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    f.dates[0]().value.set(new PlainDate('2024-01-01'));
+
+    expect(f.dates[0]().value()).toBe(initial);
+  });
+
+  it('supports conditionally applied equality', () => {
+    const initial = new PlainDate('2024-01-01');
+    const f = form(
+      signal({enabled: false, date: initial}),
+      (p) => {
+        applyWhen(
+          p,
+          ({value}) => value().enabled,
+          (path) => equality(path.date, (a, b) => a.iso === b.iso),
+        );
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const disabledUpdate = new PlainDate('2024-01-01');
+    f.date().value.set(disabledUpdate);
+    expect(f.date().value()).toBe(disabledUpdate);
+
+    f.enabled().value.set(true);
+    const enabledUpdate = new PlainDate('2024-01-01');
+    f.date().value.set(enabledUpdate);
+    expect(f.date().value()).toBe(disabledUpdate);
+  });
+});

--- a/packages/forms/signals/test/node/deep_signal.spec.ts
+++ b/packages/forms/signals/test/node/deep_signal.spec.ts
@@ -50,6 +50,20 @@ describe('deepSignal', () => {
     expect(sourceTriggerCount).toBe(2); // Should STILL be 2 if optimization works
   });
 
+  it('should use custom equality when setting a value', () => {
+    const source = signal({value: {id: 1}});
+    const prop = signal('value' as const);
+    const deep = deepSignal(source, prop, (a, b) => a.id === b.id);
+    const initial = deep();
+
+    deep.set({id: 1});
+    expect(deep()).toBe(initial);
+
+    const next = {id: 2};
+    deep.set(next);
+    expect(deep()).toBe(next);
+  });
+
   it('should optimize sets with same value on arrays', () => {
     const source = signal(['a', 'b', 'c']);
     const prop = signal(1); // index 1, value 'b'

--- a/packages/forms/signals/test/node/logic_node.spec.ts
+++ b/packages/forms/signals/test/node/logic_node.spec.ts
@@ -8,6 +8,7 @@
 
 import {computed, signal} from '@angular/core';
 import {FieldContext} from '../../public_api';
+import {EQUALITY} from '../../src/schema/logic_node';
 import {DYNAMIC} from '../../src/schema/logic';
 import {LogicNodeBuilder} from '../../src/schema/logic_node';
 
@@ -38,6 +39,21 @@ describe('LogicNodeBuilder', () => {
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'root-err', fieldTree: undefined as any},
     ]);
+  });
+
+  it('should apply predicates to equality logic', () => {
+    const builder = LogicNodeBuilder.newRoot();
+    const enabled = signal(true);
+    const equality = () => true;
+    const conditional = LogicNodeBuilder.newRoot();
+    conditional.addEqualityRule(() => equality);
+    builder.mergeIn(conditional, {fn: () => enabled(), path: undefined!});
+
+    const logicNode = builder.build();
+    expect(logicNode.logic.getMetadata(EQUALITY).compute(fakeFieldContext)).toBe(equality);
+
+    enabled.set(false);
+    expect(logicNode.logic.getMetadata(EQUALITY).compute(fakeFieldContext)).toBeUndefined();
   });
 
   it('should build child logic', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Signal Forms currently use reference equality for object values. If a new object instance represents the same logical value, the form still treats it as a change and updates dependent signals

Issue Number: #69928 

## What is the new behavior?

Adds a custom `equality()` rule that allows callers to define custom value comparison logic for fields:

   - Fields can opt into custom equality checks.
   - Values that compare as equal no longer replace the current field value.
   - Dependent signals are not notified when the comparator reports no change.
   - Custom equality logic is consistently applied across nested fields, array items, conditional rules, and deepSignal updates.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Extracted the shared, dependency-free metadata primitives (`MetadataKey`, `MetadataReduce`r, `createMetadataKey`, `IS_ASYNC_VALIDATION_RESOURCE`,` LimitKey`, `LimitSelectionKey`, `MetadataSetterType`) into a new `schema/metadata.ts` module. This decoupling is required (imo) because the new `EQUALITY` `MetadataKey` needs to be read directly within the schema layer (`schema/logic_node.ts`) to retrieve the configured equality function during change detection
