### PR TITLE
refactor(compiler-cli): type empty host directives array

### DIFF
--- a/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
@@ -13,7 +13,7 @@ import {ClassDeclaration} from '../../reflection';
 import {flattenInheritedDirectiveMetadata} from './inheritance';
 import {isHostDirectiveMetaForGlobalMode} from './util';
 
-const EMPTY_ARRAY: ReadonlyArray<any> = [];
+const EMPTY_ARRAY: ReadonlyArray<DirectiveMeta> = [];
 
 /** Resolves the host directives of a directive to a flat array of matches. */
 export class HostDirectivesResolver {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`HostDirectivesResolver` uses a shared empty result typed as `ReadonlyArray<any>`, although every non-empty result contains `DirectiveMeta` entries.

Issue Number: N/A

## What is the new behavior?

The shared empty result is typed as `ReadonlyArray<DirectiveMeta>`, matching the resolver's return type and cache values. Runtime behavior and the public API remain unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No new tests or documentation are needed because this is an internal type-only refactor with no behavior or API changes.

Verified with:

```shell
./node_modules/.bin/bazel test //packages/compiler-cli/src/ngtsc/annotations/directive/test:test //packages/compiler-cli/src/ngtsc/annotations/component/test:test
./node_modules/.bin/bazel build //packages/compiler-cli
```
