### PR TITLE
refactor(docs-infra): drop exclude patterns for examples that no longer exist

### DIFF
--- a/adev/src/content/examples/BUILD.bazel
+++ b/adev/src/content/examples/BUILD.bazel
@@ -13,16 +13,12 @@ copy_to_bin(
     srcs = glob(
         ["**/app/**"],
         exclude = [
-            "testing/**",  # Can't embed test code
             "i18n/**",  # @angular/localize/init not available in docs app
             "elements/**",  # @angular/elements not available in docs app
             "service-worker-getting-started/**",  # @angular/service-worker not available in docs app
             # TODO: The following examples have broken code that does not compile, fix them and remove them from this list.
-            "ssr/**",
-            "resolution-modifiers/**",
             "reactive-forms/**",
             "form-validation/**",
-            "dependency-injection/**",
         ],
     ),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
The `embeddable` glob excludes nine example directories. Four of them, `testing`, `ssr`, `resolution-modifiers` and `dependency-injection`, were removed by #66753 and #61686 without updating this file, so those patterns match nothing.

Three of the four sit under a TODO about examples that do not compile. Those were deleted rather than fixed, which leaves `reactive-forms` and `form-validation` as the only two the note still applies to.