### PR TITLE
refactor(forms): type async validator subscription

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -14,7 +14,7 @@ import {
   untracked,
   ɵWritable as Writable,
 } from '@angular/core';
-import {Observable, Subject} from 'rxjs';
+import {Observable, Subject, Subscription} from 'rxjs';
 
 import {
   asyncValidatorsDroppedWithOptsWarning,
@@ -507,7 +507,7 @@ export abstract class AbstractControl<
   _hasRequired = signal(false);
 
   private _parent: FormGroup | FormArray | null = null;
-  private _asyncValidationSubscription: any;
+  private _asyncValidationSubscription: Subscription | undefined;
 
   /**
    * Contains the result of merging synchronous validators into a single validator function


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`AbstractControl._asyncValidationSubscription` is typed as `any`, even though it only stores the `Subscription` returned by the async validator observable.

Issue Number: N/A

## What is the new behavior?

The private field uses `Subscription | undefined`, matching both the value returned by `Observable.subscribe` and the field's initial unassigned state. This removes an unnecessary `any` without changing runtime behavior or the public API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No new tests or documentation are needed because this is an internal type-only refactor with no behavior or API changes.

Verified with:

```shell
./node_modules/.bin/bazel test //packages/forms/test:test
./node_modules/.bin/bazel build //packages/forms
```
