### PR TITLE
fix(compiler): keep generated property names as data

### DIFF
--- a/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
+++ b/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
+import {isUnsafeObjectKey} from '@angular/compiler';
 import {types as t} from '@babel/core';
 
 import {assert} from '../../../../linker';
@@ -219,9 +220,10 @@ export class BabelAstFactory implements AstFactory<
           return t.spreadElement(prop.expression);
         }
 
-        const key = prop.quoted
-          ? t.stringLiteral(prop.propertyName)
-          : t.identifier(prop.propertyName);
+        const key =
+          prop.quoted || isUnsafeObjectKey(prop.propertyName)
+            ? t.stringLiteral(prop.propertyName)
+            : t.identifier(prop.propertyName);
         return t.objectProperty(key, prop.value);
       }),
     );
@@ -230,7 +232,9 @@ export class BabelAstFactory implements AstFactory<
   createParenthesizedExpression = t.parenthesizedExpression;
 
   createPropertyAccess(expression: t.Expression, propertyName: string): t.Expression {
-    return t.memberExpression(expression, t.identifier(propertyName), /* computed */ false);
+    return isUnsafeObjectKey(propertyName)
+      ? t.memberExpression(expression, t.stringLiteral(propertyName), /* computed */ true)
+      : t.memberExpression(expression, t.identifier(propertyName), /* computed */ false);
   }
 
   createPropertyAccessChain(
@@ -238,12 +242,19 @@ export class BabelAstFactory implements AstFactory<
     propertyName: string,
     isOptional: boolean,
   ): t.Expression {
-    return t.optionalMemberExpression(
-      expression,
-      t.identifier(propertyName),
-      /* computed */ false,
-      /* optional */ isOptional,
-    );
+    return isUnsafeObjectKey(propertyName)
+      ? t.optionalMemberExpression(
+          expression,
+          t.stringLiteral(propertyName),
+          /* computed */ true,
+          /* optional */ isOptional,
+        )
+      : t.optionalMemberExpression(
+          expression,
+          t.identifier(propertyName),
+          /* computed */ false,
+          /* optional */ isOptional,
+        );
   }
 
   createReturnStatement(expression: t.Expression | null): t.Statement {

--- a/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
+++ b/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
@@ -327,6 +327,18 @@ describe('BabelAstFactory', () => {
         ['{', '  prop1: 42,', '  "prop2": "moo",', '  ...foo', '}'].join('\n'),
       );
     });
+
+    it('should quote property names that are not valid identifiers, even if they are not marked as quoted', () => {
+      const prop1 = expression.ast`42`;
+      const prop2 = expression.ast`"moo"`;
+      const obj = factory.createObjectLiteral([
+        {propertyName: 'a: 0, evil: 1, b', value: prop1, kind: 'property', quoted: false},
+        {propertyName: 'ɵcmp', value: prop2, kind: 'property', quoted: false},
+      ]);
+      expect(generate(obj).code).toEqual(
+        ['{', '  "a: 0, evil: 1, b": 42,', '  ɵcmp: "moo"', '}'].join('\n'),
+      );
+    });
   });
 
   describe('createParenthesizedExpression()', () => {
@@ -342,6 +354,26 @@ describe('BabelAstFactory', () => {
       const expr = expression.ast`obj`;
       const access = factory.createPropertyAccess(expr, 'moo');
       expect(generate(access).code).toEqual('obj.moo');
+    });
+
+    it('should create an element access expression node if the property name is not a valid identifier', () => {
+      const expr = expression.ast`obj`;
+      const access = factory.createPropertyAccess(expr, 'a, evil(), b');
+      expect(generate(access).code).toEqual('obj["a, evil(), b"]');
+    });
+  });
+
+  describe('createPropertyAccessChain()', () => {
+    it('should create an optional property access expression node', () => {
+      const expr = expression.ast`obj`;
+      const access = factory.createPropertyAccessChain(expr, 'moo', true);
+      expect(generate(access).code).toEqual('obj?.moo');
+    });
+
+    it('should create an optional element access expression node if the property name is not a valid identifier', () => {
+      const expr = expression.ast`obj`;
+      const access = factory.createPropertyAccessChain(expr, 'a, evil(), b', true);
+      expect(generate(access).code).toEqual('obj?.["a, evil(), b"]');
     });
   });
 

--- a/packages/compiler-cli/linker/test/ast/ast_value_spec.ts
+++ b/packages/compiler-cli/linker/test/ast/ast_value_spec.ts
@@ -208,10 +208,7 @@ describe('AstValue', () => {
     });
 
     it('should return the name of a property access', () => {
-      const propertyAccess = factory.createPropertyAccess(
-        factory.createIdentifier('Foo'),
-        factory.createIdentifier('Bar'),
-      );
+      const propertyAccess = factory.createPropertyAccess(factory.createIdentifier('Foo'), 'Bar');
       expect(createAstValue(propertyAccess).getSymbolName()).toEqual('Bar');
     });
 

--- a/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
@@ -213,7 +213,8 @@ export interface AstFactory<TStatement, TExpression, TType> {
   createParenthesizedExpression(expression: TExpression): TExpression;
 
   /**
-   * Create a property access (e.g. `obj.prop`).
+   * Create a property access (e.g. `obj.prop`). Implementations use an element access instead if
+   * `propertyName` is not a valid identifier.
    *
    * @param expression an expression that evaluates to the object to be accessed.
    * @param propertyName the name of the property to access.
@@ -221,7 +222,8 @@ export interface AstFactory<TStatement, TExpression, TType> {
   createPropertyAccess(expression: TExpression, propertyName: string): TExpression;
 
   /**
-   * Create a property access chain expression (e.g. `obj?.prop`).
+   * Create a property access chain expression (e.g. `obj?.prop`). Implementations use an element
+   * access chain instead if `propertyName` is not a valid identifier.
    */
   createPropertyAccessChain(
     expression: TExpression,
@@ -375,13 +377,7 @@ export type UnaryOperator = '+' | '-' | '!';
 
 /** Supported built-in types. */
 export type BuiltInType =
-  | 'any'
-  | 'boolean'
-  | 'number'
-  | 'string'
-  | 'function'
-  | 'never'
-  | 'unknown';
+  'any' | 'boolean' | 'number' | 'string' | 'function' | 'never' | 'unknown';
 
 export interface Parameter<TType> {
   name: string;
@@ -464,7 +460,9 @@ export interface ObjectLiteralAssignment<TExpression> {
   propertyName: string;
   value: TExpression;
   /**
-   * Whether the `propertyName` should be enclosed in quotes.
+   * Whether the `propertyName` should be enclosed in quotes. Note that implementations quote the
+   * name regardless of this flag if it isn't a valid identifier, since it couldn't be emitted
+   * as-is.
    */
   quoted: boolean;
 }
@@ -479,8 +477,7 @@ export interface ObjectLiteralSpread<TExpression> {
 
 /** Possible properties in an object literal. */
 export type ObjectLiteralProperty<TExpression> =
-  | ObjectLiteralAssignment<TExpression>
-  | ObjectLiteralSpread<TExpression>;
+  ObjectLiteralAssignment<TExpression> | ObjectLiteralSpread<TExpression>;
 
 /**
  * Information used by the `AstFactory` to create a template literal string (i.e. a back-ticked

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
+import {isUnsafeObjectKey} from '@angular/compiler';
 import ts from 'typescript';
 
 import {
@@ -302,7 +303,7 @@ export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Express
         }
 
         return ts.factory.createPropertyAssignment(
-          prop.quoted
+          prop.quoted || isUnsafeObjectKey(prop.propertyName)
             ? ts.factory.createStringLiteral(prop.propertyName)
             : ts.factory.createIdentifier(prop.propertyName),
           prop.value,
@@ -313,18 +314,31 @@ export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Express
 
   createParenthesizedExpression = ts.factory.createParenthesizedExpression;
 
-  createPropertyAccess = ts.factory.createPropertyAccessExpression;
+  createPropertyAccess(expression: ts.Expression, propertyName: string): ts.Expression {
+    return isUnsafeObjectKey(propertyName)
+      ? ts.factory.createElementAccessExpression(
+          expression,
+          ts.factory.createStringLiteral(propertyName),
+        )
+      : ts.factory.createPropertyAccessExpression(expression, propertyName);
+  }
 
   createPropertyAccessChain(
     expression: ts.Expression,
     propertyName: string,
     isOptional: boolean,
   ): ts.Expression {
-    return ts.factory.createPropertyAccessChain(
-      expression,
-      isOptional ? ts.factory.createToken(ts.SyntaxKind.QuestionDotToken) : undefined,
-      propertyName,
-    );
+    const questionDotToken = isOptional
+      ? ts.factory.createToken(ts.SyntaxKind.QuestionDotToken)
+      : undefined;
+
+    return isUnsafeObjectKey(propertyName)
+      ? ts.factory.createElementAccessChain(
+          expression,
+          questionDotToken,
+          ts.factory.createStringLiteral(propertyName),
+        )
+      : ts.factory.createPropertyAccessChain(expression, questionDotToken, propertyName);
   }
 
   createSpreadElement = ts.factory.createSpreadElement;

--- a/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
@@ -373,6 +373,18 @@ describe('TypeScriptAstFactory', () => {
       ]);
       expect(generate(obj)).toEqual('{ prop1: 42, "prop2": "moo", ...foo }');
     });
+
+    it('should quote property names that are not valid identifiers, even if they are not marked as quoted', () => {
+      const {
+        items: [prop1, prop2],
+        generate,
+      } = setupExpressions('42', '"moo"');
+      const obj = factory.createObjectLiteral([
+        {propertyName: 'a: 0, evil: 1, b', value: prop1, kind: 'property', quoted: false},
+        {propertyName: 'ɵcmp', value: prop2, kind: 'property', quoted: false},
+      ]);
+      expect(generate(obj)).toEqual('{ "a: 0, evil: 1, b": 42, ɵcmp: "moo" }');
+    });
   });
 
   describe('createParenthesizedExpression()', () => {
@@ -394,6 +406,35 @@ describe('TypeScriptAstFactory', () => {
       } = setupExpressions(`obj`);
       const access = factory.createPropertyAccess(expr, 'moo');
       expect(generate(access)).toEqual('obj.moo');
+    });
+
+    it('should create an element access expression node if the property name is not a valid identifier', () => {
+      const {
+        items: [expr],
+        generate,
+      } = setupExpressions(`obj`);
+      const access = factory.createPropertyAccess(expr, 'a, evil(), b');
+      expect(generate(access)).toEqual('obj["a, evil(), b"]');
+    });
+  });
+
+  describe('createPropertyAccessChain()', () => {
+    it('should create an optional property access expression node', () => {
+      const {
+        items: [expr],
+        generate,
+      } = setupExpressions(`obj`);
+      const access = factory.createPropertyAccessChain(expr, 'moo', true);
+      expect(generate(access)).toEqual('obj?.moo');
+    });
+
+    it('should create an optional element access expression node if the property name is not a valid identifier', () => {
+      const {
+        items: [expr],
+        generate,
+      } = setupExpressions(`obj`);
+      const access = factory.createPropertyAccessChain(expr, 'a, evil(), b', true);
+      expect(generate(access)).toEqual('obj?.["a, evil(), b"]');
     });
   });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -199,6 +199,11 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE)).toContain('var _t2 = _t1.$implicit;');
   });
 
+  it('should use an element access for template variables that are not valid identifiers', () => {
+    const TEMPLATE = `<ng-template let-a="a, evil(), b"></ng-template>`;
+    expect(tcb(TEMPLATE)).toContain('var _t2 = (_t1["a, evil(), b"]);');
+  });
+
   it('should handle method calls of template variables', () => {
     const TEMPLATE = `<ng-template let-a>{{a(1)}}</ng-template>`;
     expect(tcb(TEMPLATE)).toContain('var _t2 = _t1.$implicit;');

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -7479,6 +7479,89 @@ runInEachFileSystem((os: string) => {
       expect(trim(jsContents)).toContain(trim(inputsAndOutputs));
     });
 
+    it('should quote "inputs" and "outputs" keys that are not valid identifiers', () => {
+      env.write(
+        `test.ts`,
+        `
+      import {Directive, Input, Output, EventEmitter} from '@angular/core';
+
+      @Directive({selector: '[somedir]'})
+      export class SomeDir {
+        @Input() 'a: 0, evil: 1, b' = 1;
+        @Output() 'c: 0, evil: 2, d' = new EventEmitter<void>();
+      }
+    `,
+      );
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      const inputsAndOutputs = `
+      inputs: { "a: 0, evil: 1, b": "a: 0, evil: 1, b" },
+      outputs: { "c: 0, evil: 2, d": "c: 0, evil: 2, d" }
+    `;
+      expect(trim(jsContents)).toContain(trim(inputsAndOutputs));
+    });
+
+    it('should use an element access to assign to a query field that is not a valid identifier', () => {
+      env.write(
+        `test.ts`,
+        `
+      import {Component, ContentChild, ViewChild, ElementRef} from '@angular/core';
+
+      @Component({selector: 'test-cmp', template: '<div #ref></div>'})
+      export class TestCmp {
+        @ViewChild('ref') 'a, evil(), b': ElementRef;
+        @ContentChild('ref') 'c, evil(), d': ElementRef;
+      }
+    `,
+      );
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('ctx["a, evil(), b"] = _t.first');
+      expect(jsContents).toContain('ctx["c, evil(), d"] = _t.first');
+    });
+
+    it('should use an element access for a template context alias that is not a valid identifier', () => {
+      env.write(
+        `test.ts`,
+        `
+      import {Component} from '@angular/core';
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<ng-template let-value="a, evil(), b">{{value}}</ng-template>',
+      })
+      export class TestCmp {}
+    `,
+      );
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('const value_r1 = ctx["a, evil(), b"];');
+    });
+
+    it('should quote unsafe keys when compiling a declaration partially', () => {
+      env.tsconfig({compilationMode: 'partial'});
+      env.write(
+        `test.ts`,
+        `
+      import {Directive, Input, Output, EventEmitter} from '@angular/core';
+
+      @Directive({selector: '[somedir]'})
+      export class SomeDir {
+        @Input() 'a: 0, evil: 1, b' = 1;
+        @Output() 'c: 0, evil: 2, d' = new EventEmitter<void>();
+      }
+    `,
+      );
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('inputs: { "a: 0, evil: 1, b": "a: 0, evil: 1, b" }');
+      expect(jsContents).toContain('outputs: { "c: 0, evil: 2, d": "c: 0, evil: 2, d" }');
+    });
+
     it('should generate the correct declaration for class members decorated with @Input', () => {
       env.write(
         'test.ts',

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -12,8 +12,22 @@ import * as o from './output_ast';
 import {SourceMapGenerator} from './source_map';
 
 const SINGLE_QUOTE_ESCAPE_STRING_RE = /'|\\|\n|\r/g;
+/**
+ * Names that `escapeIdentifier` may leave unquoted. This is deliberately stricter than
+ * `IDENTIFIER_NAME_REGEXP` below: quoting a name that didn't need it is harmless, so the ASCII-only
+ * subset is safe to keep for the callers that already rely on it.
+ */
 const LEGAL_IDENTIFIER_RE = /^[$A-Z_][0-9A-Z_$]*$/i;
+const IDENTIFIER_NAME_REGEXP = /^[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*$/u;
 const INDENT_WITH = '  ';
+
+/**
+ * Checks whether a name matches the `IdentifierName` production of the ECMAScript grammar.
+ * Reserved words match, because they are valid object literal keys and property names.
+ */
+export function isIdentifierName(name: string): boolean {
+  return IDENTIFIER_NAME_REGEXP.test(name);
+}
 
 class EmittedLine {
   partsLength = 0;

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -522,8 +522,14 @@ export abstract class AbstractEmitterVisitor
   visitReadPropExpr(ast: o.ReadPropExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ast.receiver.visitExpression(this, ctx);
-    ctx.print(ast, ast.isOptional ? `?.` : `.`);
-    ctx.print(ast, ast.name);
+    if (isIdentifierName(ast.name)) {
+      ctx.print(ast, ast.isOptional ? `?.` : `.`);
+      ctx.print(ast, ast.name);
+    } else {
+      ctx.print(ast, ast.isOptional ? `?.[` : `[`);
+      ctx.print(ast, escapeIdentifier(ast.name)!);
+      ctx.print(ast, `]`);
+    }
   }
 
   visitReadKeyExpr(ast: o.ReadKeyExpr, ctx: EmitterVisitorContext): void {

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -6,13 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {escapeIdentifier} from '../output/abstract_emitter';
+import {escapeIdentifier, isIdentifierName} from '../output/abstract_emitter';
 import * as o from '../output/output_ast';
 
 import {Identifiers} from './r3_identifiers';
-
-/** Regex that includes unsafe characters in an object literal property name. */
-const UNSAFE_OBJECT_KEY_NAME_REGEXP = /[-.]/;
 
 /** Pattern used to validate a JavaScript identifier. */
 export const IDENTIFIER_PATTERN = /^[$A-Z_][0-9A-Z_$]*$/i;
@@ -89,8 +86,16 @@ export function tsIgnoreComment(): o.LeadingComment {
   return o.leadingComment('@ts-ignore', true, true);
 }
 
+/**
+ * Checks whether a name has to be quoted when it is used as an object literal key, or accessed
+ * with an element access rather than a property access. Names can come from user code (e.g. a
+ * class member declared with a string literal), so they aren't guaranteed to be valid identifiers.
+ *
+ * Note that we don't quote all keys, because doing so can prevent a minifier from mangling them.
+ * Anything that isn't an identifier can't be mangled anyway, so quoting it costs nothing.
+ */
 export function isUnsafeObjectKey(key: string): boolean {
-  return UNSAFE_OBJECT_KEY_NAME_REGEXP.test(key);
+  return !isIdentifierName(key);
 }
 
 /**

--- a/packages/compiler/src/typecheck/ops/variables.ts
+++ b/packages/compiler/src/typecheck/ops/variables.ts
@@ -7,6 +7,7 @@
  */
 
 import {Template, Variable} from '../../render3/r3_ast';
+import {isUnsafeObjectKey} from '../../render3/util';
 import {TcbOp} from './base';
 import type {Context} from './context';
 import type {Scope} from './scope';
@@ -67,7 +68,15 @@ export class TcbTemplateVariableOp extends TcbOp {
     // Allocate an identifier for the Variable, and initialize it to a read of the variable
     // on the template context.
     const id = new TcbExpr(this.tcb.allocateId());
-    const initializer = new TcbExpr(`${ctx.print()}.${this.variable.value || '$implicit'}`);
+    // The value is used verbatim as the name of the context property, but it isn't guaranteed to be
+    // a valid identifier. Fall back to an element access in that case so that the check matches the
+    // code that the compiler will actually generate.
+    const value = this.variable.value || '$implicit';
+    const initializer = new TcbExpr(
+      isUnsafeObjectKey(value)
+        ? `${ctx.print()}[${TcbExpr.quoteAndEscape(value)}]`
+        : `${ctx.print()}.${value}`,
+    );
     id.addParseSpanInfo(this.variable.keySpan);
 
     // Declare the variable, and return its identifier.

--- a/packages/compiler/test/output/abstract_emitter_spec.ts
+++ b/packages/compiler/test/output/abstract_emitter_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {escapeIdentifier} from '../../src/output/abstract_emitter';
+import {escapeIdentifier, isIdentifierName} from '../../src/output/abstract_emitter';
 
 describe('AbstractEmitter', () => {
   describe('escapeIdentifier', () => {
@@ -31,6 +31,42 @@ describe('AbstractEmitter', () => {
     });
     it('does not escape class (but it probably should)', () => {
       expect(escapeIdentifier('class', false)).toEqual('class');
+    });
+  });
+
+  describe('isIdentifierName', () => {
+    it('should accept valid property names, including reserved words and Unicode identifiers', () => {
+      for (const name of [
+        'value',
+        '_value',
+        '$value',
+        'class',
+        '\u0275cmp',
+        'a\u200cb',
+        '\u{10400}x',
+      ]) {
+        expect(isIdentifierName(name)).withContext(name).toBeTrue();
+      }
+    });
+
+    it('should reject names that can escape an identifier position', () => {
+      for (const name of [
+        '',
+        '0',
+        'a b',
+        'a-b',
+        'a.b',
+        'a,b',
+        'a:b',
+        'a; evil()',
+        'a\\b',
+        'a"b',
+        "a'b",
+        'a\nb',
+        '\u200ca',
+      ]) {
+        expect(isIdentifierName(name)).withContext(JSON.stringify(name)).toBeFalse();
+      }
     });
   });
 });

--- a/packages/compiler/test/output/output_jit_spec.ts
+++ b/packages/compiler/test/output/output_jit_spec.ts
@@ -54,6 +54,44 @@ describe('Output JIT', () => {
     }).toThrowError();
   });
 
+  describe('visitReadPropExpr', () => {
+    function emit(expr: o.Expression): string {
+      const converter = new JitEmitterVisitor(new R3JitReflector({}));
+      const ctx = EmitterVisitorContext.createRoot();
+      converter.visitAllStatements([expr.toStmt()], ctx);
+      return ctx
+        .toSource()
+        .replace(/^'use strict';\s*/, '')
+        .trim();
+    }
+
+    it('should emit a property access for valid identifiers', () => {
+      expect(emit(o.variable('ctx').prop('foo'))).toBe('ctx.foo;');
+      // Reserved words and non-ASCII identifiers are valid property names.
+      expect(emit(o.variable('ctx').prop('class'))).toBe('ctx.class;');
+      expect(emit(o.variable('ctx').prop('\u0275cmp'))).toBe('ctx.\u0275cmp;');
+    });
+
+    it('should emit an element access for names that are not valid identifiers', () => {
+      expect(emit(o.variable('ctx').prop('a-b'))).toBe(`ctx['a-b'];`);
+      expect(emit(o.variable('ctx').prop(`a; evil(); b`))).toBe(`ctx['a; evil(); b'];`);
+      // The name has to be escaped so that it cannot terminate the string literal either.
+      expect(emit(o.variable('ctx').prop(`a'; evil(); '`))).toBe(`ctx['a\\'; evil(); \\''];`);
+    });
+
+    it('should emit an optional element access for an optional read', () => {
+      const optional = new o.ReadPropExpr(
+        o.variable('ctx'),
+        'a; evil(); b',
+        null,
+        null,
+        undefined,
+        true,
+      );
+      expect(emit(optional)).toBe(`ctx?.['a; evil(); b'];`);
+    });
+  });
+
   it('should not add more than one strict mode statement if there is already one present', () => {
     const converter = new JitEmitterVisitor(new R3JitReflector({}));
     const ctx = EmitterVisitorContext.createRoot();


### PR DESCRIPTION
#### fix(compiler): keep generated property names as data
Class members and template context aliases may use names that JavaScript cannot safely emit as identifiers. The TypeScript and Babel emitters trusted the producer-provided `quoted` flag, so a crafted name could become executable code or make the linker fail instead of remaining a property name.

Validate names where code is emitted and use string-literal keys or element access whenever needed, including optional chains and template type-check blocks. Ordinary ASCII, reserved-word, and Unicode property names continue to use their existing output.

Fixes #70444 

#### fix(compiler): escape non-identifier names in JIT output
The JIT text emitter had the same unsafe assumption as the structured emitters: it wrote every ReadPropExpr name directly after a dot. A crafted template context alias could therefore be interpreted as JavaScript instead of data.

Use dot access only for valid IdentifierName values and emit escaped, quoted element access for every other name, including optional reads. Cover the full JIT path with a test that confirms the alias never executes and the original property still renders.
 