### PR TITLE
refactor(core): clarify ICU translation errors.

### DIFF
--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -181,7 +181,11 @@ export function i18nStartFirstCreatePass(
           // the value can change based on the locale and users aren't guaranteed to hit
           // an invalid string while they're developing.
           if (typeof icuExpression !== 'object') {
-            throw new Error(`Unable to parse ICU expression in "${message}" message.`);
+            throw new Error(
+              `Unable to parse ICU expression in "${message}" message. ` +
+                `Check that the translation preserves the ICU expression from the source message. ` +
+                `ICU expressions cannot be introduced only in a translation.`,
+            );
           }
           const icuContainerTNode = createTNodeAndAddOpCode(
             tView,

--- a/packages/localize/src/localize/src/localize.ts
+++ b/packages/localize/src/localize/src/localize.ts
@@ -58,6 +58,10 @@ export interface TranslateFn {
  * $localize `some string to localize`
  * ```
  *
+ * IMPORTANT: `$localize` does not support ICU expressions. Use an Angular template with an `i18n`
+ * marker for ICU messages. An ICU expression must also be present in the source template; it cannot
+ * be introduced only by a translation.
+ *
  * **Providing meaning, description and id**
  *
  * You can optionally specify one or more of `meaning`, `description` and `id` for a localized


### PR DESCRIPTION
refactor(core): clarify ICU translation errors
Summary
clarify the runtime error shown when a translation introduces ICU syntax that is not present in the source message
document that $localize tagged messages do not support ICU expressions
keep the existing i18n acceptance coverage rather than adding a duplicate test file
Fixes #48217
Testing
previous CI runs passed the framework, adev, devtools, integration, TypeScript, and code-lint checks
this update rebases the same two-file change onto current main; CI will re-run for the rewritten commit

