### PR TITLE
fix(compiler): match directives on ng-template inside SVG

### DIFF
--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -8749,6 +8749,35 @@ suppress
         expect(diags.length).toBe(0);
       });
 
+      it('should not report a directive used on an ng-template inside an SVG as unused', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive, Input} from '@angular/core';
+
+          @Directive({selector: '[ngTemplateOutlet]'})
+          export class NgTemplateOutlet {
+            @Input() ngTemplateOutlet: unknown;
+          }
+
+          @Component({
+            template: \`
+              <ng-template #foo>foo</ng-template>
+
+              <svg>
+                <ng-template [ngTemplateOutlet]="foo"></ng-template>
+              </svg>
+            \`,
+            imports: [NgTemplateOutlet]
+          })
+          export class MyComp {}
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
       it('should report when all imports in an import array are not used', () => {
         env.write(
           'test.ts',

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -8,7 +8,7 @@
 
 import {InputFlags} from '../../core';
 import {BindingType} from '../../expression_parser/ast';
-import {splitNsName} from '../../ml_parser/tags';
+import {isNgTemplate, splitNsName} from '../../ml_parser/tags';
 import * as o from '../../output/output_ast';
 import {CssSelector} from '../../directive_matching';
 import * as t from '../r3_ast';
@@ -201,7 +201,10 @@ export function createCssSelectorFromNode(node: t.Element | t.Template): CssSele
 function getAttrsForDirectiveMatching(elOrTpl: t.Element | t.Template): {[name: string]: string} {
   const attributesMap: {[name: string]: string} = {};
 
-  if (elOrTpl instanceof t.Template && elOrTpl.tagName !== 'ng-template') {
+  if (
+    elOrTpl instanceof t.Template &&
+    (elOrTpl.tagName === null || !isNgTemplate(elOrTpl.tagName))
+  ) {
     elOrTpl.templateAttrs.forEach((a) => (attributesMap[a.name] = ''));
   } else {
     elOrTpl.attributes.forEach((a) => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the Angular commit guidelines.
- [x] Tests for the changes have been added.
- [x] Documentation is not applicable to this compiler bug fix.

## PR Type

- [x] Bugfix

## What is the current behavior?

Explicit `ng-template` elements nested inside SVG are represented with a namespaced tag name. Attribute collection for directive matching compares the tag name directly with `ng-template`, so these nodes are treated like structural templates. As a result, directives such as `NgTemplateOutlet` do not match and can be incorrectly reported as unused by NG8113.

Fixes #70471.

## What is the new behavior?

Recognize `ng-template` elements independently of their namespace when collecting attributes for directive matching. Directives applied to `ng-template` inside SVG now match and are included in the component's used directives.

The regression test covers the minimized reproduction from the issue.

## Does this PR introduce a breaking change?

- [x] No
