### PR TITLE
fix(compiler): correctly match directives on `<ng-template>` nested i…

### DIFF
--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -9190,6 +9190,31 @@ suppress
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(0);
       });
+
+      it('should not report unused directives on ng-template nested an an svg element', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component} from '@angular/core';
+          import {CommonModule} from '@angular/common';
+
+
+          @Component({
+            template: \`
+              <ng-template #foo>foo</ng-template>
+              <svg>
+                <ng-template [ngTemplateOutlet]="foo"></ng-template>
+              </svg>
+            \`,
+            imports: [CommonModule]
+          })
+          export class MyComp {}
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
     });
 
     describe('DOM event target type inference', () => {

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -8,7 +8,7 @@
 
 import {InputFlags} from '../../core';
 import {BindingType} from '../../expression_parser/ast';
-import {splitNsName} from '../../ml_parser/tags';
+import {isNgTemplate, splitNsName} from '../../ml_parser/tags';
 import * as o from '../../output/output_ast';
 import {CssSelector} from '../../directive_matching';
 import * as t from '../r3_ast';
@@ -201,7 +201,7 @@ export function createCssSelectorFromNode(node: t.Element | t.Template): CssSele
 function getAttrsForDirectiveMatching(elOrTpl: t.Element | t.Template): {[name: string]: string} {
   const attributesMap: {[name: string]: string} = {};
 
-  if (elOrTpl instanceof t.Template && elOrTpl.tagName !== 'ng-template') {
+  if (elOrTpl instanceof t.Template && (!elOrTpl.tagName || !isNgTemplate(elOrTpl.tagName))) {
     elOrTpl.templateAttrs.forEach((a) => (attributesMap[a.name] = ''));
   } else {
     elOrTpl.attributes.forEach((a) => {

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -254,6 +254,22 @@ describe('t2 binding', () => {
     expect(directives[0].name).toBe('Dir');
   });
 
+  it('should match directives on ng-template nested in namespaced elements', () => {
+    const template = parseTemplate(
+      '<svg><ng-template [hasInput]="true"></ng-template></svg>',
+      '',
+      {},
+    );
+    const binder = new R3TargetBinder(makeSelectorMatcher());
+    const res = binder.bind({template: template.nodes});
+    const svgNode = template.nodes[0] as a.Element;
+    const tmplNode = svgNode.children[0] as a.Template;
+    const directives = res.getDirectivesOfNode(tmplNode)!;
+    expect(directives).not.toBeNull();
+    expect(directives.length).toBe(1);
+    expect(directives[0].name).toBe('HasInput');
+  });
+
   it('should not match directives intended for an element on a microsyntax template', () => {
     const template = parseTemplate('<div *ngFor="let item of items" dir></div>', '', {});
     const binder = new R3TargetBinder(makeSelectorMatcher());

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -157,6 +157,16 @@ describe('directives', () => {
       expect(nodesWithDirective.length).toBe(1);
     });
 
+    it('should match directives on ng-template inside of SVG elements', () => {
+      TestBed.configureTestingModule({declarations: [TestComponent, TestDirective]});
+      TestBed.overrideTemplate(TestComponent, `<svg><ng-template test></ng-template></svg>`);
+
+      const fixture = TestBed.createComponent(TestComponent);
+      const nodesWithDirective = fixture.debugElement.queryAllNodes(By.directive(TestDirective));
+
+      expect(nodesWithDirective.length).toBe(1);
+    });
+
     it('should match directives on <ng-container>', () => {
       @Directive({
         selector: 'ng-container[directiveA]',


### PR DESCRIPTION
…n various namespaces

With this commit with correctly detect directive attached to ng-templates in namespaces

fixes #70471
