### PR TITLE
fix(compiler-cli): check @let declarations in interpolated_signal_not_invoked diagnostic (#70476)

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -19,6 +19,7 @@ import {
   TmplAstBoundAttribute,
   TmplAstElement,
   TmplAstIfBlock,
+  TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstSwitchBlock,
   TmplAstTemplate,
@@ -106,6 +107,12 @@ class InterpolatedSignalCheck extends TemplateCheckWithVisitor<ErrorCode.INTERPO
       if (expression instanceof PropertyRead) {
         return buildDiagnosticForSignal(ctx, expression, component);
       }
+    }
+    // @let declarations like `@let x = mySignal;`
+    else if (node instanceof TmplAstLetDeclaration) {
+      const ast = node.value instanceof ASTWithSource ? node.value.ast : node.value;
+      const propertyReads = getPropertyReads(ast);
+      return propertyReads.flatMap((item) => buildDiagnosticForSignal(ctx, item, component));
     }
 
     return [];

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/interpolated_signal_not_invoked_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/interpolated_signal_not_invoked_spec.ts
@@ -53,6 +53,67 @@ runInEachFileSystem(() => {
       const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
       expect(diags.length).toBe(0);
     });
+
+    it('should produce a warning when a signal is not invoked in an @let declaration', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `@let x = mySignal;`,
+          },
+          source: `
+          import {signal} from '@angular/core';
+
+          export class TestCmp {
+            mySignal = signal<number>(0);
+          }`,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [interpolatedSignalFactory],
+        {},
+        /* options */
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED));
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe(`mySignal`);
+    });
+
+    it('should not produce a warning when a signal is invoked in an @let declaration', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `@let x = mySignal();`,
+          },
+          source: `
+          import {signal} from '@angular/core';
+
+          export class TestCmp {
+            mySignal = signal<number>(0);
+          }`,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [interpolatedSignalFactory],
+        {},
+        /* options */
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
   });
 
   it('should produce a warning when a signal is not invoked', () => {


### PR DESCRIPTION
PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

PR Type
What kind of change does this PR introduce?
- [ ] Bug fix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

What is the current behavior?
The `interpolated_signal_not_invoked` extended template diagnostic (`NG8109`) inspects interpolations (`{{ }}`), bound attributes (`[prop]`), `@if`, and `@switch` blocks for uninvoked signal references. However, it does not inspect `@let` declarations (`TmplAstLetDeclaration`).

Writing `@let count = countSignal;` results in no diagnostic warning at build time.

Fixes #70476

What is the new behavior?
`InterpolatedSignalCheck` now visits `TmplAstLetDeclaration` nodes in `visitNode`. Uninvoked signal references in `@let` initializers (e.g. `@let count = countSignal;`) generate the `NG8109` compiler warning, while invoked signal references (`@let count = countSignal();`) continue to pass without warnings.

Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
