### PR TITLE
feat(core): add addtional built-in prefetch triggers for async injection

### DIFF
--- a/adev/src/content/guide/di/lazy-loading-services.md
+++ b/adev/src/content/guide/di/lazy-loading-services.md
@@ -46,14 +46,16 @@ private exporter = injectAsync(() => import('./report-exporter'));
 
 By default, the lazy chunk is only fetched when you invoke the returned function. You can start the download earlier by passing a `prefetch` trigger in the options. A trigger is any function that returns a `Promise`, when it resolves, Angular kicks off the loader.
 
-Angular ships with `onIdle`, a built-in trigger that waits until the browser becomes idle:
+Angular ships with built-in trigger helpers for common prefetching strategies: `onIdle`, `onTimer`, `onHover`, and `onInteraction`.
+
+### Prefetching on idle
+
+`onIdle` waits until the browser becomes idle before kicking off the download:
 
 ```ts
 import {Component, injectAsync, onIdle} from '@angular/core';
 
-@Component({
-  /* … */
-})
+@Component({/* … */})
 export class Report {
   private exporter = injectAsync(() => import('./report-exporter').then((m) => m.ReportExporter), {
     prefetch: onIdle,
@@ -67,19 +69,75 @@ You can also configure `onIdle` with a maximum wait time so the prefetch always 
 injectAsync(loader, {prefetch: () => onIdle({timeout: 1_000})});
 ```
 
+### Prefetching on a timer
+
+`onTimer` delays prefetching by a specified number of milliseconds:
+
+```ts
+import {Component, injectAsync, onTimer} from '@angular/core';
+
+@Component({/* … */})
+export class Report {
+  // Starts downloading 2 seconds after injection context initialization
+  private exporter = injectAsync(() => import('./report-exporter').then((m) => m.ReportExporter), {
+    prefetch: () => onTimer(2_000),
+  });
+}
+```
+
+### Prefetching on user hover
+
+`onHover` triggers prefetching as soon as the user hovers over a target element (`pointerenter`). It accepts either a raw `HTMLElement` or an `ElementRef`:
+
+```ts
+import {Component, ElementRef, injectAsync, onHover, viewChild} from '@angular/core';
+
+@Component({
+  template: `<button #exportBtn (click)="export()">Export Report</button>`,
+})
+export class Report {
+  private exportBtn = viewChild.required<ElementRef<HTMLButtonElement>>('exportBtn');
+
+  // Prefetches as soon as the user hovers over the button
+  private exporter = injectAsync(() => import('./report-exporter').then((m) => m.ReportExporter), {
+    prefetch: () => onHover(this.exportBtn()),
+  });
+}
+```
+
+### Prefetching on user interaction
+
+`onInteraction` triggers prefetching when the user performs any common interaction with the target element (`pointerenter`, `focus`, or `click`). Like `onHover`, it accepts either a raw `HTMLElement` or an `ElementRef`:
+
+```ts
+import {Component, ElementRef, injectAsync, onInteraction, viewChild} from '@angular/core';
+
+@Component({
+  template: `<button #exportBtn (click)="export()">Export Report</button>`,
+})
+export class Report {
+  private exportBtn = viewChild.required<ElementRef<HTMLButtonElement>>('exportBtn');
+
+  // Prefetches on hover, focus, or click
+  private exporter = injectAsync(() => import('./report-exporter').then((m) => m.ReportExporter), {
+    prefetch: () => onInteraction(this.exportBtn()),
+  });
+}
+```
+
 NOTE: Prefetching is opportunistic. If the user invokes the feature before the prefetch fires, Angular still loads the dependency immediately and resolves your `await` as soon as it's ready.
 
 ## Provide a custom prefetch trigger
 
-A `PrefetchTrigger` is just a function that returns a promise, the loader runs as soon as the promise resolves. Use this to align prefetching with your own signals, such as a hover or a scheduler tick:
+A `PrefetchTrigger` is just a function that returns a promise; the loader runs as soon as the promise resolves. Use this to create custom prefetch behavior, such as delaying until the next animation frame:
 
 ```ts
 import {PrefetchTrigger} from '@angular/core';
 
-export function onHover(target: HTMLElement): PrefetchTrigger {
+export function onNextFrame(): PrefetchTrigger {
   return () =>
     new Promise<void>((resolve) => {
-      target.addEventListener('pointerenter', () => resolve(), {once: true});
+      requestAnimationFrame(() => resolve());
     });
 }
 ```

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1340,6 +1340,9 @@ export interface OnDestroy {
 }
 
 // @public
+export function onHover(target: HTMLElement | ElementRef<HTMLElement>): Promise<void>;
+
+// @public
 export function onIdle(options?: {
     timeout?: number;
 }): Promise<void>;
@@ -1348,6 +1351,12 @@ export function onIdle(options?: {
 export interface OnInit {
     ngOnInit(): void;
 }
+
+// @public
+export function onInteraction(target: HTMLElement | ElementRef<HTMLElement>): Promise<void>;
+
+// @public
+export function onTimer(delay: number): Promise<void>;
 
 // @public
 export interface Optional {

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -17,7 +17,15 @@ export {forwardRef, ForwardRefFn, resolveForwardRef} from './forward_ref';
 export {HostAttributeToken} from './host_attribute_token';
 export {HOST_TAG_NAME} from './host_tag_name_token';
 export {ENVIRONMENT_INITIALIZER} from './initializer_token';
-export {injectAsync, InjectAsyncOptions, onIdle, PrefetchTrigger} from './inject_async';
+export {
+  injectAsync,
+  InjectAsyncOptions,
+  onIdle,
+  onTimer,
+  onHover,
+  onInteraction,
+  PrefetchTrigger,
+} from './inject_async';
 export {Injectable, InjectableDecorator, InjectableProvider} from './injectable';
 export {InjectionToken} from './injection_token';
 export {DestroyableInjector, Injector} from './injector';

--- a/packages/core/src/di/inject_async.ts
+++ b/packages/core/src/di/inject_async.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {DestroyRef} from '../core';
 import {IDLE_SERVICE} from '../defer/idle_service';
+import {ElementRef} from '../linker/element_ref';
 import {DefaultExport, maybeUnwrapDefaultExport} from '../util/default_export';
 import {promiseWithResolvers} from '../util/promise_with_resolvers';
 import {assertInInjectionContext} from './contextual';
@@ -110,6 +112,11 @@ export interface InjectAsyncOptions {
  */
 export type PrefetchTrigger = () => Promise<void>;
 
+/** Helper to extract HTMLElement from raw Element or ElementRef. */
+function unwrapElement(target: HTMLElement | ElementRef<HTMLElement>): HTMLElement {
+  return target instanceof ElementRef ? target.nativeElement : target;
+}
+
 /**
  * A `PrefetchTrigger` helper function to provide the logic of triggering dependency loading
  * when the browser becomes idle.
@@ -140,6 +147,117 @@ export function onIdle(options?: {timeout?: number}): Promise<void> {
   const idleService = inject(IDLE_SERVICE);
   const {promise, resolve} = promiseWithResolvers<void>();
   idleService.requestOnIdle(() => resolve(), options);
+
+  return promise;
+}
+
+/**
+ * A `PrefetchTrigger` helper function to provide the logic of triggering dependency loading
+ * after a timer delay.
+ *
+ * @usageNotes
+ *
+ * ```ts
+ * injectAsync(() => import('./my.service'), {prefetch: () => onTimer(1000)});
+ * ```
+ *
+ * @see [Prefetching the dependency](guide/di/lazy-loading-services#prefetching-the-dependency)
+ *
+ * @publicApi 22.0
+ */
+export function onTimer(delay: number): Promise<void> {
+  if (ngDevMode) {
+    assertInInjectionContext(onTimer);
+  }
+
+  const destroyRef = inject(DestroyRef);
+  const {promise, resolve} = promiseWithResolvers<void>();
+
+  const timerId = setTimeout(() => resolve(), delay);
+
+  destroyRef.onDestroy(() => clearTimeout(timerId));
+
+  return promise;
+}
+
+/**
+ * A `PrefetchTrigger` helper function to provide the logic of triggering dependency loading
+ * when the user hovers over a target element.
+ *
+ * @usageNotes
+ *
+ * ```ts
+ * const buttonRef = inject(ElementRef);
+ * injectAsync(() => import('./my.service'), {prefetch: () => onHover(buttonRef)});
+ * ```
+ *
+ * @see [Prefetching the dependency](guide/di/lazy-loading-services#prefetching-the-dependency)
+ *
+ * @publicApi 22.0
+ */
+export function onHover(target: HTMLElement | ElementRef<HTMLElement>): Promise<void> {
+  if (ngDevMode) {
+    assertInInjectionContext(onHover);
+  }
+
+  const element = unwrapElement(target);
+  const destroyRef = inject(DestroyRef);
+  const {promise, resolve} = promiseWithResolvers<void>();
+
+  const controller = new AbortController();
+
+  element.addEventListener(
+    'pointerenter',
+    () => {
+      controller.abort();
+      resolve();
+    },
+    {signal: controller.signal},
+  );
+
+  destroyRef.onDestroy(() => controller.abort());
+
+  return promise;
+}
+
+/**
+ * A `PrefetchTrigger` helper function to provide the logic of triggering dependency loading
+ * when the user interacts with a target element.
+ *
+ * @usageNotes
+ *
+ * ```ts
+ * const buttonRef = inject(ElementRef);
+ * injectAsync(() => import('./my.service'), {prefetch: () => onInteraction(buttonRef)});
+ * ```
+ *
+ * @see [Prefetching the dependency](guide/di/lazy-loading-services#prefetching-the-dependency)
+ *
+ * @publicApi 22.0
+ */
+export function onInteraction(target: HTMLElement | ElementRef<HTMLElement>): Promise<void> {
+  if (ngDevMode) {
+    assertInInjectionContext(onInteraction);
+  }
+
+  const element = unwrapElement(target);
+  const destroyRef = inject(DestroyRef);
+  const {promise, resolve} = promiseWithResolvers<void>();
+
+  const controller = new AbortController();
+
+  const handler = () => {
+    controller.abort();
+    resolve();
+  };
+
+  const events = ['pointerenter', 'focus', 'click'];
+
+  for (const event of events) {
+    element.addEventListener(event, handler, {signal: controller.signal});
+  }
+
+  destroyRef.onDestroy(() => controller.abort());
 
   return promise;
 }

--- a/packages/core/test/di/inject_async/inject_async_spec.ts
+++ b/packages/core/test/di/inject_async/inject_async_spec.ts
@@ -22,6 +22,9 @@ import {
   InjectionToken,
   Injector,
   onIdle,
+  onTimer,
+  onHover,
+  onInteraction,
   ProviderToken,
   runInInjectionContext,
 } from '@angular/core';
@@ -89,15 +92,6 @@ describe('injectAsync', () => {
 
       const foo = await fooPromise();
       expect(foo).toBeInstanceOf(MyMockedFooService);
-    });
-  });
-
-  it('should inject asynchronously with onIdle trigger', async () => {
-    await TestBed.runInInjectionContext(async () => {
-      const fooPromise = injectAsync(() => Promise.resolve(FooService), {prefetch: onIdle});
-
-      const foo = await fooPromise();
-      expect(foo).toBeInstanceOf(FooService);
     });
   });
 
@@ -248,60 +242,6 @@ describe('injectAsync', () => {
     });
   });
 
-  it('should fire on onIdle timeout', async () => {
-    jasmine.clock().install();
-    jasmine.clock().autoTick();
-
-    const idleService: IdleService = {
-      requestOnIdle(
-        callback: (deadline?: IdleDeadline) => void,
-        options?: IdleRequestOptions,
-      ): number {
-        // Do not run idle callbacks eagerly in tests; only honor explicit timeout path.
-        if (options?.timeout == null) {
-          return -1;
-        }
-
-        return setTimeout(callback, options.timeout) as unknown as number;
-      },
-      cancelOnIdle(id: number): void {
-        if (id !== -1) {
-          clearTimeout(id);
-        }
-      },
-    };
-
-    TestBed.configureTestingModule({
-      providers: [{provide: IDLE_SERVICE, useValue: idleService}],
-    });
-
-    let loaderCalled = false;
-    const loader = () =>
-      new Promise<ProviderToken<FooService>>((resolve) => {
-        loaderCalled = true;
-        resolve(FooService);
-      });
-
-    await TestBed.runInInjectionContext(async () => {
-      const fooPromise = injectAsync(loader, {prefetch: () => onIdle({timeout: 500})});
-
-      jasmine.clock().tick(300);
-      await Promise.resolve(); // wait for the loader promise to resolve
-      expect(loaderCalled).toBe(false);
-
-      // Simulate the passage of time until the onIdle timeout fires
-      jasmine.clock().tick(600);
-      await Promise.resolve(); // wait for the loader promise to resolve
-
-      expect(loaderCalled).toBe(true);
-
-      const foo = await fooPromise();
-      expect(foo).toBeInstanceOf(FooService);
-    });
-
-    jasmine.clock().uninstall();
-  });
-
   it('should not cause an unhandled promise rejection if prefetch trigger rejects', async () => {
     await TestBed.runInInjectionContext(async () => {
       const fooPromise = injectAsync(() => Promise.resolve(FooService), {
@@ -334,6 +274,250 @@ describe('injectAsync', () => {
 
       expect(error).toBeDefined();
       expect(error.message).toBe('loader error');
+    });
+  });
+
+  describe('built-in prefetch triggers', () => {
+    describe('onIdle', () => {
+      it('should inject asynchronously with onIdle trigger', async () => {
+        await TestBed.runInInjectionContext(async () => {
+          const fooPromise = injectAsync(() => Promise.resolve(FooService), {prefetch: onIdle});
+
+          const foo = await fooPromise();
+          expect(foo).toBeInstanceOf(FooService);
+        });
+      });
+
+      it('should fire on onIdle timeout', async () => {
+        jasmine.clock().install();
+        jasmine.clock().autoTick();
+
+        const idleService: IdleService = {
+          requestOnIdle(
+            callback: (deadline?: IdleDeadline) => void,
+            options?: IdleRequestOptions,
+          ): number {
+            // Do not run idle callbacks eagerly in tests; only honor explicit timeout path.
+            if (options?.timeout == null) {
+              return -1;
+            }
+
+            return setTimeout(callback, options.timeout) as unknown as number;
+          },
+          cancelOnIdle(id: number): void {
+            if (id !== -1) {
+              clearTimeout(id);
+            }
+          },
+        };
+
+        TestBed.configureTestingModule({
+          providers: [{provide: IDLE_SERVICE, useValue: idleService}],
+        });
+
+        let loaderCalled = false;
+        const loader = () =>
+          new Promise<ProviderToken<FooService>>((resolve) => {
+            loaderCalled = true;
+            resolve(FooService);
+          });
+
+        await TestBed.runInInjectionContext(async () => {
+          const fooPromise = injectAsync(loader, {prefetch: () => onIdle({timeout: 500})});
+
+          jasmine.clock().tick(300);
+          await Promise.resolve(); // wait for the loader promise to resolve
+          expect(loaderCalled).toBe(false);
+
+          // Simulate the passage of time until the onIdle timeout fires
+          jasmine.clock().tick(600);
+          await Promise.resolve(); // wait for the loader promise to resolve
+
+          expect(loaderCalled).toBe(true);
+
+          const foo = await fooPromise();
+          expect(foo).toBeInstanceOf(FooService);
+        });
+
+        jasmine.clock().uninstall();
+      });
+    });
+
+    describe('onTimer', () => {
+      it('should trigger prefetching after specified delay', async () => {
+        jasmine.clock().install();
+        jasmine.clock().autoTick();
+
+        let loaderCalled = false;
+        const loader = () => {
+          loaderCalled = true;
+          return Promise.resolve(FooService);
+        };
+
+        await TestBed.runInInjectionContext(async () => {
+          const fooPromise = injectAsync(loader, {prefetch: () => onTimer(200)});
+
+          jasmine.clock().tick(100);
+          await Promise.resolve();
+          expect(loaderCalled).toBe(false);
+
+          jasmine.clock().tick(150);
+          await Promise.resolve();
+          expect(loaderCalled).toBe(true);
+
+          const foo = await fooPromise();
+          expect(foo).toBeInstanceOf(FooService);
+        });
+
+        jasmine.clock().uninstall();
+      });
+    });
+
+    describe('onHover', () => {
+      it('should trigger prefetching on pointerenter event', async () => {
+        const button = document.createElement('button');
+        let loaderCalled = false;
+        const loader = () => {
+          loaderCalled = true;
+          return Promise.resolve(FooService);
+        };
+
+        await TestBed.runInInjectionContext(async () => {
+          const fooPromise = injectAsync(loader, {prefetch: () => onHover(button)});
+
+          expect(loaderCalled).toBe(false);
+
+          button.dispatchEvent(new Event('pointerenter'));
+          await Promise.resolve();
+
+          expect(loaderCalled).toBe(true);
+          const foo = await fooPromise();
+          expect(foo).toBeInstanceOf(FooService);
+        });
+      });
+
+      it('should unsubscribe event listener after triggering', async () => {
+        const button = document.createElement('button');
+        let loaderCallCount = 0;
+
+        await TestBed.runInInjectionContext(async () => {
+          injectAsync(
+            () => {
+              loaderCallCount++;
+              return Promise.resolve(FooService);
+            },
+            {prefetch: () => onHover(button)},
+          );
+
+          // Fire first hover to trigger prefetch
+          button.dispatchEvent(new Event('pointerenter'));
+          await Promise.resolve();
+
+          expect(loaderCallCount).toBe(1);
+
+          // Fire subsequent hovers - listener must be detached
+          button.dispatchEvent(new Event('pointerenter'));
+          button.dispatchEvent(new Event('pointerenter'));
+          await Promise.resolve();
+
+          // Loader should still only have been called once
+          expect(loaderCallCount).toBe(1);
+        });
+      });
+    });
+
+    describe('onInteraction', () => {
+      it('should trigger prefetching on pointerenter', async () => {
+        const button = document.createElement('button');
+        let loaderCalled = false;
+
+        await TestBed.runInInjectionContext(async () => {
+          const fooPromise = injectAsync(
+            () => {
+              loaderCalled = true;
+              return Promise.resolve(FooService);
+            },
+            {prefetch: () => onInteraction(button)},
+          );
+
+          button.dispatchEvent(new Event('pointerenter'));
+          await Promise.resolve();
+
+          expect(loaderCalled).toBe(true);
+          expect(await fooPromise()).toBeInstanceOf(FooService);
+        });
+      });
+
+      it('should trigger prefetching on focus', async () => {
+        const button = document.createElement('button');
+        let loaderCalled = false;
+
+        await TestBed.runInInjectionContext(async () => {
+          const fooPromise = injectAsync(
+            () => {
+              loaderCalled = true;
+              return Promise.resolve(FooService);
+            },
+            {prefetch: () => onInteraction(button)},
+          );
+
+          button.dispatchEvent(new Event('focus'));
+          await Promise.resolve();
+
+          expect(loaderCalled).toBe(true);
+          expect(await fooPromise()).toBeInstanceOf(FooService);
+        });
+      });
+
+      it('should trigger prefetching on click', async () => {
+        const button = document.createElement('button');
+        let loaderCalled = false;
+
+        await TestBed.runInInjectionContext(async () => {
+          const fooPromise = injectAsync(
+            () => {
+              loaderCalled = true;
+              return Promise.resolve(FooService);
+            },
+            {prefetch: () => onInteraction(button)},
+          );
+
+          button.dispatchEvent(new Event('click'));
+          await Promise.resolve();
+
+          expect(loaderCalled).toBe(true);
+          expect(await fooPromise()).toBeInstanceOf(FooService);
+        });
+      });
+
+      it('should clean up all listeners once any single event triggers', async () => {
+        const button = document.createElement('button');
+        let loaderCallCount = 0;
+
+        await TestBed.runInInjectionContext(async () => {
+          injectAsync(
+            () => {
+              loaderCallCount++;
+              return Promise.resolve(FooService);
+            },
+            {prefetch: () => onInteraction(button)},
+          );
+
+          // Fire 'focus' to trigger the prefetch and abort remaining listeners
+          button.dispatchEvent(new Event('focus'));
+          await Promise.resolve();
+
+          expect(loaderCallCount).toBe(1);
+
+          // Fire more events - they should be detached and ignored
+          button.dispatchEvent(new Event('pointerenter'));
+          button.dispatchEvent(new Event('click'));
+          await Promise.resolve();
+
+          // Loader should still have only been executed once
+          expect(loaderCallCount).toBe(1);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`injectAsync` currently only provides `onIdle` as a built-in prefetch trigger option.

Issue Number: #68771 

## What is the new behavior?

Introduces three new built-in prefetch triggers for `injectAsync`:
- `onTimer`: Triggers prefetching after a specified duration in milliseconds.
- `onHover`: Triggers prefetching when a `pointerenter` event fires on the target element.
- `onInteraction`: Triggers prefetching when a `pointerenter`, `focus`, or `click` event fires on the target element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
