### PR TITLE
refactor(router): replace internal any types

### DIFF
--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -125,7 +125,7 @@ export class RouterPreloader implements OnDestroy {
   }
 
   private processRoutes(injector: EnvironmentInjector, routes: Routes): Observable<void> {
-    const res: Observable<any>[] = [];
+    const res: Observable<void>[] = [];
     for (const route of routes) {
       if (route.providers && !route._injector) {
         route._injector = createEnvironmentInjector(

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -733,7 +733,7 @@ class UrlParser {
       return;
     }
     this.capture(key);
-    let value: any = '';
+    let value = '';
     if (this.consumeOptional('=')) {
       const valueMatch = matchSegments(this.remaining);
       if (valueMatch) {
@@ -752,7 +752,7 @@ class UrlParser {
       return;
     }
     this.capture(key);
-    let value: any = '';
+    let value = '';
     if (this.consumeOptional('=')) {
       const valueMatch = matchUrlQueryParamValue(this.remaining);
       if (valueMatch) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The URL parser stores matrix and query parameter values as `any`, although the matching helpers only produce strings. The route preloader also stores `Observable<void>` operations in an `Observable<any>[]` array.

Issue Number: N/A

## What is the new behavior?

URL parameter values are inferred as strings and the preloading operation array is typed as `Observable<void>[]`. These types match the existing internal data flows without changing runtime behavior or the public API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No new tests or documentation are needed because this is an internal type-only refactor with no behavior or API changes.

Verified with:

```shell
./node_modules/.bin/bazel test //packages/router/test:test
./node_modules/.bin/bazel build //packages/router
```
