### PR TITLE
feat(common): add getOffset method to ViewportScroller

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -1036,6 +1036,7 @@ export const VERSION: Version;
 
 // @public
 export abstract class ViewportScroller {
+    abstract getOffset(): [number, number];
     abstract getScrollPosition(): [number, number];
     abstract scrollToAnchor(anchor: string, options?: ScrollOptions): void;
     abstract scrollToPosition(position: [number, number], options?: ScrollOptions): void;

--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -41,6 +41,12 @@ export abstract class ViewportScroller {
   abstract setOffset(offset: [number, number] | (() => [number, number])): void;
 
   /**
+   * Retrieves the current scroll offset.
+   * @returns A position in screen coordinates (a tuple with x and y values).
+   */
+  abstract getOffset(): [number, number];
+
+  /**
    * Retrieves the current scroll position.
    * @returns A position in screen coordinates (a tuple with x and y values).
    */
@@ -98,6 +104,14 @@ export class BrowserViewportScroller implements ViewportScroller {
    */
   getScrollPosition(): [number, number] {
     return [this.window.scrollX, this.window.scrollY];
+  }
+
+  /**
+   * Retrieves the current scroll offset.
+   * @returns The position in screen coordinates.
+   */
+  getOffset(): [number, number] {
+    return this.offset();
   }
 
   /**
@@ -222,6 +236,13 @@ export class NullViewportScroller implements ViewportScroller {
    * Empty implementation
    */
   setOffset(offset: [number, number] | (() => [number, number])): void {}
+
+  /**
+   * Empty implementation
+   */
+  getOffset(): [number, number] {
+    return [0, 0];
+  }
 
   /**
    * Empty implementation

--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {BrowserViewportScroller, ViewportScroller} from '../src/viewport_scroller';
+import {
+  BrowserViewportScroller,
+  NullViewportScroller,
+  ViewportScroller,
+} from '../src/viewport_scroller';
 import {isNode, waitFor} from '@angular/private/testing';
 
 describe('BrowserViewportScroller', () => {
@@ -194,5 +198,34 @@ describe('BrowserViewportScroller', () => {
       anchorNode.href = '#';
       return anchorNode;
     }
+  });
+
+  describe('getOffset', () => {
+    it('should return default offset [0, 0]', () => {
+      const scroller = new BrowserViewportScroller(document, window);
+      expect(scroller.getOffset()).toEqual([0, 0]);
+    });
+
+    it('should return offset when set as a tuple', () => {
+      const scroller = new BrowserViewportScroller(document, window);
+      scroller.setOffset([10, 50]);
+      expect(scroller.getOffset()).toEqual([10, 50]);
+    });
+
+    it('should return offset when set as a function', () => {
+      const scroller = new BrowserViewportScroller(document, window);
+      let y = 100;
+      scroller.setOffset(() => [0, y]);
+      expect(scroller.getOffset()).toEqual([0, 100]);
+      y = 200;
+      expect(scroller.getOffset()).toEqual([0, 200]);
+    });
+
+    it('should return [0, 0] for NullViewportScroller', () => {
+      const scroller = new NullViewportScroller();
+      expect(scroller.getOffset()).toEqual([0, 0]);
+      scroller.setOffset([10, 20]);
+      expect(scroller.getOffset()).toEqual([0, 0]);
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`ViewportScroller` provides `setOffset()` to configure anchor scroll offset coordinates (e.g. for fixed or sticky navigation headers) using a static tuple or dynamic function. However, there is no getter method to retrieve the currently active offset. Applications and custom scroll strategies needing to calculate target scroll positions relative to the configured viewport offset must maintain redundant state or duplicate measurement logic outside `ViewportScroller`.

Fixes #70469

## What is the new behavior?

- Added `abstract getOffset(): [number, number]` to `ViewportScroller`.
- Implemented `getOffset(): [number, number]` in `BrowserViewportScroller` to return the evaluated `[x, y]` coordinates from `this.offset()`.
- Implemented `getOffset(): [number, number]` in `NullViewportScroller` returning `[0, 0]`.
- Updated public API goldens for `@angular/common`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
