### PR TITLE
refactor(compiler): emit any as type argument for ɵɵInjectableDeclara…

### DIFF
--- a/goldens/public-api/animations/browser/index.api.md
+++ b/goldens/public-api/animations/browser/index.api.md
@@ -42,7 +42,7 @@ export class NoopAnimationDriver implements AnimationDriver {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NoopAnimationDriver, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<NoopAnimationDriver>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/goldens/public-api/animations/index.api.md
+++ b/goldens/public-api/animations/index.api.md
@@ -51,7 +51,7 @@ export abstract class AnimationBuilder {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<AnimationBuilder, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<AnimationBuilder>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public @deprecated

--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -25,7 +25,7 @@ export class FetchBackend implements HttpBackend {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FetchBackend, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<FetchBackend>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -41,7 +41,7 @@ export abstract class HttpBackend implements HttpHandler {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpBackend, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<HttpBackend>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -540,7 +540,7 @@ export class HttpClient {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpClient, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<HttpClient>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -684,7 +684,7 @@ export abstract class HttpHandler {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpHandler, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<HttpHandler>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -1200,7 +1200,7 @@ export class HttpXhrBackend implements HttpBackend {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpXhrBackend, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<HttpXhrBackend>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -1209,7 +1209,7 @@ export abstract class HttpXsrfTokenExtractor {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpXsrfTokenExtractor, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<HttpXsrfTokenExtractor>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public @deprecated
@@ -1219,7 +1219,7 @@ export class JsonpClientBackend implements HttpBackend {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<JsonpClientBackend, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<JsonpClientBackend>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public @deprecated
@@ -1229,7 +1229,7 @@ export class JsonpInterceptor {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<JsonpInterceptor, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<JsonpInterceptor>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public

--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -102,7 +102,7 @@ export class BrowserPlatformLocation extends PlatformLocation {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<BrowserPlatformLocation, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<BrowserPlatformLocation>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -294,7 +294,7 @@ export class HashLocationStrategy extends LocationStrategy implements OnDestroy 
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HashLocationStrategy, [null, { optional: true; }]>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<HashLocationStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -420,7 +420,7 @@ class Location_2 implements OnDestroy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Location_2, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<Location_2>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export { Location_2 as Location }
 
@@ -466,7 +466,7 @@ export abstract class LocationStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<LocationStrategy, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<LocationStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -600,7 +600,7 @@ export class NgLocaleLocalization extends NgLocalization {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgLocaleLocalization, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<NgLocaleLocalization>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public (undocumented)
@@ -610,7 +610,7 @@ export abstract class NgLocalization {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgLocalization, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<NgLocalization>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -748,7 +748,7 @@ export class NoTrailingSlashPathLocationStrategy extends PathLocationStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NoTrailingSlashPathLocationStrategy, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<NoTrailingSlashPathLocationStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public @deprecated
@@ -811,7 +811,7 @@ export class PathLocationStrategy extends LocationStrategy implements OnDestroy 
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<PathLocationStrategy, [null, { optional: true; }]>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<PathLocationStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -864,7 +864,7 @@ export abstract class PlatformLocation {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<PlatformLocation, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<PlatformLocation>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -908,7 +908,7 @@ export abstract class PlatformNavigation implements ɵNavigation {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<PlatformNavigation, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<PlatformNavigation>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public @deprecated
@@ -1006,7 +1006,7 @@ export class TrailingSlashPathLocationStrategy extends PathLocationStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<TrailingSlashPathLocationStrategy, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<TrailingSlashPathLocationStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public @deprecated
@@ -1070,7 +1070,7 @@ export abstract class XhrFactory {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<XhrFactory, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<XhrFactory>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/goldens/public-api/common/testing/index.api.md
+++ b/goldens/public-api/common/testing/index.api.md
@@ -48,7 +48,7 @@ export class MockLocationStrategy extends LocationStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MockLocationStrategy, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<MockLocationStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -93,7 +93,7 @@ export class MockPlatformLocation implements PlatformLocation {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MockPlatformLocation, [{ optional: true; }]>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<MockPlatformLocation>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -147,7 +147,7 @@ export class SpyLocation implements Location_2 {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SpyLocation, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<SpyLocation>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -115,7 +115,7 @@ export class ApplicationInitStatus {
     // (undocumented)
     static ɵfac: ɵɵFactoryDeclaration<ApplicationInitStatus, never>;
     // (undocumented)
-    static ɵprov: ɵɵInjectableDeclaration<ApplicationInitStatus>;
+    static ɵprov: ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -155,7 +155,7 @@ export class ApplicationRef {
     // (undocumented)
     static ɵfac: ɵɵFactoryDeclaration<ApplicationRef, never>;
     // (undocumented)
-    static ɵprov: ɵɵInjectableDeclaration<ApplicationRef>;
+    static ɵprov: ɵɵInjectableDeclaration<any>;
 }
 
 // @public (undocumented)
@@ -250,7 +250,7 @@ export class Compiler {
     // (undocumented)
     static ɵfac: ɵɵFactoryDeclaration<Compiler, never>;
     // (undocumented)
-    static ɵprov: ɵɵInjectableDeclaration<Compiler>;
+    static ɵprov: ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -1466,7 +1466,7 @@ export class PlatformRef {
     // (undocumented)
     static ɵfac: ɵɵFactoryDeclaration<PlatformRef, never>;
     // (undocumented)
-    static ɵprov: ɵɵInjectableDeclaration<PlatformRef>;
+    static ɵprov: ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -1913,7 +1913,7 @@ export class Testability implements PublicTestability {
     // (undocumented)
     static ɵfac: ɵɵFactoryDeclaration<Testability, never>;
     // (undocumented)
-    static ɵprov: ɵɵInjectableDeclaration<Testability>;
+    static ɵprov: ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -1928,7 +1928,7 @@ export class TestabilityRegistry {
     // (undocumented)
     static ɵfac: ɵɵFactoryDeclaration<TestabilityRegistry, never>;
     // (undocumented)
-    static ɵprov: ɵɵInjectableDeclaration<TestabilityRegistry>;
+    static ɵprov: ɵɵInjectableDeclaration<any>;
 }
 
 // @public

--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -375,7 +375,7 @@ export class FormBuilder {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FormBuilder, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<FormBuilder>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -822,7 +822,7 @@ export abstract class NonNullableFormBuilder {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NonNullableFormBuilder, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<NonNullableFormBuilder>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -973,7 +973,7 @@ export class UntypedFormBuilder extends FormBuilder {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<UntypedFormBuilder, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<UntypedFormBuilder>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public

--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -60,7 +60,7 @@ export class CssVarNamespacer {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CssVarNamespacer, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<CssVarNamespacer>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -77,7 +77,7 @@ export abstract class DomSanitizer implements Sanitizer {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<DomSanitizer, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<DomSanitizer>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -94,7 +94,7 @@ export class EventManager {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<EventManager, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<EventManager>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -142,7 +142,7 @@ export class Meta {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Meta, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<Meta>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -209,7 +209,7 @@ export class Title {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Title, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<Title>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public (undocumented)

--- a/goldens/public-api/platform-server/index.api.md
+++ b/goldens/public-api/platform-server/index.api.md
@@ -39,7 +39,7 @@ export class PlatformState {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<PlatformState, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<PlatformState>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -193,7 +193,7 @@ export class ChildrenOutletContexts {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ChildrenOutletContexts, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<ChildrenOutletContexts>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -233,7 +233,7 @@ export class DefaultTitleStrategy extends TitleStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<DefaultTitleStrategy, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<DefaultTitleStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -534,7 +534,7 @@ export class NoPreloading implements PreloadingStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NoPreloading, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<NoPreloading>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -578,7 +578,7 @@ export class PreloadAllModules implements PreloadingStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<PreloadAllModules, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<PreloadAllModules>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -738,7 +738,7 @@ export class Router {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Router, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<Router>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -773,7 +773,7 @@ export abstract class RouteReuseStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RouteReuseStrategy, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<RouteReuseStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -958,7 +958,7 @@ export class RouterPreloader implements OnDestroy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RouterPreloader, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<RouterPreloader>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -1029,7 +1029,7 @@ export abstract class TitleStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<TitleStrategy, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<TitleStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -1049,7 +1049,7 @@ export abstract class UrlHandlingStrategy {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<UrlHandlingStrategy, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<UrlHandlingStrategy>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -1103,7 +1103,7 @@ export abstract class UrlSerializer {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<UrlSerializer, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<UrlSerializer>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public

--- a/goldens/public-api/service-worker/index.api.md
+++ b/goldens/public-api/service-worker/index.api.md
@@ -64,7 +64,7 @@ export class SwPush {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SwPush, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<SwPush>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public
@@ -87,7 +87,7 @@ export class SwUpdate {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SwUpdate, never>;
     // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<SwUpdate>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 // @public

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/GOLDEN_PARTIAL.js
@@ -70,11 +70,11 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class BasicInjectable {
     static ɵfac: i0.ɵɵFactoryDeclaration<BasicInjectable, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<BasicInjectable>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class RootInjectable {
     static ɵfac: i0.ɵɵFactoryDeclaration<RootInjectable, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<RootInjectable>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class ComponentWithExternalResource {
     static ɵfac: i0.ɵɵFactoryDeclaration<ComponentWithExternalResource, never>;
@@ -288,35 +288,35 @@ declare class Service {
 export declare class ParameterizedInjectable {
     constructor(service: Service, token: string, custom: Service, mixed: string);
     static ɵfac: i0.ɵɵFactoryDeclaration<ParameterizedInjectable, [null, null, null, { skipSelf: true; }]>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<ParameterizedInjectable>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class NoCtor {
     static ɵfac: i0.ɵɵFactoryDeclaration<NoCtor, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<NoCtor>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class EmptyCtor {
     constructor();
     static ɵfac: i0.ɵɵFactoryDeclaration<EmptyCtor, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<EmptyCtor>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class NoDecorators {
     constructor(service: Service);
     static ɵfac: i0.ɵɵFactoryDeclaration<NoDecorators, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<NoDecorators>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class CustomInjectable {
     constructor(service: Service);
     static ɵfac: i0.ɵɵFactoryDeclaration<CustomInjectable, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<CustomInjectable>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class DerivedInjectable extends ParameterizedInjectable {
     static ɵfac: i0.ɵɵFactoryDeclaration<DerivedInjectable, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<DerivedInjectable>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class DerivedInjectableWithCtor extends ParameterizedInjectable {
     constructor();
     static ɵfac: i0.ɵɵFactoryDeclaration<DerivedInjectableWithCtor, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<DerivedInjectableWithCtor>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export {};
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_isolated.golden.d.ts
@@ -6,35 +6,35 @@ declare class Service {
 export declare class ParameterizedInjectable {
     constructor(service: Service, token: string, custom: Service, mixed: string);
     static ɵfac: i0.ɵɵFactoryDeclaration<ParameterizedInjectable, [null, null, null, { skipSelf: true; }]>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<ParameterizedInjectable>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class NoCtor {
     static ɵfac: i0.ɵɵFactoryDeclaration<NoCtor, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<NoCtor>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class EmptyCtor {
     constructor();
     static ɵfac: i0.ɵɵFactoryDeclaration<EmptyCtor, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<EmptyCtor>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class NoDecorators {
     constructor(service: Service);
     static ɵfac: i0.ɵɵFactoryDeclaration<NoDecorators, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<NoDecorators>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class CustomInjectable {
     constructor(service: Service);
     static ɵfac: i0.ɵɵFactoryDeclaration<CustomInjectable, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<CustomInjectable>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class DerivedInjectable extends ParameterizedInjectable {
     static ɵfac: i0.ɵɵFactoryDeclaration<DerivedInjectable, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<DerivedInjectable>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class DerivedInjectableWithCtor extends ParameterizedInjectable {
     constructor();
     static ɵfac: i0.ɵɵFactoryDeclaration<DerivedInjectableWithCtor, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<DerivedInjectableWithCtor>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export {};
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/GOLDEN_PARTIAL.js
@@ -258,17 +258,17 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class Thing {
     static ɵfac: i0.ɵɵFactoryDeclaration<Thing, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Thing>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class BaseService {
     protected thing: Thing;
     constructor(thing: Thing);
     static ɵfac: i0.ɵɵFactoryDeclaration<BaseService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<BaseService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class ChildService extends BaseService {
     static ɵfac: i0.ɵɵFactoryDeclaration<ChildService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<ChildService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class FooModule {
     static ɵfac: i0.ɵɵFactoryDeclaration<FooModule, never>;
@@ -566,7 +566,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class Service {
     static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Service>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class BaseModule {
     private service;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance_isolated.golden.d.ts
@@ -1,7 +1,7 @@
 import * as i0 from "@angular/core";
 export declare class Service {
     static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Service>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class BaseModule {
     private service;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/providers_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/providers_isolated.golden.d.ts
@@ -1,17 +1,17 @@
 import * as i0 from "@angular/core";
 export declare class Thing {
     static ɵfac: i0.ɵɵFactoryDeclaration<Thing, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Thing>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class BaseService {
     protected thing: Thing;
     constructor(thing: Thing);
     static ɵfac: i0.ɵɵFactoryDeclaration<BaseService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<BaseService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class ChildService extends BaseService {
     static ɵfac: i0.ɵɵFactoryDeclaration<ChildService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<ChildService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class FooModule {
     static ɵfac: i0.ɵɵFactoryDeclaration<FooModule, never>;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
@@ -59,7 +59,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class MyComponent {
     constructor(name: string, other: string, s1: MyService, s2: MyService, s4: MyService, s3: MyService, s5: MyService, s6: MyService);
@@ -97,7 +97,7 @@ declare class MyDependency {
 export declare class MyService {
     constructor(dep: MyDependency);
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export {};
 
@@ -130,7 +130,7 @@ declare class MyDependency {
 export declare class MyService {
     constructor(dep: MyDependency);
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, [null, { optional: true; }]>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export {};
 
@@ -159,7 +159,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 /****************************************************************************************************
@@ -191,7 +191,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 /****************************************************************************************************
@@ -221,7 +221,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 /****************************************************************************************************
@@ -254,7 +254,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 /****************************************************************************************************
@@ -319,12 +319,12 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class Dep {
     static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Dep>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class Service {
     constructor(dep: Dep);
     static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Service>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class Mod {
     static ɵfac: i0.ɵɵFactoryDeclaration<Mod, never>;
@@ -408,21 +408,21 @@ import { PipeTransform } from '@angular/core';
 import * as i0 from "@angular/core";
 declare class Service {
     static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Service>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class MyPipe implements PipeTransform {
     constructor(service: Service);
     transform(value: any, ...args: any[]): any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyPipe, never>;
     static ɵpipe: i0.ɵɵPipeDeclaration<MyPipe, "myPipe", false>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyPipe>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class MyOtherPipe implements PipeTransform {
     constructor(service: Service);
     transform(value: any, ...args: any[]): any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyOtherPipe, never>;
     static ɵpipe: i0.ɵɵPipeDeclaration<MyOtherPipe, "myOtherPipe", false>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyOtherPipe>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class MyApp {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/component_factory_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/component_factory_isolated.golden.d.ts
@@ -1,7 +1,7 @@
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class MyComponent {
     constructor(name: string, other: string, s1: MyService, s2: MyService, s4: MyService, s3: MyService, s5: MyService, s6: MyService);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/ctor_overload_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/ctor_overload_isolated.golden.d.ts
@@ -4,7 +4,7 @@ declare class MyDependency {
 export declare class MyService {
     constructor(dep: MyDependency);
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, [null, { optional: true; }]>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export {};
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/injectable_factory_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/injectable_factory_isolated.golden.d.ts
@@ -4,7 +4,7 @@ declare class MyDependency {
 export declare class MyService {
     constructor(dep: MyDependency);
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export {};
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_isolated.golden.d.ts
@@ -2,21 +2,21 @@ import { PipeTransform } from '@angular/core';
 import * as i0 from "@angular/core";
 declare class Service {
     static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Service>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class MyPipe implements PipeTransform {
     constructor(service: Service);
     transform(value: any, ...args: any[]): any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyPipe, never>;
     static ɵpipe: i0.ɵɵPipeDeclaration<MyPipe, "myPipe", false>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyPipe>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class MyOtherPipe implements PipeTransform {
     constructor(service: Service);
     transform(value: any, ...args: any[]): any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyOtherPipe, never>;
     static ɵpipe: i0.ɵɵPipeDeclaration<MyOtherPipe, "myOtherPipe", false>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyOtherPipe>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class MyApp {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/providedin_forwardref_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/providedin_forwardref_isolated.golden.d.ts
@@ -1,12 +1,12 @@
 import * as i0 from "@angular/core";
 export declare class Dep {
     static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Dep>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class Service {
     constructor(dep: Dep);
     static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<Service>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 export declare class Mod {
     static ɵfac: i0.ɵɵFactoryDeclaration<Mod, never>;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/useclass_with_deps_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/useclass_with_deps_isolated.golden.d.ts
@@ -1,6 +1,6 @@
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/useclass_without_deps_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/useclass_without_deps_isolated.golden.d.ts
@@ -1,6 +1,6 @@
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps_isolated.golden.d.ts
@@ -1,6 +1,6 @@
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_without_deps_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_without_deps_isolated.golden.d.ts
@@ -1,6 +1,6 @@
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/service_decorator/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/service_decorator/GOLDEN_PARTIAL.js
@@ -17,7 +17,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 /****************************************************************************************************
@@ -42,7 +42,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 /****************************************************************************************************
@@ -65,7 +65,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 /****************************************************************************************************
@@ -88,7 +88,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 
 /****************************************************************************************************
@@ -118,6 +118,6 @@ export declare class MyService<T extends number, V = T> {
     getOne(): T;
     getTwo(): V;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService<any, any>, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService<any, any>>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/service_decorator/basic_service_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/service_decorator/basic_service_isolated.golden.d.ts
@@ -1,6 +1,6 @@
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/service_decorator/explicitly_provided_service_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/service_decorator/explicitly_provided_service_isolated.golden.d.ts
@@ -1,6 +1,6 @@
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/service_decorator/generic_service_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/service_decorator/generic_service_isolated.golden.d.ts
@@ -3,6 +3,6 @@ export declare class MyService<T extends number, V = T> {
     getOne(): T;
     getTwo(): V;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService<any, any>, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService<any, any>>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/service_decorator/not_provided_service_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/service_decorator/not_provided_service_isolated.golden.d.ts
@@ -1,6 +1,6 @@
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/service_decorator/service_with_factory_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/service_decorator/service_with_factory_isolated.golden.d.ts
@@ -1,6 +1,6 @@
 import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<any>;
 }
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -114,8 +114,7 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain('Service.ɵprov =');
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Dep>;');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<any>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;');
     });
@@ -137,7 +136,7 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain('Store.ɵprov =');
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Store<any>, never>;');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Store<any>>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<any>;');
     });
 
     it('should compile Injectables with providedIn without errors', () => {
@@ -167,8 +166,7 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain("providedIn: 'root' })");
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Dep>;');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<any>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;');
     });
@@ -197,7 +195,7 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain(", providedIn: 'root' });");
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<any>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;');
     });
 
@@ -503,7 +501,7 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain("return __ngConditionalFactory__; }, providedIn: 'root' });");
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<any>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;');
     });
 
@@ -543,7 +541,7 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain(`return __ngConditionalFactory__; }, providedIn: 'root' });`);
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<any>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;');
     });
 
@@ -578,8 +576,7 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain('providedIn: i0.forwardRef(() => Mod) })');
       expect(jsContents).not.toContain('__decorate');
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Dep>;');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<Service>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<any>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Dep, never>;');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<Service, never>;');
       expect(dtsContents).toContain('i0.ɵɵFactoryDeclaration<Mod, never>;');
@@ -3706,10 +3703,7 @@ runInEachFileSystem((os: string) => {
 
         // Validate that each class's .d.ts declaration also has an injectable
         // definition.
-        expect(dtsContents).toContain('ɵɵInjectableDeclaration<TestCmp');
-        expect(dtsContents).toContain('ɵɵInjectableDeclaration<TestDir');
-        expect(dtsContents).toContain('ɵɵInjectableDeclaration<TestPipe');
-        expect(dtsContents).toContain('ɵɵInjectableDeclaration<TestNgModule');
+        expect(dtsContents.match(/ɵɵInjectableDeclaration<any>/g)?.length).toBe(4);
       });
 
       it('should not compile a component and a directive annotation on the same class', () => {

--- a/packages/compiler-cli/test/ngtsc/service_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/service_spec.ts
@@ -40,7 +40,7 @@ runInEachFileSystem(() => {
       expect(jsContents).toContain('TestService.ɵfac =');
       expect(jsContents).toContain('TestService.ɵprov =');
       expect(dtsContents).toContain('static ɵfac: i0.ɵɵFactoryDeclaration<TestService, never>;');
-      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<TestService>;');
+      expect(dtsContents).toContain('static ɵprov: i0.ɵɵInjectableDeclaration<any>;');
     });
 
     it('should report if an @Service class has another Angular decorator', () => {

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -20,7 +20,6 @@ import {
   MaybeForwardRefExpression,
   R3CompiledExpression,
   R3Reference,
-  typeWithParameters,
 } from './render3/util';
 import {DefinitionMap} from './render3/view/util';
 
@@ -146,9 +145,7 @@ export function compileInjectable(
 }
 
 export function createInjectableType(type: o.Expression, typeArgumentCount: number) {
-  return new o.ExpressionType(
-    o.importExpr(Identifiers.InjectableDeclaration, [typeWithParameters(type, typeArgumentCount)]),
-  );
+  return new o.ExpressionType(o.importExpr(Identifiers.InjectableDeclaration, [o.DYNAMIC_TYPE]));
 }
 
 export function delegateToFactory(


### PR DESCRIPTION
…tion

The static `ɵprov` field emitted on `@Injectable()` classes uses `ɵɵInjectableDeclaration<T>`. When a subclass extends a generic `@Injectable()` base class with contravariant parameters (such as callback/transformer methods depending on generic type parameters), TypeScript's static side inheritance check (`typeof Sub extends typeof Super`) fails with `TS2417` because `ɵɵInjectableDeclaration<Sub>` is not assignable to `ɵɵInjectableDeclaration<Super<any>>`.

Using `any` (`o.DYNAMIC_TYPE`) in `createInjectableType` avoids strict variance checks on static inheritance for internal Ivy definitions and aligns with other Ivy declaration types.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
