### PR TITLE
fix(localize): safely identify Babel parse errors

### DIFF
--- a/packages/localize/tools/src/source_file_utils.ts
+++ b/packages/localize/tools/src/source_file_utils.ts
@@ -451,8 +451,8 @@ export class BabelParseError extends Error {
   }
 }
 
-export function isBabelParseError(e: any): e is BabelParseError {
-  return e.type === 'BabelParseError';
+export function isBabelParseError(e: unknown): e is BabelParseError {
+  return typeof e === 'object' && e !== null && 'type' in e && e.type === 'BabelParseError';
 }
 
 export function buildCodeFrameError(

--- a/packages/localize/tools/test/source_file_utils_spec.ts
+++ b/packages/localize/tools/test/source_file_utils_spec.ts
@@ -15,9 +15,11 @@ import generate from '@babel/generator';
 import {ɵmakeTemplateObject} from '../../index';
 
 import {
+  BabelParseError,
   buildLocalizeReplacement,
   getLocation,
   isArrayOfExpressions,
+  isBabelParseError,
   isGlobalIdentifier,
   isNamedIdentifier,
   isStringLiteralArray,
@@ -34,6 +36,25 @@ runInNativeFileSystem('utils', () => {
   let fs: PathManipulation;
   beforeEach(() => (fs = getFileSystem()));
   describe('', () => {
+    describe('isBabelParseError()', () => {
+      it('should identify a BabelParseError', () => {
+        expect(
+          isBabelParseError(new BabelParseError(t.identifier('value'), 'test error')),
+        ).toBeTrue();
+      });
+
+      it('should return false for non-object values', () => {
+        expect(isBabelParseError(null)).toBeFalse();
+        expect(isBabelParseError(undefined)).toBeFalse();
+        expect(isBabelParseError('test error')).toBeFalse();
+        expect(isBabelParseError(1)).toBeFalse();
+      });
+
+      it('should return false for other errors', () => {
+        expect(isBabelParseError(new Error('test error'))).toBeFalse();
+      });
+    });
+
     describe('isNamedIdentifier()', () => {
       it('should return true if the expression is an identifier with name `$localize`', () => {
         const taggedTemplate = getTaggedTemplate('$localize ``;');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`isBabelParseError` is called from three `catch` blocks to decide whether an exception is a known parse error or should propagate unchanged. JavaScript allows any value to be thrown, but the guard accepts `any` and reads its `type` property without checking that the value is an object.

For example, passing a thrown `null` value currently produces:

```text
TypeError: Cannot read properties of null (reading 'type')
```

This replaces the original exception with an error from the guard itself, which makes failures harder to diagnose and changes error propagation behavior.

Issue Number: N/A

## What is the new behavior?

The guard accepts `unknown` and narrows the caught value before reading the marker property. Non-object thrown values now return `false`, allowing the original exception to propagate unchanged.

Regression tests cover `BabelParseError`, non-object values, and unrelated errors.

## Why is this useful rather than cosmetic?

This is not only an annotation change:

- It prevents a runtime `TypeError` in the error-handling path.
- It preserves the original thrown value instead of masking it.
- The `unknown` parameter makes the compiler require narrowing before future property access.
- The regression test fails against the previous implementation with the exact runtime error shown above.

The existing marker-based detection behavior for `BabelParseError` remains unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

