### PR TITLE
refactor(docs-infra): share the angular.dev origin constant

### DIFF
--- a/adev/src/app/app.component.ts
+++ b/adev/src/app/app.component.ts
@@ -22,6 +22,7 @@ import {Footer} from './core/layout/footer/footer.component';
 import {Navigation} from './core/layout/navigation/navigation.component';
 import {ProgressBarComponent} from './core/layout/progress-bar/progress-bar.component';
 import {SecondaryNavigation} from './core/layout/secondary-navigation/secondary-navigation.component';
+import {ANGULAR_DEV} from './core/constants/links';
 import {HeaderService} from './core/services/header.service';
 
 @Component({
@@ -101,7 +102,7 @@ export class AppComponent {
       // In debug this shortcut allows us to open the same page on adev
       // Helpful to compare differences
       event.preventDefault();
-      window.open(`https://angular.dev/${location.pathname}`, '_blank');
+      window.open(`${ANGULAR_DEV}/${location.pathname}`, '_blank');
     }
   }
 

--- a/adev/src/app/core/constants/links.ts
+++ b/adev/src/app/core/constants/links.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+export const ANGULAR_DEV = 'https://angular.dev';
+
 export const ANGULAR_LINKS = {
   GITHUB: 'https://github.com/angular/angular',
   X: 'https://x.com/angular',

--- a/adev/src/app/core/services/header.service.ts
+++ b/adev/src/app/core/services/header.service.ts
@@ -9,7 +9,7 @@
 import {DOCUMENT} from '@angular/common';
 import {inject, Service} from '@angular/core';
 
-const ANGULAR_DEV = 'https://angular.dev';
+import {ANGULAR_DEV} from '../constants/links';
 
 /**
  * Information about the deployment of this application.

--- a/adev/src/app/core/services/version-manager.service.ts
+++ b/adev/src/app/core/services/version-manager.service.ts
@@ -10,6 +10,7 @@ import {httpResource} from '@angular/common/http';
 import {DOCUMENT, Service, VERSION, computed, inject} from '@angular/core';
 
 import versionJson from '../../../assets/others/versions.json';
+import {ANGULAR_DEV} from '../constants/links';
 
 export interface Version {
   displayName: string;
@@ -60,7 +61,7 @@ export class VersionManager {
   // which is the most up-to-date anyway.
   remoteVersions = httpResource(
     () => ({
-      url: 'https://angular.dev/assets/others/versions.json',
+      url: `${ANGULAR_DEV}/assets/others/versions.json`,
       transferCache: false,
       cache: 'no-cache',
     }),

--- a/adev/src/app/editor/code-editor/code-editor.component.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.ts
@@ -29,6 +29,7 @@ import {TerminalType} from '../terminal/terminal-handler.service';
 
 import {CdkMenu, CdkMenuItem, CdkMenuTrigger} from '@angular/cdk/menu';
 import {IconComponent} from '@angular/docs';
+import {ANGULAR_DEV} from '../../core/constants/links';
 import {MatTooltip} from '@angular/material/tooltip';
 import {DownloadManager} from '../download-manager.service';
 import {LoadingStep} from '../enums/loading-steps';
@@ -43,8 +44,6 @@ export const REQUIRED_FILES = new Set([
   'src/index.html',
   'src/app/app.component.ts',
 ]);
-
-const ANGULAR_DEV = 'https://angular.dev';
 
 @Component({
   selector: 'docs-tutorial-code-editor',


### PR DESCRIPTION
The angular.dev origin was declared twice as a local `ANGULAR_DEV` const and hardcoded inline in two more places. It now lives once in `core/constants/links.ts`, next to `ANGULAR_LINKS`.