### PR TITLE
fix(compiler): report unterminated interpolations instead of silently treating them as text

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -132,6 +132,14 @@ function _unknownEntityErrorMsg(entitySrc: string): string {
   return `Unknown entity "${entitySrc}" - use the "&#<decimal>;" or  "&#x<hex>;" syntax`;
 }
 
+function _unterminatedInterpolationErrorMsg(): string {
+  return (
+    'Unterminated interpolation. Could not find a closing "}}" - this can happen if a quote ' +
+    '(" or \') inside the interpolation expression is not closed, causing the rest of the ' +
+    'template to be treated as part of the expression.'
+  );
+}
+
 function _unparsableEntityErrorMsg(type: CharacterReferenceType, entityStr: string): string {
   return `Unable to parse entity "${entityStr}" - ${type} character reference entities must end with ";"`;
 }
@@ -1332,9 +1340,21 @@ class _Tokenizer {
       }
     }
 
-    // We hit EOF without finding a closing interpolation marker
+    // We have stopped consuming the interpolation without finding its closing marker. This is
+    // either because we hit a premature end (e.g. the end of an attribute value) - which is
+    // handled elsewhere and is not an error here - or because we hit the actual end of the file.
+    // The latter can happen, for example, if a quote inside the interpolation expression is never
+    // closed (e.g. `{{ a ? b : ' }}`), which causes the `}}` that follows to be treated as part
+    // of the (still open) string instead of as the end of the interpolation.
+    const isRealEof = this._cursor.peek() === chars.$EOF;
     parts.push(this._getProcessedChars(expressionStart, this._cursor));
     this._endToken(parts);
+    if (isRealEof) {
+      throw this._createError(
+        _unterminatedInterpolationErrorMsg(),
+        this._cursor.getSpan(interpolationStart),
+      );
+    }
   }
 
   private _consumeDirective(start: CharacterCursor, nameStart: CharacterCursor) {

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -2011,6 +2011,16 @@ describe('HtmlParser', () => {
         ]);
       });
 
+      it('should report an unterminated interpolation caused by an unclosed quote (#59507)', () => {
+        // The `'` right before the final `}}` is never closed, so the `}}` is treated as part
+        // of the (still open) string and the interpolation is never terminated. Previously this
+        // was silently treated as plain text with no diagnostic at all.
+        const {errors} = parser.parse(`{{ name ? (name | translate) : ' }}`, 'TestComp');
+        expect(humanizeErrors(errors)).toEqual([
+          [jasmine.stringMatching(/^Unterminated interpolation\./), '0:0'],
+        ]);
+      });
+
       describe('incomplete element tag', () => {
         it('should parse and report incomplete tags after the tag name', () => {
           const {errors, rootNodes} = parser.parse('<div<span><div  </span>', 'TestComp');

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -2474,12 +2474,19 @@ describe('HtmlLexer', () => {
       ]);
     });
 
-    it('should capture everything up to the end of file in the interpolation expression part if there are mismatched quotes', () => {
-      expect(tokenizeAndHumanizeParts('{{ "{{a}}\' }}')).toEqual([
+    it('should capture everything up to the end of file in the interpolation expression part if there are mismatched quotes, and report an error', () => {
+      // The `"` inside the interpolation is never closed, so the lexer never finds the `}}`
+      // that follows (it is treated as part of the still-open string) and runs to the end of
+      // the file. This is a template author error and should be reported (see #59507).
+      const input = '{{ "{{a}}\' }}';
+      const result = tokenize(input, 'someUrl', getHtmlTagDefinition);
+      expect(humanizeParts(result.tokens)).toEqual([
         [TokenType.TEXT, ''],
         [TokenType.INTERPOLATION, '{{', ' "{{a}}\' }}'],
-        [TokenType.TEXT, ''],
         [TokenType.EOF],
+      ]);
+      expect(result.errors.map((e) => e.msg)).toEqual([
+        jasmine.stringMatching(/^Unterminated interpolation\./),
       ]);
     });
 
@@ -3058,6 +3065,25 @@ describe('HtmlLexer', () => {
           '0:56',
         ],
       ]);
+    });
+
+    it('should report an unterminated interpolation caused by an unclosed quote (#59507)', () => {
+      // The `'` that opens the string right before the final `}}` is never closed, so the `}}`
+      // is treated as part of the string and the interpolation runs to the end of the template
+      // without ever finding its closing marker.
+      expect(tokenizeAndHumanizeErrors(`{{ name ? (name | translate) : ' }}`)).toEqual([
+        [jasmine.stringMatching(/^Unterminated interpolation\./), '0:0'],
+      ]);
+    });
+
+    it('should report an unterminated interpolation when there is no closing marker at all', () => {
+      expect(tokenizeAndHumanizeErrors(`{{ foo`)).toEqual([
+        [jasmine.stringMatching(/^Unterminated interpolation\./), '0:0'],
+      ]);
+    });
+
+    it('should not report an unterminated interpolation when it is prematurely (and validly) ended by a tag', () => {
+      expect(tokenizeAndHumanizeErrors(`{{ a <b></b>`)).toEqual([]);
     });
 
     it('should include 2 lines of context in message', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — N/A

## PR Type

- [x] Bugfix

## What is the current behavior?

A template such as

```html
{{ name ? (name | translate) : ' }}
```

(missing the closing `'`) compiles without any error. The HTML lexer keeps scanning the interpolation until the end of the file because the `}}` is considered part of the still-open string, and the whole remainder of the template is silently emitted as plain text.

Issue Number: #59507

## What is the new behavior?

The lexer reports a parse error (`Unterminated interpolation. Could not find a closing "}}" ...`) when an interpolation reaches the end of the file without finding its closing marker. The error goes through the tokenizer's regular error handling, so parsing continues and the language service still gets tokens for incomplete templates.

Interpolations that are prematurely ended by a tag start or by the end of an attribute value keep their existing behavior; the existing tests for those paths are unchanged and a guard test was added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Strictly speaking templates that previously compiled (rendering the broken interpolation as text) now produce a diagnostic, which is the behavior requested in the issue. Verified locally with `//packages/compiler/test/ml_parser/...`, `//packages/compiler-cli/test/ngtsc:ngtsc` and `//packages/language-service/test:test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
