### PR TITLE
fix(docs-infra): point the tutorial .gitignore at live GitHub docs

### DIFF
--- a/adev/shared-docs/pipeline/tutorials/common/.gitignore
+++ b/adev/shared-docs/pipeline/tutorials/common/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # Compiled output
 /dist


### PR DESCRIPTION
The common tutorial scaffold's .gitignore opens with a link to help.github.com/ignore-files/, which 404s. That directory is copied into every tutorial and playground, so the dead link ships to anyone who opens one.