### PR TITLE
fix(core): explicitly reject foreign components in JIT mode

### DIFF
--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -91,6 +91,13 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
           type: type,
         });
 
+        if (metadata.foreignImports !== undefined) {
+          throw new Error(
+            `Foreign components are not supported in JIT mode. ` +
+              `Component '${type.name}' cannot specify 'foreignImports'.`,
+          );
+        }
+
         if (componentNeedsResolution(metadata)) {
           const error = [`Component '${type.name}' is not resolved:`];
           if (metadata.templateUrl) {

--- a/packages/core/src/render3/jit/util.ts
+++ b/packages/core/src/render3/jit/util.ts
@@ -8,11 +8,16 @@
 
 import {isForwardRef, resolveForwardRef} from '../../di/forward_ref';
 import {ModuleWithProviders} from '../../di/interface/provider';
+import {ForeignComponent, RENDER} from '../../interface/foreign_component';
 import {Type} from '../../interface/type';
 import {NgModuleDef} from '../../metadata/ng_module_def';
 import {getComponentDef, getDirectiveDef, getPipeDef, getNgModuleDef} from '../def_getters';
 import type {ComponentType, DirectiveType, PipeType} from '../interfaces/definition';
 import {stringifyForError} from '../util/stringify_utils';
+
+export function isForeignComponent(value: any): value is ForeignComponent {
+  return typeof value === 'object' && value !== null && RENDER in value;
+}
 
 export function isModuleWithProviders(value: any): value is ModuleWithProviders<{}> {
   return (value as {ngModule?: any}).ngModule !== undefined;
@@ -74,6 +79,12 @@ export function verifyStandaloneImport(depType: Type<unknown>, importingType: Ty
           `A module with providers was imported from "${stringifyForError(
             importingType,
           )}". Modules with providers are not supported in standalone components imports.`,
+        );
+      } else if (isForeignComponent(depType)) {
+        throw new Error(
+          `A foreign component, imported from "${stringifyForError(
+            importingType,
+          )}", cannot be imported using 'imports'. Foreign components are only supported in AOT mode and must be registered in 'foreignImports'.`,
         );
       } else {
         throw new Error(

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -31,6 +31,7 @@ import {ɵɵdefineInjectable, ɵɵInjectorDef} from '../../../src/di/interface/d
 import {FactoryFn} from '../../../src/render3/definition_factory';
 import {ComponentDef, PipeDef} from '../../../src/render3/interfaces/definition';
 import {InputFlags} from '../../../src/render3/interfaces/input_flags';
+import {foreignImport} from '../../../src/render3/foreign_import';
 
 describe('render3 jit', () => {
   let injector: any;
@@ -543,6 +544,52 @@ describe('render3 jit', () => {
       expect(TestDirAny.ɵfac).toBeDefined();
       expect(() => TestDirAny.ɵfac()).toThrowError(
         /constructor is not compatible with Angular Dependency Injection because its dependency at index 0 of the parameter list is invalid/,
+      );
+    });
+  });
+
+  describe('foreign components', () => {
+    function fooImport<TProps>(component: (props: TProps) => Node[]) {
+      return foreignImport<TProps>(
+        (props) => [component(props)],
+        () => {},
+        (producer) => producer(),
+      );
+    }
+
+    function FooComponent(props: {children?: Node[]}): Node[] {
+      return [];
+    }
+
+    it('should error when foreignImports is specified on a component in JIT mode', () => {
+      expect(() => {
+        @Component({
+          selector: 'test-cmp',
+          template: 'test',
+          // @ts-ignore
+          foreignImports: [fooImport(FooComponent)],
+        })
+        class SomeCmp {}
+
+        const _ = (SomeCmp as any).ɵcmp;
+      }).toThrowError(
+        `Foreign components are not supported in JIT mode. Component 'SomeCmp' cannot specify 'foreignImports'.`,
+      );
+    });
+
+    it('should error when a foreign component is imported via imports array in JIT mode', () => {
+      @Component({
+        selector: 'test-cmp',
+        template: 'test',
+        imports: [fooImport(FooComponent) as any],
+      })
+      class SomeCmp {}
+
+      const cmpDef = (SomeCmp as any).ɵcmp as ComponentDef<SomeCmp>;
+      expect(() => {
+        (cmpDef.directiveDefs! as () => unknown)();
+      }).toThrowError(
+        /A foreign component, imported from "SomeCmp", cannot be imported using 'imports'\. Foreign components are only supported in AOT mode and must be registered in 'foreignImports'\./,
       );
     });
   });


### PR DESCRIPTION
Foreign components are only supported in AOT mode. Using them in JIT mode previously resulted in silent failures or confusing runtime errors (such as unknown element errors or crashed template ingestion).

This commit adds explicit validation in JIT compilation:
- Throws an error during component compilation if `foreignImports` is specified on `@Component`.
- Throws an error during standalone import verification if a foreign component is mistakenly passed to `@Component.imports`.