### PR TITLE
fix(forms): preserve intermediate keystrokes in signal formField

### DIFF
--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -122,9 +122,24 @@ export function nativeControlCreate(
       input.type === 'radio' && bindingUpdated(bindings, 'radioValue', input.value);
 
     if (controlValueChanged || radioValueChanged) {
-      setNativeControlValue(input, controlValue);
+      const isFocused = typeof document !== 'undefined' && document.activeElement === input;
+      if (!(isFocused && isIntermediate(input.value, controlValue))) {
+        setNativeControlValue(input, controlValue);
+      }
     }
 
     updateMode = true;
   };
+}
+
+function isIntermediate(inputValue: string, controlValue: unknown): boolean {
+  if (inputValue === '-' || inputValue === '.' || inputValue === '-.') return true;
+  if (inputValue.endsWith('.')) return true;
+  if (typeof controlValue === 'number' && !Number.isNaN(controlValue) && inputValue.includes('.')) {
+    const parsed = Number(inputValue);
+    if (!Number.isNaN(parsed) && parsed === controlValue && inputValue !== String(controlValue)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -39,6 +39,7 @@ export function nativeControlCreate(
     Signal<readonly ValidationError.WithoutFieldTree[]> | undefined
   >,
   validityMonitor: InputValidityMonitor,
+  document: Document,
 ): () => void {
   let updateMode = false;
   const input = parent.nativeFormElement;
@@ -123,7 +124,7 @@ export function nativeControlCreate(
       input.type === 'radio' && bindingUpdated(bindings, 'radioValue', input.value);
 
     if (controlValueChanged || radioValueChanged) {
-      const isFocused = typeof document !== 'undefined' && document.activeElement === input;
+      const isFocused = document.activeElement === input;
       if (!(isFocused && isIntermediate(input.value, controlValue))) {
         setNativeControlValue(input, controlValue);
       }

--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -26,6 +26,7 @@ import {
   getNativeControlValue,
   inputRequiresValidityTracking,
   isInput,
+  parseDecimalNumber,
   setNativeControlValue,
   setNativeDomProperty,
 } from './native';
@@ -135,9 +136,9 @@ export function nativeControlCreate(
 function isIntermediate(inputValue: string, controlValue: unknown): boolean {
   if (inputValue === '-' || inputValue === '.' || inputValue === '-.') return true;
   if (inputValue.endsWith('.')) return true;
-  if (typeof controlValue === 'number' && !Number.isNaN(controlValue) && inputValue.includes('.')) {
-    const parsed = Number(inputValue);
-    if (!Number.isNaN(parsed) && parsed === controlValue && inputValue !== String(controlValue)) {
+  if (typeof controlValue === 'number' && !Number.isNaN(controlValue)) {
+    const parsed = parseDecimalNumber(inputValue);
+    if (parsed !== undefined && parsed === controlValue && inputValue !== String(controlValue)) {
       return true;
     }
   }

--- a/packages/forms/signals/src/directive/form_field.ts
+++ b/packages/forms/signals/src/directive/form_field.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {DOCUMENT} from '@angular/common';
 import {
   afterRenderEffect,
   computed,
@@ -166,6 +167,7 @@ export class FormField<T> {
 
   private readonly config = inject(SIGNAL_FORMS_CONFIG, {optional: true});
   private readonly validityMonitor = inject(InputValidityMonitor);
+  private readonly document = inject(DOCUMENT);
 
   /** @internal */
   readonly parseErrorsSource = signal<
@@ -394,6 +396,7 @@ export class FormField<T> {
         this as FormField<unknown>,
         this.parseErrorsSource,
         this.validityMonitor,
+        this.document,
       );
     } else {
       throw new RuntimeError(

--- a/packages/forms/signals/src/directive/native.ts
+++ b/packages/forms/signals/src/directive/native.ts
@@ -84,8 +84,8 @@ export function getNativeControlValue(
       if (element.value === '') {
         return {value: null};
       }
-      const parsed = Number(element.value);
-      if (Number.isNaN(parsed)) {
+      const parsed = parseDecimalNumber(element.value);
+      if (parsed === undefined) {
         return {error: new NativeInputParseError() as WithoutFieldTree<NativeInputParseError>};
       }
       return {value: parsed};
@@ -94,6 +94,20 @@ export function getNativeControlValue(
 
   // Default to reading the value as a string.
   return {value: element.value};
+}
+
+/**
+ * Strictly parses a decimal number from a string, rejecting the other numeric literal forms
+ * that `Number()` accepts on its own (hex, binary, octal, etc). `parseFloat` doesn't consume
+ * those non-decimal prefixes, while `Number` rejects trailing garbage, so requiring both to
+ * agree keeps decimal input permissive without accepting other JavaScript numeric literal forms.
+ */
+export function parseDecimalNumber(value: string): number | undefined {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed) || !Object.is(parsed, parseFloat(value))) {
+    return undefined;
+  }
+  return parsed;
 }
 
 /**

--- a/packages/forms/signals/test/web/number_input.spec.ts
+++ b/packages/forms/signals/test/web/number_input.spec.ts
@@ -98,6 +98,73 @@ describe('numeric inputs', () => {
       expect(input1.value).toBe('42');
       expect(input2.value).toBe('42');
     });
+
+    it('should preserve a negative decimal typed into a number input', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="number" step="0.01" [formField]="f" />`,
+      })
+      class TestCmp {
+        readonly data = signal<number | null>(null);
+        readonly f = form(this.data);
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+      input.focus();
+
+      act(() => {
+        validityMonitor.setInputState(input, '-', true);
+      });
+
+      expect(fixture.componentInstance.f().value()).toBeNull();
+      expect(fixture.componentInstance.f().errors()).toEqual([
+        jasmine.objectContaining({kind: 'parse'}),
+      ]);
+
+      act(() => {
+        validityMonitor.setInputState(input, '-0', false);
+      });
+
+      expect(fixture.componentInstance.f().value()).toBe(0);
+      expect(fixture.componentInstance.f().errors()).toEqual([]);
+      expect(input.value).toBe('-0');
+
+      act(() => {
+        validityMonitor.setInputState(input, '-0.5', false);
+      });
+
+      expect(fixture.componentInstance.f().value()).toBe(-0.5);
+      expect(input.value).toBe('-0.5');
+    });
+
+    it('should preserve fractional zeroes while editing a number input', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="number" step="0.01" [formField]="f" />`,
+      })
+      class TestCmp {
+        readonly data = signal<number | null>(null);
+        readonly f = form(this.data);
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+      input.focus();
+
+      act(() => {
+        validityMonitor.setInputState(input, '1', false);
+      });
+      act(() => {
+        validityMonitor.setInputState(input, '1.0', false);
+      });
+      act(() => {
+        validityMonitor.setInputState(input, '1.00', false);
+      });
+
+      expect(fixture.componentInstance.f().value()).toBe(1);
+      expect(input.value).toBe('1.00');
+    });
   });
 
   describe('nullability', () => {
@@ -203,6 +270,82 @@ describe('text input with numeric model', () => {
 
     expect(fixture.componentInstance.f().value()).toBe(123);
     expect(fixture.componentInstance.f().errors()).toEqual([]);
+  });
+
+  it('should preserve a negative decimal typed into a text input with a numeric model', () => {
+    @Component({
+      imports: [FormField],
+      template: `<input type="text" inputmode="decimal" [formField]="f" />`,
+    })
+    class TestCmp {
+      readonly data = signal<number | null>(null);
+      readonly f = form(this.data);
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    input.focus();
+
+    act(() => {
+      input.value = '-';
+      input.dispatchEvent(new Event('input'));
+    });
+
+    expect(fixture.componentInstance.f().value()).toBeNull();
+    expect(fixture.componentInstance.f().errors()).toEqual([
+      jasmine.objectContaining({kind: 'parse'}),
+    ]);
+    expect(input.value).toBe('-');
+
+    act(() => {
+      input.value = '-0';
+      input.dispatchEvent(new Event('input'));
+    });
+
+    expect(fixture.componentInstance.f().errors()).toEqual([]);
+    expect(input.value).toBe('-0');
+
+    act(() => {
+      input.value = '-0.5';
+      input.dispatchEvent(new Event('input'));
+    });
+
+    expect(fixture.componentInstance.f().value()).toBe(-0.5);
+    expect(input.value).toBe('-0.5');
+  });
+
+  it('should not parse non-decimal numeric text', () => {
+    @Component({
+      imports: [FormField],
+      template: `<input type="text" [formField]="f" />`,
+    })
+    class TestCmp {
+      readonly data = signal<number | null>(42);
+      readonly f = form(this.data);
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    act(() => {
+      input.value = '0b0101';
+      input.dispatchEvent(new Event('input'));
+    });
+
+    expect(fixture.componentInstance.f().value()).toBe(42);
+    expect(fixture.componentInstance.f().errors()).toEqual([
+      jasmine.objectContaining({kind: 'parse'}),
+    ]);
+
+    act(() => {
+      input.value = '0x22';
+      input.dispatchEvent(new Event('input'));
+    });
+
+    expect(fixture.componentInstance.f().value()).toBe(42);
+    expect(fixture.componentInstance.f().errors()).toEqual([
+      jasmine.objectContaining({kind: 'parse'}),
+    ]);
   });
 
   it('should produce a parse error when user types non-numeric text', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When a user types an intermediate value into a signal FormField number input (such as `-`, `1.`, or `1.0`), the native control is normalized via valueAsNumber on every keystroke, discarding the raw input. This causes the display to jump and intermediate input to be lost, making it impossible to type decimal numbers naturally.

Fixes #69635.

## What is the new behavior?

The fix guards the native value write-back when the input is focused and contains an intermediate value. The `isIntermediate()` function detects incomplete decimal input (leading `-`, trailing `.`, strings like `1.0` that parse to the same numeric value but differ in representation). While intermediate, the raw string is preserved in the DOM until the user blurs the field.

Parsing now also goes through a strict decimal parser shared by `isIntermediate()` and the text-input numeric read path: `Number()` and `parseFloat()` must agree on the same value. This closes two edge cases raised in review:

- A typed `-0` is preserved instead of being normalized to `0` on the next update pass.
- Non-decimal numeric literals such as `0b0101` and `0x22` are rejected as parse errors instead of being silently accepted by `Number()`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Unit tests cover: preserving `-`, `.`, `-.`, trailing `.`, decimal strings whose numeric values match controlValue but whose string representation differs (e.g. `1.0` vs `1`, `1.00` vs `1`), preserving a typed `-0` and `-0.5` on both a number input and a text input with a numeric model, and rejecting `0b0101` / `0x22` as parse errors.
