### PR TITLE
fix(core): use closest element to resolve dynamic host namespace

### DIFF
--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -58,7 +58,12 @@ import {
   getParentInjectorView,
   hasParentInjector,
 } from '../render3/util/injector_utils';
-import {getNativeByTNode, unwrapRNode, viewAttachedToContainer} from '../render3/util/view_utils';
+import {
+  getLViewParent,
+  getNativeByTNode,
+  unwrapRNode,
+  viewAttachedToContainer,
+} from '../render3/util/view_utils';
 import {shouldAddViewToDom} from '../render3/view_manipulation';
 import {ViewRef as R3ViewRef} from '../render3/view_ref';
 import {addToArray, removeFromArray} from '../util/array_utils';
@@ -520,24 +525,29 @@ class R3ViewContainerRef extends ViewContainerRef {
 
   /** Returns the namespace used by nodes inserted at this container's render location. */
   private _getHostElementNamespace(): string | null {
-    if (this._hostTNode.type & TNodeType.Element) {
-      const parentTNode = this._hostTNode.parent ?? this._hostLView[T_HOST];
+    let lView: LView | null = this._hostLView;
+    let tNode: TNode | null = this._hostTNode.parent;
 
-      // SVG foreignObject elements are namespace integration points: the foreignObject itself is
-      // SVG, but its children are HTML.
-      if (
-        parentTNode !== null &&
-        parentTNode.type & TNodeType.Element &&
-        typeof parentTNode.value === 'string' &&
-        parentTNode.value.toLowerCase() === 'foreignobject'
-      ) {
-        return null;
+    while (lView !== null) {
+      // Only elements are rendered into, so anything else has to be skipped. Their `namespace` is
+      // whichever one happened to be active while they were created, not the one they render in.
+      while (tNode !== null && !(tNode.type & TNodeType.Element)) {
+        tNode = tNode.parent;
       }
 
-      return parentTNode?.namespace ?? null;
+      if (tNode !== null) {
+        // SVG foreignObject elements are namespace integration points: the foreignObject itself is
+        // SVG, but its children are HTML.
+        return typeof tNode.value === 'string' && tNode.value.toLowerCase() === 'foreignobject'
+          ? null
+          : tNode.namespace;
+      }
+
+      tNode = lView[T_HOST];
+      lView = getLViewParent(lView);
     }
 
-    return this._hostTNode.namespace;
+    return null;
   }
 
   override insert(viewRef: ViewRef, index?: number): ViewRef {

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -49,6 +49,7 @@ import {
   RENDERER,
   T_HOST,
   TVIEW,
+  TViewType,
 } from '../render3/interfaces/view';
 import {assertTNodeType} from '../render3/node_assert';
 import {destroyLView} from '../render3/node_manipulation';
@@ -541,6 +542,12 @@ class R3ViewContainerRef extends ViewContainerRef {
         return typeof tNode.value === 'string' && tNode.value.toLowerCase() === 'foreignobject'
           ? null
           : tNode.namespace;
+      }
+
+      // A component's template always starts out in the HTML namespace, so the namespace of its
+      // host element must not leak into it.
+      if (lView[TVIEW].type === TViewType.Component) {
+        return null;
       }
 
       tNode = lView[T_HOST];

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -373,6 +373,41 @@ describe('ViewContainerRef', () => {
           'http://www.w3.org/1999/xhtml',
         );
       });
+
+      it('should use the HTML namespace inside a block that follows an SVG element', () => {
+        @Component({
+          selector: 'div[dynamic-html]',
+          template: 'HTML content',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
+        })
+        class HtmlComp {}
+
+        @Component({
+          template: `
+            <svg></svg>
+            @if (true) {
+              <div #container></div>
+            }
+          `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
+        })
+        class TestComp {
+          @ViewChild('container', {read: ViewContainerRef}) container!: ViewContainerRef;
+        }
+
+        TestBed.configureTestingModule({imports: [TestComp, HtmlComp]});
+        const fixture = TestBed.createComponent(TestComp);
+        fixture.detectChanges();
+
+        const componentRef = fixture.componentInstance.container.createComponent(HtmlComp);
+        fixture.detectChanges();
+
+        expect(componentRef.location.nativeElement.namespaceURI).toBe(
+          'http://www.w3.org/1999/xhtml',
+        );
+      });
     });
 
     it('should apply attributes and classes to host element based on selector', () => {

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -408,6 +408,87 @@ describe('ViewContainerRef', () => {
           'http://www.w3.org/1999/xhtml',
         );
       });
+
+      it('should use the HTML namespace inside a component rendered in an SVG element', () => {
+        @Component({
+          selector: 'div[dynamic-html]',
+          template: 'HTML content',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
+        })
+        class HtmlComp {}
+
+        @Component({
+          selector: 'g[inner]',
+          template: `
+            @if (true) {
+              <ng-container #container></ng-container>
+            }
+          `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
+        })
+        class InnerComp {
+          @ViewChild('container', {read: ViewContainerRef}) container!: ViewContainerRef;
+        }
+
+        @Component({
+          template: '<svg><g inner></g></svg>',
+          imports: [InnerComp],
+
+          changeDetection: ChangeDetectionStrategy.Eager,
+        })
+        class TestComp {
+          @ViewChild(InnerComp) inner!: InnerComp;
+        }
+
+        TestBed.configureTestingModule({imports: [TestComp, InnerComp, HtmlComp]});
+        const fixture = TestBed.createComponent(TestComp);
+        fixture.detectChanges();
+
+        const componentRef = fixture.componentInstance.inner.container.createComponent(HtmlComp);
+        fixture.detectChanges();
+
+        expect(componentRef.location.nativeElement.namespaceURI).toBe(
+          'http://www.w3.org/1999/xhtml',
+        );
+      });
+
+      it('should inherit the namespace of an element anchor across a view boundary', () => {
+        @Component({
+          selector: 'g[dynamic-group]',
+          template: '<svg:text>SVG content</svg:text>',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
+        })
+        class SvgGroupComp {}
+
+        @Component({
+          template: `
+            <svg><g #anchor></g></svg>
+            <ng-template #tpl><ng-container #inner></ng-container></ng-template>
+          `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
+        })
+        class TestComp {
+          @ViewChild('anchor', {read: ViewContainerRef}) anchor!: ViewContainerRef;
+          @ViewChild('tpl', {read: TemplateRef}) tpl!: TemplateRef<unknown>;
+          @ViewChild('inner', {read: ViewContainerRef}) inner!: ViewContainerRef;
+        }
+
+        TestBed.configureTestingModule({imports: [TestComp, SvgGroupComp]});
+        const fixture = TestBed.createComponent(TestComp);
+        fixture.detectChanges();
+
+        fixture.componentInstance.anchor.createEmbeddedView(fixture.componentInstance.tpl);
+        fixture.detectChanges();
+
+        const componentRef = fixture.componentInstance.inner.createComponent(SvgGroupComp);
+        fixture.detectChanges();
+
+        expect(componentRef.location.nativeElement.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      });
     });
 
     it('should apply attributes and classes to host element based on selector', () => {

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -393,7 +393,6 @@ describe('ViewContainerRef', () => {
           @ViewChild('container', {read: ViewContainerRef}) container!: ViewContainerRef;
         }
 
-        TestBed.configureTestingModule({imports: [TestComp, HtmlComp]});
         const fixture = TestBed.createComponent(TestComp);
         fixture.detectChanges();
 
@@ -432,7 +431,6 @@ describe('ViewContainerRef', () => {
           @ViewChild(InnerComp) inner!: InnerComp;
         }
 
-        TestBed.configureTestingModule({imports: [TestComp, InnerComp, HtmlComp]});
         const fixture = TestBed.createComponent(TestComp);
         fixture.detectChanges();
 
@@ -466,7 +464,6 @@ describe('ViewContainerRef', () => {
           @ViewChild('inner', {read: ViewContainerRef}) inner!: ViewContainerRef;
         }
 
-        TestBed.configureTestingModule({imports: [TestComp, SvgGroupComp]});
         const fixture = TestBed.createComponent(TestComp);
         fixture.detectChanges();
 

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -378,8 +378,6 @@ describe('ViewContainerRef', () => {
         @Component({
           selector: 'div[dynamic-html]',
           template: 'HTML content',
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HtmlComp {}
 
@@ -390,8 +388,6 @@ describe('ViewContainerRef', () => {
               <div #container></div>
             }
           `,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComp {
           @ViewChild('container', {read: ViewContainerRef}) container!: ViewContainerRef;
@@ -413,8 +409,6 @@ describe('ViewContainerRef', () => {
         @Component({
           selector: 'div[dynamic-html]',
           template: 'HTML content',
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HtmlComp {}
 
@@ -425,8 +419,6 @@ describe('ViewContainerRef', () => {
               <ng-container #container></ng-container>
             }
           `,
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class InnerComp {
           @ViewChild('container', {read: ViewContainerRef}) container!: ViewContainerRef;
@@ -435,8 +427,6 @@ describe('ViewContainerRef', () => {
         @Component({
           template: '<svg><g inner></g></svg>',
           imports: [InnerComp],
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComp {
           @ViewChild(InnerComp) inner!: InnerComp;
@@ -458,8 +448,6 @@ describe('ViewContainerRef', () => {
         @Component({
           selector: 'g[dynamic-group]',
           template: '<svg:text>SVG content</svg:text>',
-
-          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SvgGroupComp {}
 
@@ -468,7 +456,8 @@ describe('ViewContainerRef', () => {
             <svg><g #anchor></g></svg>
             <ng-template #tpl><ng-container #inner></ng-container></ng-template>
           `,
-
+          // Eager, because the `inner` query only resolves once the host view is refreshed
+          // again after the embedded view is created.
           changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComp {


### PR DESCRIPTION
A dynamic component host picks up its namespace from the node the `ViewContainerRef` anchors to, but nodes that don't render an element of their own, like the anchor of an `@if` block, keep whichever namespace happened to be active when they were created. An `<svg>` earlier in the same template leaves that namespace on them, so a `<router-outlet>` inside a following `@if` created its routed host in the SVG namespace and the view laid out as 0x0.

The namespace is now resolved by walking up to the closest ancestor element, crossing into the parent view where needed.

Fixes #70465