### PR TITLE
build: point the integration .gitignore comments at live GitHub docs

### DIFF
--- a/integration/animations/.gitignore
+++ b/integration/animations/.gitignore
@@ -1,4 +1,4 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/cli-hello-world-ivy-i18n/.gitignore
+++ b/integration/cli-hello-world-ivy-i18n/.gitignore
@@ -1,4 +1,4 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/cli-hello-world-lazy/.gitignore
+++ b/integration/cli-hello-world-lazy/.gitignore
@@ -1,4 +1,4 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/cli-hello-world/.gitignore
+++ b/integration/cli-hello-world/.gitignore
@@ -1,4 +1,4 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/cli-signal-inputs/.gitignore
+++ b/integration/cli-signal-inputs/.gitignore
@@ -1,4 +1,4 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/defer/.gitignore
+++ b/integration/defer/.gitignore
@@ -1,4 +1,4 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/legacy-animations-async/.gitignore
+++ b/integration/legacy-animations-async/.gitignore
@@ -1,4 +1,4 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/legacy-animations/.gitignore
+++ b/integration/legacy-animations/.gitignore
@@ -1,4 +1,4 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/ng-add-localize/.gitignore
+++ b/integration/ng-add-localize/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/platform-server-hydration/.gitignore
+++ b/integration/platform-server-hydration/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # Compiled output
 /dist

--- a/integration/platform-server-zoneless/.gitignore
+++ b/integration/platform-server-zoneless/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # Compiled output
 /dist

--- a/integration/platform-server/.gitignore
+++ b/integration/platform-server/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # Compiled output
 /dist

--- a/integration/standalone-bootstrap/.gitignore
+++ b/integration/standalone-bootstrap/.gitignore
@@ -1,4 +1,4 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist

--- a/integration/trusted-types/.gitignore
+++ b/integration/trusted-types/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://docs.github.com/en/get-started/git-basics/ignoring-files for more about ignoring files.
 
 # compiled output
 /dist


### PR DESCRIPTION
help.github.com/ignore-files/ 404s since GitHub retired that domain. Five of the files still linked to it over plain http as well.