### PR TITLE
fix(elements): resolve environment injector for custom elements

### DIFF
--- a/packages/core/src/render3/util/injector_discovery_utils.ts
+++ b/packages/core/src/render3/util/injector_discovery_utils.ts
@@ -390,8 +390,7 @@ function walkProviderTreeToDiscoverImportPaths(
         let containerDef = getInjectorDef(container);
         if (!containerDef) {
           const ngModule: Type<unknown> | undefined = (container as any).ngModule as
-            | Type<unknown>
-            | undefined;
+            Type<unknown> | undefined;
           containerDef = getInjectorDef(ngModule);
         }
 
@@ -683,7 +682,24 @@ function getModuleInjectorOfNodeInjector(injector: NodeInjector): Injector {
   }
 
   const inj = lView[INJECTOR] as R3Injector | ChainedInjector;
-  const moduleInjector = inj instanceof ChainedInjector ? inj.parentInjector : inj.parent;
+  let moduleInjector: Injector | null =
+    inj instanceof ChainedInjector ? inj.parentInjector : inj.parent;
+
+  // Walk up the parent chain to find a non-NodeInjector. This handles cases
+  // where the lView's injector has a NodeInjector parent (e.g. when a custom
+  // element is created with a NodeInjector via @angular/elements). Without this
+  // guard, getInjectorResolutionPathHelper would infinitely recurse between the
+  // custom element's NodeInjector and the host app's NodeInjector.
+  while (moduleInjector instanceof NodeInjector) {
+    const parentLView = getNodeInjectorLView(moduleInjector);
+    const parentInj = parentLView[INJECTOR] as R3Injector | ChainedInjector | null;
+    if (parentInj == null) {
+      moduleInjector = null;
+      break;
+    }
+    moduleInjector = parentInj instanceof ChainedInjector ? parentInj.parentInjector : parentInj;
+  }
+
   if (!moduleInjector) {
     throwError('NodeInjector must have some connection to the module injector tree');
   }

--- a/packages/core/test/acceptance/injector_profiler_spec.ts
+++ b/packages/core/test/acceptance/injector_profiler_spec.ts
@@ -14,6 +14,7 @@ import {
   ChangeDetectorRef,
   ClassProvider,
   Component,
+  createComponent,
   DestroyRef,
   Directive,
   ElementRef,
@@ -1482,5 +1483,41 @@ describe('getInjectorResolutionPath', () => {
 
       expect(path[6]).toBeInstanceOf(NullInjector);
     }
+  });
+
+  it('should not infinite loop when resolving resolution path of a component created with a parent NodeInjector cast as EnvironmentInjector', () => {
+    @Component({
+      selector: 'child-cmp',
+      template: 'child',
+    })
+    class ChildCmp {
+      nodeInjector = inject(Injector);
+    }
+
+    @Component({
+      selector: 'parent-cmp',
+      template: 'parent',
+    })
+    class ParentCmp {
+      nodeInjector = inject(Injector);
+    }
+
+    const parentFixture = TestBed.createComponent(ParentCmp);
+    const parentNodeInjector = parentFixture.componentInstance.nodeInjector;
+
+    // Simulate the custom element creation where NodeInjector is cast to EnvironmentInjector
+    const childInjector = Injector.create({providers: [], parent: parentNodeInjector});
+    const childRef = createComponent(ChildCmp, {
+      environmentInjector: parentNodeInjector as any,
+      elementInjector: childInjector,
+    });
+
+    const childNodeInjector = childRef.instance.nodeInjector;
+    expect(() => {
+      const path = getInjectorResolutionPath(childNodeInjector);
+      expect(path.length).toBeGreaterThan(0);
+    }).not.toThrow();
+
+    childRef.destroy();
   });
 });

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -198,13 +198,17 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    * sets up its initial inputs, listens for outputs changes, and runs an initial change detection.
    */
   protected initializeComponent(element: HTMLElement) {
+    const environmentInjector =
+      this.injector instanceof EnvironmentInjector
+        ? this.injector
+        : (this.injector.get(EnvironmentInjector, this.injector as any) as EnvironmentInjector);
     const childInjector = Injector.create({providers: [], parent: this.injector});
     const projectableNodes = extractProjectableNodes(
       element,
       reflectComponentType(this.component)!.ngContentSelectors as string[],
     );
     this.componentRef = createComponent(this.component, {
-      environmentInjector: this.injector as EnvironmentInjector,
+      environmentInjector,
       elementInjector: childInjector,
       hostElement: element,
       projectableNodes,

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -357,6 +357,30 @@ describe('ComponentFactoryNgElementStrategy', () => {
       ).toEqual('foofoo');
     });
   });
+
+  it('should initialize component correctly when configured with a NodeInjector', async () => {
+    @Component({
+      template: `<div id="parent"></div>`,
+    })
+    class ParentComponent {
+      nodeInjector = inject(Injector);
+    }
+
+    const parentFixture = TestBed.createComponent(ParentComponent);
+    const parentNodeInjector = parentFixture.componentInstance.nodeInjector;
+
+    const strategyFactory = new ComponentNgElementStrategyFactory(TestComponent);
+    const nodeStrategy = strategyFactory.create(parentNodeInjector);
+
+    expect(() => {
+      nodeStrategy.connect(document.createElement('div'));
+    }).not.toThrow();
+
+    await whenStable();
+    const componentRef = (nodeStrategy as any).componentRef;
+    expect(componentRef).toBeTruthy();
+    nodeStrategy.disconnect();
+  });
 });
 
 @Directive({


### PR DESCRIPTION
Resolve the correct EnvironmentInjector from the provided injector in ComponentNgElementStrategy instead of casting a NodeInjector directly. This prevents a malformed injector hierarchy which causes infinite loop recursion when Angular DevTools resolves the injector resolution path.

Also, add a defensive check in getModuleInjectorOfNodeInjector to ensure we don't cycle when a NodeInjector is configured as the parent of an R3Injector.

Fixes #70452