### PR TITLE
docs: integrate modern web guidance with Angular skills

### DIFF
--- a/skills/dev-skills/README.md
+++ b/skills/dev-skills/README.md
@@ -17,6 +17,16 @@ To use these skills in your own environment you may follow the instructions for 
 npx skills add https://github.com/angular/skills
 ```
 
+### Modern Web Platform Guidance
+
+Angular Skills can be paired with [Modern Web Guidance](https://github.com/GoogleChrome/modern-web-guidance) for current HTML, CSS, browser API, and compatibility recommendations:
+
+```bash
+npx skills add GoogleChrome/modern-web-guidance
+```
+
+Modern Web Guidance is framework-agnostic. The `angular-developer` skill describes how to adapt its recommendations without replacing Angular application patterns. Installation, updates, and runtime behavior remain owned by the Modern Web Guidance project.
+
 ## Contributions
 
 We welcome contributions to the Angular agent skills. If you would like to contribute to the skills, please make the updates directly in `angular/angular` repository, and to that repository will be output here as a part of our infrastructure setup.

--- a/skills/dev-skills/angular-developer/SKILL.md
+++ b/skills/dev-skills/angular-developer/SKILL.md
@@ -15,6 +15,10 @@ metadata:
 
 3. Once you finish generating code, run `ng build` to ensure there are no build errors. If there are errors, analyze the error messages and fix them before proceeding. Do not skip this step, as it is critical for ensuring the generated code is correct and functional.
 
+## Modern Web Platform Guidance
+
+When the `modern-web-guidance` skill is available and a task involves browser APIs, HTML, or CSS, use it for current web platform guidance. Read [modern-web-guidance.md](references/modern-web-guidance.md) before adapting its framework-agnostic recommendations to Angular.
+
 ## Creating New Projects
 
 If no guidelines are provided by the user, here are some default rules to follow when creating a new Angular project:

--- a/skills/dev-skills/angular-developer/references/modern-web-guidance.md
+++ b/skills/dev-skills/angular-developer/references/modern-web-guidance.md
@@ -1,0 +1,36 @@
+# Using Modern Web Guidance with Angular
+
+[Modern Web Guidance](https://github.com/GoogleChrome/modern-web-guidance) complements Angular guidance with current recommendations for HTML, CSS, browser APIs, accessibility, and browser compatibility. It is optional and must not be installed or executed unless it is already available or the user requests it.
+
+## Responsibilities
+
+Use Angular guidance for application architecture, including:
+
+- components and templates;
+- state management with signals or RxJS;
+- Angular forms;
+- HTTP communication;
+- routing and dependency injection;
+- rendering lifecycle, SSR, and testing.
+
+Use Modern Web Guidance for web platform concerns, including:
+
+- semantic HTML and native element behavior;
+- modern CSS features;
+- browser APIs without an Angular-specific equivalent;
+- browser support, progressive enhancement, and fallbacks.
+
+The project's Angular version, browser support policy, and existing architecture take precedence over defaults from either skill.
+
+## Adapting Platform Guidance
+
+Modern Web Guidance examples are framework-agnostic. Preserve the recommended platform feature, semantics, and compatibility behavior while expressing application code with Angular patterns:
+
+- Prefer template event bindings and host metadata over manually registering DOM listeners for component events.
+- Prefer Angular queries and dependency injection over global DOM queries when accessing elements or platform objects.
+- Use the existing Angular forms strategy as the source of truth. Add native attributes such as `autocomplete`, `inputmode`, and validation constraints without creating a second, conflicting validation model.
+- Prefer `HttpClient` or `httpResource` for application data access. Use a direct browser API only when the required platform capability is not represented by Angular's HTTP APIs.
+- Guard browser-only APIs from SSR execution and acquire DOM state during the appropriate rendering lifecycle.
+- Clean up observers, listeners, and other browser resources when their owner is destroyed.
+
+Direct DOM access is appropriate when no Angular abstraction exists or when integrating a third-party API. Keep it localized instead of replacing component rendering or state management with DOM manipulation.


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the Angular commit message guidelines.
- [x] Tests are not required for this documentation-only change.
- [x] Documentation has been added and updated.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

Angular Skills do not explain how to combine their framework guidance with the framework-agnostic Modern Web Guidance skill. When both skills are available, an agent can apply vanilla DOM, form, or HTTP examples without adapting them to Angular architecture.

Related to #70221.

## What is the new behavior?

This change documents Modern Web Guidance as an optional, separately maintained companion to Angular Skills and defines how to resolve overlap:

- Angular guidance remains responsible for application architecture, forms, HTTP, rendering lifecycle, SSR, and testing.
- Modern Web Guidance supplies current HTML, CSS, browser API, accessibility, compatibility, and fallback recommendations.
- Framework-agnostic examples are adapted to Angular bindings, queries, dependency injection, forms, and HTTP APIs.
- Direct DOM access remains available for platform and third-party integrations, but stays localized and lifecycle-safe.

The integration uses a focused reference instead of copying external guides into this repository, so platform guidance can continue to update independently.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
