### PR TITLE
fix(common): use locale NaN symbol in number formatting

### DIFF
--- a/packages/common/src/i18n/format_number.ts
+++ b/packages/common/src/i18n/format_number.ts
@@ -43,7 +43,11 @@ function formatNumberToLocaleString(
   let isZero = false;
 
   if (!isFinite(value)) {
-    formattedText = getLocaleNumberSymbol(locale, NumberSymbol.Infinity);
+    // `Number.isNaN` (not `!isFinite`) so NaN uses the locale NaN symbol, not Infinity.
+    formattedText = getLocaleNumberSymbol(
+      locale,
+      Number.isNaN(value) ? NumberSymbol.NaN : NumberSymbol.Infinity,
+    );
   } else {
     let parsedNumber = parseNumber(value);
 

--- a/packages/common/test/i18n/format_number_spec.ts
+++ b/packages/common/test/i18n/format_number_spec.ts
@@ -38,6 +38,16 @@ describe('Format number', () => {
         expect(formatNumber(1e100, ɵDEFAULT_LOCALE_ID)).toEqual('1E+100');
       });
 
+      it('should format NaN and Infinity with locale symbols', () => {
+        expect(formatNumber(NaN, ɵDEFAULT_LOCALE_ID)).toEqual('NaN');
+        expect(formatNumber(Infinity, ɵDEFAULT_LOCALE_ID)).toEqual('∞');
+        expect(formatNumber(-Infinity, ɵDEFAULT_LOCALE_ID)).toEqual('-∞');
+        expect(formatPercent(NaN, ɵDEFAULT_LOCALE_ID)).toEqual('NaN%');
+        expect(formatPercent(Infinity, ɵDEFAULT_LOCALE_ID)).toEqual('∞%');
+        expect(formatCurrency(NaN, ɵDEFAULT_LOCALE_ID, '$')).toEqual('$NaN');
+        expect(formatCurrency(Infinity, ɵDEFAULT_LOCALE_ID, '$')).toEqual('$∞');
+      });
+
       it('should throw if minFractionDigits is explicitly higher than maxFractionDigits', () => {
         expect(() => formatNumber(1.1, ɵDEFAULT_LOCALE_ID, '3.4-2')).toThrowError(
           /is higher than the maximum/,


### PR DESCRIPTION
## Summary
- `formatNumberToLocaleString` used `!isFinite`, so `NaN` was formatted with `NumberSymbol.Infinity` (`∞`) instead of `NumberSymbol.NaN`.
- `formatNumber` / `formatPercent` / `formatCurrency` share that helper; `±Infinity` is unchanged.
- DecimalPipe still returns `null` for `NaN` (existing pipe tests).

## Test plan
- [x] `pnpm test //packages/common/test:test`
- [x] Spec: `NaN` → locale NaN; `Infinity` / `-Infinity` still `∞` / `-∞`