### PR TITLE
fix(docs-infra): restore the edit link on decorative header pages

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-decorative-header.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-decorative-header.mts
@@ -8,6 +8,7 @@
 
 import {TokenizerThis, Tokens, RendererThis} from 'marked';
 import {loadWorkspaceRelativeFile} from '../helpers.mjs';
+import {AdevDocsRenderer} from '../renderer.mjs';
 import {getPageTitle} from '../transformations/heading.mjs';
 
 interface DocsDecorativeHeaderToken extends Tokens.Generic {
@@ -75,7 +76,7 @@ function getStandardDecorativeHeader(renderer: RendererThis, token: DocsDecorati
       <div class="docs-header-content">
         <docs-breadcrumb></docs-breadcrumb>
 
-        ${getPageTitle(token.title)}
+        ${getPageTitle(token.title, (renderer.parser.renderer as AdevDocsRenderer).context.markdownFilePath)}
 
         <p>${token.body}</p>
       </div>
@@ -97,7 +98,7 @@ function getGradientDecorativeHeader(renderer: RendererThis, token: DocsDecorati
   <div class="docs-decorative-header-container">
     <div class="docs-decorative-gradient-header">
       <div class="docs-header-content">
-        ${getPageTitle(token.title)}
+        ${getPageTitle(token.title, (renderer.parser.renderer as AdevDocsRenderer).context.markdownFilePath)}
         <p>${token.body}</p>
       </div>
       <!-- illustration -->

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-decorative-header/docs-decorative-header.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-decorative-header/docs-decorative-header.spec.mts
@@ -33,4 +33,19 @@ describe('markdown to html', () => {
   it('passes the header text to the content', () => {
     expect(markdownDocument.querySelector('p')?.textContent?.trim()).toBe('This is header text');
   });
+
+  for (const gradientBackground of [false, true]) {
+    it(`links to the source file on GitHub (gradientBackground=${gradientBackground})`, () => {
+      const markdownDocument = JSDOM.fragment(
+        parseMarkdown(
+          `<docs-decorative-header title="Custom Title" gradientBackground="${gradientBackground}"></docs-decorative-header>`,
+          {...rendererContext, markdownFilePath: 'adev/src/content/overview.md'},
+        ),
+      );
+
+      expect(markdownDocument.querySelector('.docs-github-links')?.getAttribute('href')).toBe(
+        'https://github.com/angular/angular/edit/main/adev/src/content/overview.md',
+      );
+    });
+  }
 });


### PR DESCRIPTION
The 34 pages using `<docs-decorative-header>` render their title through `getPageTitle()` without passing the markdown file path, so the "Edit this page" link is silently dropped. Every other page keeps it. Compare https://v19.angular.dev/guide/components, which still has the pencil, against https://angular.dev/guide/components, which does not.

`filePath` was required until #63536 made it optional, so API descriptions with no editable source could render a title without a link. That removed the compile error forcing the decorative header to supply it, and the argument was lost with nothing to catch it.

Pass the path again and cover both header variants with tests, since the edit link had no coverage at all.

Before:
<img width="867" height="265" alt="Screenshot 2026-08-30 at 22 53 12" src="https://github.com/user-attachments/assets/1f06b58d-f394-46e2-aabb-e8ee7c056236" />

After:
<img width="829" height="235" alt="Screenshot 2026-08-30 at 22 55 04" src="https://github.com/user-attachments/assets/fdb4600a-9788-402a-a374-7b98c4b70c23" />
