### PR TITLE
docs: warn against using in-memory-web-api in production

### DIFF
--- a/packages/misc/angular-in-memory-web-api/README.md
+++ b/packages/misc/angular-in-memory-web-api/README.md
@@ -3,6 +3,13 @@
 An in-memory web api for Angular demos and tests
 that emulates CRUD operations over a RESTy API.
 
+> **WARNING**
+>
+> This package is a development and testing tool only.
+> The in-memory data store applies no authentication or authorization
+> to the requests it answers.
+> Never ship it in a production app.
+
 It intercepts Angular `Http` and `HttpClient` requests that would otherwise go to the remote server and redirects them to an in-memory data store that you control.
 
 See [Austin McDaniel's article](https://medium.com/@amcdnl/mocking-with-angular-more-than-just-unit-testing-cbb7908c9fcc)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: 70308
Closes #70308

The README does say the package is "not intended for production use", but it lands at the tail of a sentence about emulating real world web APIs, inside a block titled LIMITATIONS. The setup notes mention production once more, framed as a bundling concern rather than a security one. Neither reads as a warning if you are skimming the intro to get started.

## What is the new behavior?

A short warning under the opening description: development and testing tool, no authentication or authorization on the requests the store answers, don't ship it. The LIMITATIONS block and the setup notes stay as they are.

The issue also asks for the angular.dev docs page, but nothing under `adev/` references the package, so the README is the only place to change. npm renders it too.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
