### PR TITLE
docs: add missing tap import and AppConfig interface to environment configuration reference

### DIFF
--- a/skills/dev-skills/angular-developer/references/environment-configuration.md
+++ b/skills/dev-skills/angular-developer/references/environment-configuration.md
@@ -81,10 +81,15 @@ Load the configuration before the application starts:
 ```ts
 import {Service, inject} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
+import {tap} from 'rxjs';
+
+interface AppConfig {
+  apiUrl: string;
+}
 
 @Service()
 export class AppConfigService {
-  private config!: {apiUrl: string};
+  private config!: AppConfig;
 
   private readonly http = inject(HttpClient);
 


### PR DESCRIPTION
## Description
This PR fixes the code snippet in `skills/dev-skills/angular-developer/references/environment-configuration.md` by:
- Adding the missing `tap` operator import from `rxjs`.
- Explicitly defining the `AppConfig` interface used by `http.get<AppConfig>` to make the TypeScript code self-contained and valid.

## PR Checklist
- [x] Follows the commit message guidelines
- [x] Documentation is accurate and code snippet is self-contained