### PR TITLE
refactor(forms): use SimpleChanges for control changes

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -215,7 +215,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
     this.update.emit(newValue);
   }
 
-  private _isControlChanged(changes: {[key: string]: any}): boolean {
+  private _isControlChanged(changes: SimpleChanges): boolean {
     return Object.hasOwn(changes, 'form');
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`FormControlDirective._isControlChanged` accepts an `any`-valued index signature even though it is only called with the `SimpleChanges` value received by `ngOnChanges`.

Issue Number: N/A

## What is the new behavior?

The private helper uses the precise `SimpleChanges` type already provided by the lifecycle hook. This removes an unnecessary `any` without changing runtime behavior or the public API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No new tests or documentation are needed because this is an internal type-only refactor with no behavior or API changes.

Verified with:

```shell
./node_modules/.bin/bazel test //packages/forms/test:test
```
