### PR TITLE
refactor(core): Decouple ɵɵFactoryDeclaration and ɵɵInjectableDeclara…

### DIFF
--- a/packages/core/primitives/di/src/injection_token.ts
+++ b/packages/core/primitives/di/src/injection_token.ts
@@ -47,12 +47,12 @@ export interface ɵɵInjectableDeclaration<T> {
   /**
    * Factory method to execute to create an instance of the injectable.
    */
-  factory?: (t?: Type<any>) => T;
+  factory?: (t?: Type<any>) => any;
 
   /**
    * In a case of no explicit injector, a location where the instance of the injectable is stored.
    */
-  value?: T;
+  value?: any;
 }
 
 /**

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -55,12 +55,12 @@ export interface ɵɵInjectableDeclaration<T> {
   /**
    * Factory method to execute to create an instance of the injectable.
    */
-  factory: (t?: Type<any>) => T;
+  factory: (t?: Type<any>) => any;
 
   /**
    * In a case of no explicit injector, a location where the instance of the injectable is stored.
    */
-  value: T | undefined;
+  value: any;
 }
 
 /**


### PR DESCRIPTION
…tion from type parameter T.

When compiling under standalone compilation, generated runtime static declarations (static ɵfac and static ɵprov) are emitted into preprocessed TypeScript files and visible to the compiler during semantic typechecking.

When a subclass extends a base class where the subclass is not structurally subtype-compatible with the superclass (such as differing generic type constraints, contravariant method parameters, or EventEmitter<this>), TypeScript's class static side heritage check (TS2417) fails because ɵɵFactoryDeclaration<T> and ɵɵInjectableDeclaration<T> structurally referenced the instance type T.

This change updates ɵɵFactoryDeclaration to return any instead of T, and sets factory return and value types in ɵɵInjectableDeclaration to any. This decouples static side inheritance from T, resolving TS2417 errors across subclassed components and injectables while preserving .d.ts metadata indexing and assignability to ɵɵdefineInjectable. This brings ɵfac and ɵprov into alignment with other Ivy declarations (ɵcmp, ɵdir, ɵpipe, ɵinj), which already treat their generic parameters as phantom metadata.
