### PR TITLE
refactor(core):  widen ɵɵclassProp value parameter type to any

### DIFF
--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -104,10 +104,7 @@ export function ɵɵstyleProp(
  *
  * @codeGenApi
  */
-export function ɵɵclassProp(
-  className: string,
-  value: boolean | undefined | null,
-): typeof ɵɵclassProp {
+export function ɵɵclassProp(className: string, value: any): typeof ɵɵclassProp {
   checkStylingProperty(className, value, null, true);
   return ɵɵclassProp;
 }


### PR DESCRIPTION
When Angular type-checks host bindings and template class bindings (`[class.foo]="expr"`), the Type Check Block (TCB) emits the binding as a standalone expression statement (e.g. `(expr);`). This verifies that the expression itself is syntactically and semantically valid (e.g. properties exist on the component instance), but does not constrain the expression to `boolean` because Angular evaluates class bindings using standard JavaScript truthiness.

In classic `ngtsc`, the runtime Ivy instructions (`ɵɵdefineComponent`) were generated only during the JS emit phase, after TypeScript type-checking had completed. Thus, `tsc` never validated the arguments passed to `ɵɵclassProp`.

Under standalone commpilation, Ivy definitions are generated directly into the TypeScript AST and type-checked by `tsc`. This causes `tsc` to check the emitted `ɵɵclassProp('foo', expr)` call against the instruction's declared signature. Because `ɵɵclassProp` was strictly typed as `boolean | undefined | null`, any valid truthy non-boolean expression (e.g., `1`, `items.length`, or non-empty strings) produces a `TS2345` compiler error.

At runtime, `ɵɵclassProp` delegates to `checkStylingProperty`, which evaluates the value via truthiness (`!!value`). Widening the parameter type to `any` aligns the instruction's type signature with Angular's binding semantics and prevents type-checking failures during in-place compilation.
