### PR TITLE
feat(router): allow string destination in RedirectCommand

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -601,11 +601,11 @@ export type QueryParamsHandling = 'merge' | 'preserve' | 'replace' | '';
 
 // @public
 export class RedirectCommand extends Error {
-    constructor(redirectTo: UrlTree, navigationBehaviorOptions?: NavigationBehaviorOptions | undefined);
+    constructor(redirectTo: UrlTree | `/${string}`, navigationBehaviorOptions?: NavigationBehaviorOptions | undefined);
     // (undocumented)
     readonly navigationBehaviorOptions?: NavigationBehaviorOptions | undefined;
     // (undocumented)
-    readonly redirectTo: UrlTree;
+    readonly redirectTo: UrlTree | `/${string}`;
 }
 
 // @public

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -168,7 +168,7 @@ export type GuardResult = boolean | UrlTree | RedirectCommand;
  */
 export class RedirectCommand extends Error {
   constructor(
-    readonly redirectTo: UrlTree,
+    readonly redirectTo: UrlTree | `/${string}`,
     readonly navigationBehaviorOptions?: NavigationBehaviorOptions,
   ) {
     super();

--- a/packages/router/src/navigation_canceling_error.ts
+++ b/packages/router/src/navigation_canceling_error.ts
@@ -26,15 +26,16 @@ export function redirectingNavigationError(
   urlSerializer: UrlSerializer,
   redirect: UrlTree | RedirectCommand,
 ): RedirectingNavigationCancelingError {
-  const {redirectTo, navigationBehaviorOptions} = isUrlTree(redirect)
-    ? {redirectTo: redirect, navigationBehaviorOptions: undefined}
-    : redirect;
+  const target = isUrlTree(redirect) ? redirect : redirect.redirectTo;
+  const url = isUrlTree(target) ? target : urlSerializer.parse(target);
   const error = navigationCancelingError(
-    ngDevMode && `Redirecting to "${urlSerializer.serialize(redirectTo)}"`,
+    ngDevMode && `Redirecting to "${urlSerializer.serialize(url)}"`,
     NavigationCancellationCode.Redirect,
   ) as RedirectingNavigationCancelingError;
-  error.url = redirectTo;
-  error.navigationBehaviorOptions = navigationBehaviorOptions;
+  error.url = url;
+  error.navigationBehaviorOptions = isUrlTree(redirect)
+    ? undefined
+    : redirect.navigationBehaviorOptions;
   return error;
 }
 

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -944,10 +944,8 @@ export class NavigationTransitions {
                 );
 
                 if (navigationErrorHandlerResult instanceof RedirectCommand) {
-                  const {message, cancellationCode} = redirectingNavigationError(
-                    this.urlSerializer,
-                    navigationErrorHandlerResult,
-                  );
+                  const {url, message, cancellationCode, navigationBehaviorOptions} =
+                    redirectingNavigationError(this.urlSerializer, navigationErrorHandlerResult);
                   this.events.next(
                     new NavigationCancel(
                       overallTransitionState.id,
@@ -956,12 +954,7 @@ export class NavigationTransitions {
                       cancellationCode,
                     ),
                   );
-                  this.events.next(
-                    new RedirectRequest(
-                      navigationErrorHandlerResult.redirectTo,
-                      navigationErrorHandlerResult.navigationBehaviorOptions,
-                    ),
-                  );
+                  this.events.next(new RedirectRequest(url, navigationBehaviorOptions));
                 } else {
                   this.events.next(navigationError);
                   throw e;

--- a/packages/router/test/integration/guards.spec.ts
+++ b/packages/router/test/integration/guards.spec.ts
@@ -530,6 +530,30 @@ export function guardsIntegrationSuite() {
           expect(location.path()).toEqual('/redirected');
           expect(location.getState()).toEqual(jasmine.objectContaining({test: 1}));
         });
+
+        it('can redirect with string URL', async () => {
+          TestBed.configureTestingModule({
+            providers: [provideRouter([])],
+          });
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          router.resetConfig([
+            {path: '', component: SimpleCmp},
+            {
+              path: 'one',
+              component: RouteCmp,
+              canActivate: [() => new RedirectCommand('/redirected')],
+            },
+            {path: 'redirected', component: SimpleCmp},
+          ]);
+          const fixture = await createRoot(router, RootCmp);
+          router.navigateByUrl('/one');
+
+          await advance(fixture);
+
+          expect(location.path()).toEqual('/redirected');
+          expect(router.url.toString()).toEqual('/redirected');
+        });
       });
 
       it('can redirect to 404 without changing the URL', async () => {


### PR DESCRIPTION
RedirectCommand now accepts a URL string starting with '/' in addition to UrlTree. This improves developer experience by allowing guards, resolvers, and error handlers to redirect to absolute paths without requiring the Router to be injected solely to call parseUrl().

BREAKING CHANGE: `RedirectCommand.redirectTo` can now be a string

The `redirectTo` property on `RedirectCommand` can now be a `string` (specifically `UrlTree | '/${string}'`). Any code reading `RedirectCommand.redirectTo` directly may need to handle `string` values in addition to `UrlTree`.
