### PR TITLE
fix(elements): support exposed host directive bindings

### DIFF
--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -36,7 +36,13 @@ import {
   NgElementStrategyFactory,
 } from './element-strategy';
 import {extractProjectableNodes} from './extract-projectable-nodes';
-import {scheduler} from './utils';
+import {
+  getCustomElementHostDirectiveInputs,
+  getHostDirectiveBindings,
+  HostDirectiveInput,
+  HostDirectiveOutput,
+  scheduler,
+} from './utils';
 
 /** Time in milliseconds to wait before destroying the component ref when disconnected. */
 const DESTROY_DELAY = 10;
@@ -50,15 +56,31 @@ export class ComponentNgElementStrategyFactory implements NgElementStrategyFacto
 
   inputMap = new Map<string, string>();
 
+  private readonly hostDirectiveInputs = new Map<string, HostDirectiveInput>();
+  private readonly hostDirectiveOutputs: readonly HostDirectiveOutput[];
+
   constructor(private component: Type<any>) {
     this.componentMirror = reflectComponentType(component)!;
     for (const input of this.componentMirror.inputs) {
       this.inputMap.set(input.propName, input.templateName);
     }
+
+    for (const input of getCustomElementHostDirectiveInputs(component)) {
+      this.inputMap.set(input.publicName, input.publicName);
+      this.hostDirectiveInputs.set(input.publicName, input);
+    }
+
+    this.hostDirectiveOutputs = getHostDirectiveBindings(component).outputs;
   }
 
   create(injector: Injector) {
-    return new ComponentNgElementStrategy(this.component, injector, this.inputMap);
+    return new ComponentNgElementStrategy(
+      this.component,
+      injector,
+      this.inputMap,
+      this.hostDirectiveInputs,
+      this.hostDirectiveOutputs,
+    );
   }
 }
 
@@ -102,6 +124,8 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
     private component: Type<any>,
     private injector: Injector,
     private inputMap: Map<string, string>,
+    private hostDirectiveInputs: Map<string, HostDirectiveInput>,
+    private hostDirectiveOutputs: readonly HostDirectiveOutput[],
   ) {
     this.ngZone = this.injector.get(NgZone);
     this.appRef = this.injector.get(ApplicationRef);
@@ -159,6 +183,15 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
     return this.runInZone(() => {
       if (this.componentRef === null) {
         return this.initialInputValues.get(property);
+      }
+
+      const hostDirectiveInput = this.hostDirectiveInputs.get(property);
+      if (hostDirectiveInput) {
+        const instance = this.componentRef.injector.get(hostDirectiveInput.directive) as Record<
+          string,
+          unknown
+        >;
+        return instance[hostDirectiveInput.directivePropName];
       }
 
       return this.componentRef.instance[property];
@@ -232,13 +265,26 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
       this.component,
     )!.outputs.map(({propName, templateName}) => {
       const emitter: EventEmitter<any> | OutputRef<any> = componentRef.instance[propName];
-      return new Observable((observer) => {
-        const sub = emitter.subscribe((value) => observer.next({name: templateName, value}));
-        return () => sub.unsubscribe();
-      });
+      return this.createOutputObservable(emitter, templateName);
     });
 
+    for (const output of this.hostDirectiveOutputs) {
+      const instance = componentRef.injector.get(output.directive) as Record<string, unknown>;
+      const emitter = instance[output.directivePropName] as EventEmitter<any> | OutputRef<any>;
+      eventEmitters.push(this.createOutputObservable(emitter, output.publicName));
+    }
+
     this.eventEmitters.next(eventEmitters);
+  }
+
+  private createOutputObservable(
+    emitter: EventEmitter<any> | OutputRef<any>,
+    name: string,
+  ): Observable<NgElementStrategyEvent> {
+    return new Observable((observer) => {
+      const sub = emitter.subscribe((value) => observer.next({name, value}));
+      return () => sub.unsubscribe();
+    });
   }
 
   /** Runs in the angular zone, if present. */

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -5,7 +5,16 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Injector, reflectComponentType, Type} from '@angular/core';
+import {
+  Injector,
+  reflectComponentType,
+  Type,
+  ɵComponentDef as ComponentDef,
+  ɵNG_COMP_DEF as NG_COMP_DEF,
+} from '@angular/core';
+
+// Mirrors `InputFlags.SignalBased` from Angular's internal input metadata.
+const SIGNAL_BASED_INPUT = 1 << 0;
 
 /**
  * Provide methods for scheduling the execution of a callback.
@@ -92,6 +101,99 @@ export function getDefaultAttributeToPropertyInputs(
   return attributeToPropertyInputs;
 }
 
+export interface HostDirectiveInput {
+  directive: Type<unknown>;
+  publicName: string;
+  directivePropName: string;
+  transform?: (value: any) => any;
+  isSignal: boolean;
+}
+
+export interface HostDirectiveOutput {
+  directive: Type<unknown>;
+  publicName: string;
+  directivePropName: string;
+}
+
+export interface HostDirectiveBindings {
+  inputs: readonly HostDirectiveInput[];
+  outputs: readonly HostDirectiveOutput[];
+}
+
+const hostDirectiveBindingsCache = new WeakMap<Type<any>, HostDirectiveBindings>();
+
+/**
+ * Gets the inputs and outputs that host directives expose through a component.
+ *
+ * Host directive resolution is delegated to Angular's runtime resolver instead of duplicating
+ * its traversal, aliasing, de-duplication, and forward-ref behavior here.
+ */
+export function getHostDirectiveBindings(component: Type<any>): HostDirectiveBindings {
+  const cached = hostDirectiveBindingsCache.get(component);
+  if (cached) {
+    return cached;
+  }
+
+  const componentDef = (component as any)[NG_COMP_DEF] as ComponentDef<unknown> | undefined;
+  const hostDirectiveDefs = componentDef?.resolveHostDirectives?.([componentDef])[1] ?? null;
+  const inputs: HostDirectiveInput[] = [];
+  const outputs: HostDirectiveOutput[] = [];
+
+  hostDirectiveDefs?.forEach((config, directiveDef) => {
+    for (const inputName in config.inputs) {
+      if (Object.hasOwn(config.inputs, inputName)) {
+        const [directivePropName, flags, transform] = directiveDef.inputs[inputName];
+        inputs.push({
+          directive: config.directive,
+          publicName: config.inputs[inputName],
+          directivePropName,
+          transform: transform ?? undefined,
+          isSignal: (flags & SIGNAL_BASED_INPUT) !== 0,
+        });
+      }
+    }
+
+    for (const outputName in config.outputs) {
+      if (Object.hasOwn(config.outputs, outputName)) {
+        outputs.push({
+          directive: config.directive,
+          publicName: config.outputs[outputName],
+          directivePropName: directiveDef.outputs[outputName],
+        });
+      }
+    }
+  });
+
+  const result = {inputs, outputs};
+  hostDirectiveBindingsCache.set(component, result);
+  return result;
+}
+
+/**
+ * Gets host directive inputs that can be added to the custom-element property namespace without
+ * replacing one of the component's existing input properties or aliases.
+ */
+export function getCustomElementHostDirectiveInputs(
+  component: Type<any>,
+): readonly HostDirectiveInput[] {
+  const componentInputs = reflectComponentType(component)!.inputs;
+  const occupiedPropNames = new Set(componentInputs.map((input) => input.propName));
+  const occupiedTemplateNames = new Set(componentInputs.map((input) => input.templateName));
+  const result: HostDirectiveInput[] = [];
+
+  for (const input of getHostDirectiveBindings(component).inputs) {
+    if (occupiedPropNames.has(input.publicName) || occupiedTemplateNames.has(input.publicName)) {
+      continue;
+    }
+
+    occupiedPropNames.add(input.publicName);
+    occupiedTemplateNames.add(input.publicName);
+    result.push(input);
+  }
+
+  return result;
+}
+
 /**
  * Gets a component's set of inputs. Uses the injector to get the component factory where the inputs
  * are defined.
@@ -105,5 +207,14 @@ export function getComponentInputs(
   transform?: (value: any) => any;
   isSignal: boolean;
 }[] {
-  return reflectComponentType(component)!.inputs;
+  const componentInputs = reflectComponentType(component)!.inputs;
+  return [
+    ...componentInputs,
+    ...getCustomElementHostDirectiveInputs(component).map((input) => ({
+      propName: input.publicName,
+      templateName: input.publicName,
+      transform: input.transform,
+      isSignal: input.isSignal,
+    })),
+  ];
 }

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -79,6 +79,23 @@ describe('ComponentFactoryNgElementStrategy', () => {
     });
   });
 
+  it('should allow subscribing to exposed host directive output events', () => {
+    const events: NgElementStrategyEvent[] = [];
+    strategy.events.subscribe((e) => events.push(e));
+
+    strategy.connect(document.createElement('div'));
+    const componentRef = getComponentRef(strategy)!;
+    const hostDirective = componentRef.injector.get(TestHostDirective);
+
+    hostDirective.hostOutput.next('host-output-a');
+    hostDirective.hostOutput.next('host-output-b');
+
+    expect(events).toEqual([
+      {name: 'exposedHostOutput', value: 'host-output-a'},
+      {name: 'exposedHostOutput', value: 'host-output-b'},
+    ]);
+  });
+
   describe('after connected', () => {
     let componentRef: ComponentRef<TestComponent>;
 
@@ -134,6 +151,16 @@ describe('ComponentFactoryNgElementStrategy', () => {
       expect(componentRef.instance.fooFoo).toBe('fooFoo-1');
     });
 
+    it('should set and read exposed host directive inputs', async () => {
+      const hostDirective = componentRef.injector.get(TestHostDirective);
+
+      strategy.setInputValue('exposedHostInput', 'value');
+      await whenStable();
+
+      expect(hostDirective.hostInput).toBe('host:value');
+      expect(strategy.getInputValue('exposedHostInput')).toBe('host:value');
+    });
+
     it('should initialize the component with falsy initial values', () => {
       expect(strategy.getInputValue('falsyUndefined')).toEqual(undefined);
       expect(componentRef.instance.falsyUndefined).toEqual(undefined);
@@ -170,6 +197,21 @@ describe('ComponentFactoryNgElementStrategy', () => {
         barBar: new SimpleChange(undefined, 'barBar-1', true),
         falsyUndefined: new SimpleChange(undefined, 'notanymore', false),
       });
+    });
+  });
+
+  describe('host directive inputs before connected', () => {
+    it('should apply cached values when the component is created', () => {
+      const strategyFactory = new ComponentNgElementStrategyFactory(TestComponent);
+      const hostStrategy = strategyFactory.create(injector);
+
+      hostStrategy.setInputValue('exposedHostInput', 'initial');
+      hostStrategy.connect(document.createElement('div'));
+
+      const componentRef = getComponentRef(hostStrategy)!;
+      const hostDirective = componentRef.injector.get(TestHostDirective);
+      expect(hostDirective.hostInput).toBe('host:initial');
+      expect(hostStrategy.getInputValue('exposedHostInput')).toBe('host:initial');
     });
   });
 
@@ -370,9 +412,23 @@ export class CdTrackerDir {
   }
 }
 
+@Directive()
+export class TestHostDirective {
+  @Input({transform: (value: unknown) => `host:${value}`}) hostInput!: string;
+  @Input() hiddenHostInput!: string;
+  @Output() hostOutput = new Subject<string>();
+}
+
 @Component({
   selector: 'fake-component',
   imports: [CdTrackerDir],
+  hostDirectives: [
+    {
+      directive: TestHostDirective,
+      inputs: ['hostInput: exposedHostInput'],
+      outputs: ['hostOutput: exposedHostOutput'],
+    },
+  ],
   template: `
     <ng-container cdTracker></ng-container>
     <ng-content select="content-1"></ng-content>

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -9,6 +9,7 @@
 import {
   Component,
   destroyPlatform,
+  Directive,
   DoBootstrap,
   EventEmitter,
   Injector,
@@ -35,6 +36,8 @@ interface WithFooBar {
   barBar: string;
   fooTransformed: unknown;
   fooSignal: string | null;
+  exposedHostInput: string;
+  exposedHostSignal: string | null;
 }
 
 describe('createCustomElement', () => {
@@ -75,6 +78,8 @@ describe('createCustomElement', () => {
       'barbar',
       'foo-transformed',
       'foo-signal',
+      'exposed-host-input',
+      'exposed-host-signal',
     ]);
   });
 
@@ -91,6 +96,21 @@ describe('createCustomElement', () => {
     expect(strategy.getInputValue('barBar')).toBe('value-barbar');
     expect(strategy.getInputValue('fooTransformed')).toBe(true);
     expect(strategy.getInputValue('fooSignal')).toBe('value-signal');
+  });
+
+  it('should expose host directive inputs and preserve their transforms', () => {
+    const element = new NgElementCtor(injector);
+
+    element.setAttribute('exposed-host-input', 'initial');
+    element.connectedCallback();
+
+    expect(strategy.getInputValue('exposedHostInput')).toBe('host:initial');
+
+    element.exposedHostInput = 'updated';
+    expect(strategy.getInputValue('exposedHostInput')).toBe('host:updated');
+
+    // Inputs that the component did not expose must not become part of the custom-element API.
+    expect(NgElementCtor.observedAttributes).not.toContain('hidden-host-input');
   });
 
   it('should work even if the constructor is not called (due to polyfill)', () => {
@@ -342,6 +362,19 @@ describe('createCustomElement', () => {
     expect(isSignal(element.fooFoo)).toBe(true);
   });
 
+  it('should return the value from an exposed host directive signal input getter', () => {
+    const {selector, ElementCtor} = createTestCustomElementWithDefaultStrategy();
+    const element = document.createElement(selector) as HTMLElement & {
+      exposedHostSignal: string | null;
+    };
+    element.setAttribute('exposed-host-signal', 'host-signal-value');
+
+    customElements.define(selector, ElementCtor);
+    testContainer.appendChild(element);
+
+    expect(element.exposedHostSignal).toBe('host-signal-value');
+  });
+
   // Helpers
   function createAndRegisterTestCustomElement(strategyFactory: NgElementStrategyFactory) {
     const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
@@ -365,10 +398,34 @@ describe('createCustomElement', () => {
     };
   }
 
+  function createTestCustomElementWithDefaultStrategy() {
+    return {
+      selector: `test-element-${++selectorUid}`,
+      ElementCtor: createCustomElement(TestComponent, {injector}),
+    };
+  }
+
+  @Directive()
+  class TestHostDirective {
+    @Input({transform: (value: unknown) => `host:${value}`}) hostInput!: string;
+    @Input() hiddenHostInput!: string;
+    // This needs to apply the decorator and pass `isSignal`, because
+    // the compiler transform doesn't run against JIT tests.
+    @Input({isSignal: true} as Input) hostSignal = input<string | null>(null);
+    @Output() hostOutput = new EventEmitter<string>();
+  }
+
   @Component({
     selector: 'test-component',
     template: 'TestComponent|foo({{ fooFoo }})|bar({{ barBar }})',
     standalone: false,
+    hostDirectives: [
+      {
+        directive: TestHostDirective,
+        inputs: ['hostInput: exposedHostInput', 'hostSignal: exposedHostSignal'],
+        outputs: ['hostOutput: exposedHostOutput'],
+      },
+    ],
   })
   class TestComponent {
     @Input() fooFoo: string = 'foo';


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

No documentation changes are required because this fixes existing custom-element behavior without introducing a new public API.

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When a component that exposes host directive inputs or outputs is converted to a custom element with `createCustomElement`, those exposed bindings are not included in the custom-element API.

As a result, exposed host directive inputs cannot be set through element properties or attributes, and exposed host directive outputs are not dispatched as custom-element events.

Issue Number: #53193

## What is the new behavior?

Custom elements now include host directive bindings that are explicitly exposed by the component.

The implementation:

- reuses Angular's runtime host directive resolution instead of duplicating host directive traversal and alias handling;
- exposes host directive input aliases as custom-element properties and observed attributes;
- keeps input writes routed through `ComponentRef.setInput`, preserving Angular's input transforms, signal-input behavior, and change detection;
- resolves host directive instances from the component injector for input reads and output subscriptions;
- dispatches exposed host directive outputs using their public aliases;
- does not expose host directive inputs or outputs that are not part of the component's public host-directive API.

Regression tests cover exposed input aliases, input transforms, values set before and after connection, signal input getters, output events, and hidden host directive inputs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Fixes #53193.
