### PR TITLE
refactor(core): loosen return type of ɵɵFactoryDeclaration to any

### DIFF
--- a/packages/core/src/render3/interfaces/public_definitions.ts
+++ b/packages/core/src/render3/interfaces/public_definitions.ts
@@ -82,7 +82,7 @@ export type ɵɵInjectorDeclaration<T> = unknown;
  */
 export type ɵɵFactoryDeclaration<T, CtorDependencies extends CtorDependency[]> = (
   parent?: Type<any>,
-) => T;
+) => any;
 
 /**
  * An object literal of this type is used to represent the metadata of a constructor dependency.


### PR DESCRIPTION
When a derived class inherits from a base class, TypeScript enforces that static properties on the derived class are assignable to those on the base class. Because `ɵɵFactoryDeclaration<T, ...>` had a return type of `T`, static `ɵfac` members across inheritance hierarchies could result in type incompatibilities (for example, when dealing with generics or differing class shapes where the derived factory return type is not compatible with the base class factory).

Updating the return type of `ɵɵFactoryDeclaration` from `T` to `any` avoids these static type conflicts across inheriting classes.
