### PR TITLE
docs(core): clarify toObservable synchronization behavior

### DIFF
--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -37,6 +37,8 @@ export interface ToObservableOptions {
  * As it reflects a state, the observable will always emit the latest value upon subscription.
  *
  * The signal's value will be propagated into the `Observable`'s subscribers using an `effect`.
+ * Because the `effect` runs asynchronously, the observable is not guaranteed to be immediately synchronized when the signal is updated.
+ * If the signal is updated multiple times before the `effect` runs, the observable will only emit the last signal value.
  *
  * `toObservable` must be called in an injection context unless an injector is provided via options.
  *


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [~] Tests for the changes have been added (for bug fixes / features)
- [~] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The documentation for `toObservable` does not clearly highlight the delayed synchronization between derived observables and the base signal.

Issue Number: #70307 

## What is the new behavior?

Adds documentation for `toObservable` to explicitly outline the delayed synchronization behavior for the derived observable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
