### PR TITLE
refactor(core): remove old `deferredImports` structure

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -984,9 +984,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
     let explicitlyDeferredTypes: R3DeferPerComponentDependency[] | null = null;
     let explicitlyDeferredTypesByBlock: Map<string, R3DeferPerComponentDependency[]> | null = null;
     if (metadata.isStandalone && rawDeferredImports !== null) {
-      if (ts.isArrayLiteralExpression(rawDeferredImports)) {
-        explicitlyDeferredTypes = this.collectExplicitlyDeferredSymbols(node, rawDeferredImports);
-      } else if (ts.isObjectLiteralExpression(rawDeferredImports)) {
+      if (ts.isObjectLiteralExpression(rawDeferredImports)) {
         explicitlyDeferredTypesByBlock = new Map();
         for (const property of rawDeferredImports.properties) {
           if (!ts.isPropertyAssignment(property)) {
@@ -1351,7 +1349,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
               makeDiagnostic(
                 ErrorCode.DEFER_BLOCK_MISSING_NAME_PARAMETER,
                 analysis.rawDeferredImports!,
-                `@defer block must specify a 'name' parameter (e.g. '@defer (name blockName)') when 'deferredImports' is defined as an object.`,
+                `@defer block must specify a 'name' parameter (e.g. '@defer (name blockName)') when 'deferredImports' is defined.`,
               ),
             );
             continue;
@@ -1388,7 +1386,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
               makeDiagnostic(
                 ErrorCode.DEFER_BLOCK_INVALID_NAME_PARAMETER,
                 analysis.rawDeferredImports ?? node,
-                `The 'name' parameter can only be used when '@Component.deferredImports' is defined as an object.`,
+                `The 'name' parameter can only be used when '@Component.deferredImports' is defined.`,
               ),
             );
           }
@@ -2496,7 +2494,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
             makeDiagnostic(
               ErrorCode.DEFER_BLOCK_MISSING_NAME_PARAMETER,
               analysisData.rawDeferredImports!,
-              `@defer block must specify a 'name' parameter (e.g. '@defer (name blockName)') when 'deferredImports' is defined as an object.`,
+              `@defer block must specify a 'name' parameter (e.g. '@defer (name blockName)') when 'deferredImports' is defined.`,
             ),
           );
           continue;
@@ -2549,7 +2547,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
             makeDiagnostic(
               ErrorCode.DEFER_BLOCK_INVALID_NAME_PARAMETER,
               analysisData.rawDeferredImports ?? componentClassDecl,
-              `The 'name' parameter can only be used when '@Component.deferredImports' is defined as an object.`,
+              `The 'name' parameter can only be used when '@Component.deferredImports' is defined.`,
             ),
           );
           continue;

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
@@ -97,37 +97,46 @@ export function validateAndFlattenComponentImports(
   let importsByBlock: Map<string, Reference<ClassDeclaration>[]> | null = null;
 
   const errorMessage = isDeferred
-    ? `'deferredImports' must be an array of components, directives, or pipes, or an object mapping block names to dependency arrays.`
+    ? `'deferredImports' must be an object mapping block names to dependency arrays.`
     : `'imports' must be an array of components, directives, pipes, or NgModules.`;
 
-  if (isDeferred && imports instanceof Map) {
-    importsByBlock = new Map();
-    for (const [blockName, blockValue] of imports.entries()) {
-      let propExpr = expr;
-      if (ts.isObjectLiteralExpression(expr)) {
-        const prop = expr.properties.find(
-          (p) =>
-            ts.isPropertyAssignment(p) &&
-            (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) &&
-            p.name.text === blockName,
-        );
-        if (prop && ts.isPropertyAssignment(prop)) {
-          propExpr = prop.initializer;
+  if (isDeferred) {
+    if (imports instanceof Map) {
+      importsByBlock = new Map();
+      for (const [blockName, blockValue] of imports.entries()) {
+        let propExpr = expr;
+        if (ts.isObjectLiteralExpression(expr)) {
+          const prop = expr.properties.find(
+            (p) =>
+              ts.isPropertyAssignment(p) &&
+              (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) &&
+              p.name.text === blockName,
+          );
+          if (prop && ts.isPropertyAssignment(prop)) {
+            propExpr = prop.initializer;
+          }
         }
-      }
 
-      const {imports: blockImports, diagnostics: blockDiagnostics} =
-        validateAndFlattenComponentImports(blockValue, propExpr, isDeferred);
+        const {imports: blockImports, diagnostics: blockDiagnostics} =
+          validateAndFlattenComponentImports(blockValue, propExpr, false);
 
-      diagnostics.push(...blockDiagnostics);
-      for (const blockImport of blockImports) {
-        if (!flattened.some((existing) => existing.node === blockImport.node)) {
-          flattened.push(blockImport);
+        diagnostics.push(...blockDiagnostics);
+        for (const blockImport of blockImports) {
+          if (!flattened.some((existing) => existing.node === blockImport.node)) {
+            flattened.push(blockImport);
+          }
         }
+        importsByBlock.set(blockName, blockImports);
       }
-      importsByBlock.set(blockName, blockImports);
+      return {imports: flattened, importsByBlock, diagnostics};
+    } else {
+      const error = createValueHasWrongTypeError(expr, imports, errorMessage).toDiagnostic();
+      return {
+        imports: [],
+        importsByBlock: null,
+        diagnostics: [error],
+      };
     }
-    return {imports: flattened, importsByBlock, diagnostics};
   }
 
   if (!Array.isArray(imports)) {

--- a/packages/compiler-cli/test/ngtsc/defer_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/defer_spec.ts
@@ -987,15 +987,15 @@ runInEachFileSystem(() => {
           import {PipeA} from './pipe-a';
           @Component({
             // @ts-ignore
-            deferredImports: [DeferredCmpA, DeferredCmpB, PipeA],
+            deferredImports: { block1: [DeferredCmpA, PipeA], block2: [DeferredCmpB] },
             template: \`
               @for (item of items; track item) {
                 @if (true) {
-                  @defer {
+                  @defer (name block1) {
                     {{ 'Hi!' | pipea }}
                     <deferred-cmp-a />
                   }
-                  @defer {
+                  @defer (name block2) {
                     <deferred-cmp-b />
                   }
                 }
@@ -1097,13 +1097,13 @@ runInEachFileSystem(() => {
             @Component({
               imports: [EagerCmpA],
               // @ts-ignore
-              deferredImports: [DeferredCmpA, DeferredCmpB],
+              deferredImports: { block1: [DeferredCmpA], block2: [DeferredCmpB] },
               template: \`
-                @defer {
+                @defer (name block1) {
                   <eager-cmp-a />
                   <deferred-cmp-a />
                 }
-                @defer {
+                @defer (name block2) {
                   <eager-cmp-a />
                   <deferred-cmp-b />
                 }
@@ -1121,11 +1121,11 @@ runInEachFileSystem(() => {
         // Other imported symbols remain eager.
         expect(cleanNewLines(jsContents)).toContain(
           'const AppCmp_Defer_1_DepsFn = () => [/* @ts-ignore */ ' +
-            'import("./deferred-a").then(m => m.DeferredCmpA), EagerCmpA];',
+            'import("./deferred-a").then(m => m.DeferredCmpA)];',
         );
         expect(cleanNewLines(jsContents)).toContain(
           'const AppCmp_Defer_4_DepsFn = () => [/* @ts-ignore */ ' +
-            'import("./deferred-b").then(m => m.DeferredCmpB), EagerCmpA];',
+            'import("./deferred-b").then(m => m.DeferredCmpB)];',
         );
 
         // Make sure there are no eager imports present in the output.
@@ -1158,7 +1158,7 @@ runInEachFileSystem(() => {
               class MyInjectable {}
               @Component({
                 // @ts-ignore
-                deferredImports: [MyInjectable],
+                deferredImports: { block1: [MyInjectable] },
                 template: '',
               })
               export class AppCmp {
@@ -1180,7 +1180,7 @@ runInEachFileSystem(() => {
               class MyModule {}
               @Component({
                 // @ts-ignore
-                deferredImports: [MyModule],
+                deferredImports: { block1: [MyModule] },
                 template: '',
               })
               export class AppCmp {
@@ -1230,10 +1230,10 @@ runInEachFileSystem(() => {
               import {DeferredCmpB} from './deferred-b';
               @Component({
                 // @ts-ignore
-                deferredImports: [DeferredCmpA, DeferredCmpB],
+                deferredImports: { block1: [DeferredCmpA, DeferredCmpB] },
                 template: \`
                   <deferred-cmp-a />
-                  @defer {
+                  @defer (name block1) {
                     <deferred-cmp-b />
                   }
                 \`,
@@ -1275,10 +1275,10 @@ runInEachFileSystem(() => {
 
               @Component({
                 // @ts-ignore
-                deferredImports: [DeferredCmpA],
+                deferredImports: { block1: [DeferredCmpA] },
                 imports: [DeferredCmpA],
                 template: \`
-                  @defer {
+                  @defer (name block1) {
                     <deferred-cmp-a />
                   }
                 \`,
@@ -1323,10 +1323,10 @@ runInEachFileSystem(() => {
               import {DeferredPipeB} from './deferred-pipe-b';
               @Component({
                 // @ts-ignore
-                deferredImports: [DeferredPipeA, DeferredPipeB],
+                deferredImports: { block1: [DeferredPipeA, DeferredPipeB] },
                 template: \`
                   {{ 'Eager' | deferredPipeA }}
-                  @defer {
+                  @defer (name block1) {
                     {{ 'Deferred' | deferredPipeB }}
                   }
                 \`,
@@ -1361,12 +1361,12 @@ runInEachFileSystem(() => {
             import {DeferredCmpA} from './deferred-a';
             @Component({
               // @ts-ignore
-              deferredImports: [DeferredCmpA],
+              deferredImports: { block1: [DeferredCmpA] },
               template: \`
                 @if (true) {
                   @if (true) {
                   @if (true) {
-                    @defer {
+                    @defer (name block1) {
                       <deferred-cmp-a />
                     }
                   }
@@ -1405,9 +1405,9 @@ runInEachFileSystem(() => {
               import {DeferredCmpA} from './deferred-a';
               @Component({
                 // @ts-ignore
-                deferredImports: [DeferredCmpA],
+                deferredImports: { block1: [DeferredCmpA] },
                 template: \`
-                  @defer {
+                  @defer (name block1) {
                     @if (true) {
                       @if (true) {
                         @if (true) {
@@ -1830,45 +1830,6 @@ runInEachFileSystem(() => {
           );
         });
 
-        it('should report error when name parameter is used but deferredImports is an array', () => {
-          env.write(
-            'deferred-a.ts',
-            `
-            import {Component} from '@angular/core';
-            @Component({
-              selector: 'deferred-cmp-a',
-              template: 'DeferredCmpA contents',
-            })
-            export class DeferredCmpA {}
-          `,
-          );
-
-          env.write(
-            'test.ts',
-            `
-            import {Component} from '@angular/core';
-            import {DeferredCmpA} from './deferred-a';
-            @Component({
-              // @ts-ignore
-              deferredImports: [DeferredCmpA],
-              template: \`
-                @defer (name blockA) {
-                  <deferred-cmp-a />
-                }
-              \`,
-            })
-            export class AppCmp {}
-          `,
-          );
-
-          const diags = env.driveDiagnostics();
-          expect(diags.length).toBe(1);
-          expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_BLOCK_INVALID_NAME_PARAMETER));
-          expect(diags[0].messageText).toContain(
-            `The 'name' parameter can only be used when '@Component.deferredImports' is defined as an object.`,
-          );
-        });
-
         it('should report error when name parameter is used but component has no deferredImports in standard compilation', () => {
           env.write(
             'deferred-a.ts',
@@ -1903,7 +1864,7 @@ runInEachFileSystem(() => {
           expect(diags.length).toBe(1);
           expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_BLOCK_INVALID_NAME_PARAMETER));
           expect(diags[0].messageText).toContain(
-            `The 'name' parameter can only be used when '@Component.deferredImports' is defined as an object.`,
+            `The 'name' parameter can only be used when '@Component.deferredImports' is defined.`,
           );
         });
 
@@ -1946,7 +1907,7 @@ runInEachFileSystem(() => {
           expect(diags.length).toBe(1);
           expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_BLOCK_INVALID_NAME_PARAMETER));
           expect(diags[0].messageText).toContain(
-            `The 'name' parameter can only be used when '@Component.deferredImports' is defined as an object.`,
+            `The 'name' parameter can only be used when '@Component.deferredImports' is defined.`,
           );
         });
 

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -2196,12 +2196,12 @@ runInEachFileSystem(() => {
           import {DeferredCmpA} from './deferred-a';
           import {DeferredCmpB} from './deferred-b';
           @Component({
-            deferredImports: [DeferredCmpA, DeferredCmpB],
+            deferredImports: { block1: [DeferredCmpA], block2: [DeferredCmpB] },
             template: \`
-              @defer {
+              @defer (name block1) {
                 <deferred-cmp-a />
               }
-              @defer {
+              @defer (name block2) {
                 <deferred-cmp-b />
               }
             \`,
@@ -2218,8 +2218,11 @@ runInEachFileSystem(() => {
         // are located in a single function (since we can't detect in
         // the local mode which components belong to which block).
         expect(cleanNewLines(jsContents)).toContain(
-          'const AppCmp_DeferFn = () => [/* @ts-ignore */ ' +
-            'import("./deferred-a").then(m => m.DeferredCmpA), /* @ts-ignore */ ' +
+          'const AppCmp_Defer_1_DepsFn = () => [/* @ts-ignore */ ' +
+            'import("./deferred-a").then(m => m.DeferredCmpA)];',
+        );
+        expect(cleanNewLines(jsContents)).toContain(
+          'const AppCmp_Defer_4_DepsFn = () => [/* @ts-ignore */ ' +
             'import("./deferred-b").then(m => m.DeferredCmpB)];',
         );
 
@@ -2228,8 +2231,8 @@ runInEachFileSystem(() => {
         expect(jsContents).not.toContain(`from './deferred-b'`);
 
         // All defer instructions use the same dependency function.
-        expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmp_DeferFn);');
-        expect(jsContents).toContain('ɵɵdefer(4, 3, AppCmp_DeferFn);');
+        expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmp_Defer_1_DepsFn);');
+        expect(jsContents).toContain('ɵɵdefer(4, 3, AppCmp_Defer_4_DepsFn);');
 
         // Expect `ɵsetClassMetadataAsync` to contain dynamic imports too.
         expect(cleanNewLines(jsContents)).toContain(
@@ -2340,13 +2343,13 @@ runInEachFileSystem(() => {
               import {EagerCmpA} from './eager-a';
               @Component({
                 imports: [EagerCmpA],
-                deferredImports: [DeferredCmpA, DeferredCmpB],
+                deferredImports: { block1: [DeferredCmpA], block2: [DeferredCmpB] },
                 template: \`
-                  @defer {
+                  @defer (name block1) {
                     <eager-cmp-a />
                     <deferred-cmp-a />
                   }
-                  @defer {
+                  @defer (name block2) {
                     <eager-cmp-a />
                     <deferred-cmp-b />
                   }
@@ -2365,8 +2368,11 @@ runInEachFileSystem(() => {
         // the local mode which components belong to which block).
         // Eager dependencies are **not* included here.
         expect(cleanNewLines(jsContents)).toContain(
-          'const AppCmp_DeferFn = () => [/* @ts-ignore */ ' +
-            'import("./deferred-a").then(m => m.DeferredCmpA), /* @ts-ignore */ ' +
+          'const AppCmp_Defer_1_DepsFn = () => [/* @ts-ignore */ ' +
+            'import("./deferred-a").then(m => m.DeferredCmpA)];',
+        );
+        expect(cleanNewLines(jsContents)).toContain(
+          'const AppCmp_Defer_4_DepsFn = () => [/* @ts-ignore */ ' +
             'import("./deferred-b").then(m => m.DeferredCmpB)];',
         );
 
@@ -2378,8 +2384,8 @@ runInEachFileSystem(() => {
         expect(jsContents).toContain(`from './eager-a';`);
 
         // All defer instructions use the same dependency function.
-        expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmp_DeferFn);');
-        expect(jsContents).toContain('ɵɵdefer(4, 3, AppCmp_DeferFn);');
+        expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmp_Defer_1_DepsFn);');
+        expect(jsContents).toContain('ɵɵdefer(4, 3, AppCmp_Defer_4_DepsFn);');
 
         // Expect `ɵsetClassMetadataAsync` to contain dynamic imports too.
         expect(cleanNewLines(jsContents)).toContain(
@@ -2426,9 +2432,9 @@ runInEachFileSystem(() => {
               import {DeferredCmpA, DeferredCmpB} from './deferred-deps';
 
               @Component({
-                deferredImports: [DeferredCmpA],
+                deferredImports: { block1: [DeferredCmpA] },
                 template: \`
-                  @defer {
+                  @defer (name block1) {
                     <deferred-cmp-a />
                   }
                 \`,
@@ -2436,9 +2442,9 @@ runInEachFileSystem(() => {
               export class AppCmpA {}
 
               @Component({
-                deferredImports: [DeferredCmpB],
+                deferredImports: { block1: [DeferredCmpB] },
                 template: \`
-                  @defer {
+                  @defer (name block1) {
                     <deferred-cmp-b />
                   }
                 \`,
@@ -2453,11 +2459,11 @@ runInEachFileSystem(() => {
           // Expect that we generate 2 different defer functions
           // (one for each component).
           expect(cleanNewLines(jsContents)).toContain(
-            'const AppCmpA_DeferFn = () => [/* @ts-ignore */ ' +
+            'const AppCmpA_Defer_1_DepsFn = () => [/* @ts-ignore */ ' +
               'import("./deferred-deps").then(m => m.DeferredCmpA)]',
           );
           expect(cleanNewLines(jsContents)).toContain(
-            'const AppCmpB_DeferFn = () => [/* @ts-ignore */ ' +
+            'const AppCmpB_Defer_1_DepsFn = () => [/* @ts-ignore */ ' +
               'import("./deferred-deps").then(m => m.DeferredCmpB)]',
           );
 
@@ -2465,8 +2471,8 @@ runInEachFileSystem(() => {
           expect(jsContents).not.toContain(`from './deferred-deps'`);
 
           // Defer instructions use per-component dependency function.
-          expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmpA_DeferFn)');
-          expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmpB_DeferFn)');
+          expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmpA_Defer_1_DepsFn)');
+          expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmpB_Defer_1_DepsFn)');
 
           // Expect `ɵsetClassMetadataAsync` to contain dynamic imports too.
           expect(cleanNewLines(jsContents)).toContain(
@@ -2520,9 +2526,9 @@ runInEachFileSystem(() => {
               import {DeferredCmpA, DeferredCmpB, utilityFn} from './deferred-deps';
 
               @Component({
-                deferredImports: [DeferredCmpA],
+                deferredImports: { block1: [DeferredCmpA] },
                 template: \`
-                  @defer {
+                  @defer (name block1) {
                     <deferred-cmp-a />
                   }
                 \`,
@@ -2534,9 +2540,9 @@ runInEachFileSystem(() => {
               }
 
               @Component({
-                deferredImports: [DeferredCmpB],
+                deferredImports: { block1: [DeferredCmpB] },
                 template: \`
-                  @defer {
+                  @defer (name block1) {
                     <deferred-cmp-b />
                   }
                 \`,

--- a/packages/compiler-cli/test/ngtsc/selectorless_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/selectorless_spec.ts
@@ -296,7 +296,7 @@ runInEachFileSystem(() => {
       );
     });
 
-    it('should not allow a `deferredImports` array in a selectorless component', () => {
+    it('should not allow a `deferredImports` object in a selectorless component', () => {
       env.write(
         'test.ts',
         `
@@ -308,7 +308,7 @@ runInEachFileSystem(() => {
           @Component({
             template: '<Dep/>',
             // @ts-ignore
-            deferredImports: [Dep]
+            deferredImports: { block1: [Dep] }
           })
           export class Comp {}
         `,

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -659,8 +659,7 @@ export interface Component extends Directive {
    * Note: this is an internal-only field, use regular `@Component.imports` field instead.
    * @internal // 3p-only
    */
-  deferredImports?:
-    (Type<any> | ReadonlyArray<any>)[] | {[blockName: string]: (Type<any> | ReadonlyArray<any>)[]};
+  deferredImports?: {[blockName: string]: (Type<any> | ReadonlyArray<any>)[]};
 
   /**
    * The set of schemas that declare elements to be allowed in a standalone component. Elements and


### PR DESCRIPTION
This finishes the migration to the keyed object structure
