### PR TITLE
fix(service-worker): validate redirected assets against the original hash

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -363,9 +363,13 @@ export abstract class AssetGroup {
     }
   }
 
-  protected async fetchFromNetwork(req: Request, redirectLimit: number = 3): Promise<Response> {
+  protected async fetchFromNetwork(
+    req: Request,
+    redirectLimit: number = 3,
+    canonicalUrl: NormalizedUrl = this.adapter.normalizeUrl(req.url),
+  ): Promise<Response> {
     // Make a cache-busted request for the resource.
-    const res = await this.cacheBustedFetchFromNetwork(req);
+    const res = await this.cacheBustedFetchFromNetwork(req, canonicalUrl);
 
     // Check for redirected responses, and follow the redirects.
     if ((res as any)['redirected'] && !!res.url) {
@@ -376,8 +380,16 @@ export abstract class AssetGroup {
         );
       }
 
-      // Unwrap the redirect directly.
-      return this.fetchFromNetwork(this.newRequestWithMetadata(res.url, req), redirectLimit - 1);
+      // Unwrap the redirect directly. The response that is eventually returned here is cached
+      // under the *original* request, so `canonicalUrl` is carried through the recursion to keep
+      // validating against the hash the manifest specifies for that original URL. Validating
+      // against the redirect target instead would leave the cached contents unvalidated, since
+      // the target is not itself a manifest entry.
+      return this.fetchFromNetwork(
+        this.newRequestWithMetadata(res.url, req),
+        redirectLimit - 1,
+        canonicalUrl,
+      );
     }
 
     return res;
@@ -385,10 +397,14 @@ export abstract class AssetGroup {
 
   /**
    * Load a particular asset from the network, accounting for hash validation.
+   *
+   * `url` is the normalized URL whose manifest hash the response must satisfy. It differs from the
+   * URL of `req` when a redirect is being followed on behalf of a hashed asset.
    */
-  protected async cacheBustedFetchFromNetwork(req: Request): Promise<Response> {
-    const url = this.adapter.normalizeUrl(req.url);
-
+  protected async cacheBustedFetchFromNetwork(
+    req: Request,
+    url: NormalizedUrl = this.adapter.normalizeUrl(req.url),
+  ): Promise<Response> {
     // If a hash is available for this resource, then compare the fetched version with the
     // canonical hash. Otherwise, the network version will have to be trusted.
     if (this.hashes.has(url)) {

--- a/packages/service-worker/worker/test/prefetch_spec.ts
+++ b/packages/service-worker/worker/test/prefetch_spec.ts
@@ -18,7 +18,7 @@ import {
   tmpHashTable,
   tmpManifestSingleAssetGroup,
 } from '../testing/mock';
-import {SwTestHarnessBuilder} from '../testing/scope';
+import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
 import {envIsSupported} from '../testing/utils';
 
 (function () {
@@ -59,6 +59,33 @@ import {envIsSupported} from '../testing/utils';
         'test',
       );
     });
+
+    /**
+     * Build a scope in which `/foo.txt` is served as a response that has already been redirected
+     * to `/redirect-target.txt`, where `redirectedBody` is what the redirected response carries
+     * and `targetBody` is what a direct request for the redirect target returns.
+     */
+    function scopeForRedirect(redirectedBody: string, targetBody: string) {
+      const server = new MockServerStateBuilder()
+        .withStaticFiles(dist.extend().addFile('/redirect-target.txt', targetBody).build())
+        .withManifest(manifest)
+        .withRedirect('/foo.txt', '/redirect-target.txt', redirectedBody)
+        .build();
+      return new SwTestHarnessBuilder().withServerState(server).build();
+    }
+
+    function groupForScope(harness: SwTestHarness): PrefetchAssetGroup {
+      return new PrefetchAssetGroup(
+        harness,
+        harness,
+        idle,
+        manifest.assetGroups![0],
+        tmpHashTable(manifest),
+        new CacheDatabase(harness),
+        'test',
+      );
+    }
+
     it('initializes without crashing', async () => {
       await group.initializeFully();
     });
@@ -117,6 +144,35 @@ import {envIsSupported} from '../testing/utils';
       const err = await errorFrom(group.initializeFully());
       expect(err.message).toContain('Hash mismatch');
     });
+    it('caches a redirected resource whose redirect target matches the manifest hash', async () => {
+      // A hashed asset served through a redirect to another location, where that location serves
+      // the contents the manifest expects. This is the ordinary "assets are served from a CDN"
+      // deployment and must keep working.
+      const redirectScope = scopeForRedirect('this is foo', 'this is foo');
+      group = groupForScope(redirectScope);
+
+      await group.initializeFully();
+
+      const res = await group.handleFetch(redirectScope.newRequest('/foo.txt'), testEvent);
+      expect(await res!.text()).toEqual('this is foo');
+    });
+
+    it('throws if the redirect target does not match the manifest hash of the original URL', async () => {
+      // The browser follows the redirect before the service worker sees the response, so the
+      // redirected response carries the target's contents and is validated against the hash the
+      // manifest lists for `/foo.txt`. The redirect is then unwrapped with a second request, and
+      // it is that second response which gets cached under `/foo.txt`. Serving the expected
+      // contents first and different contents second must not result in the latter being cached
+      // unvalidated.
+      const redirectScope = scopeForRedirect('this is foo', 'malicious contents');
+      group = groupForScope(redirectScope);
+
+      const err = await errorFrom(group.initializeFully());
+      expect(err?.message).toContain('Hash mismatch');
+
+      expect(redirectScope.caches.original.dehydrate()).not.toContain('malicious contents');
+    });
+
     it('CacheQueryOptions are passed through', async () => {
       await group.initializeFully();
       const matchSpy = spyOn(MockCache.prototype, 'match').and.callThrough();

--- a/packages/service-worker/worker/testing/mock.ts
+++ b/packages/service-worker/worker/testing/mock.ts
@@ -110,8 +110,14 @@ export class MockServerStateBuilder {
     return this;
   }
 
-  withRedirect(from: string, to: string): MockServerStateBuilder {
-    this.resources.set(from, new MockResponse('', {redirected: true, url: to}));
+  /**
+   * Serve `from` as a response that has already been redirected to `to`.
+   *
+   * `body` defaults to empty, but can be set to model the browser behavior of following the
+   * redirect and exposing the *target's* contents on the redirected response.
+   */
+  withRedirect(from: string, to: string, body: string = ''): MockServerStateBuilder {
+    this.resources.set(from, new MockResponse(body, {redirected: true, url: to}));
     return this;
   }
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`AssetGroup.fetchFromNetwork()` hash-validates a response, and then, if the response was
redirected, throws that validated body away and re-requests the redirect target:

```ts
const res = await this.cacheBustedFetchFromNetwork(req);

if ((res as any)['redirected'] && !!res.url) {
  // ...
  return this.fetchFromNetwork(this.newRequestWithMetadata(res.url, req), redirectLimit - 1);
}
```

The recursive call re-derives the canonical hash from `res.url`. That URL is the redirect
target, which is not a manifest entry, so `cacheBustedFetchFromNetwork()` takes its unhashed
branch and returns the second response without comparing it to anything. `fetchAndCacheOnce()`
then caches that second body under the *original* request.

So for a manifest-hashed asset served through a redirect, the body that ends up in the cache is
not the body that was validated. A server that answers the first request with the expected
contents and the second with different contents gets those different contents cached under the
original hashed URL, and `ngsw.json`'s hash for that URL no longer describes what is stored.

This is reachable on a normal `ng add @angular/pwa` production build whenever a hashed build
artifact is served via a redirect — e.g. the app origin redirects its bundles to an asset host.

The reason this wasn't caught: every existing redirect test uses a URL with no manifest hash.
`/redirected.txt` and `/lazy/redirected.txt` are declared in asset group `urls` but are not files
in `dist`, so they never enter the hash table and the hashed-plus-redirected path is never
exercised.

## What is the new behavior?

The original normalized URL is carried through the redirect recursion, so the body that is
ultimately cached is validated against the hash the manifest specifies for the URL it is being
cached under. A redirect whose target serves the expected contents behaves exactly as before; a
target that serves something else now fails hash validation like any other mismatch, and nothing
is cached.

Two tests are added to `prefetch_spec.ts` covering a hashed asset served through a redirect:
one where the target matches the manifest hash (must still cache and serve), and one where it
does not (must throw `Hash mismatch` and cache nothing). `MockServerStateBuilder.withRedirect()`
gains an optional body so the mock can model the browser behavior of following the redirect and
exposing the target's contents on the redirected response; the default is unchanged.

Verification:

- Full `packages/service-worker/worker` suite passes with the change (155 specs).
- The new mismatch test fails against unpatched `main` (no error is thrown, and the second body
  is cached) and passes with the change, so it genuinely covers the path.
- Checked in a real browser as well, using a stock `ng new` + `ng add @angular/pwa` production
  build whose generated `loadChildren()` chunk is served through a redirect: before the change the
  redirect target's second response is what lands in the SW cache under the app-origin chunk URL;
  after the change nothing is cached, while the legitimate case still caches the generated chunk
  and the lazy route loads normally.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`fetchFromNetwork()` and `cacheBustedFetchFromNetwork()` gain an optional trailing parameter that
defaults to today's behavior. Both are internal to the worker.

## Other information

The two existing redirect hardening advisories in this area address different state, and neither
covers this: [GHSA-gv2q-mqqv-365m](https://github.com/angular/angular/security/advisories/GHSA-gv2q-mqqv-365m)
preserves a caller's explicit `redirect: "error"`, and
[GHSA-qxh6-94w6-9r5p](https://github.com/angular/angular/security/advisories/GHSA-qxh6-94w6-9r5p)
strips sensitive headers on cross-origin redirects. This is about which body gets hash-checked,
under ordinary default redirect handling and with no special headers involved.

Happy to move this to a private advisory instead if the team would prefer to handle it that way.
