### PR TITLE
fix(http): strip xsrf token after cross-origin rewrite

### DIFF
--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -31,6 +31,7 @@ import {
   interceptorChainEndFn,
   REQUESTS_CONTRIBUTE_TO_STABILITY,
 } from './interceptor';
+import {validateXsrfRequest} from './xsrf';
 
 /**
  * A final `HttpHandler` which will dispatch the request via browser HTTP APIs to a backend.
@@ -57,6 +58,7 @@ export function resetFetchBackendWarningFlag() {
 @Injectable({providedIn: 'root'})
 export class HttpInterceptorHandler implements HttpHandler {
   private chain: ChainedInterceptorFn<unknown> | null = null;
+  private isDelegating = false;
   private readonly pendingTasks = inject(PendingTasks);
   private readonly contributeToStability = inject(REQUESTS_CONTRIBUTE_TO_STABILITY);
 
@@ -100,11 +102,11 @@ export class HttpInterceptorHandler implements HttpHandler {
   handle(initialRequest: HttpRequest<any>): Observable<HttpEvent<any>> {
     if (this.chain === null) {
       const parentHandler = this.injector.get(HttpHandler, null, {skipSelf: true});
-      const isDelegating = parentHandler !== null && this.backend === parentHandler;
+      this.isDelegating = parentHandler !== null && this.backend === parentHandler;
       const rootInterceptorFns = this.injector.get(
         HTTP_ROOT_INTERCEPTOR_FNS,
         [],
-        isDelegating ? {self: true} : undefined,
+        this.isDelegating ? {self: true} : undefined,
       );
       const dedupedInterceptorFns = Array.from(
         new Set([...this.injector.get(HTTP_INTERCEPTOR_FNS), ...rootInterceptorFns]),
@@ -122,15 +124,20 @@ export class HttpInterceptorHandler implements HttpHandler {
     }
 
     const chain = this.chain;
+    const finalHandlerFn = (downstreamRequest: HttpRequest<unknown>) => {
+      // Delegating handlers are not terminal: parent interceptors can still rewrite the request.
+      // Validate only immediately before the actual backend so the final request origin is used.
+      const request = this.isDelegating
+        ? downstreamRequest
+        : validateXsrfRequest(downstreamRequest);
+      return this.backend.handle(request);
+    };
+
     if (this.contributeToStability) {
       const removeTask = this.pendingTasks.add();
-      return untracked(() =>
-        chain(initialRequest, (downstreamRequest) => this.backend.handle(downstreamRequest)),
-      ).pipe(finalize(removeTask));
+      return untracked(() => chain(initialRequest, finalHandlerFn)).pipe(finalize(removeTask));
     } else {
-      return untracked(() =>
-        chain(initialRequest, (downstreamRequest) => this.backend.handle(downstreamRequest)),
-      );
+      return untracked(() => chain(initialRequest, finalHandlerFn));
     }
   }
 }

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -18,6 +18,7 @@ import {Observable} from 'rxjs';
 import {DOCUMENT, ɵparseCookieValue as parseCookieValue, PlatformLocation} from '../../index';
 
 import type {HttpHandler} from './backend';
+import {HttpContextToken} from './context';
 import type {HttpHandlerFn, HttpInterceptor} from './interceptor';
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
@@ -45,6 +46,60 @@ export const XSRF_HEADER_NAME = new InjectionToken<string>(
     factory: () => XSRF_DEFAULT_HEADER_NAME,
   },
 );
+
+type AddedXsrfHeader = Readonly<{name: string; value: string; origin: string}>;
+
+/**
+ * Tracks headers added by Angular's XSRF interceptor so that the terminal HTTP handler can
+ * remove only Angular-owned token values if a downstream interceptor changes the request origin.
+ */
+const XSRF_ADDED_HEADERS = new HttpContextToken<readonly AddedXsrfHeader[]>(() => []);
+
+function getSameOrigin(req: HttpRequest<unknown>): string | null {
+  try {
+    const locationHref = inject(PlatformLocation).href;
+    const {origin: locationOrigin} = new URL(locationHref);
+    // We can use `new URL` to normalize a relative URL like '//something.com' to
+    // 'https://something.com' in order to make consistent same-origin comparisons.
+    const {origin: requestOrigin} = new URL(req.url, locationOrigin);
+    return locationOrigin === requestOrigin ? locationOrigin : null;
+  } catch {
+    // Treat invalid URLs as non-same-origin. This matches the interceptor's existing behavior of
+    // not adding XSRF headers when the request origin cannot be validated.
+    return null;
+  }
+}
+
+function isRequestSameOrigin(req: HttpRequest<unknown>, origin: string): boolean {
+  try {
+    return new URL(req.url, origin).origin === origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Removes Angular-added XSRF header values when the final request is no longer same-origin.
+ *
+ * This is invoked immediately before the terminal backend. The request context tracks only values
+ * that Angular itself added, so user-provided values with the same header name are preserved.
+ */
+export function validateXsrfRequest(req: HttpRequest<unknown>): HttpRequest<unknown> {
+  if (!req.context.has(XSRF_ADDED_HEADERS)) {
+    return req;
+  }
+
+  let headers = req.headers;
+  let changed = false;
+  for (const {name, value, origin} of req.context.get(XSRF_ADDED_HEADERS)) {
+    if (!isRequestSameOrigin(req, origin) && headers.getAll(name)?.includes(value)) {
+      headers = headers.delete(name, value);
+      changed = true;
+    }
+  }
+
+  return changed ? req.clone({headers}) : req;
+}
 
 /**
  * `HttpXsrfTokenExtractor` which retrieves the token from a cookie.
@@ -101,18 +156,8 @@ export function xsrfInterceptorFn(
     return next(req);
   }
 
-  try {
-    const locationHref = inject(PlatformLocation).href;
-    const {origin: locationOrigin} = new URL(locationHref);
-    // We can use `new URL` to normalize a relative URL like '//something.com' to
-    // 'https://something.com' in order to make consistent same-origin comparisons.
-    const {origin: requestOrigin} = new URL(req.url, locationOrigin);
-
-    if (locationOrigin !== requestOrigin) {
-      return next(req);
-    }
-  } catch {
-    // Handle invalid URLs gracefully.
+  const origin = getSameOrigin(req);
+  if (origin === null) {
     return next(req);
   }
 
@@ -122,6 +167,10 @@ export function xsrfInterceptorFn(
   // Be careful not to overwrite an existing header of the same name.
   if (token != null && !req.headers.has(headerName)) {
     req = req.clone({headers: req.headers.set(headerName, token)});
+    req.context.set(XSRF_ADDED_HEADERS, [
+      ...req.context.get(XSRF_ADDED_HEADERS),
+      {name: headerName, value: token, origin},
+    ]);
   }
   return next(req);
 }

--- a/packages/common/http/test/xsrf_origin_rewrite_spec.ts
+++ b/packages/common/http/test/xsrf_origin_rewrite_spec.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {MockPlatformLocation} from '@angular/common/testing';
+import {createEnvironmentInjector, EnvironmentInjector} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+import {PlatformLocation} from '../..';
+import {HttpClient} from '../src/client';
+import {HttpHeaders} from '../src/headers';
+import {HttpInterceptorFn} from '../src/interceptor';
+import {
+  provideHttpClient,
+  withInterceptors,
+  withRequestsMadeViaParent,
+  withXsrfConfiguration,
+} from '../src/provider';
+import {HttpXsrfTokenExtractor} from '../src/xsrf';
+import {HttpTestingController, provideHttpClientTesting} from '../testing';
+
+class SampleTokenExtractor extends HttpXsrfTokenExtractor {
+  override getToken(): string | null {
+    return 'test-token';
+  }
+}
+
+describe('XSRF protection after request origin rewrites', () => {
+  const crossOriginRewrite: HttpInterceptorFn = (req, next) =>
+    next(req.clone({url: 'https://api.example.test/update'}));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([crossOriginRewrite])),
+        provideHttpClientTesting(),
+        {provide: HttpXsrfTokenExtractor, useClass: SampleTokenExtractor},
+        {
+          provide: PlatformLocation,
+          useFactory: () => new MockPlatformLocation({startUrl: 'https://app.example.test/'}),
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.inject(HttpTestingController).verify();
+  });
+
+  it('removes an Angular-added XSRF header when a later interceptor changes the origin', () => {
+    TestBed.inject(HttpClient).post('/update', '', {responseType: 'text'}).subscribe();
+
+    const req = TestBed.inject(HttpTestingController).expectOne('https://api.example.test/update');
+    expect(req.request.headers.has('X-XSRF-TOKEN')).toBeFalse();
+    req.flush('');
+  });
+
+  it('keeps an Angular-added XSRF header when a later interceptor stays same-origin', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(
+          withInterceptors([
+            (req, next) => next(req.clone({url: 'https://app.example.test/rewritten'})),
+          ]),
+        ),
+        provideHttpClientTesting(),
+        {provide: HttpXsrfTokenExtractor, useClass: SampleTokenExtractor},
+        {
+          provide: PlatformLocation,
+          useFactory: () => new MockPlatformLocation({startUrl: 'https://app.example.test/'}),
+        },
+      ],
+    });
+
+    TestBed.inject(HttpClient).post('/update', '', {responseType: 'text'}).subscribe();
+
+    const req = TestBed.inject(HttpTestingController).expectOne(
+      'https://app.example.test/rewritten',
+    );
+    expect(req.request.headers.get('X-XSRF-TOKEN')).toBe('test-token');
+    req.flush('');
+  });
+
+  it('preserves user-provided values while removing only the Angular-added token', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(
+          withInterceptors([
+            (req, next) =>
+              next(
+                req.clone({
+                  url: 'https://api.example.test/update',
+                  headers: req.headers.append('X-XSRF-TOKEN', 'user-value'),
+                }),
+              ),
+          ]),
+        ),
+        provideHttpClientTesting(),
+        {provide: HttpXsrfTokenExtractor, useClass: SampleTokenExtractor},
+        {
+          provide: PlatformLocation,
+          useFactory: () => new MockPlatformLocation({startUrl: 'https://app.example.test/'}),
+        },
+      ],
+    });
+
+    TestBed.inject(HttpClient).post('/update', '', {responseType: 'text'}).subscribe();
+
+    const req = TestBed.inject(HttpTestingController).expectOne('https://api.example.test/update');
+    expect(req.request.headers.getAll('X-XSRF-TOKEN')).toEqual(['user-value']);
+    req.flush('');
+  });
+
+  it('does not remove an XSRF-like header that Angular did not add', () => {
+    TestBed.inject(HttpClient)
+      .post('/update', '', {
+        headers: new HttpHeaders().set('X-XSRF-TOKEN', 'application-value'),
+        responseType: 'text',
+      })
+      .subscribe();
+
+    const req = TestBed.inject(HttpTestingController).expectOne('https://api.example.test/update');
+    expect(req.request.headers.get('X-XSRF-TOKEN')).toBe('application-value');
+    req.flush('');
+  });
+
+  it('validates only at the terminal backend when requests delegate through a parent client', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([crossOriginRewrite])),
+        provideHttpClientTesting(),
+        {provide: HttpXsrfTokenExtractor, useClass: SampleTokenExtractor},
+        {
+          provide: PlatformLocation,
+          useFactory: () => new MockPlatformLocation({startUrl: 'https://app.example.test/'}),
+        },
+      ],
+    });
+
+    const child = createEnvironmentInjector(
+      [
+        provideHttpClient(
+          withRequestsMadeViaParent(),
+          withXsrfConfiguration({headerName: 'X-Child-XSRF'}),
+        ),
+      ],
+      TestBed.inject(EnvironmentInjector),
+    );
+
+    child.get(HttpClient).post('/update', '', {responseType: 'text'}).subscribe();
+
+    const req = TestBed.inject(HttpTestingController).expectOne('https://api.example.test/update');
+    expect(req.request.headers.has('X-Child-XSRF')).toBeFalse();
+    expect(req.request.headers.has('X-XSRF-TOKEN')).toBeFalse();
+    req.flush('');
+    child.destroy();
+  });
+
+  it('does not validate before a delegated parent chain reaches its terminal backend', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(
+          withInterceptors([
+            (req, next) => next(req.clone({url: 'https://app.example.test/final'})),
+          ]),
+        ),
+        provideHttpClientTesting(),
+        {provide: HttpXsrfTokenExtractor, useClass: SampleTokenExtractor},
+        {
+          provide: PlatformLocation,
+          useFactory: () => new MockPlatformLocation({startUrl: 'https://app.example.test/'}),
+        },
+      ],
+    });
+
+    const middle = createEnvironmentInjector(
+      [provideHttpClient(withRequestsMadeViaParent(), withInterceptors([crossOriginRewrite]))],
+      TestBed.inject(EnvironmentInjector),
+    );
+    const child = createEnvironmentInjector(
+      [provideHttpClient(withRequestsMadeViaParent())],
+      middle,
+    );
+
+    child.get(HttpClient).post('/update', '', {responseType: 'text'}).subscribe();
+
+    const req = TestBed.inject(HttpTestingController).expectOne('https://app.example.test/final');
+    expect(req.request.headers.get('X-XSRF-TOKEN')).toBe('test-token');
+    req.flush('');
+    child.destroy();
+    middle.destroy();
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (not required for this internal behavior fix)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #70077

The XSRF interceptor validates the request origin and adds the configured XSRF header before later interceptors execute. A downstream interceptor can clone the request, change its URL from same-origin to cross-origin, and pass the request to the backend with Angular's XSRF token still attached.

The interceptor contract explicitly allows downstream requests to use a different URL or origin, so validating only the URL seen by the XSRF interceptor does not necessarily validate the request that reaches the backend.

## What is the new behavior?

When Angular adds an XSRF header, the request context records the exact header name, token value, and origin that justified adding it.

Immediately before the terminal HTTP backend, Angular compares the final request URL with those recorded origins. If a final URL is cross-origin (or cannot be parsed), only the token values added by Angular are removed.

Application-provided values with the same header name are preserved. If a later interceptor appends its own value, only the Angular-added token value is deleted.

For `withRequestsMadeViaParent()`, validation is deferred across delegating handlers and runs only before the actual terminal backend. This allows parent interceptor chains to finish rewriting the request before the final origin check.

The change intentionally does not reorder the XSRF interceptor relative to user interceptors, avoiding a behavioral change for interceptors that currently observe the XSRF header.

Regression coverage includes:

- same-origin -> cross-origin URL rewrite removes the Angular XSRF token;
- same-origin rewrites keep the token;
- user-provided/appended values are preserved;
- custom child XSRF headers are removed after a parent rewrite;
- delegated multi-level clients do not validate before the terminal backend.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Before submitting, run:

```bash
pnpm ng-dev format changed
pnpm test //packages/common/http/test:test --nocache_test_results
pnpm test //packages/common/http/test:test_web --nocache_test_results
git diff --check
```
