### PR TITLE
fix(docs-infra): parse docs-callout attributes correctly

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-callout.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-callout.mts
@@ -27,11 +27,13 @@ interface DocsCalloutToken extends Tokens.Generic {
 
 // Capture group 1: all attributes on the opening tag
 // Capture group 2: all content between the open and close tags
-const calloutRule = /^<docs-callout([^>]*)>((?:.(?!\/docs-callout))*)<\/docs-callout>/s;
+const calloutRule =
+  /^<docs-callout((?:[^>"'`]|"[^"]*"|'[^']*'|`[^`]*`)*)>((?:.(?!\/docs-callout))*)<\/docs-callout>/s;
 
-const titleRule = /title="([^"]*)"/;
-const isImportantRule = /important/;
-const isCriticalRule = /critical/;
+const titleRule = /title=(['"`])(.*?)\1/; // The 2nd capture matters here
+const attributeValueRule = /=(['"`])(?:.*?)\1/gs;
+const isImportantRule = /\bimportant\b/;
+const isCriticalRule = /\bcritical\b/;
 
 export const docsCalloutExtension = {
   name: 'docs-callout',
@@ -46,9 +48,12 @@ export const docsCalloutExtension = {
       const attr = match[1].trim();
       const title = titleRule.exec(attr);
 
+      // Severity is a bare word on the tag, so it must not be matched inside an attribute value.
+      const flags = attr.replace(attributeValueRule, '');
+
       let severityLevel = CalloutSeverityLevel.HELPFUL;
-      if (isImportantRule.exec(attr)) severityLevel = CalloutSeverityLevel.IMPORTANT;
-      if (isCriticalRule.exec(attr)) severityLevel = CalloutSeverityLevel.CRITICAL;
+      if (isImportantRule.exec(flags)) severityLevel = CalloutSeverityLevel.IMPORTANT;
+      if (isCriticalRule.exec(flags)) severityLevel = CalloutSeverityLevel.CRITICAL;
 
       const body = match[2].trim();
 
@@ -56,7 +61,7 @@ export const docsCalloutExtension = {
         type: 'docs-callout',
         raw: match[0],
         severityLevel: severityLevel,
-        title: title ? title[1] : '',
+        title: title ? title[2] : '',
         titleTokens: [],
         body: body ?? '',
         bodyTokens: [],

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-callout/docs-callout.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-callout/docs-callout.spec.mts
@@ -25,4 +25,56 @@ describe('markdown to html', () => {
       markdownDocument.querySelector('#default-marker')!.parentElement?.parentElement;
     calloutDiv?.classList.contains('docs-callout-helpful');
   });
+
+  const parse = (markdown: string) => JSDOM.fragment(parseMarkdown(markdown, rendererContext));
+
+  it('reads a title quoted with any of the supported quote characters', () => {
+    for (const quote of ['"', "'", '`']) {
+      expect(
+        parse(`<docs-callout title=${quote}Quoted${quote}>Body</docs-callout>`).querySelector('h3')
+          ?.textContent,
+      )
+        .withContext(`quoted with ${quote}`)
+        .toBe('Quoted');
+    }
+  });
+
+  it('reads a title that contains the other quote characters', () => {
+    expect(
+      parse(
+        `<docs-callout title='Illustrating the "pristine" state'>Body</docs-callout>`,
+      ).querySelector('h3')?.textContent,
+    ).toBe('Illustrating the "pristine" state');
+    expect(
+      parse(`<docs-callout title="It's here">Body</docs-callout>`).querySelector('h3')?.textContent,
+    ).toBe("It's here");
+  });
+
+  it('reads a title that contains a closing angle bracket', () => {
+    expect(
+      parse('<docs-callout title="Migrate a > b">Body</docs-callout>').querySelector('h3')
+        ?.textContent,
+    ).toBe('Migrate a > b');
+  });
+
+  it('takes the severity from the tag, not from the title text', () => {
+    expect(
+      parse('<docs-callout title="Why this is important">Body</docs-callout>').querySelector(
+        '.docs-callout',
+      )?.className,
+    ).toBe('docs-callout docs-callout-helpful');
+    expect(
+      parse('<docs-callout title="A critical note">Body</docs-callout>').querySelector(
+        '.docs-callout',
+      )?.className,
+    ).toBe('docs-callout docs-callout-helpful');
+    expect(
+      parse('<docs-callout important title="X">Body</docs-callout>').querySelector('.docs-callout')
+        ?.className,
+    ).toBe('docs-callout docs-callout-important');
+    expect(
+      parse('<docs-callout critical title="X">Body</docs-callout>').querySelector('.docs-callout')
+        ?.className,
+    ).toBe('docs-callout docs-callout-critical');
+  });
 });

--- a/adev/src/content/guide/i18n/prepare.md
+++ b/adev/src/content/guide/i18n/prepare.md
@@ -265,7 +265,7 @@ other { default_quantity }
 
 HELPFUL: For more information about pluralization categories, see [Choosing plural category names][UnicodeCldrIndexCldrSpecPluralRulesTocChoosingPluralCategoryNames] in the [CLDR - Unicode Common Locale Data Repository][UnicodeCldrMain].
 
-<docs-callout header='Background: Locales may not support some pluralization categories'>
+<docs-callout title="Background: Locales may not support some pluralization categories">
 
 Many locales don't support some of the pluralization categories.
 The default locale \(`en-US`\) uses a very simple `plural()` function that doesn't support the `few` pluralization category.


### PR DESCRIPTION
adev's `<docs-callout>` reads its attributes with a few small regexes that
were too strict in three ways.

The visible one: the title was only picked up with double quotes. Two
pages use single quotes, one of them because its title contains
"pristine". Both render with no heading on angular.dev today.

Two more nobody has hit yet: a title containing `>` was dropped, and the
severity flags matched anywhere in the tag, so a callout titled "Why this
is important" would quietly turn orange.

Attributes are now parsed with quoting in mind. Tests cover all three.

https://angular.dev/guide/forms/template-driven-forms#:~:text=check-,In%20this%20example%2C,-you%20hide%20the

Before:
<img width="847" height="299" alt="Screenshot 2026-08-31 at 18 12 55" src="https://github.com/user-attachments/assets/474e110d-bf2c-4f9a-a06c-9e4c65020271" />

After:
<img width="856" height="343" alt="Screenshot 2026-08-31 at 18 12 48" src="https://github.com/user-attachments/assets/0bfb9232-fb48-4691-bd4e-2360b7bad58c" />

