### PR TITLE
docs: repair the AST link in the AOT compiler guide

### DIFF
--- a/adev/src/content/tools/cli/aot-compiler.md
+++ b/adev/src/content/tools/cli/aot-compiler.md
@@ -258,7 +258,7 @@ The following table describes which expressions the collector can and cannot fol
 | Conditional operator             | yes, if condition is foldable            |
 | Parentheses                      | yes, if the expression is foldable       |
 
-If an expression is not foldable, the collector writes it to `.metadata.json` as an [AST](https://en.wikipedia.org/wiki/Abstract*syntax*tree) for the compiler to resolve.
+If an expression is not foldable, the collector writes it to `.metadata.json` as an [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) for the compiler to resolve.
 
 ## Phase 2: code generation
 


### PR DESCRIPTION
The link to the Wikipedia article on abstract syntax trees spelled the underscores as asterisks, which 404s. The same link two paragraphs earlier in this guide is correct.