### PR TITLE
Validate event attributes in `@HostBinding`

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
@@ -23,6 +23,7 @@ import {
   R3InputMetadata,
   R3PartialDeclaration,
   R3QueryMetadata,
+  verifyHostBindings,
 } from '@angular/compiler';
 
 import semver from 'semver';
@@ -77,12 +78,22 @@ export function toR3DirectiveMeta<TExpression>(
     );
   }
 
+  const host = toHostMetadata(metaObj);
+  // Partial declarations are external linker inputs, so validate them before emitting host code.
+  if (metaObj.has('host')) {
+    const hostMeta = metaObj.getValue('host');
+    const errors = verifyHostBindings(host, createSourceSpan(hostMeta.getRange(), code, sourceUrl));
+    if (errors.length > 0) {
+      throw new FatalLinkerError(hostMeta.expression, errors.map((error) => error.msg).join('\n'));
+    }
+  }
+
   return {
     typeSourceSpan: createSourceSpan(typeExpr.getRange(), code, sourceUrl),
     type: wrapReference(typeExpr.getOpaque()),
     typeArgumentCount: 0,
     deps: null,
-    host: toHostMetadata(metaObj),
+    host,
     inputs: metaObj.has('inputs') ? metaObj.getObject('inputs').toLiteral(toInputMapping) : {},
     outputs: metaObj.has('outputs')
       ? metaObj.getObject('outputs').toLiteral((value) => value.getString())

--- a/packages/compiler-cli/linker/test/file_linker/file_linker_spec.ts
+++ b/packages/compiler-cli/linker/test/file_linker/file_linker_spec.ts
@@ -179,6 +179,64 @@ describe('FileLinker', () => {
     });
   });
 
+  describe('host binding validation', () => {
+    function linkDeclarationWithHost(
+      declarationFn: 'ɵɵngDeclareDirective' | 'ɵɵngDeclareComponent',
+      host: string,
+      version = '0.0.0-PLACEHOLDER',
+    ): string {
+      const componentMetadata =
+        declarationFn === 'ɵɵngDeclareComponent' ? `template: '', isInline: true,` : '';
+      const source = `
+        ${declarationFn}({
+          minVersion: '0.0.0-PLACEHOLDER',
+          version: '${version}',
+          ngImport: core,
+          type: SomeType,
+          ${componentMetadata}
+          host: ${host}
+        });
+      `;
+
+      const {fileLinker} = createFileLinker(source);
+      const sourceFile = ts.createSourceFile('', source, ts.ScriptTarget.Latest, true);
+      const call = (sourceFile.statements[0] as ts.ExpressionStatement)
+        .expression as ts.CallExpression;
+      const result = fileLinker.linkPartialDeclaration(
+        declarationFn,
+        [call.arguments[0]],
+        new MockDeclarationScope(),
+      );
+      return ts.createPrinter().printNode(ts.EmitHint.Unspecified, result, sourceFile);
+    }
+
+    it('should reject event attribute host bindings in partial directives', () => {
+      expect(() =>
+        linkDeclarationWithHost(
+          'ɵɵngDeclareDirective',
+          `{properties: {'attr.onmouseover': 'this.pay'}}`,
+          '22.0.6',
+        ),
+      ).toThrowError(/Binding to event attribute 'onmouseover' is disallowed for security reasons/);
+    });
+
+    it('should reject case-insensitive event property host bindings in partial components', () => {
+      expect(() =>
+        linkDeclarationWithHost('ɵɵngDeclareComponent', `{properties: {OnError: 'this.pay'}}`),
+      ).toThrowError(/Binding to event property 'OnError' is disallowed for security reasons/);
+    });
+
+    it('should preserve legitimate host properties and listeners', () => {
+      const result = linkDeclarationWithHost(
+        'ɵɵngDeclareDirective',
+        `{properties: {'attr.title': 'this.title'}, listeners: {click: 'this.onClick($event)'}}`,
+      );
+
+      expect(result).toContain(`core.ɵɵattribute("title", ctx.title)`);
+      expect(result).toContain(`core.ɵɵlistener("click"`);
+    });
+  });
+
   describe('legacyOptionalChaining support', () => {
     function linkComponentWithTemplate(version: string, template: string): string {
       // Note that the `minVersion` is set to the placeholder,

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -696,7 +696,11 @@ function extractHostBindings(
         // through `this` so that further down the line it can't be confused for a literal value
         // (e.g. if there's a property called `true`). There is no size penalty, because all
         // values (except literals) are converted to `ctx.propName` eventually.
-        bindings.properties[hostPropertyName] = getSafePropertyAccessString('this', member.name);
+        const hostPropertyExpression = getSafePropertyAccessString('this', member.name);
+        const decoratorBinding = parseHostBindings({});
+        decoratorBinding.properties[hostPropertyName] = hostPropertyExpression;
+        assertValidHostBindings(decoratorBinding, decorator.args?.[0] ?? decorator.node);
+        bindings.properties[hostPropertyName] = hostPropertyExpression;
       });
     },
   );
@@ -2066,30 +2070,34 @@ function evaluateHostExpressionBindings(
     );
   }
 
-  const errors = verifyHostBindings(bindings, createSourceSpan(hostExpr));
+  assertValidHostBindings(bindings, hostExpr);
+
+  return bindings;
+}
+
+function assertValidHostBindings(bindings: ParsedHostBindings, node: ts.Node): void {
+  const errors = verifyHostBindings(bindings, createSourceSpan(node));
   if (errors.length > 0) {
     throw new FatalDiagnosticError(
       ErrorCode.HOST_BINDING_PARSE_ERROR,
-      getHostBindingErrorNode(errors[0], hostExpr),
+      getHostBindingErrorNode(errors[0], node),
       errors.map((error: ParseError) => error.msg).join('\n'),
     );
   }
-
-  return bindings;
 }
 
 /**
  * Attempts to match a parser error to the host binding expression that caused it.
  * @param error Error to match.
- * @param hostExpr Expression declaring the host bindings.
+ * @param node Node declaring the host bindings.
  */
-function getHostBindingErrorNode(error: ParseError, hostExpr: ts.Expression): ts.Node {
+function getHostBindingErrorNode(error: ParseError, node: ts.Node): ts.Node {
   // In the most common case the `host` object is an object literal with string values. We can
   // confidently match the error to its expression by looking at the string value that the parser
   // failed to parse and the initializers for each of the properties. If we fail to match, we fall
   // back to the old behavior where the error is reported on the entire `host` object.
-  if (ts.isObjectLiteralExpression(hostExpr)) {
-    for (const prop of hostExpr.properties) {
+  if (ts.isObjectLiteralExpression(node)) {
+    for (const prop of node.properties) {
       if (
         ts.isPropertyAssignment(prop) &&
         ts.isStringLiteralLike(prop.initializer) &&
@@ -2100,7 +2108,7 @@ function getHostBindingErrorNode(error: ParseError, hostExpr: ts.Expression): ts
     }
   }
 
-  return hostExpr;
+  return node;
 }
 
 /**

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -3213,6 +3213,43 @@ runInEachFileSystem((os: string) => {
         );
       });
 
+      [
+        {
+          description: 'class field',
+          hostPropertyName: 'attr.onclick',
+          member: `handler = '';`,
+        },
+        {
+          description: 'getter with a mixed-case name',
+          hostPropertyName: 'attr.OnError',
+          member: `get handler() { return ''; }`,
+        },
+      ].forEach(({description, hostPropertyName, member}) => {
+        it(`should disallow event attributes in @HostBinding on a ${description}`, () => {
+          env.tsconfig({});
+          env.write(
+            'test.ts',
+            `
+            import {Directive, HostBinding} from '@angular/core';
+
+            @Directive({selector: '[test-dir]'})
+            export class TestDir {
+              @HostBinding('title') title = '';
+              @HostBinding('${hostPropertyName}') ${member}
+            }
+          `,
+          );
+
+          const errors = env.driveDiagnostics();
+          expect(errors.length).toBe(1);
+          expect(errors[0].code).toBe(ngErrorCode(ErrorCode.HOST_BINDING_PARSE_ERROR));
+          expect(ts.flattenDiagnosticMessageText(errors[0].messageText, '\n')).toContain(
+            `Binding to event attribute '${hostPropertyName.slice(5)}' is disallowed for security reasons`,
+          );
+          expect(getDiagnosticSourceCode(errors[0])).toBe(`'${hostPropertyName}'`);
+        });
+      });
+
       it('should throw error if @Directive.host field has wrong type', () => {
         env.tsconfig({});
         env.write(


### PR DESCRIPTION
Run host-binding validation as `@HostBinding` decorators are merged. Without this, `@HostBinding('attr.onclick')` bypasses the event-attribute check. Event attributes have no sanitizer, so the bound value can become a browser handler.

---
#68419 showed that production builds could render [attr.onclick] and host: {'attr.onclick': ...} as real inline event handlers because the runtime check was gated behind ngDevMode.

#68438 fixed this by moving the protection to compile time: it removed the runtime validateAgainstEventAttributes check and added validation through verifyHostBindings(). That makes sense since failing the build is better than throwing in the browser, but the validation is only effective on paths that actually call it.

Two paths were missed. In ngtsc, `@HostBinding` decorators are merged after host bindings are validated, so `@HostBinding('attr.onclick')` bypasses the check. This is basically the same ordering issue #68438 fixed for JIT, but still present in AOT. The linker also never validates host bindings, meaning a partial-compiled library can contain bindings that ngtsc would normally reject, including older libraries built before the fix.

The regression test didn’t catch either case because it uses JIT, which is exactly the path that was fixed. And since #68438 removed the old runtime guard, these paths are slightly worse now: previously development mode would at least throw; now they reach runtime without that fallback.
