### PR TITLE
docs(core): repoint or drop dead jsperf links in the render3 notes

### DIFF
--- a/packages/core/src/render3/PERF_NOTES.md
+++ b/packages/core/src/render3/PERF_NOTES.md
@@ -8,8 +8,7 @@ Each Array costs 70 bytes and is composed of `Array` and `(array)` object
 Each Object cost is 24 bytes plus 8 bytes per property.
 
 For small arrays, it is more efficient to store the data as a linked list
-of items rather than small arrays. However, the array access is faster as
-shown here: https://jsperf.com/small-arrays-vs-linked-objects
+of items rather than small arrays. However, the array access is faster.
 
 ## Monomorphic vs Megamorphic code
 
@@ -20,8 +19,6 @@ Great reads:
 
 1. Monomorphic prop access is 100 times faster than megamorphic.
 2. Monomorphic call is 4 times faster the megamorphic call.
-
-See benchmark [here](https://jsperf.com/mono-vs-megamorphic-property-access).
 
 ## Packed vs. holey Array
 
@@ -75,8 +72,8 @@ Also writing to a property of `exports` might change its hidden class resulting 
 
 ## Iterating over Keys of an Object.
 
-https://jsperf.com/object-keys-vs-for-in-with-closure/3 implies that `Object.keys` is the fastest way of iterating
-over properties of an object.
+[This benchmark](https://jsperf.app/object-keys-vs-for-in-with-closure/3) implies that
+`Object.keys` is the fastest way of iterating over properties of an object.
 
 ```
 for (var i = 0, keys = Object.keys(obj); i < keys.length; i++) {
@@ -87,7 +84,6 @@ for (var i = 0, keys = Object.keys(obj); i < keys.length; i++) {
 ## Recursive functions
 
 Avoid recursive functions when possible because they cannot be inlined.
-https://jsperf.com/cost-of-recursion
 
 ## Function Inlining
 
@@ -127,7 +123,7 @@ export function i18nStartfirstCreatePass(tView: TView, index: number, message: s
 ## Loops
 
 Don't use `forEach`, it can cause megamorphic function calls (depending on the browser) and function allocations.
-It is [a lot slower than regular `for` loops](https://jsperf.com/for-vs-foreach-misko)
+It is a lot slower than regular `for` loops.
 
 ## Limit global state access
 

--- a/packages/core/src/render3/VIEW_DATA.md
+++ b/packages/core/src/render3/VIEW_DATA.md
@@ -308,7 +308,6 @@ function factory(fn) {
 }
 const FactoryPrototype = Factory.prototype;
 function isFactory(obj: any): obj is Factory {
-  // See: https://jsperf.com/instanceof-vs-getprototypeof
   return typeof obj === 'object' && Object.getPrototypeOf(obj) === FactoryPrototype;
 }
 ```

--- a/packages/core/src/util/array_utils.ts
+++ b/packages/core/src/util/array_utils.ts
@@ -78,7 +78,7 @@ export function newArray<T>(size: number, value?: T): T[] {
  * removed. This causes memory pressure and slows down code when most of the time we don't
  * care about the deleted items array.
  *
- * https://jsperf.com/fast-array-splice (About 20x faster)
+ * https://jsperf.app/fast-array-splice (About 20x faster)
  *
  * @param array Array to splice
  * @param index Index of element in array to remove.


### PR DESCRIPTION
jsperf.com now returns 410 for every benchmark. Two of them still exist on the successor site and are repointed at jsperf.app; the other five are gone, so the links are removed and the performance claims they backed are kept.