### PR TITLE
docs: clarify onSameUrlNavigation reload behavior

### DIFF
--- a/adev/src/content/guide/routing/customizing-route-behavior.md
+++ b/adev/src/content/guide/routing/customizing-route-behavior.md
@@ -29,7 +29,7 @@ provideRouter(routes, withRouterConfig({canceledNavigationResolution: 'computed'
 
 ### React to same-URL navigations
 
-`onSameUrlNavigation` configures what should happen when the user asks to navigate to the current URL. The default `'ignore'` skips work, while `'reload'` re-runs guards and resolvers and refreshes component instances.
+`onSameUrlNavigation` configures what should happen when the user asks to navigate to the current URL. The default `'ignore'` skips work, while `'reload'` instructs the Router to process the URL in its navigation pipeline rather than skipping it. Guard and resolver reruns are governed by [`runGuardsAndResolvers`](api/router/RunGuardsAndResolvers), and component reuse is determined by the [route reuse strategy](#route-reuse-strategy).
 
 This is useful when you want repeated clicks on a list filter, left-nav item, or refresh button to trigger new data retrieval even though the URL does not change.
 
@@ -75,9 +75,7 @@ export const routes: Routes = [
 ```
 
 ```ts
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class Customer {
   private route = inject(ActivatedRoute);
 
@@ -94,9 +92,7 @@ This ensures matrix parameters, route data, and resolved values are available fu
 ```
 
 ```ts
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class Customer {
   private route = inject(ActivatedRoute);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `onSameUrlNavigation` section says `'reload'` "re-runs guards and resolvers and refreshes component instances," which reads as a guarantee. In practice guard/resolver execution is gated by the route's `runGuardsAndResolvers` config and component recreation is gated by the `RouteReuseStrategy`, so `'reload'` alone does neither.

Issue Number: #70367

## What is the new behavior?

The paragraph now says `'reload'` reprocesses the navigation (redirects, guards, resolvers) as if the URL had changed, and calls out that actual guard/resolver rerun and component recreation are controlled separately by `runGuardsAndResolvers` and the route reuse strategy, with links to both.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information