### PR TITLE
docs(zone.js): point the Bluebird link at the project repo

### DIFF
--- a/packages/zone.js/NON-STANDARD-APIS.md
+++ b/packages/zone.js/NON-STANDARD-APIS.md
@@ -27,7 +27,7 @@ Usage:
 
 ## Currently Supported Non-Standard Common APIs
 
-- [Bluebird](http://bluebirdjs.com/docs/getting-started.html) Promise
+- [Bluebird](https://github.com/petkaantonov/bluebird) Promise
 
 Browser Usage:
 


### PR DESCRIPTION
bluebirdjs.com no longer resolves. npm lists the GitHub repo as the package's homepage, so the link now goes there.