### PR TITLE
build: pin `vscode-languageserver-textdocument` version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1401,7 +1401,7 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       vscode-languageserver-textdocument:
-        specifier: ^1.0.12
+        specifier: 1.0.12
         version: 1.0.12
       vscode-uri:
         specifier: 3.1.0

--- a/vscode-ng-language-service/server/package.json
+++ b/vscode-ng-language-service/server/package.json
@@ -25,7 +25,7 @@
     "vscode-html-languageservice": "5.6.2",
     "vscode-css-languageservice": "6.3.10",
     "vscode-languageserver": "9.0.1",
-    "vscode-languageserver-textdocument": "^1.0.12",
+    "vscode-languageserver-textdocument": "1.0.12",
     "vscode-uri": "3.1.0"
   }
 }


### PR DESCRIPTION
This will prevent mismatches with the parent directory
