### PR TITLE
fix(core): avoid overlapping pure function slots in inherited host bindings

### DIFF
--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -16,12 +16,12 @@ import {
   ContentQueriesFunction,
   DirectiveDef,
   DirectiveDefFeature,
-  HostBindingsFunction,
   RenderFlags,
   ViewQueriesFunction,
 } from '../interfaces/definition';
 import {TAttributes} from '../interfaces/node';
 import {isComponentDef} from '../interfaces/type_checks';
+import {getBindingRoot, getCurrentDirectiveIndex, setBindingRootForHostBindings} from '../state';
 import {mergeHostAttrs} from '../util/attrs_utils';
 import {stringifyForError} from '../util/stringify_utils';
 
@@ -82,8 +82,7 @@ export function ɵɵInheritDefinitionFeature(
         writeableDef.outputs = maybeUnwrapEmpty(definition.outputs);
 
         // Merge hostBindings
-        const superHostBindings = superDef.hostBindings;
-        superHostBindings && inheritHostBindings(definition, superHostBindings);
+        superDef.hostBindings && inheritHostBindings(definition, superDef);
 
         // Merge queries
         const superViewQuery = superDef.viewQuery;
@@ -214,12 +213,30 @@ function inheritContentQueries(
 
 function inheritHostBindings(
   definition: WritableDef,
-  superHostBindings: HostBindingsFunction<any>,
+  superDef: DirectiveDef<any> | ComponentDef<any>,
 ) {
+  const superHostBindings = superDef.hostBindings;
+  if (!superHostBindings) {
+    return;
+  }
+  // `superDef.hostVars` is the total number of binding slots that the superclass' `hostBindings`
+  // function (including anything it inherited itself) expects to own, starting at the binding
+  // root. It is already final at this point, because the superclass' own
+  // `InheritDefinitionFeature` ran when the superclass was defined, and the cumulative rewrite in
+  // `mergeHostAttrsAcrossInheritance` never changes it.
+  const superHostVars = superDef.hostVars;
   const prevHostBindings = definition.hostBindings;
   if (prevHostBindings) {
     definition.hostBindings = (rf: RenderFlags, ctx: any) => {
+      // Both functions were compiled independently, so each of them assumes that its slots start
+      // at the binding root (regular bindings first, followed by pure function/pipe slots, see
+      // `pure_function.ts` and `pipe.ts`). The merged function is invoked with a single binding
+      // root covering the sum of both `hostVars`, so we run the superclass' function as-is and
+      // then move the root (and the binding index) past the slots it owns before running the
+      // subclass' own function. Without this, pure function slots of the two functions overlap.
+      const bindingRoot = getBindingRoot();
       superHostBindings(rf, ctx);
+      setBindingRootForHostBindings(bindingRoot + superHostVars, getCurrentDirectiveIndex());
       prevHostBindings(rf, ctx);
     };
   } else {

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -68,6 +68,73 @@ describe('inheritance', () => {
     );
   });
 
+  // https://github.com/angular/angular/issues/66263
+  describe('pure function slots in inherited host bindings', () => {
+    it('should not write parent and child host bindings into the same LView slot', () => {
+      @Directive({host: {'[attr.parent]': '["parent"][0]'}})
+      class ParentDir {}
+
+      @Directive({host: {'[attr.child]': '["child"][0]'}, selector: '[some-dir]'})
+      class SomeDir extends ParentDir {}
+
+      @Component({template: '<div some-dir></div>', imports: [SomeDir]})
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      // Prior to the fix, this would throw NG0100 (ExpressionChangedAfterItHasBeenCheckedError)
+      // because both `pureFunction` instructions wrote into the same LView slot.
+      expect(() => fixture.detectChanges()).not.toThrow();
+
+      const div: HTMLDivElement = fixture.nativeElement.querySelector('div');
+      expect(div.getAttribute('parent')).toBe('parent');
+      expect(div.getAttribute('child')).toBe('child');
+    });
+
+    it('should support pure functions across three levels of inheritance', () => {
+      @Directive({host: {'[attr.a]': '["a"][0]'}})
+      class ADir {}
+
+      @Directive({host: {'[attr.b]': '["b"][0]'}})
+      class BDir extends ADir {}
+
+      @Directive({host: {'[attr.c]': '["c"][0]'}, selector: '[some-dir]'})
+      class CDir extends BDir {}
+
+      @Component({template: '<div some-dir></div>', imports: [CDir]})
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      expect(() => fixture.detectChanges()).not.toThrow();
+
+      const div: HTMLDivElement = fixture.nativeElement.querySelector('div');
+      expect(div.getAttribute('a')).toBe('a');
+      expect(div.getAttribute('b')).toBe('b');
+      expect(div.getAttribute('c')).toBe('c');
+    });
+
+    it('should support a component inheriting pure function host bindings from a directive', () => {
+      @Directive({host: {'[attr.parent]': '["parent"][0]'}})
+      class ParentDir {}
+
+      @Component({
+        selector: 'some-cmp',
+        template: '',
+        host: {'[attr.child]': '["child"][0]'},
+      })
+      class SomeCmp extends ParentDir {}
+
+      @Component({template: '<some-cmp></some-cmp>', imports: [SomeCmp]})
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      expect(() => fixture.detectChanges()).not.toThrow();
+
+      const cmp: HTMLElement = fixture.nativeElement.querySelector('some-cmp');
+      expect(cmp.getAttribute('parent')).toBe('parent');
+      expect(cmp.getAttribute('child')).toBe('child');
+    });
+  });
+
   it('should ignore inherited ɵdir from polluted Object.prototype', () => {
     const originalDir = (Object.prototype as any).ɵdir;
     let hadOwnDir = false;


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — N/A

## PR Type

- [x] Bugfix

## What is the current behavior?

When a directive with host bindings inherits from another directive that also has host bindings, `InheritDefinitionFeature` merges both `hostBindings` functions into one that runs under a single binding root. Pure function and pipe slots are resolved as `bindingRoot + slotOffset` with compile-time offsets that start at 0 for each independently compiled function, so the parent and child functions write into the same `LView` slots. Depending on the bindings this shows up as `NG0100` ("changed after it was checked") or as an index assertion in dev mode.

Issue Number: #66263

## What is the new behavior?

`inheritHostBindings` runs the superclass function as-is, then moves the binding root (and the binding index) past the `superDef.hostVars` slots it owns before running the subclass' own function. Every level of the inheritance chain therefore gets its own contiguous range of host vars, which is what each compiled function expects. Works for arbitrary depth (A → B → C) and for a component extending a directive; tests cover all three cases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified locally with `//packages/core/test/acceptance:acceptance` (the three new tests fail without the runtime change) and `//packages/core/test:test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
