### PR TITLE
fix(platform-browser): avoid false NG05106 errors on insertBefore

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -354,19 +354,24 @@ class DefaultDomRenderer2 implements Renderer2 {
   insertBefore(parent: any, newChild: any, refChild: any): void {
     if (parent) {
       const targetParent = isTemplateNode(parent) ? parent.content : parent;
-      // If something outside Angular removed or moved `refChild` (a browser extension, for
-      // example), the native call below throws a `NotFoundError` with no useful info. Catch it
-      // here so we can say what actually happened.
-      if (refChild != null && refChild.parentNode !== targetParent) {
-        throw new RuntimeError(
-          RuntimeErrorCode.INSERT_BEFORE_NODE_NOT_FOUND,
-          ngDevMode &&
-            `Angular could not insert a node before ${describeDomNode(refChild)} because it is no longer a child of ${describeDomNode(targetParent)}. ` +
-              `This can happen when code outside of Angular's control (for example, a browser extension or a script that directly manipulates the DOM) ` +
-              `has moved or removed a node that Angular is still managing.`,
-        );
+      try {
+        targetParent.insertBefore(newChild, refChild);
+      } catch (error) {
+        // When something outside Angular removed or moved `refChild` (a browser extension, for
+        // example), the native call above throws a `NotFoundError` with no useful info. It cannot
+        // be ruled out beforehand, because `parentNode` is only specified to return the parent
+        // node, not one particular object for it.
+        if (refChild != null && refChild.parentNode !== targetParent) {
+          throw new RuntimeError(
+            RuntimeErrorCode.INSERT_BEFORE_NODE_NOT_FOUND,
+            ngDevMode &&
+              `Angular could not insert a node before ${describeDomNode(refChild)} because it is no longer a child of ${describeDomNode(targetParent)}. ` +
+                `This can happen when code outside of Angular's control (for example, a browser extension or a script that directly manipulates the DOM) ` +
+                `has moved or removed a node that Angular is still managing.`,
+          );
+        }
+        throw error;
       }
-      targetParent.insertBefore(newChild, refChild);
     }
   }
 

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -190,6 +190,24 @@ describe('DefaultDomRendererV2', () => {
     expect(child.parentNode).toBe(parent);
   });
 
+  it('should be able to insert a child when the parent is not the object `refChild.parentNode` returns', () => {
+    const realParent = document.createElement('div');
+    const refChild = document.createElement('span');
+    const newChild = document.createElement('div');
+    realParent.appendChild(refChild);
+
+    // some DOM implementations hand out more than one object for the same element
+    const parentAlias = {
+      tagName: 'DIV',
+      insertBefore: (n: Node, r: Node) => realParent.insertBefore(n, r),
+    };
+
+    renderer.insertBefore(parentAlias, newChild, refChild);
+
+    expect(newChild.parentNode).toBe(realParent);
+    expect(newChild.nextSibling).toBe(refChild);
+  });
+
   describe('when the reference node was detached outside of Angular', () => {
     it('should throw a descriptive error instead of a native NotFoundError', () => {
       const parent = document.createElement('div');


### PR DESCRIPTION
`DefaultDomRenderer2.insertBefore` checks that `refChild.parentNode` is the parent it is about to insert into and throws NG05106 when it is not. `parentNode` only guarantees the parent node itself though, not one particular object for it, so an implementation may hand out more than one wrapper for the same element. happy-dom does that for `<form>` and `<select>`, whose constructors return a `Proxy` while children attached before the element was connected keep a reference to the raw instance. A component whose template root is a form then throws on insertions the native call would have completed.

Run the native call first and inspect the reference node only after it throws, so the descriptive error still replaces the opaque `NotFoundError` in both cases the guard was written for.

Fixes #70418