### PR TITLE
docs: clarify that toObservable replays the last propagated value

### DIFF
--- a/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
+++ b/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
@@ -126,6 +126,18 @@ mySignal.set(3);
 
 Here, only the last value (3) will be logged.
 
+For the same reason, the `ReplaySubject` holds the value the effect propagated last, not the current value of the signal. If you subscribe right after updating the signal, you receive the previous value until the effect runs again.
+
+```ts
+// `mySignal` holds 0, and the effect has already propagated that value.
+mySignal.set(1);
+obs$.pipe(take(1)).subscribe((value) => console.log(value));
+```
+
+Here, 0 is logged instead of 1.
+
+IMPORTANT: If you need the current value of a signal synchronously, read the signal directly instead of subscribing to the Observable.
+
 ## Using `rxResource` for async data
 
 Angular's [`resource` function](/guide/signals/resource) gives you a way to incorporate async data into your application's signal-based code. Building on top of this pattern, `rxResource` lets you define a resource where the source of your data is defined in terms of an RxJS `Observable`. Instead of accepting a `loader` function, `rxResource` accepts a `stream` function that accepts an RxJS `Observable`.

--- a/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
+++ b/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
@@ -126,15 +126,14 @@ mySignal.set(3);
 
 Here, only the last value (3) will be logged.
 
-For the same reason, the `ReplaySubject` holds the value the effect propagated last, not the current value of the signal. If you subscribe right after updating the signal, you receive the previous value until the effect runs again.
+The `ReplaySubject` holds the value the effect propagated last, not the current value of the signal. If you subscribe right after updating the signal, you receive the previous value until the effect runs again.
 
 ```ts
-// `mySignal` holds 0, and the effect has already propagated that value.
-mySignal.set(1);
+mySignal.set(4);
 obs$.pipe(take(1)).subscribe((value) => console.log(value));
 ```
 
-Here, 0 is logged instead of 1.
+Here, the new subscriber receives 3 instead of 4.
 
 IMPORTANT: If you need the current value of a signal synchronously, read the signal directly instead of subscribing to the Observable.
 

--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -34,9 +34,10 @@ export interface ToObservableOptions {
 
 /**
  * Exposes the value of an Angular `Signal` as an RxJS `Observable`.
- * As it reflects a state, the observable will always emit the latest value upon subscription.
  *
  * The signal's value will be propagated into the `Observable`'s subscribers using an `effect`.
+ * On subscription, the `Observable` replays the value that effect propagated last, which is stale
+ * if the signal changed since then.
  *
  * `toObservable` must be called in an injection context unless an injector is provided via options.
  *

--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -36,8 +36,8 @@ export interface ToObservableOptions {
  * Exposes the value of an Angular `Signal` as an RxJS `Observable`.
  *
  * The signal's value will be propagated into the `Observable`'s subscribers using an `effect`.
- * On subscription, the `Observable` replays the value that effect propagated last, which is stale
- * if the signal changed since then.
+ * On subscription, the `Observable` replays the value that the effect propagated last. If the
+ * signal changed since then, that value is stale.
  *
  * `toObservable` must be called in an injection context unless an injector is provided via options.
  *


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (documentation only)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #70307

Fixes #70307

The timing section of the RxJS interop guide explains that emissions are batched until the signal stabilizes, but it never says what a *new* subscriber gets in the meantime. The `toObservable` API docs go further and state the opposite of what happens: "the observable will always emit the latest value upon subscription". Subscribing right after `set()` replays the value the effect propagated last, so the subscriber reads the old value.

## What is the new behavior?

The guide now spells out that the `ReplaySubject` holds the last propagated value rather than the signal's current one, with a short example, and points readers at the signal itself when they need the value synchronously. The API doc sentence is corrected to match.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
