### PR TITLE
fix(core): cancel stale debounce timers

### DIFF
--- a/packages/core/src/resource/debounce.ts
+++ b/packages/core/src/resource/debounce.ts
@@ -48,8 +48,17 @@ export function debounced<T>(
 
   let active: Promise<void> | void | undefined;
   let pendingValue: T | undefined;
+  let activeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const cancelTimer = () => {
+    if (activeTimer !== undefined) {
+      clearTimeout(activeTimer);
+      activeTimer = undefined;
+    }
+  };
 
   injector.get(DestroyRef).onDestroy(() => {
+    cancelTimer();
     active = undefined;
   });
 
@@ -93,6 +102,7 @@ export function debounced<T>(
       } catch (err) {
         rethrowFatalErrors(err);
         state.set({status: 'error', error: err as Error});
+        cancelTimer();
         active = pendingValue = undefined;
         return;
       } finally {
@@ -109,9 +119,18 @@ export function debounced<T>(
         if (equal(value, currentState.value!)) return;
       }
 
+      // The value has changed, so any pending timer from a previous wait is now obsolete.
+      cancelTimer();
+
       const waitFn =
         typeof wait === 'number'
-          ? () => new Promise<void>((resolve) => setTimeout(resolve, wait))
+          ? () =>
+              new Promise<void>((resolve) => {
+                activeTimer = setTimeout(() => {
+                  activeTimer = undefined;
+                  resolve();
+                }, wait);
+              })
           : wait;
 
       const result = waitFn(value, currentState);

--- a/packages/core/test/resource/debounce_spec.ts
+++ b/packages/core/test/resource/debounce_spec.ts
@@ -332,6 +332,145 @@ describe('debounced', () => {
     expect(res.value()).toBe('recovered');
   });
 
+  describe('timer cleanup', () => {
+    // A distinctive delay, so the timers scheduled by `debounced` can be told apart from
+    // any scheduled by change detection or the test infrastructure.
+    const WAIT = 1234;
+
+    let setSpy: jasmine.Spy;
+    let clearSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      setSpy = spyOn(globalThis, 'setTimeout').and.callThrough();
+      clearSpy = spyOn(globalThis, 'clearTimeout').and.callThrough();
+    });
+
+    function timerIds(): unknown[] {
+      return setSpy.calls
+        .all()
+        .filter((call) => call.args[1] === WAIT)
+        .map((call) => call.returnValue);
+    }
+
+    function lastTimerId(): unknown {
+      return timerIds().at(-1);
+    }
+
+    function wasCleared(id: unknown): boolean {
+      return clearSpy.calls.allArgs().some(([arg]) => arg === id);
+    }
+
+    function fireTimer(id: unknown): void {
+      setSpy.calls
+        .all()
+        .find((call) => call.returnValue === id)!
+        .args[0]();
+    }
+
+    it('should clear the previous timer when a newer value supersedes it', () => {
+      const source = signal('initial');
+      debounced(source, WAIT, {injector});
+
+      TestBed.tick();
+
+      expect(lastTimerId()).toBeUndefined();
+
+      source.set('a');
+      TestBed.tick();
+
+      const firstTimer = lastTimerId();
+
+      expect(firstTimer).toBeDefined();
+      expect(wasCleared(firstTimer)).withContext('timer for "a" cleared too early').toBe(false);
+
+      source.set('b');
+      TestBed.tick();
+
+      expect(wasCleared(firstTimer)).withContext('timer for "a" not cleared').toBe(true);
+
+      const secondTimer = lastTimerId();
+
+      expect(secondTimer).not.toBe(firstTimer);
+
+      source.set('c');
+      TestBed.tick();
+
+      expect(wasCleared(secondTimer)).withContext('timer for "b" not cleared').toBe(true);
+
+      const ids = timerIds();
+
+      expect(ids.length).toBe(3);
+      expect(ids.filter((id) => wasCleared(id)).length)
+        .withContext('exactly one timer should still be queued')
+        .toBe(2);
+    });
+
+    it('should not clear a timer that has already fired', async () => {
+      const source = signal('initial');
+      const res = debounced(source, WAIT, {injector});
+
+      TestBed.tick();
+      source.set('a');
+      TestBed.tick();
+
+      const firstTimer = lastTimerId();
+
+      fireTimer(firstTimer);
+      await timeout();
+
+      expect(res.status()).toBe('resolved');
+
+      source.set('b');
+      TestBed.tick();
+
+      expect(wasCleared(firstTimer)).withContext('fired timer cleared').toBe(false);
+      expect(lastTimerId()).not.toBe(firstTimer);
+    });
+
+    it('should clear the pending timer when the injector is destroyed', () => {
+      const inj = createEnvironmentInjector([], TestBed.inject(EnvironmentInjector));
+      const source = signal('initial');
+      debounced(source, WAIT, {injector: inj});
+
+      TestBed.tick();
+      source.set('updated');
+      TestBed.tick();
+
+      const timer = lastTimerId();
+
+      expect(timer).toBeDefined();
+
+      inj.destroy();
+
+      expect(wasCleared(timer)).withContext('timer outlived the injector').toBe(true);
+    });
+
+    it('should clear the pending timer when the source throws', () => {
+      const val = signal('initial');
+      const source = computed(() => {
+        if (val() === 'error') throw new Error('fail');
+        return val();
+      });
+      const res = debounced(source, WAIT, {injector});
+
+      TestBed.tick();
+      val.set('updated');
+      TestBed.tick();
+
+      expect(res.status()).toBe('loading');
+
+      const timer = lastTimerId();
+
+      expect(timer).toBeDefined();
+
+      val.set('error');
+      TestBed.tick();
+
+      expect(res.status()).toBe('error');
+      expect(wasCleared(timer)).withContext('timer survived the error').toBe(true);
+    });
+  });
+
   it('should throw if used in params of another resource', () => {
     const res = resource({
       params: () => debounced(signal(1), 1),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — N/A, no public API or documented behavior changes

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When `debounced()` is given a numeric `wait`, the `setTimeout` scheduled on each source
change is never cancelled. Superseded timers stay queued until they fire, at which point
the `active === result` guard discards their result. The resource reports the correct
value, so there is no incorrect state — but the timers outlive their usefulness:

- A timer still pending when the injector is destroyed stays queued for the remainder of
  its delay, retaining its callback closure and the captured value. In a `fakeAsync` test
  this fails the spec with `1 timer(s) still in the queue.`, which is what a consumer hits
  when a component holding a `debounced()` is torn down mid-wait.
- Rapid source changes queue one timer per change instead of one per wait window. Each
  surplus timer wakes up only to be discarded by the guard.

Issue Number: N/A

## What is the new behavior?

The pending timer is tracked and cleared once it becomes obsolete, in three places:

- when a newer value supersedes it,
- when the source throws and the resource enters the error state,
- when the injector is destroyed.

The timer id is also released when the timer fires, so a completed timer is never cleared
afterwards — in a browser its id may already have been reused by an unrelated timer.

Cancellation deliberately happens *after* the equality check that returns early, so a
value that is `equal` to the one already pending leaves the running timer counting down.
This is why the cleanup is explicit rather than done through the effect's `onCleanup`:
the effect re-runs whenever the source notifies, including for equal values, and
cancelling on that path would kill a live debounce with nothing rescheduled, leaving the
resource stuck in `loading`.

No public API or observable state transitions change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Four specs were added under a `timer cleanup` block in `debounce_spec.ts`. Three of them
fail without the fix:

| Spec | Without the fix |
| --- | --- |
| should clear the previous timer when a newer value supersedes it | FAIL — `timer for "a" not cleared`, `Expected 0 to be 2` |
| should clear the pending timer when the injector is destroyed | FAIL — `timer outlived the injector` |
| should clear the pending timer when the source throws | FAIL — `timer survived the error` |
| should not clear a timer that has already fired | passes (regression guard) |

They assert on `clearTimeout` via a spy, comparing timer ids by identity — in Node a timer
id is a `Timeout` object, which no deep-equality matcher should try to serialize.

Verified with:

```
pnpm test //packages/core/test/resource:resource
```

70 specs, 0 failures with the fix; 3 failures on the parent commit.
