### PR TITLE
fix(compiler): respect injector context for pipe factories

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipe_di_change_detector_ref_my_other_pipe_fac.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipe_di_change_detector_ref_my_other_pipe_fac.js
@@ -2,7 +2,7 @@ export class MyOtherPipe {
   …
   static ɵfac = function MyOtherPipe_Factory(__ngFactoryType__) {
     /* @ts-ignore */
-    return new (__ngFactoryType__ || MyOtherPipe)($i0$.ɵɵdirectiveInject($i0$.ChangeDetectorRef, 24));
+    return new (__ngFactoryType__ || MyOtherPipe)($i0$.ɵɵinject($i0$.ChangeDetectorRef, 24));
   };
   …
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipe_di_change_detector_ref_my_pipe_fac.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipe_di_change_detector_ref_my_pipe_fac.js
@@ -2,7 +2,7 @@ export class MyPipe {
   …
   static ɵfac = function MyPipe_Factory(__ngFactoryType__) {
     /* @ts-ignore */
-    return new (__ngFactoryType__ || MyPipe)($i0$.ɵɵdirectiveInject($i0$.ChangeDetectorRef, 16));
+    return new (__ngFactoryType__ || MyPipe)($i0$.ɵɵinject($i0$.ChangeDetectorRef, 16));
   };
   …
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_pipe_first.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_pipe_first.js
@@ -3,7 +3,7 @@ export class MyOtherPipe {
   // ...
   static ɵfac = function MyOtherPipe_Factory(__ngFactoryType__) {
     /* @ts-ignore */
-    return new (__ngFactoryType__ || MyOtherPipe)(i0.ɵɵdirectiveInject(Service, 16));
+    return new (__ngFactoryType__ || MyOtherPipe)(i0.ɵɵinject(Service, 16));
   };
   static ɵpipe = /*@__PURE__*/ i0.ɵɵdefinePipe({ name: "myOtherPipe", type: MyOtherPipe, pure: true, standalone: false });
   static ɵprov = /*@__PURE__*/ i0.ɵɵdefineInjectable({ token: MyOtherPipe, factory: MyOtherPipe.ɵfac });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_pipe_last.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_pipe_last.js
@@ -3,7 +3,7 @@ export class MyPipe {
   // ...
   static ɵfac = function MyPipe_Factory(__ngFactoryType__) {
     /* @ts-ignore */
-    return new (__ngFactoryType__ || MyPipe)(i0.ɵɵdirectiveInject(Service, 16));
+    return new (__ngFactoryType__ || MyPipe)(i0.ɵɵinject(Service, 16));
   };
   static ɵpipe = /*@__PURE__*/ i0.ɵɵdefinePipe({ name: "myPipe", type: MyPipe, pure: true, standalone: false });
   static ɵprov = /*@__PURE__*/ i0.ɵɵdefineInjectable({ token: MyPipe, factory: MyPipe.ɵfac });

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -1196,7 +1196,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainPipe.ɵfac = function MainPipe_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainPipe)(i0.ɵɵdirectiveInject(i1.SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(i2.SomeService3, 16), i0.ɵɵdirectiveInject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`,
+          `MainPipe.ɵfac = function MainPipe_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainPipe)(i0.ɵɵinject(i1.SomeService1, 16), i0.ɵɵinject(SomeService2, 16), i0.ɵɵinject(i2.SomeService3, 16), i0.ɵɵinject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN, 16)); };`,
         );
       });
 
@@ -1229,7 +1229,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainPipe.ɵfac = function MainPipe_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainPipe)(i0.ɵɵdirectiveInject(i1.SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(i2.SomeService3, 16), i0.ɵɵdirectiveInject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`,
+          `MainPipe.ɵfac = function MainPipe_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainPipe)(i0.ɵɵinject(i1.SomeService1, 16), i0.ɵɵinject(SomeService2, 16), i0.ɵɵinject(i2.SomeService3, 16), i0.ɵɵinject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN, 16)); };`,
         );
       });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2524,7 +2524,7 @@ runInEachFileSystem((os: string) => {
 
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain(
-        'return new (__ngFactoryType__ || TestPipe)(i0.ɵɵdirectiveInject(Dep, 16));',
+        'return new (__ngFactoryType__ || TestPipe)(i0.ɵɵinject(Dep, 16));',
       );
     });
 

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -332,8 +332,10 @@ function getInjectFn(target: FactoryTarget): o.ExternalReference {
   switch (target) {
     case FactoryTarget.Component:
     case FactoryTarget.Directive:
-    case FactoryTarget.Pipe:
       return R3.directiveInject;
+    // Pipe factories can run in either a node or an environment injector, so defer to the
+    // current inject implementation.
+    case FactoryTarget.Pipe:
     case FactoryTarget.NgModule:
     case FactoryTarget.Injectable:
     default:

--- a/packages/core/src/render3/instructions/di.ts
+++ b/packages/core/src/render3/instructions/di.ts
@@ -19,8 +19,9 @@ import {getCurrentTNode, getLView} from '../state';
 /**
  * Returns the value associated to the given token from the injectors.
  *
- * `directiveInject` is intended to be used for directive, component and pipe factories.
- *  All other injection use `inject` which does not walk the node injector tree.
+ * `directiveInject` is intended to be used for directive and component factories. Pipe factories
+ * use `inject` so their dependencies are resolved from the injector creating the pipe. When a pipe
+ * is created in a view, `inject` is configured to use `directiveInject`.
  *
  * Usage example (in factory function):
  *

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -4316,6 +4316,37 @@ describe('di', () => {
       expect(fixture.nativeElement.innerHTML).toEqual('default value');
     });
 
+    it('should not give environment-provided pipes access to the node context', () => {
+      const TOKEN = new InjectionToken<string>('TOKEN');
+
+      @Pipe({name: 'test'})
+      class TestPipe {
+        readonly injectedValue = inject(TOKEN);
+
+        constructor(@Inject(TOKEN) readonly constructorValue: string) {}
+
+        transform(value: string): string {
+          return value;
+        }
+      }
+
+      @Component({
+        template: '',
+        providers: [{provide: TOKEN, useValue: 'node value'}],
+      })
+      class TestCmp {
+        readonly pipe = inject(TestPipe);
+      }
+
+      TestBed.configureTestingModule({
+        providers: [TestPipe, {provide: TOKEN, useValue: 'environment value'}],
+      });
+      const pipe = TestBed.createComponent(TestCmp).componentInstance.pipe;
+
+      expect(pipe.constructorValue).toBe('environment value');
+      expect(pipe.injectedValue).toBe('environment value');
+    });
+
     describe('with an options object argument', () => {
       it('should be able to optionally inject a service', () => {
         const TOKEN = new InjectionToken<string>('TOKEN');


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the Angular commit guidelines
- [x] Tests for the bug fix have been added
- [x] Relevant internal DI documentation has been updated

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

Fixes #50952.

Angular currently compiles constructor dependencies for a `@Pipe` class with `ɵɵdirectiveInject`, regardless of which injector creates the pipe.

This is correct when Angular creates the pipe for a template, but the same factory can also be invoked when the pipe class is registered as an environment or NgModule provider. In that case, the hard-coded `ɵɵdirectiveInject` call can leak the active component node context into the EnvironmentInjector-created pipe.

As a result, constructor injection and `inject()` resolve dependencies from different injector hierarchies:

- constructor injection can incorrectly resolve a component-scoped provider;
- `inject()` correctly resolves from the EnvironmentInjector and may report that no provider exists.

The behavior depends on the injection syntax even though both calls construct the same class through the same provider.

## Why is this important?

Injector ownership determines service lifetime and scope. An EnvironmentInjector-created instance must not accidentally capture a provider from whichever component happens to trigger its first creation.

Besides making constructor injection and `inject()` inconsistent, the current behavior can make a supposedly environment-scoped pipe depend on component state and on creation order. Migrating constructor parameters to `inject()` can then expose an unexpected runtime failure even though the requested dependency did not change.

## What is the new behavior?

Pipe factory dependencies are emitted with the context-sensitive `ɵɵinject` instruction.

- When a pipe is created for a template, the existing `ɵɵpipe` runtime instruction installs `ɵɵdirectiveInject` as the active implementation. Template pipes therefore retain access to the appropriate node-scoped providers.
- When a pipe is created by an EnvironmentInjector, `ɵɵinject` uses that EnvironmentInjector. Constructor injection and direct `inject()` calls now resolve from the same context.

Component and directive factories continue to emit `ɵɵdirectiveInject`; the change is intentionally scoped to pipe factories.

Compiler expectations were updated for full compilation, linked partial compilation, local compilation, standalone pipes, optional injection flags, `ChangeDetectorRef`, and pipe/injectable decorator ordering.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Code that relies on an environment-provided pipe constructor accessing a component-scoped provider will no longer receive that provider.

For per-component scope, provide both the pipe and its dependency in the same component or directive injector. For environment scope, provide both through the same EnvironmentInjector or NgModule provider hierarchy.

This aligns constructor injection with the behavior already exposed by `inject()` and restores the injector boundary expected for environment-provided instances.

## Verification

The regression test was run without the compiler fix first and failed because constructor injection returned the node value instead of the environment value. After the fix, both constructor injection and `inject()` return the environment value.

The following Bazel targets pass:

- `//packages/core/test/acceptance:acceptance`
- `//packages/compiler-cli/test/ngtsc:ngtsc`
- `//packages/compiler-cli/test/compliance/full:full`
- `//packages/compiler-cli/test/compliance/linked:linked`
- `//packages/compiler-cli/test/compliance/local:local`

Formatting checks pass for all changed files, and `git diff --check` reports no errors.
