### PR TITLE
feat(core): add passiveRead utility for non-recomputing signal reads

### DIFF
--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -55,9 +55,7 @@ export class CounterState {
   }
 }
 
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class AwesomeCounter {
   state = inject(CounterState);
 
@@ -185,6 +183,30 @@ effect(() => {
   });
 });
 ```
+
+### Reading without triggering recomputation
+
+`untracked` still forces a signal to compute its value if it's currently dirty; it only stops the read from being tracked as a dependency. Sometimes you want the opposite: keep the dependency, but avoid forcing an expensive `computed` to recompute just to check whether it currently has a value.
+
+`passiveRead` reads a signal's current value if one has already been computed, without forcing recomputation. It still registers the caller as a dependent, so the reactive context re-runs when the signal's value later changes.
+
+```ts
+effect(() => {
+  const result = passiveRead(myResource.value);
+  if (!result.hasValue) {
+    // No value has been computed yet, so no recomputation was forced.
+    return;
+  }
+
+  // `hasValue` is only `true` if some non-passive read has already computed this signal.
+  console.log('Passive update:', result.value);
+});
+```
+
+`passiveRead` returns a `PassiveReadResult`, since the signal may not have a value available yet:
+
+- `hasValue: true` - the signal already has a computed value, available as `value`.
+- `hasValue: false` - the signal hasn't been computed yet (or is currently computing), so no value is available.
 
 ### Reactive context and async operations
 

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1410,6 +1410,12 @@ export interface OutputRefSubscription {
 }
 
 // @public
+export function passiveRead<T>(signal: () => T): PassiveReadResult<T>;
+
+// @public
+export type PassiveReadResult<T> = PassiveReadResult_2<T>;
+
+// @public
 export class PendingTasks {
     add(): () => void;
     run(fn: () => Promise<unknown>): void;

--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -102,6 +102,18 @@ export function linkedSignalSetFn<S, D>(node: LinkedSignalNode<S, D>, newValue: 
 export function linkedSignalUpdateFn<S, D>(node: LinkedSignalNode<S, D>, updater: (value: D) => D): void;
 
 // @public (undocumented)
+export function passiveRead<T>(signal: () => T): PassiveReadResult<T>;
+
+// @public
+export type PassiveReadResult<T> = {
+    hasValue: true;
+    value: T;
+} | {
+    hasValue: false;
+    value: undefined;
+};
+
+// @public (undocumented)
 export type PreviousValue<S, D> = {
     source: S;
     value: D;
@@ -109,6 +121,9 @@ export type PreviousValue<S, D> = {
 
 // @public
 export function producerAccessed(node: ReactiveNode): void;
+
+// @public
+export function producerAccessedPassively(node: ReactiveNode): void;
 
 // @public
 export function producerIncrementEpoch(): void;
@@ -179,7 +194,7 @@ export function runPostSignalSetFn<T>(node: SignalNode<T>): void;
 // @public (undocumented)
 export function setActiveConsumer(consumer: ReactiveNode | null): ReactiveNode | null;
 
-// @public
+// @public (undocumented)
 export function setAlternateWeakRefImpl(impl: unknown): void;
 
 // @public (undocumented)

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -9,6 +9,7 @@
 import {installDevToolsSignalFormatter} from './src/formatter';
 
 export {ComputedNode, createComputed, ERRORED} from './src/computed';
+export {passiveRead, PassiveReadResult} from './src/passive_read';
 export {
   ComputationFn,
   LinkedSignalNode,
@@ -37,6 +38,7 @@ export {
   isInNotificationPhase,
   isReactive,
   producerAccessed,
+  producerAccessedPassively,
   producerIncrementEpoch,
   producerMarkClean,
   producerNotifyConsumers,

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -82,6 +82,7 @@ export const REACTIVE_NODE: ReactiveNode = {
 interface ReactiveLink {
   producer: ReactiveNode;
   consumer: ReactiveNode;
+  isPassive: boolean;
 
   /**
    * Stores the epoch that holds when this link was observed, allowing subsequent observations of the same producer to
@@ -210,6 +211,19 @@ export interface ReactiveNode {
  * Called by implementations when a producer's signal is read.
  */
 export function producerAccessed(node: ReactiveNode): void {
+  producerAccessedWithOptions(node, false);
+}
+
+/**
+ * Called when a producer's signal is passively read by a consumer.
+ *
+ * Passive dependencies receive change notifications but do not cause the producer to be polled.
+ */
+export function producerAccessedPassively(node: ReactiveNode): void {
+  producerAccessedWithOptions(node, true);
+}
+
+function producerAccessedWithOptions(node: ReactiveNode, isPassive: boolean): void {
   if (inNotificationPhase) {
     throw new Error(
       typeof ngDevMode !== 'undefined' && ngDevMode
@@ -230,6 +244,7 @@ export function producerAccessed(node: ReactiveNode): void {
   // If the last producer we accessed is the same as the current one, we can skip adding a new
   // link
   if (prevProducerLink !== undefined && prevProducerLink.producer === node) {
+    updateProducerLinkType(prevProducerLink, node, activeConsumer, isPassive);
     return;
   }
 
@@ -249,6 +264,7 @@ export function producerAccessed(node: ReactiveNode): void {
       activeConsumer.producersTail = nextProducerLink;
       nextProducerLink.lastReadVersion = node.version;
       nextProducerLink.knownValidAtEpoch = epoch;
+      updateProducerLinkType(nextProducerLink, node, activeConsumer, isPassive);
       return;
     }
   }
@@ -266,7 +282,9 @@ export function producerAccessed(node: ReactiveNode): void {
   }
 
   // If we got here, it means that we need to create a new link between the producer and the consumer.
-  const isLive = consumerIsLive(activeConsumer);
+  // Passive dependencies must be live so their consumers are notified when the producer becomes
+  // dirty, even when the consumer would otherwise rely on polling.
+  const isLive = isPassive || consumerIsLive(activeConsumer);
   const newLink: ReactiveLink = {
     producer: node,
     consumer: activeConsumer,
@@ -280,6 +298,7 @@ export function producerAccessed(node: ReactiveNode): void {
     prevConsumer: undefined,
     knownValidAtEpoch: epoch,
     lastReadVersion: node.version,
+    isPassive,
     nextConsumer: undefined,
   };
   activeConsumer.producersTail = newLink;
@@ -292,6 +311,35 @@ export function producerAccessed(node: ReactiveNode): void {
   if (isLive) {
     producerAddLiveConsumer(node, newLink);
   }
+}
+
+/**
+ * Update a reused dependency link when the consumer changes between an active and passive read.
+ *
+ * Passive links must remain in the producer's live-consumer list even when their consumer is not
+ * otherwise live, so that invalidation is propagated without polling the producer.
+ */
+function updateProducerLinkType(
+  link: ReactiveLink,
+  producer: ReactiveNode,
+  consumer: ReactiveNode,
+  isPassive: boolean,
+): void {
+  if (link.isPassive === isPassive) {
+    return;
+  }
+
+  if (!consumerIsLive(consumer)) {
+    if (isPassive) {
+      // The link became passive, so it now needs invalidation notifications.
+      producerAddLiveConsumer(producer, link);
+    } else {
+      // The link became active again and no longer keeps this consumer live by itself.
+      producerRemoveLiveConsumerLink(link);
+    }
+  }
+
+  link.isPassive = isPassive;
 }
 
 /**
@@ -454,6 +502,16 @@ export function finalizeConsumerAfterComputation(node: ReactiveNode): void {
       do {
         toRemove = producerRemoveLiveConsumerLink(toRemove);
       } while (toRemove !== undefined);
+    } else {
+      for (
+        let link: ReactiveLink | undefined = toRemove;
+        link !== undefined;
+        link = link.nextProducer
+      ) {
+        if (link.isPassive) {
+          producerRemoveLiveConsumerLink(link);
+        }
+      }
     }
 
     // Now, we can truncate the producers list to remove all stale links.
@@ -472,6 +530,13 @@ export function finalizeConsumerAfterComputation(node: ReactiveNode): void {
 export function consumerPollProducersForChange(node: ReactiveNode): boolean {
   // Poll producers for change.
   for (let link = node.producers; link !== undefined; link = link.nextProducer) {
+    if (link.isPassive) {
+      if (link.producer.dirty || link.lastReadVersion !== link.producer.version) {
+        return true;
+      }
+      continue;
+    }
+
     const producer = link.producer;
     const seenVersion = link.lastReadVersion;
 
@@ -504,6 +569,12 @@ export function consumerDestroy(node: ReactiveNode): void {
     let link = node.producers;
     while (link !== undefined) {
       link = producerRemoveLiveConsumerLink(link);
+    }
+  } else {
+    for (let link = node.producers; link !== undefined; link = link.nextProducer) {
+      if (link.isPassive) {
+        producerRemoveLiveConsumerLink(link);
+      }
     }
   }
 

--- a/packages/core/primitives/signals/src/passive_read.ts
+++ b/packages/core/primitives/signals/src/passive_read.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {COMPUTING, ERRORED, UNSET} from './computed';
+import {producerAccessedPassively, ReactiveNode, SIGNAL} from './graph';
+
+// Required as the signals library is in a separate package, so we need to explicitly ensure the
+// global `ngDevMode` type is defined.
+declare const ngDevMode: boolean | undefined;
+
+export type PassiveReadResult<T> =
+  | {
+      /** Whether the signal has a computed value. */
+      hasValue: true;
+      /** The current value of the signal. */
+      value: T;
+    }
+  | {
+      /** The signal is unset or still computing, so no forced recomputation occurred. */
+      hasValue: false;
+      /** Undefined because the signal has not yet been computed. */
+      value: undefined;
+    };
+
+export function passiveRead<T>(signal: () => T): PassiveReadResult<T> {
+  const node = (signal as any)?.[SIGNAL] as ReactiveNode | undefined;
+
+  if (!node) {
+    throw new Error(
+      typeof ngDevMode !== 'undefined' && ngDevMode
+        ? 'passiveRead: provided value is not a signal'
+        : '',
+    );
+  }
+
+  producerAccessedPassively(node);
+
+  const currentValue = (node as any).value;
+  const hasValue = currentValue !== UNSET && currentValue !== COMPUTING && currentValue !== ERRORED;
+
+  return hasValue ? {hasValue: true, value: currentValue} : {hasValue: false, value: undefined};
+}

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -17,6 +17,7 @@ export {
   ɵunwrapWritableSignal,
 } from './render3/reactivity/signal';
 export {linkedSignal} from './render3/reactivity/linked_signal';
+export {passiveRead, PassiveReadResult} from './render3/reactivity/passive_read';
 export {untracked} from './render3/reactivity/untracked';
 export {
   CreateEffectOptions,

--- a/packages/core/src/render3/reactivity/passive_read.ts
+++ b/packages/core/src/render3/reactivity/passive_read.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  passiveRead as passiveReadPrimitive,
+  PassiveReadResult as PassiveReadResultPrimitive,
+} from '../../../primitives/signals';
+
+/**
+ * Result of a passive signal read operation.
+ *
+ * Indicates whether a signal has a computed value available and provides access to it.
+ *
+ * @publicApi
+ */
+export type PassiveReadResult<T> = PassiveReadResultPrimitive<T>;
+
+/**
+ * Performs a passive read of a signal without triggering its recomputation.
+ *
+ * This utility allows reading a signal's current value within a reactive context
+ * (effect or computed) without forcing the signal to recompute if it is currently dirty.
+ * The caller is still registered as a dependent, so the reactive context will re-run
+ * when the signal's value changes.
+ *
+ * Use this when you need to conditionally observe a signal without triggering
+ * expensive computations or side effects.
+ *
+ * @param signal The signal getter to read passively
+ *
+ * @see [Reading without triggering recomputation](guide/signals#reading-without-triggering-recomputation)
+ * @publicApi 22.2
+ */
+export function passiveRead<T>(signal: () => T): PassiveReadResult<T> {
+  return passiveReadPrimitive(signal);
+}

--- a/packages/core/test/signals/passive_read_spec.ts
+++ b/packages/core/test/signals/passive_read_spec.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {computed, passiveRead, signal} from '../../src/core';
+
+import {flushEffects, resetEffects, testingEffect} from './effect_util';
+
+describe('passiveRead', () => {
+  afterEach(() => {
+    resetEffects();
+  });
+
+  it('should return an uncomputed signal without computing it', () => {
+    let computations = 0;
+    const value = computed(() => ++computations);
+
+    expect(passiveRead(value)).toEqual({hasValue: false, value: undefined});
+    expect(computations).toBe(0);
+  });
+
+  it('should return a cached value without recomputing a dirty signal', () => {
+    const source = signal(1);
+    let computations = 0;
+    const value = computed(() => {
+      computations++;
+      return source() * 2;
+    });
+
+    expect(value()).toBe(2);
+    source.set(2);
+
+    expect(passiveRead(value)).toEqual({hasValue: true, value: 2});
+    expect(computations).toBe(1);
+  });
+
+  it('should track a passive dependency from a computed without recomputing it', () => {
+    const source = signal(1);
+    let valueComputations = 0;
+    const value = computed(() => {
+      valueComputations++;
+      return source() * 2;
+    });
+    let observerComputations = 0;
+    const observer = computed(() => {
+      observerComputations++;
+      const result = passiveRead(value);
+      return result.hasValue ? result.value : -1;
+    });
+
+    expect(value()).toBe(2);
+    expect(observer()).toBe(2);
+    expect(valueComputations).toBe(1);
+
+    source.set(2);
+
+    expect(observer()).toBe(2);
+    expect(valueComputations).toBe(1);
+    expect(observerComputations).toBe(2);
+  });
+
+  it('should remove a passive dependency when a computed stops reading it', () => {
+    const shouldRead = signal(true);
+    const source = signal(1);
+    const value = computed(() => source() * 2);
+    let observerComputations = 0;
+    const observer = computed(() => {
+      observerComputations++;
+      if (!shouldRead()) {
+        return -1;
+      }
+
+      const result = passiveRead(value);
+      return result.hasValue ? result.value : -1;
+    });
+
+    expect(value()).toBe(2);
+    expect(observer()).toBe(2);
+
+    shouldRead.set(false);
+    expect(observer()).toBe(-1);
+
+    source.set(2);
+    expect(observer()).toBe(-1);
+    expect(observerComputations).toBe(2);
+  });
+
+  it('should schedule an effect when a passively read signal becomes dirty', () => {
+    const source = signal(1);
+    let computations = 0;
+    const value = computed(() => {
+      computations++;
+      return source() * 2;
+    });
+    const results: number[] = [];
+    let runs = 0;
+
+    expect(value()).toBe(2);
+
+    testingEffect(() => {
+      runs++;
+      const result = passiveRead(value);
+      if (result.hasValue) {
+        results.push(result.value);
+      }
+    });
+
+    flushEffects();
+    expect(results).toEqual([2]);
+    expect(computations).toBe(1);
+
+    source.set(2);
+    flushEffects();
+    expect(runs).toBe(2);
+    expect(results).toEqual([2, 2]);
+    expect(computations).toBe(1);
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

There is currently no way to read a signal within a reactive context while both (1) tracking it as a dependency and (2) avoiding forced recomputation if it is dirty

Issue Number: #67741 

## What is the new behavior?

Adds `passiveRead()` to read a signal's value without forcing recomputation, still tracking as a dependency

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
