### PR TITLE
docs: document reactive forms in child components

### DIFF
--- a/adev/src/content/examples/BUILD.bazel
+++ b/adev/src/content/examples/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "copy_to_bin")
+load("//tools:defaults.bzl", "ng_project", "zoneless_web_test_suite")
 
 # All example files.
 filegroup(
@@ -22,4 +23,32 @@ copy_to_bin(
         ],
     ),
     visibility = ["//visibility:public"],
+)
+
+ng_project(
+    name = "reactive_forms_profile_editor_test_lib",
+    testonly = True,
+    srcs = [
+        "reactive-forms/src/app/profile-editor/address-editor/address-editor.component.ts",
+        "reactive-forms/src/app/profile-editor/profile-editor.component.spec.ts",
+        "reactive-forms/src/app/profile-editor/profile-editor.component.ts",
+    ],
+    assets = [
+        "reactive-forms/src/app/profile-editor/address-editor/address-editor.component.css",
+        "reactive-forms/src/app/profile-editor/address-editor/address-editor.component.html",
+        "reactive-forms/src/app/profile-editor/profile-editor.component.css",
+        "reactive-forms/src/app/profile-editor/profile-editor.component.html",
+    ],
+    tsconfig = "//packages:tsconfig_test",
+    deps = [
+        "//packages/common",
+        "//packages/core",
+        "//packages/core/testing",
+        "//packages/forms",
+    ],
+)
+
+zoneless_web_test_suite(
+    name = "reactive_forms_profile_editor_test",
+    deps = [":reactive_forms_profile_editor_test_lib"],
 )

--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/address-editor/address-editor.component.css
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/address-editor/address-editor.component.css
@@ -1,0 +1,16 @@
+fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  font-size: 1.5em;
+  font-weight: bold;
+}
+
+label {
+  display: block;
+  margin: 0.5em 0;
+  font-weight: bold;
+}

--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/address-editor/address-editor.component.html
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/address-editor/address-editor.component.html
@@ -1,0 +1,15 @@
+<fieldset>
+  <legend>Address</legend>
+
+  <label for="street">Street: </label>
+  <input id="street" type="text" formControlName="street" />
+
+  <label for="city">City: </label>
+  <input id="city" type="text" formControlName="city" />
+
+  <label for="state">State: </label>
+  <input id="state" type="text" formControlName="state" />
+
+  <label for="zip">Zip Code: </label>
+  <input id="zip" type="text" formControlName="zip" required />
+</fieldset>

--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/address-editor/address-editor.component.ts
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/address-editor/address-editor.component.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+import {ControlContainer, FormGroupName, ReactiveFormsModule} from '@angular/forms';
+
+@Component({
+  selector: 'app-address-editor',
+  templateUrl: './address-editor.component.html',
+  styleUrls: ['./address-editor.component.css'],
+  imports: [ReactiveFormsModule],
+  viewProviders: [{provide: ControlContainer, useExisting: FormGroupName}],
+})
+export class AddressEditorComponent {}

--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.html
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.html
@@ -8,21 +8,9 @@
   <label for="last-name">Last Name: </label>
   <input id="last-name" type="text" formControlName="lastName" />
 
-  <div formGroupName="address">
-    <h2>Address</h2>
-
-    <label for="street">Street: </label>
-    <input id="street" type="text" formControlName="street" />
-
-    <label for="city">City: </label>
-    <input id="city" type="text" formControlName="city" />
-
-    <label for="state">State: </label>
-    <input id="state" type="text" formControlName="state" />
-
-    <label for="zip">Zip Code: </label>
-    <input id="zip" type="text" formControlName="zip" />
-  </div>
+  <!-- #docregion address-editor -->
+  <app-address-editor formGroupName="address" />
+  <!-- #enddocregion address-editor -->
 
   <!-- #docregion formarrayname -->
   <div formArrayName="aliases">

--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.spec.ts
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.spec.ts
@@ -1,0 +1,26 @@
+import {TestBed} from '@angular/core/testing';
+
+import {ProfileEditorComponent} from './profile-editor.component';
+
+describe('ProfileEditorComponent', () => {
+  it('updates the parent form value and validation from the child component', async () => {
+    const fixture = TestBed.createComponent(ProfileEditorComponent);
+    await fixture.whenStable();
+
+    fixture.componentInstance.profileForm.controls.firstName.setValue('Nancy');
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.profileForm.invalid).toBeTrue();
+
+    const zipInput = fixture.nativeElement.querySelector('#zip');
+    if (!(zipInput instanceof HTMLInputElement)) {
+      throw new Error('Expected the address editor to contain a zip input.');
+    }
+    zipInput.value = '12345';
+    zipInput.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.profileForm.controls.address.controls.zip.value).toBe('12345');
+    expect(fixture.componentInstance.profileForm.valid).toBeTrue();
+  });
+});

--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.ts
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.ts
@@ -6,12 +6,17 @@ import {Validators} from '@angular/forms';
 // #enddocregion validator-imports
 import {FormArray} from '@angular/forms';
 import {JsonPipe} from '@angular/common';
+// #docregion address-editor-import
+import {AddressEditorComponent} from './address-editor/address-editor.component';
+// #enddocregion address-editor-import
 
 @Component({
   selector: 'app-profile-editor',
   templateUrl: './profile-editor.component.html',
   styleUrls: ['./profile-editor.component.css'],
-  imports: [ReactiveFormsModule, JsonPipe],
+  // #docregion address-editor-import
+  imports: [ReactiveFormsModule, JsonPipe, AddressEditorComponent],
+  // #enddocregion address-editor-import
 })
 export class ProfileEditorComponent {
   // #docregion required-validator, aliases
@@ -24,7 +29,7 @@ export class ProfileEditorComponent {
       street: [''],
       city: [''],
       state: [''],
-      zip: [''],
+      zip: ['', Validators.required],
     }),
     // #enddocregion required-validator
     aliases: this.formBuilder.array([this.formBuilder.control('')]),

--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -207,6 +207,34 @@ Display the value for the form group instance in the component template using th
 </docs-step>
 </docs-workflow>
 
+### Splitting a form into child components
+
+You can split a large form into child components while keeping the form model in the parent
+component. Apply the `formGroupName` directive to the child component's host element to connect it
+to the relevant nested `FormGroup`. Changes to controls in the child then propagate to the parent
+form, including value and validity changes.
+
+The following child component imports `ReactiveFormsModule` so that its template can use reactive
+form directives. Controls in the component view need the host `FormGroupName` directive exposed as
+their `ControlContainer`, so the component provides it through `viewProviders`.
+
+<docs-code header="address-editor.component.ts" path="adev/src/content/examples/reactive-forms/src/app/profile-editor/address-editor/address-editor.component.ts"/>
+
+Controls in the child template can then use `formControlName` as usual.
+
+<docs-code header="address-editor.component.html" path="adev/src/content/examples/reactive-forms/src/app/profile-editor/address-editor/address-editor.component.html"/>
+
+Import the child component and bind it to the nested address group by name.
+
+<docs-code header="profile-editor.component.ts (import address editor)" path="adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.ts" region="address-editor-import"/>
+
+<docs-code header="profile-editor.component.html (address editor)" path="adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.html" region="address-editor"/>
+
+The parent remains the source of truth for the entire form. It can read the latest nested values and
+validation status from `profileForm`, so the child does not need to emit its form value separately.
+You can repeat this pattern at deeper levels by applying another `formGroupName` directive to the
+next child component.
+
 ### Updating parts of the data model
 
 When updating the value for a form group instance that contains multiple controls, you might only want to update parts of the model.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The reactive forms guide demonstrates nested form groups within one component, but does not explain how to move a nested group into a child component while preserving value and validation propagation.

Issue Number: #43595

## What is the new behavior?

The guide documents how to apply `formGroupName` to a child component and expose the host `FormGroupName` as the `ControlContainer` for the child view. The example keeps the complete form model in the parent, demonstrates nested validation, and explains that the pattern can be repeated for deeper child components without emitting separate form values.

A zoneless browser test verifies that editing the child component updates both the nested value and validity of the parent form.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
