### PR TITLE
docs: correct out-of-range highlight indices in two code blocks

### DIFF
--- a/adev/src/content/ecosystem/rxjs-interop/output-interop.md
+++ b/adev/src/content/ecosystem/rxjs-interop/output-interop.md
@@ -8,7 +8,7 @@ The `@angular/rxjs-interop` package offers two APIs related to component and dir
 
 The `outputFromObservable` lets you create a component or directive output that emits based on an RxJS observable:
 
-```ts {highlight:[11]}
+```ts {highlight:[9]}
 import {Directive} from '@angular/core';
 import {outputFromObservable} from '@angular/core/rxjs-interop';
 

--- a/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/README.md
@@ -110,7 +110,7 @@ handleSubmit() {
 You have access to the form values, now it is time to handle the submission event and use the `handleSubmit` method.
 Angular has an event handler for this specific purpose called `ngSubmit`. Update the form element to call the `handleSubmit` method when the form is submitted.
 
-```angular-html {highlight:[3]}
+```angular-html {highlight:[1]}
 <form [formGroup]="profileForm" (ngSubmit)="handleSubmit()"></form>
 ```
 


### PR DESCRIPTION
Both indices point past the end of their block, so the intended lines are never highlighted. The reactive forms block renders with no highlight at all, and the first example in output-interop.md highlights nothing while its sibling block is unaffected.

Pages

1. https://angular.dev/ecosystem/rxjs-interop/output-interop

Before:
<img width="906" height="618" alt="Screenshot 2026-08-30 at 16 45 38" src="https://github.com/user-attachments/assets/25d3ae61-a129-4d91-aa55-a827c6d29361" />

After:
<img width="844" height="599" alt="Screenshot 2026-08-30 at 16 45 33" src="https://github.com/user-attachments/assets/201568c1-f97d-40b6-9cd3-8d5a0917f896" />

2. https://angular.dev/tutorials/learn-angular/17-reactive-forms

Before:
<img width="700" height="396" alt="Screenshot 2026-08-30 at 16 45 23" src="https://github.com/user-attachments/assets/fdec3087-57c0-4b09-ab85-2ae45f4c5c9d" />

After:
<img width="693" height="329" alt="Screenshot 2026-08-30 at 16 45 18" src="https://github.com/user-attachments/assets/d18157dd-9a87-41dc-8228-f8349be4e1a2" />



