### PR TITLE
fix(platform-server): avoid stripping unicode whitespace during url resolution

### DIFF
--- a/packages/platform-server/src/url.ts
+++ b/packages/platform-server/src/url.ts
@@ -54,8 +54,6 @@ export function parseUrl(
     return originUrl || null;
   }
 
-  urlStr = urlStr.trim();
-
   // Fast-path: if the URL is a valid, standard absolute URL, parse and return it immediately.
   let resolved: URL | undefined;
   try {

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -1578,6 +1578,17 @@ class HiddenModule {}
           });
         });
 
+        it('should resolve non-breaking space prefixed URLs as relative paths on the same origin', async () => {
+          ref.injector.get(NgZone).run(() => {
+            http.get('\u00A0//attacker.example/collect').subscribe((body) => {
+              expect(body).toEqual('success!');
+            });
+            mock
+              .expectOne('http://localhost:4000/%C2%A0//attacker.example/collect')
+              .flush('success!');
+          });
+        });
+
         it('should reject backslash bypass SSRF attempts in relative requests and throw a suspicious origin error', async () => {
           const badUrls = [
             '/\\attacker.com',
@@ -1592,7 +1603,7 @@ class HiddenModule {}
                 next: () => fail(`Expected request for ${badUrl} to fail, but it succeeded.`),
                 error: (err) => {
                   expect(err.message).toBe(
-                    `NG05703: URL ${badUrl.trim()} changed origin unexpectedly. This is suspicious and may indicate a security bypass attempt.`,
+                    `NG05703: URL ${badUrl} changed origin unexpectedly. This is suspicious and may indicate a security bypass attempt.`,
                   );
                 },
               });
@@ -1615,7 +1626,7 @@ class HiddenModule {}
                 next: () => fail(`Expected request for ${badUrl} to fail, but it succeeded.`),
                 error: (err) => {
                   expect(err.message).toBe(
-                    `NG05703: URL ${badUrl.trim()} changed origin unexpectedly. This is suspicious and may indicate a security bypass attempt.`,
+                    `NG05703: URL ${badUrl} changed origin unexpectedly. This is suspicious and may indicate a security bypass attempt.`,
                   );
                 },
               });

--- a/packages/platform-server/test/url_spec.ts
+++ b/packages/platform-server/test/url_spec.ts
@@ -74,12 +74,29 @@ describe('parseUrl', () => {
         `NG05703: URL ${url} changed origin unexpectedly. This is suspicious and may indicate a security bypass attempt.`,
       );
     });
+
+    it('should not trim unicode whitespace into protocol-relative URLs', () => {
+      const urls = ['\u00A0//attacker.example/collect', '\uFEFF//attacker.example/collect'];
+
+      for (const urlStr of urls) {
+        const urlWithProtocolRelative = parseUrl(urlStr, 'http://test.com', {
+          allowProtocolRelative: true,
+        });
+        expect(urlWithProtocolRelative.origin).toBe('http://test.com');
+        expect(urlWithProtocolRelative.pathname).toContain('//attacker.example/collect');
+
+        const urlWithoutProtocolRelative = parseUrl(urlStr, 'http://test.com');
+        expect(urlWithoutProtocolRelative.origin).toBe('http://test.com');
+        expect(urlWithoutProtocolRelative.pathname).toContain('//attacker.example/collect');
+      }
+    });
   });
 
   describe('without origin', () => {
     it('should return null for relative paths', () => {
       expect(parseUrl('/deep/path?query#hash')).toBeNull();
       expect(parseUrl('deep/path')).toBeNull();
+      expect(parseUrl('\u00A0//attacker.com/deep/path')).toBeNull();
     });
 
     it('should parse valid absolute URLs', () => {


### PR DESCRIPTION
Avoid trimming urlStr with String.prototype.trim() in parseUrl to ensure URL parsing and resolution align with the WHATWG URL standard.