### PR TITLE
docs: update dead links in the contributing docs

### DIFF
--- a/contributing-docs/building-and-testing-angular.md
+++ b/contributing-docs/building-and-testing-angular.md
@@ -36,7 +36,7 @@ following on your development machine:
 
 - [Git](https://git-scm.com/) and/or the [**GitHub app**](https://desktop.github.com/) (for Mac and
   Windows);
-  [GitHub's Guide to Installing Git](https://help.github.com/articles/set-up-git) is a good source
+  [GitHub's Guide to Installing Git](https://docs.github.com/en/get-started/git-basics/set-up-git) is a good source
   of information.\
   **Windows Users**: Git Bash or an equivalent shell is required\
   _Windows Powershell and cmd shells are not
@@ -79,7 +79,7 @@ Fork and clone the Angular repository:
 
 1. Login to your GitHub account or create one by following the instructions given
    [here](https://github.com/signup/free).
-2. [Fork](https://help.github.com/forking) the [main Angular
+2. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the [main Angular
    repository](https://github.com/angular/angular).
 3. Clone your fork of the Angular repository and define an `upstream` remote pointing back to
    the Angular repository that you forked in the first place.

--- a/contributing-docs/building-with-bazel.md
+++ b/contributing-docs/building-with-bazel.md
@@ -83,7 +83,7 @@ using the proper flags with your Bazel test runs in Angular.
   e.g. `pnpm bazel test packages/core/test:test --config=debug`
 
 The process should automatically connect to the debugger.
-For more, see the [rules_nodejs Debugging documentation](https://bazelbuild.github.io/rules_nodejs/index.html#debugging).
+For more, see the [rules_nodejs Debugging documentation](https://github.com/bazel-contrib/rules_nodejs/blob/stable/docs/debugging.md).
 
 - Click on "Resume script execution" to let the code run until the first `debugger` statement or a
   previously set breakpoint.


### PR DESCRIPTION
The fork guide link 404s since GitHub retired help.github.com, and the rules_nodejs debugging docs moved to the bazel-contrib org. Also points the git setup link straight at its current home rather than through a redirect.