### PR TITLE
ci: add Alan as a zone.js reviewer

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -207,6 +207,7 @@ groups:
         - crisbeto
         - devversion
         - kirjs
+        - alan-agius4
         - ~thePunderWoman
         - ~pkozlowski-opensource
         - ~amishne


### PR DESCRIPTION
This updates the zone.js owners and adds alan-agius4 to compiler approvers.
