### PR TITLE
build: enable stableTypeOrdering tsconfig flag

### DIFF
--- a/dev-app/tsconfig.json
+++ b/dev-app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "stableTypeOrdering": true,
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,

--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -1042,7 +1042,7 @@ export abstract class ViewportScroller {
     abstract setHistoryScrollRestoration(scrollRestoration: 'auto' | 'manual'): void;
     abstract setOffset(offset: [number, number] | (() => [number, number])): void;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<NullViewportScroller | BrowserViewportScroller>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<BrowserViewportScroller | NullViewportScroller>;
 }
 
 // @public @deprecated

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -80,7 +80,7 @@ export interface AfterViewInit {
 }
 
 // @public
-export const ANIMATION_MODULE_TYPE: InjectionToken<"NoopAnimations" | "BrowserAnimations">;
+export const ANIMATION_MODULE_TYPE: InjectionToken<"BrowserAnimations" | "NoopAnimations">;
 
 // @public
 export type AnimationCallbackEvent = {

--- a/modules/tsconfig.json
+++ b/modules/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "outDir": "../dist/all/",
     "noImplicitAny": true,
+    "stableTypeOrdering": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
       "selenium-webdriver": ["../node_modules/@types/selenium-webdriver/index.d.ts"],
@@ -22,11 +23,7 @@
     "target": "es5",
     "types": ["angular"]
   },
-  "exclude": [
-    "payload_tests",
-    "playground/",
-    "benchmarks/"
-  ],
+  "exclude": ["payload_tests", "playground/", "benchmarks/"],
   "angularCompilerOptions": {
     "strictTemplates": true,
     "skipTemplateCodegen": true

--- a/packages/language-service/test/legacy/project/tsconfig.json
+++ b/packages/language-service/test/legacy/project/tsconfig.json
@@ -1,19 +1,15 @@
 {
   "//00": "This file is used for both IDE and the actual Project creation in Ivy language service for testing purpose",
   "compilerOptions": {
-    "lib": [
-      "es2015",
-      "dom"
-    ],
+    "stableTypeOrdering": true,
+    "lib": ["es2015", "dom"],
     "strict": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "target": "es2015",
     "baseUrl": "../../../../../",
     "paths": {
-      "@angular/*": [
-        "packages/*"
-      ]
+      "@angular/*": ["packages/*"]
     }
   },
   "angularCompilerOptions": {

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -10,6 +10,7 @@
     "noImplicitAny": true,
     "noImplicitOverride": true,
     "strictNullChecks": true,
+    "stableTypeOrdering": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "esModuleInterop": true,
@@ -36,9 +37,9 @@
       "@angular/common/locales/*": ["./common/locales/*"],
       "@angular/compiler-cli": ["./compiler-cli"],
       "@angular/compiler-cli/*": ["./compiler-cli/*"],
-      "@angular/compiler-cli/src/ngtsc/reflection":  ["./compiler-cli/src/ngtsc/reflection/index"],
-      "@angular/compiler-cli/src/ngtsc/metadata":  ["./compiler-cli/src/ngtsc/metadata/index"],
-      "@angular/compiler-cli/private/migrations":  ["./compiler-cli/private/migrations"],
+      "@angular/compiler-cli/src/ngtsc/reflection": ["./compiler-cli/src/ngtsc/reflection/index"],
+      "@angular/compiler-cli/src/ngtsc/metadata": ["./compiler-cli/src/ngtsc/metadata/index"],
+      "@angular/compiler-cli/private/migrations": ["./compiler-cli/private/migrations"],
       "@angular/core/schematics/utils/tsurge/*": ["./core/schematics/utils/tsurge/*"]
     }
   },

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -13,6 +13,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strictNullChecks": true,
+    "stableTypeOrdering": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "strictPropertyInitialization": true,

--- a/packages/zone.js/test/typings/tsconfig.json
+++ b/packages/zone.js/test/typings/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "stableTypeOrdering": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/zone.js/tsconfig.json
+++ b/packages/zone.js/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "stableTypeOrdering": true,
     "module": "esnext",
     "target": "es2022",
     "moduleResolution": "node",

--- a/vscode-ng-language-service/tsconfig.json
+++ b/vscode-ng-language-service/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "stableTypeOrdering": true,
     "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
`stableTypeOrdering` was recently enabled in the internal builds. While there aren't any breakages in Angular, these changes enable it so we can catch potential issues earlier.
