### PR TITLE
fix(core): allow `style` attributes in `DomSanitizer`

### DIFF
--- a/packages/core/src/sanitization/html_sanitizer.ts
+++ b/packages/core/src/sanitization/html_sanitizer.ts
@@ -84,7 +84,7 @@ const HTML_ATTRS = tagSet(
   'abbr,accesskey,align,alt,autoplay,axis,bgcolor,border,cellpadding,cellspacing,class,clear,color,cols,colspan,' +
     'compact,controls,coords,datetime,default,dir,download,face,headers,height,hidden,hreflang,hspace,' +
     'ismap,itemscope,itemprop,kind,label,lang,language,loop,media,muted,nohref,nowrap,open,preload,rel,rev,role,rows,rowspan,rules,' +
-    'scope,scrolling,shape,size,sizes,span,srclang,srcset,start,summary,tabindex,target,title,translate,type,usemap,' +
+    'scope,scrolling,shape,size,sizes,span,srclang,srcset,start,style,summary,tabindex,target,title,translate,type,usemap,' +
     'valign,value,vspace,width',
 );
 

--- a/packages/core/test/sanitization/html_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/html_sanitizer_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {isBrowser} from '@angular/private/testing';
 import {_sanitizeHtml} from '../../src/sanitization/html_sanitizer';
 import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
-import {isBrowser} from '@angular/private/testing';
 
 function sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): string {
   return _sanitizeHtml(defaultDoc, unsafeHtmlInput).toString();
@@ -153,13 +153,17 @@ describe('HTML sanitizer', () => {
   });
 
   describe('should strip dangerous attributes', () => {
-    const dangerousAttrs = ['id', 'name', 'style'];
+    const dangerousAttrs = ['id', 'name'];
 
     for (const attr of dangerousAttrs) {
       it(`${attr}`, () => {
         expect(sanitizeHtml(defaultDoc, `<a ${attr}="x">evil!</a>`)).toEqual('<a>evil!</a>');
       });
     }
+
+    it(`style`, () => {
+      expect(sanitizeHtml(defaultDoc, `<a style="x">safe!</a>`)).toEqual('<a style="x">safe!</a>');
+    });
   });
 
   it('ignores content of script elements', () => {


### PR DESCRIPTION
Modern browsers no longer execute JavaScript from within CSS (e.g., via `expression(...)` or `-moz-binding`), eliminating the primary XSS vector associated with inline styles. Because of this, Angular previously removed its internal `StyleSanitizer` in v14 (PR #43339). This commit aligns `DomSanitizer.sanitize(SecurityContext.HTML, ...)` with the current security model by adding `style` to the list of allowed HTML attributes. Safe `style` attributes will no longer be stripped from HTML output, while still being properly entity-encoded to prevent attribute breakout.

Closes #45270
