### PR TITLE
refactor(devtools): point the .gitignore comment at live GitHub docs

### DIFF
--- a/devtools/.gitignore
+++ b/devtools/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist


### PR DESCRIPTION
help.github.com/ignore-files/ 404s since GitHub retired that domain.