### PR TITLE
fix(docs-infra): keep the update guide working for unknown versions in the URL

### DIFF
--- a/adev/src/app/features/update/update.component.spec.ts
+++ b/adev/src/app/features/update/update.component.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {provideRouter} from '@angular/router';
+import {ActivatedRoute, convertToParamMap, provideRouter} from '@angular/router';
 import {provideHttpClient} from '@angular/common/http';
 import {provideHttpClientTesting} from '@angular/common/http/testing';
 import {By} from '@angular/platform-browser';
@@ -89,6 +89,50 @@ describe('UpdateComponent', () => {
         // The test verifies the component renders without errors
         expect(badges.length).toBe(0);
       }
+    });
+  });
+
+  describe('version query parameter', () => {
+    function createWithVersions(v: string): ComponentFixture<UpdateComponent> {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [UpdateComponent],
+        providers: [
+          provideRouter([]),
+          provideHttpClient(),
+          provideHttpClientTesting(),
+          {
+            provide: ActivatedRoute,
+            useValue: {snapshot: {queryParamMap: convertToParamMap({v})}},
+          },
+        ],
+      });
+
+      return TestBed.createComponent(UpdateComponent);
+    }
+
+    it('should keep the default versions when "v" names versions that do not exist', () => {
+      const versionsFixture = createWithVersions('99.0-100.0');
+
+      expect(() => versionsFixture.detectChanges()).not.toThrow();
+      expect(versionsFixture.componentInstance['from'].name).toBe('21.0');
+      expect(versionsFixture.componentInstance['to'].name).toBe('22.0');
+    });
+
+    it('should keep the default versions when "v" has no target version', () => {
+      const versionsFixture = createWithVersions('21.0');
+
+      expect(() => versionsFixture.detectChanges()).not.toThrow();
+      expect(versionsFixture.componentInstance['from'].name).toBe('21.0');
+      expect(versionsFixture.componentInstance['to'].name).toBe('22.0');
+    });
+
+    it('should use the versions named by "v" when both exist', () => {
+      const versionsFixture = createWithVersions('20.0-21.0');
+      versionsFixture.detectChanges();
+
+      expect(versionsFixture.componentInstance['from'].name).toBe('20.0');
+      expect(versionsFixture.componentInstance['to'].name).toBe('21.0');
     });
   });
 

--- a/adev/src/app/features/update/update.component.ts
+++ b/adev/src/app/features/update/update.component.ts
@@ -138,10 +138,15 @@ export default class UpdateComponent {
     // Detect versions of from and to
     const versions = queryMap.get('v');
     if (versions) {
-      const [from, to] = versions.split('-');
-      this.from = this.versions.find((version) => version.name === from)!;
-      this.to = this.versions.find((version) => version.name === to)!;
-      this.showUpdatePath();
+      const [fromName, toName] = versions.split('-');
+      const from = this.versions.find((version) => version.name === fromName);
+      const to = this.versions.find((version) => version.name === toName);
+
+      if (from && to) {
+        this.from = from;
+        this.to = to;
+        this.showUpdatePath();
+      }
     }
   }
 


### PR DESCRIPTION
The update guide picks up its two versions from the `v` query parameter and
forces both lookups with a non-null assertion:

```ts
const [from, to] = versions.split('-');
this.from = this.versions.find((version) => version.name === from)!;
this.to = this.versions.find((version) => version.name === to)!;
this.showUpdatePath();
```

`find` returns `undefined` for a version that is not in the list, and the `!`
hides that from the type system, so `from` and `to` end up undefined while
still typed as `Version`. The template dereferences them immediately, at
`{{ from.name }}` and `from.number >= futureVersion`, so the component throws.

This reproduces on angular.dev today:

- https://angular.dev/update-guide?v=99.0-100.0 — versions that do not exist
- https://angular.dev/update-guide?v=21.0 — no separator, so no target version
- https://angular.dev/update-guide?v=foo — anything unparseable

Each of those throws during hydration:

```
TypeError: Cannot read properties of undefined (reading 'number')
```