### PR TITLE
fix(router): avoid empty URL segments for trailing slashes

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -681,6 +681,18 @@ class UrlParser {
     }
 
     while (this.peekStartsWith('/') && !this.peekStartsWith('//') && !this.peekStartsWith('/(')) {
+      // A trailing slash does not represent a meaningful URL segment. Consuming it here avoids
+      // creating an empty UrlSegment, which can make `navigateByUrl` match a wildcard or a route
+      // with an extra parameter instead of the otherwise matching route.
+      if (
+        this.remaining === '/' ||
+        this.peekStartsWith('/?') ||
+        this.peekStartsWith('/#') ||
+        this.peekStartsWith('/)')
+      ) {
+        this.capture('/');
+        break;
+      }
       this.capture('/');
       segments.push(this.parseSegment());
     }

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -428,6 +428,24 @@ describe('url serializer', () => {
     });
   });
 
+  describe('trailing slashes', () => {
+    // Regression test: https://github.com/angular/angular/issues/42733
+    it('should not create an empty segment for a trailing slash', () => {
+      const tree = url.parse('/one/two/');
+
+      expectSegment(tree.root.children[PRIMARY_OUTLET], 'one/two');
+      expect(url.serialize(tree)).toEqual('/one/two');
+    });
+
+    it('should preserve query params and fragments after a trailing slash', () => {
+      expect(url.serialize(url.parse('/test/?foo=bar#frag'))).toEqual('/test?foo=bar#frag');
+    });
+
+    it('should not create an empty segment for a trailing slash in a secondary outlet', () => {
+      expect(url.serialize(url.parse('/one(left:two/)'))).toEqual('/one(left:two)');
+    });
+  });
+
   describe('multiple leading slashes', () => {
     // Regression test: https://github.com/angular/angular/issues/66233
     // `///path` was parsed into an empty UrlSegment followed by `path`, which the serializer


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — not applicable; this change does not affect the public API or documentation

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`DefaultUrlSerializer` creates an empty `UrlSegment` when parsing a URL
with a trailing slash. As a result, `navigateByUrl()` can match a wildcard
route or a route with an additional parameter instead of the otherwise
matching route.

Issue Number: #42733

## What is the new behavior?

Terminal trailing slashes are consumed without creating an empty
`UrlSegment`.

URLs such as `/test/` are therefore parsed equivalently to `/test` for
route matching, while query parameters, fragments, and secondary outlets
continue to be parsed correctly.

Regression tests cover a regular trailing slash, a trailing slash before
query parameters and fragments, and a trailing slash inside a secondary
outlet.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The change is intentionally limited to terminal trailing slashes and does
not alter handling of outlet separators, child outlet syntax, or matrix
parameters.