### PR TITLE
fix(compiler-cli): check uninvoked signal aliases in extended diagnostic

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  AbsoluteSourceSpan,
   AST,
   ForeignComponentMeta,
   LiteralPrimitive,
@@ -373,7 +374,7 @@ export interface TemplateTypeChecker {
    */
   makeTemplateDiagnostic<T extends ErrorCode>(
     clazz: ts.ClassDeclaration,
-    sourceSpan: ParseSourceSpan,
+    sourceSpan: ParseSourceSpan | AbsoluteSourceSpan,
     category: ts.DiagnosticCategory,
     errorCode: T,
     message: string,

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  AbsoluteSourceSpan,
   AST,
   CombinedRecursiveAstVisitor,
   ParseSourceSpan,
@@ -57,7 +58,7 @@ export interface TemplateContext<Code extends ErrorCode> {
    *   - Specify `sourceFile` only when referencing a separate file (e.g. directive class declaration).
    */
   makeTemplateDiagnostic(
-    sourceSpan: ParseSourceSpan,
+    sourceSpan: ParseSourceSpan | AbsoluteSourceSpan,
     message: string,
     relatedInformation?: {
       text: string;

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -202,19 +202,22 @@ function buildDiagnosticForSignal(
   const symbol = ctx.templateTypeChecker.getSymbolOfNode(node, component);
   if (
     symbol !== null &&
-    symbol.kind === SymbolKind.Expression &&
+    (symbol.kind === SymbolKind.Expression ||
+      symbol.kind === SymbolKind.LetDeclaration ||
+      symbol.kind === SymbolKind.Variable) &&
     isSignalReference(symbol, ctx.templateTypeChecker)
   ) {
-    const templateMapping = ctx.templateTypeChecker.getSourceMappingAtTcbLocation(
-      symbol.tcbLocation,
-    )!;
+    const span =
+      symbol.kind === SymbolKind.Expression
+        ? ctx.templateTypeChecker.getSourceMappingAtTcbLocation(symbol.tcbLocation)!.span
+        : node.nameSpan;
 
     const errorString = formatExtendedError(
       ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED,
       `${node.name} is a function and should be invoked: ${node.name}()}`,
     );
 
-    const diagnostic = ctx.makeTemplateDiagnostic(templateMapping.span, errorString);
+    const diagnostic = ctx.makeTemplateDiagnostic(span, errorString);
     return [diagnostic];
   }
 
@@ -237,12 +240,15 @@ function buildDiagnosticForSignal(
   const symbolOfReceiver = ctx.templateTypeChecker.getSymbolOfNode(node.receiver, component);
   if (
     symbolOfReceiver !== null &&
-    symbolOfReceiver.kind === SymbolKind.Expression &&
+    (symbolOfReceiver.kind === SymbolKind.Expression ||
+      symbolOfReceiver.kind === SymbolKind.LetDeclaration ||
+      symbolOfReceiver.kind === SymbolKind.Variable) &&
     isSignalReference(symbolOfReceiver, ctx.templateTypeChecker)
   ) {
-    const templateMapping = ctx.templateTypeChecker.getSourceMappingAtTcbLocation(
-      symbolOfReceiver.tcbLocation,
-    )!;
+    const span =
+      symbolOfReceiver.kind === SymbolKind.Expression
+        ? ctx.templateTypeChecker.getSourceMappingAtTcbLocation(symbolOfReceiver.tcbLocation)!.span
+        : (node.receiver as PropertyRead).nameSpan;
 
     const errorString = formatExtendedError(
       ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED,
@@ -251,7 +257,7 @@ function buildDiagnosticForSignal(
       } is a function and should be invoked: ${(node.receiver as PropertyRead).name}()`,
     );
 
-    const diagnostic = ctx.makeTemplateDiagnostic(templateMapping.span, errorString);
+    const diagnostic = ctx.makeTemplateDiagnostic(span, errorString);
     return [diagnostic];
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/src/extended_template_checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/src/extended_template_checker.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ParseSourceSpan} from '@angular/compiler';
+import {AbsoluteSourceSpan, ParseSourceSpan} from '@angular/compiler';
 import ts from 'typescript';
 
 import {DiagnosticCategoryLabel, NgCompilerOptions} from '../../../core/api';
@@ -79,7 +79,7 @@ export class ExtendedTemplateCheckerImpl implements ExtendedTemplateChecker {
         // Wrap `templateTypeChecker.makeTemplateDiagnostic()` to implicitly provide all the known
         // options.
         makeTemplateDiagnostic: (
-          span: ParseSourceSpan,
+          span: ParseSourceSpan | AbsoluteSourceSpan,
           message: string,
           relatedInformation?: {
             text: string;

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/interpolated_signal_not_invoked_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/interpolated_signal_not_invoked_spec.ts
@@ -1201,4 +1201,186 @@ runInEachFileSystem(() => {
       });
     },
   );
+
+  describe('@let declarations', () => {
+    it('should produce a warning when a signal aliased via @let is not invoked in interpolation', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `@let mySignal2 = mySignal; <div>{{ mySignal2 }}</div>`,
+          },
+          source: `
+            import {signal} from '@angular/core';
+
+            export class TestCmp {
+              mySignal = signal(0);
+            }`,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [interpolatedSignalFactory],
+        {},
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED));
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe('mySignal2');
+    });
+
+    it('should not produce a warning when a signal aliased via @let is invoked', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `@let mySignal2 = mySignal; <div>{{ mySignal2() }}</div>`,
+          },
+          source: `
+            import {signal} from '@angular/core';
+
+            export class TestCmp {
+              mySignal = signal(0);
+            }`,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [interpolatedSignalFactory],
+        {},
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not produce a warning when a signal is aliased via @let without being interpolated', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `@let mySignal2 = mySignal;`,
+          },
+          source: `
+            import {signal} from '@angular/core';
+
+            export class TestCmp {
+              mySignal = signal(0);
+            }`,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [interpolatedSignalFactory],
+        {},
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should produce a warning when a signal aliased via @let is used in @if', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `@let mySignal2 = mySignal; @if (mySignal2) { <div>visible</div> }`,
+          },
+          source: `
+            import {signal} from '@angular/core';
+
+            export class TestCmp {
+              mySignal = signal(true);
+            }`,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [interpolatedSignalFactory],
+        {},
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED));
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe('mySignal2');
+    });
+
+    it('should produce a warning when a signal aliased via @let is used in a bound attribute', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `@let mySignal2 = mySignal; <div [title]="mySignal2"></div>`,
+          },
+          source: `
+            import {signal} from '@angular/core';
+
+            export class TestCmp {
+              mySignal = signal('hello');
+            }`,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [interpolatedSignalFactory],
+        {},
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED));
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe('mySignal2');
+    });
+
+    it('should produce a warning when an instance property of a signal aliased via @let is accessed in interpolation', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `@let mySignal2 = mySignal; <div>{{ mySignal2.name }}</div>`,
+          },
+          source: `
+            import {signal} from '@angular/core';
+
+            export class TestCmp {
+              mySignal = signal(0);
+            }`,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [interpolatedSignalFactory],
+        {},
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED));
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe('mySignal2');
+    });
+  });
 });

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -7,19 +7,18 @@
  */
 
 import {
+  AbsoluteSourceSpan,
   AST,
   BoundTarget,
-  ForeignComponentMeta,
   CssSelector,
   DomElementSchemaRegistry,
   ExternalExpr,
+  ForeignComponentMeta,
   LiteralPrimitive,
   ParseSourceSpan,
   PropertyRead,
   ReferenceTarget,
   SafePropertyRead,
-  ScopedNode,
-  Target,
   TemplateEntity,
   TmplAstBoundAttribute,
   TmplAstBoundEvent,
@@ -53,7 +52,7 @@ import {
   PipeMeta,
 } from '../../metadata';
 import {PerfCheckpoint, PerfEvent, PerfPhase, PerfRecorder} from '../../perf';
-import {ProgramDriver, UpdateMode, InliningMode} from '../../program_driver';
+import {InliningMode, ProgramDriver, UpdateMode} from '../../program_driver';
 import {
   ClassDeclaration,
   DeclarationNode,
@@ -61,12 +60,12 @@ import {
   ReflectionHost,
 } from '../../reflection';
 import {
+  ComponentScope,
   ComponentScopeKind,
   ComponentScopeReader,
+  LocalModuleScope,
   StandaloneScope,
   TypeCheckScopeRegistry,
-  LocalModuleScope,
-  ComponentScope,
 } from '../../scope';
 import {isShim} from '../../shims';
 import {
@@ -90,7 +89,6 @@ import {
   PotentialImportKind,
   PotentialImportMode,
   PotentialPipe,
-  ReferenceSymbol,
   ProgramTypeCheckAdapter,
   SelectorlessComponentSymbol,
   SelectorlessDirectiveSymbol,
@@ -106,19 +104,19 @@ import {
 } from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
 
+import {findAllMatchingNodes} from './comments';
 import {CompletionEngine} from './completion';
 import {
   ShimTypeCheckingData,
-  TypeCheckData,
   TypeCheckContextImpl,
+  TypeCheckData,
   TypeCheckingHost,
 } from './context';
 import {shouldReportDiagnostic, translateDiagnostic} from './diagnostics';
 import {TypeCheckShimGenerator} from './shim';
 import {DirectiveSourceManager} from './source';
 import {findTypeCheckBlock, getSourceMapping, TypeCheckSourceResolver} from './tcb_util';
-import {SymbolBuilder, SymbolDirectiveMeta, SymbolBoundTarget} from './template_symbol_builder';
-import {findAllMatchingNodes} from './comments';
+import {SymbolBoundTarget, SymbolBuilder, SymbolDirectiveMeta} from './template_symbol_builder';
 import {TCB_FUNCTION_PREFIX} from './type_check_file';
 
 export class TypeCheckableDirectiveMetaAdapter implements SymbolDirectiveMeta {
@@ -900,7 +898,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
 
   makeTemplateDiagnostic<T extends ErrorCode>(
     clazz: ts.ClassDeclaration,
-    sourceSpan: ParseSourceSpan,
+    sourceSpan: ParseSourceSpan | AbsoluteSourceSpan,
     category: ts.DiagnosticCategory,
     errorCode: T,
     message: string,
@@ -915,12 +913,16 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     const fileRecord = this.state.get(sfPath)!;
     const id = fileRecord.sourceManager.getTypeCheckId(clazz);
     const mapping = fileRecord.sourceManager.getTemplateSourceMapping(id);
+    const span =
+      sourceSpan instanceof ParseSourceSpan
+        ? sourceSpan
+        : fileRecord.sourceManager.toTemplateParseSourceSpan(id, sourceSpan)!;
 
     return {
       ...makeTemplateDiagnostic(
         id,
         mapping,
-        sourceSpan,
+        span,
         category,
         ngErrorCode(errorCode),
         message,


### PR DESCRIPTION
Extended template diagnostic interpolated_signal_not_invoked previously only checked symbols with kind === SymbolKind.Expression. When a signal is aliased via @let (or a template variable), getSymbolOfNode returns a LetDeclarationSymbol (or VariableSymbol), causing the diagnostic to skip checking uninvoked usages of signal aliases in interpolations and bindings.

This commit updates interpolated_signal_not_invoked to also check LetDeclarationSymbol and VariableSymbol, using the usage site's AST name span for reporting the diagnostic.

Closes #70476
