### PR TITLE
fix(compiler): strip script elements regardless of namespace

### DIFF
--- a/packages/compiler/src/template_parser/template_preparser.ts
+++ b/packages/compiler/src/template_parser/template_preparser.ts
@@ -7,7 +7,7 @@
  */
 
 import * as html from '../ml_parser/ast';
-import {isNgContent} from '../ml_parser/tags';
+import {isNgContent, splitNsName} from '../ml_parser/tags';
 
 const NG_CONTENT_SELECT_ATTR = 'select';
 const LINK_ELEMENT = 'link';
@@ -15,7 +15,7 @@ const LINK_STYLE_REL_ATTR = 'rel';
 const LINK_STYLE_HREF_ATTR = 'href';
 const LINK_STYLE_REL_VALUE = 'stylesheet';
 const STYLE_ELEMENT = 'style';
-const SCRIPT_ELEMENTS: ReadonlySet<string> = new Set([':math:script', ':svg:script', 'script']);
+const SCRIPT_ELEMENT = 'script';
 const NG_NON_BINDABLE_ATTR = 'ngNonBindable';
 const NG_PROJECT_AS = 'ngProjectAs';
 
@@ -47,12 +47,14 @@ export function preparseElement(ast: html.Element): PreparsedElement {
   selectAttr ||= '*';
 
   const nodeName = ast.name.toLowerCase();
+  // Custom namespaces fall back to HTML, where script elements are executable.
+  const nodeNameWithoutNamespace = splitNsName(nodeName)[1];
   let type = PreparsedElementType.OTHER;
   if (isNgContent(nodeName)) {
     type = PreparsedElementType.NG_CONTENT;
   } else if (STYLE_ELEMENT === nodeName) {
     type = PreparsedElementType.STYLE;
-  } else if (SCRIPT_ELEMENTS.has(nodeName)) {
+  } else if (SCRIPT_ELEMENT === nodeNameWithoutNamespace) {
     type = PreparsedElementType.SCRIPT;
   } else if (nodeName == LINK_ELEMENT && relAttr == LINK_STYLE_REL_VALUE) {
     type = PreparsedElementType.STYLESHEET;

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -927,6 +927,17 @@ describe('R3 template transform', () => {
       expectFromHtml('<script></script>a').toEqual([['Text', 'a']]);
     });
 
+    it('should ignore <script> elements inherited into custom namespaces', () => {
+      expectFromHtml(
+        '<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"><script [textContent]="evil"></script><span>safe</span></xhtml:div>',
+      ).toEqual([
+        ['Element', ':xhtml:div'],
+        ['TextAttribute', ':xmlns:xhtml', 'http://www.w3.org/1999/xhtml'],
+        ['Element', ':xhtml:span'],
+        ['Text', 'safe'],
+      ]);
+    });
+
     it('should ignore <style> elements', () => {
       expectFromHtml('<style></style>a').toEqual([['Text', 'a']]);
     });
@@ -994,6 +1005,17 @@ describe('R3 template transform', () => {
         ['Element', 'div'],
         ['TextAttribute', 'ngNonBindable', ''],
         ['Text', 'a'],
+      ]);
+    });
+
+    it('should ignore custom-namespaced <script> elements inside of elements with ngNonBindable', () => {
+      expectFromHtml(
+        '<foo:div ngNonBindable><script>evil</script><span>safe</span></foo:div>',
+      ).toEqual([
+        ['Element', ':foo:div'],
+        ['TextAttribute', 'ngNonBindable', ''],
+        ['Element', ':foo:span'],
+        ['Text', 'safe'],
       ]);
     });
 

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -1344,7 +1344,7 @@ describe('Component host element validation', () => {
   });
 });
 
-describe('SVG <script> bindings', () => {
+describe('<script> elements in templates', () => {
   it(`should remove svg <script> element`, () => {
     @Component({
       template: `<svg><script src="https://bad.com/script.js"></script></svg>`,
@@ -1355,6 +1355,46 @@ describe('SVG <script> bindings', () => {
     const fixture = TestBed.createComponent(TestCmp);
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('script')).toBeFalsy();
+  });
+
+  it('should remove <script> elements inherited into the XHTML namespace', async () => {
+    @Component({
+      template: `
+        <xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml">
+          <script [textContent]="evil"></script>
+          <span>safe</span>
+        </xhtml:div>
+      `,
+    })
+    class TestCmp {
+      evil = 'evil';
+    }
+
+    const fixture = TestBed.createComponent(TestCmp);
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('script')).toBeFalsy();
+    expect(fixture.nativeElement.querySelector('span').textContent).toBe('safe');
+  });
+
+  it('should remove <script> elements inherited into arbitrary custom namespaces', async () => {
+    @Component({
+      template: `
+        <foo:div xmlns:foo="urn:example">
+          <script [textContent]="evil"></script>
+          <span>custom safe</span>
+        </foo:div>
+      `,
+    })
+    class TestCmp {
+      evil = 'evil';
+    }
+
+    const fixture = TestBed.createComponent(TestCmp);
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('script')).toBeFalsy();
+    expect(fixture.nativeElement.querySelector('span').textContent).toBe('custom safe');
   });
 });
 


### PR DESCRIPTION
Namespace inheritance qualifies script element names, for example :xhtml:script or a custom prefix. The existing prefix allowlist only handles known namespaces, allowing arbitrary and future namespaces to bypass template script stripping and fall back to executable HTML elements.

Classify script elements by local name in the template preparser so script stripping applies independently of namespace.
 
## What is the current behavior?

If we run something like this in any Angular application (regardless of CSR or SSR), the script is not removed by the compiler.

```ts
@Component({
  selector: 'app-space',
  template: ` <foo:div xmlns:xhtml="http://www.w3.org/1999/xhtml">
    <script>
      alert('XSS');
    </script>
  </foo:div>`,
})
export class CustomNameSpace {}

@Component({
  selector: 'app-root',
  imports: [CustomNameSpace],
  template: `
    <app-space />
    <xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml">
      <script [textContent]="evil"></script>
    </xhtml:div>
  `,
})
export class App {
  evil = 'alert("XSS Evil")';
}
```
 

## What is the new behavior?

 Any past, future, and present `script` will be removed regardless of the namespace
 
## Other information

This could be considered another bypass of https://github.com/angular/angular/security/advisories/GHSA-f3m7-gqxr-g87x, since that one only fixed the `svg:script` issue.