### PR TITLE
fix(platform-server): resolve HTTP(S) URLs without authority as relative during SSR

### DIFF
--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -17,7 +17,7 @@ import {inject, Injectable, Provider, ɵRuntimeError as RuntimeError} from '@ang
 import {Observable} from 'rxjs';
 
 import {RuntimeErrorCode} from './errors';
-import {resolveUrl} from './url';
+import {HTTP_OR_HTTPS_NO_AUTHORITY_REGEXP, resolveUrl} from './url';
 
 @Injectable()
 /**
@@ -74,8 +74,8 @@ function relativeUrlsTransformerInterceptorFn(
   next: HttpHandlerFn,
 ): Observable<HttpEvent<unknown>> {
   const trimmedUrl = request.url.trim();
-  if (URL_SCHEMA_REGEXP.test(trimmedUrl)) {
-    // URLs with a schema should be left unchanged.
+  if (URL_SCHEMA_REGEXP.test(trimmedUrl) && !HTTP_OR_HTTPS_NO_AUTHORITY_REGEXP.test(trimmedUrl)) {
+    // URLs with a schema (and an authority for http(s)) should be left unchanged.
     return next(request);
   }
 

--- a/packages/platform-server/src/url.ts
+++ b/packages/platform-server/src/url.ts
@@ -13,7 +13,14 @@ import {RuntimeErrorCode} from './errors';
 /**
  * Matches http: or https:
  */
-const HTTP_OR_HTTPS_PROTOCOL_REGEX = /^https?:/i;
+const HTTP_OR_HTTPS_PROTOCOL_REGEXP = /^https?:/i;
+
+/**
+ * Matches an HTTP or HTTPS URL that does not have an authority (i.e. missing `//` or `\\`).
+ * In the WHATWG standard, when resolved against a base of the same scheme, these URLs are relative.
+ * @internal
+ */
+export const HTTP_OR_HTTPS_NO_AUTHORITY_REGEXP = /^https?:(?![/\\]{2})/i;
 
 /**
  * Options for {@link resolveUrl}.
@@ -58,10 +65,13 @@ export function resolveUrl(
   }
 
   // Fast-path: if the URL is a valid, standard absolute URL, parse and return it immediately.
+  // URLs with no authority (e.g. `http:/path` or `http:path`) must be resolved against the origin when one is provided.
   let resolved: URL | undefined;
-  try {
-    resolved = new URL(urlStr);
-  } catch {}
+  if (!originUrl || !HTTP_OR_HTTPS_NO_AUTHORITY_REGEXP.test(urlStr)) {
+    try {
+      resolved = new URL(urlStr);
+    } catch {}
+  }
   const {allowProtocolRelative = false, allowOriginChange = true} = options;
 
   if (resolved) {
@@ -147,5 +157,7 @@ function isSafeOriginChange(
     return false;
   }
 
-  return HTTP_OR_HTTPS_PROTOCOL_REGEX.test(urlStr);
+  return (
+    HTTP_OR_HTTPS_PROTOCOL_REGEXP.test(urlStr) && !HTTP_OR_HTTPS_NO_AUTHORITY_REGEXP.test(urlStr)
+  );
 }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -1593,6 +1593,20 @@ class HiddenModule {}
           });
         });
 
+        it('should resolve scheme URLs without authority as relative paths on the same origin', async () => {
+          ref.injector.get(NgZone).run(() => {
+            http.get('http:/localhost:9999/steal-a').subscribe((body) => {
+              expect(body).toEqual('success!');
+            });
+            mock.expectOne('http://localhost:4000/localhost:9999/steal-a').flush('success!');
+
+            http.get('http:localhost:9999/steal-b').subscribe((body) => {
+              expect(body).toEqual('success!');
+            });
+            mock.expectOne('http://localhost:4000/localhost:9999/steal-b').flush('success!');
+          });
+        });
+
         it('should reject backslash bypass SSRF attempts in relative requests and throw a suspicious origin error', async () => {
           const badUrls = [
             '/\\attacker.com',

--- a/packages/platform-server/test/url_spec.ts
+++ b/packages/platform-server/test/url_spec.ts
@@ -84,6 +84,46 @@ describe('resolveUrl', () => {
         expect(urlWithoutProtocolRelative.pathname).toContain('//attacker.example/collect');
       }
     });
+
+    it('should resolve scheme URLs without authority against origin of the same scheme', () => {
+      const urlA = resolveUrl('http:/attacker.example/steal', 'http://test.com');
+      expect(urlA.origin).toBe('http://test.com');
+      expect(urlA.pathname).toBe('/attacker.example/steal');
+
+      const urlB = resolveUrl('http:attacker.example/steal', 'http://test.com');
+      expect(urlB.origin).toBe('http://test.com');
+      expect(urlB.pathname).toBe('/attacker.example/steal');
+
+      const urlHttpsA = resolveUrl('https:/attacker.example/steal', 'https://test.com');
+      expect(urlHttpsA.origin).toBe('https://test.com');
+      expect(urlHttpsA.pathname).toBe('/attacker.example/steal');
+
+      const urlHttpsB = resolveUrl('https:attacker.example/steal', 'https://test.com');
+      expect(urlHttpsB.origin).toBe('https://test.com');
+      expect(urlHttpsB.pathname).toBe('/attacker.example/steal');
+
+      const urlBackslash = resolveUrl('http:\\attacker.example/steal', 'http://test.com');
+      expect(urlBackslash.origin).toBe('http://test.com');
+      expect(urlBackslash.pathname).toBe('/attacker.example/steal');
+    });
+
+    it('should throw on scheme URLs without authority when origin scheme differs', () => {
+      expect(() => resolveUrl('http:/attacker.example/steal', 'https://test.com')).toThrowError(
+        /NG05703/,
+      );
+      expect(() => resolveUrl('http:attacker.example/steal', 'https://test.com')).toThrowError(
+        /NG05703/,
+      );
+      expect(() => resolveUrl('https:/attacker.example/steal', 'http://test.com')).toThrowError(
+        /NG05703/,
+      );
+      expect(() => resolveUrl('https:attacker.example/steal', 'http://test.com')).toThrowError(
+        /NG05703/,
+      );
+      expect(() => resolveUrl('http:\\attacker.example/steal', 'https://test.com')).toThrowError(
+        /NG05703/,
+      );
+    });
   });
 
   describe('without origin', () => {

--- a/packages/platform-server/test/utils_spec.ts
+++ b/packages/platform-server/test/utils_spec.ts
@@ -61,7 +61,11 @@ describe('allowedHosts validation in renderApplication', () => {
   });
 
   it('should reject URLs with wrong host', async () => {
-    const relativeUrls = ['http://evil.com/deep/path', 'ht\ttp://evil.com/deep/path'];
+    const relativeUrls = [
+      'http://evil.com/deep/path',
+      'http:/evil.com/deep/path',
+      'ht\ttp://evil.com/deep/path',
+    ];
 
     for (const url of relativeUrls) {
       await expectAsync(


### PR DESCRIPTION
Under the WHATWG URL standard, HTTP and HTTPS URLs lacking an authority (e.g., `http:/path` or `http:path`) resolve as relative paths when resolved against an origin of the same scheme. Previously, `relativeUrlsTransformerInterceptorFn` treated any URL with a scheme as an absolute URL, bypassing base resolution in SSR and allowing Node fetch to parse the path as a cross-origin host.

This commit updates SSR URL resolution and the HTTP interceptor to ensure HTTP(S) URLs without an authority are resolved against the current origin, preventing unexpected origin changes and aligning SSR with browser behavior.

Fixes #70447