### PR TITLE
refactor(compiler): use unknown for lexer errors

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -548,7 +548,7 @@ class _Tokenizer {
     return error;
   }
 
-  private handleError(e: any) {
+  private handleError(e: unknown) {
     if (e instanceof CursorError) {
       e = this._createError(e.msg, this._cursor.getSpan(e.cursor));
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The lexer error handler accepts `any`, although it only accesses an error after narrowing it with `instanceof` and otherwise rethrows the value.

Issue Number: N/A

## What is the new behavior?

The error handler accepts `unknown`, requiring the existing `instanceof` checks to narrow the value before accessing its properties. Runtime behavior and the public API remain unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No new tests or documentation are needed because this is an internal type-only refactor with no behavior or API changes.

Verified with:

```shell
./node_modules/.bin/bazel test //packages/compiler/test:test
./node_modules/.bin/bazel build //packages/compiler
```
