### PR TITLE
fix(docs-infra): repair redirects pointing at removed pages

### DIFF
--- a/adev/src/app/routing/redirections.spec.ts
+++ b/adev/src/app/routing/redirections.spec.ts
@@ -7,6 +7,9 @@
  */
 
 import {REDIRECT_ROUTES} from './redirections';
+import {ALL_ITEMS} from './navigation-entries';
+import {NavigationItem} from '@angular/docs';
+import {DEFAULT_PAGES} from '../core/constants/pages';
 import {Route} from '@angular/router';
 
 describe('REDIRECT_ROUTES', () => {
@@ -27,5 +30,53 @@ describe('REDIRECT_ROUTES', () => {
     };
 
     checkRoutes(REDIRECT_ROUTES);
+  });
+
+  it('should only redirect to paths that exist', () => {
+    const knownPaths = new Set<string>();
+    const collectPaths = (items: NavigationItem[]) => {
+      for (const item of items) {
+        if (item.path) {
+          knownPaths.add(item.path);
+        }
+        if (item.children) {
+          collectPaths(item.children);
+        }
+      }
+    };
+    collectPaths(ALL_ITEMS);
+    // Landing pages such as the playground are routed directly, not through the navigation.
+    for (const page of Object.values(DEFAULT_PAGES)) {
+      knownPaths.add(page);
+    }
+
+    const checkRoutes = (routes: Route[]) => {
+      for (const route of routes) {
+        if (typeof route.redirectTo === 'string') {
+          const target = route.redirectTo.replace(/^\//, '').split(/[#?]/)[0];
+          expect(knownPaths.has(target))
+            .withContext(`"${route.path}" redirects to "${route.redirectTo}", which is not a page`)
+            .toBe(true);
+        }
+        if (route.children) {
+          checkRoutes(route.children);
+        }
+      }
+    };
+
+    checkRoutes(REDIRECT_ROUTES);
+  });
+
+  it('should not redirect to another redirect', () => {
+    const redirectedPaths = new Set(REDIRECT_ROUTES.map((route) => route.path));
+
+    for (const route of REDIRECT_ROUTES) {
+      if (typeof route.redirectTo === 'string') {
+        const target = route.redirectTo.replace(/^\//, '').split(/[#?]/)[0];
+        expect(redirectedPaths.has(target))
+          .withContext(`"${route.path}" redirects to "${target}", which is itself a redirect`)
+          .toBe(false);
+      }
+    }
   });
 });

--- a/adev/src/app/routing/redirections.ts
+++ b/adev/src/app/routing/redirections.ts
@@ -33,7 +33,7 @@ export const REDIRECT_ROUTES: Route[] = [
   },
   {
     path: 'guide/components/importing',
-    redirectTo: '/guide/components/anatomy-of-components#using-components',
+    redirectTo: '/guide/components#using-components',
   },
   {
     path: 'guide/templates/attribute-binding',
@@ -89,7 +89,7 @@ export const REDIRECT_ROUTES: Route[] = [
   },
   {
     path: 'guide/signals/model',
-    redirectTo: '/guide/signals/inputs',
+    redirectTo: '/guide/components/inputs',
   },
   {
     path: 'guide/signals/inputs',
@@ -97,19 +97,19 @@ export const REDIRECT_ROUTES: Route[] = [
   },
   {
     path: 'guide/ngmodules/providers',
-    redirectTo: '/guide/ngmodules',
+    redirectTo: '/guide/ngmodules/overview',
   },
   {
     path: 'guide/ngmodules/singleton-services',
-    redirectTo: '/guide/ngmodules',
+    redirectTo: '/guide/ngmodules/overview',
   },
   {
     path: 'guide/ngmodules/lazy-loading',
-    redirectTo: '/guide/ngmodules',
+    redirectTo: '/guide/ngmodules/overview',
   },
   {
     path: 'guide/ngmodules/faq',
-    redirectTo: '/guide/ngmodules',
+    redirectTo: '/guide/ngmodules/overview',
   },
   {
     path: 'guide/components/anatomy-of-components',
@@ -145,7 +145,7 @@ export const REDIRECT_ROUTES: Route[] = [
   },
   {
     path: 'guide/animations/transitions-and-triggers',
-    redirectTo: '/guide/legacy-animations/transitions-and-triggers',
+    redirectTo: '/guide/legacy-animations/transition-and-triggers',
   },
   {
     path: 'guide/animations/complex-sequences',


### PR DESCRIPTION
Five redirects sent people to the home page instead of a guide, because their target no longer exists: the four `guide/ngmodules/*` entries point at `/guide/ngmodules`, which has no route, and
`guide/animations/transitions-and-triggers` had a plural in a target that is registered as `transition-and-triggers`.

Two more resolved only after a second hop, redirecting to a path that is itself a redirect.

The spec only checked that a `redirectTo` starts with a slash, which all seven satisfied, so it now also checks that the target is a real page and that it is not another redirect.