### PR TITLE
fix(vscode-extension): handle escaped delimiters in inline template

### DIFF
--- a/vscode-ng-language-service/syntaxes/inline-styles.json
+++ b/vscode-ng-language-service/syntaxes/inline-styles.json
@@ -75,7 +75,7 @@
       ]
     },
     "style": {
-      "begin": "\\s*([`|'|\"])",
+      "begin": "\\s*([`'\"])",
       "beginCaptures": {
         "1": {
           "name": "string"
@@ -89,6 +89,10 @@
       },
       "contentName": "source.css.scss",
       "patterns": [
+        {
+          "match": "\\\\[\\s\\S]",
+          "name": "constant.character.escape.ts"
+        },
         {
           "include": "source.css.scss"
         }

--- a/vscode-ng-language-service/syntaxes/inline-template.json
+++ b/vscode-ng-language-service/syntaxes/inline-template.json
@@ -50,7 +50,7 @@
       ]
     },
     "ngTemplate": {
-      "begin": "\\G\\s*([`|'|\"])",
+      "begin": "\\G\\s*([`'\"])",
       "beginCaptures": {
         "1": {
           "name": "string"
@@ -64,6 +64,10 @@
       },
       "contentName": "text.html.derivative",
       "patterns": [
+        {
+          "match": "\\\\[\\s\\S]",
+          "name": "constant.character.escape.ts"
+        },
         {
           "include": "text.html.derivative"
         },

--- a/vscode-ng-language-service/syntaxes/src/inline-styles.ts
+++ b/vscode-ng-language-service/syntaxes/src/inline-styles.ts
@@ -44,13 +44,18 @@ export const InlineStyles: GrammarDefinition = {
     },
 
     style: {
-      begin: /\s*([`|'|"])/,
+      begin: /\s*([`'"])/,
       beginCaptures: {1: {name: 'string'}},
       // @ts-ignore
       end: /\1/,
       endCaptures: {0: {name: 'string'}},
       contentName: 'source.css.scss',
-      patterns: [{include: 'source.css.scss'}],
+      patterns: [
+        // Consume escape sequences first so that an escaped delimiter (e.g. \`)
+        // does not terminate the style string prematurely.
+        {match: /\\[\s\S]/, name: 'constant.character.escape.ts'},
+        {include: 'source.css.scss'},
+      ],
     },
   },
 };

--- a/vscode-ng-language-service/syntaxes/src/inline-template.ts
+++ b/vscode-ng-language-service/syntaxes/src/inline-template.ts
@@ -32,13 +32,19 @@ export const InlineTemplate: GrammarDefinition = {
     },
 
     ngTemplate: {
-      begin: /\G\s*([`|'|"])/,
+      begin: /\G\s*([`'"])/,
       beginCaptures: {1: {name: 'string'}},
       // @ts-ignore
       end: /\1/,
       endCaptures: {0: {name: 'string'}},
       contentName: 'text.html.derivative',
-      patterns: [{include: 'text.html.derivative'}, {include: 'template.ng'}],
+      patterns: [
+        // Consume escape sequences first so that an escaped delimiter (e.g. \`)
+        // does not terminate the template string prematurely.
+        {match: /\\[\s\S]/, name: 'constant.character.escape.ts'},
+        {include: 'text.html.derivative'},
+        {include: 'template.ng'},
+      ],
     },
   },
 };

--- a/vscode-ng-language-service/syntaxes/test/data/inline-styles.ts
+++ b/vscode-ng-language-service/syntaxes/test/data/inline-styles.ts
@@ -22,5 +22,9 @@
   styles:  `.example { width: 100px; }` ,
   styles:  ".example { width: 100px; }" ,
   styles:  '.example { width: 100px; }' ,
+
+//// Escaped delimiter tests
+  styles: [ `.example::before { content: '\`'; }` ],
+  styles: [ '.example::before { content: "\'"; }' ],
 })
 export class TMComponent{}

--- a/vscode-ng-language-service/syntaxes/test/data/inline-styles.ts.snap
+++ b/vscode-ng-language-service/syntaxes/test/data/inline-styles.ts.snap
@@ -150,6 +150,39 @@
 #                                      ^ inline-styles.ng string
 #                                       ^ inline-styles.ng
 #                                        ^^ inline-styles.ng
+>
+>//// Escaped delimiter tests
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+>  styles: [ `.example::before { content: '\`'; }` ],
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^ inline-styles.ng
+#          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#           ^ inline-styles.ng
+#            ^ inline-styles.ng string
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css.scss
+#                                          ^^ inline-styles.ng source.css.scss constant.character.escape.ts
+#                                            ^^^^ inline-styles.ng source.css.scss
+#                                                ^ inline-styles.ng string
+#                                                 ^ inline-styles.ng
+#                                                  ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#                                                   ^^ inline-styles.ng
+>  styles: [ '.example::before { content: "\'"; }' ],
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^ inline-styles.ng
+#          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#           ^ inline-styles.ng
+#            ^ inline-styles.ng string
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css.scss
+#                                          ^^ inline-styles.ng source.css.scss constant.character.escape.ts
+#                                            ^^^^ inline-styles.ng source.css.scss
+#                                                ^ inline-styles.ng string
+#                                                 ^ inline-styles.ng
+#                                                  ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#                                                   ^^ inline-styles.ng
 >})
 #^^^ inline-styles.ng
 >export class TMComponent{}

--- a/vscode-ng-language-service/syntaxes/test/data/inline-template.ts
+++ b/vscode-ng-language-service/syntaxes/test/data/inline-template.ts
@@ -30,3 +30,17 @@ export class TMComponent{}
   template: '{{property}}',
 })
 export class TMComponent{}
+
+/* Escaped delimiter tests */
+@Component({
+  //// Escaped backtick test
+  template: `<button title="\`code\`">Hello</button>`,
+
+  //// Escaped quote tests
+  template: '<div title="it\'s">Hello</div>',
+  template: "<div title=\"quoted\">Hello</div>",
+
+  //// Escaped backslash before the closing delimiter
+  template: `<div>backslash \\</div>`,
+})
+export class TMComponent{}

--- a/vscode-ng-language-service/syntaxes/test/data/inline-template.ts.snap
+++ b/vscode-ng-language-service/syntaxes/test/data/inline-template.ts.snap
@@ -118,3 +118,68 @@
 >export class TMComponent{}
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >
+>/* Escaped delimiter tests */
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>@Component({
+#^^^^^^^^^^^^^ inline-template.ng
+>  //// Escaped backtick test
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>  template: `<button title="\`code\`">Hello</button>`,
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng string
+#             ^^^^^^^^^^^^^^^ inline-template.ng text.html.derivative
+#                            ^^ inline-template.ng text.html.derivative constant.character.escape.ts
+#                              ^^^^ inline-template.ng text.html.derivative
+#                                  ^^ inline-template.ng text.html.derivative constant.character.escape.ts
+#                                    ^^^^^^^^^^^^^^^^ inline-template.ng text.html.derivative
+#                                                    ^ inline-template.ng string
+#                                                     ^^ inline-template.ng
+>
+>  //// Escaped quote tests
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>  template: '<div title="it\'s">Hello</div>',
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng string
+#             ^^^^^^^^^^^^^^ inline-template.ng text.html.derivative
+#                           ^^ inline-template.ng text.html.derivative constant.character.escape.ts
+#                             ^^^^^^^^^^^^^^ inline-template.ng text.html.derivative
+#                                           ^ inline-template.ng string
+#                                            ^^ inline-template.ng
+>  template: "<div title=\"quoted\">Hello</div>",
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng string
+#             ^^^^^^^^^^^ inline-template.ng text.html.derivative
+#                        ^^ inline-template.ng text.html.derivative constant.character.escape.ts
+#                          ^^^^^^ inline-template.ng text.html.derivative
+#                                ^^ inline-template.ng text.html.derivative constant.character.escape.ts
+#                                  ^^^^^^^^^^^^ inline-template.ng text.html.derivative
+#                                              ^ inline-template.ng string
+#                                               ^^ inline-template.ng
+>
+>  //// Escaped backslash before the closing delimiter
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>  template: `<div>backslash \\</div>`,
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng string
+#             ^^^^^^^^^^^^^^^ inline-template.ng text.html.derivative
+#                            ^^ inline-template.ng text.html.derivative constant.character.escape.ts
+#                              ^^^^^^ inline-template.ng text.html.derivative
+#                                    ^ inline-template.ng string
+#                                     ^^ inline-template.ng
+>})
+#^^^ inline-template.ng
+>export class TMComponent{}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>


### PR DESCRIPTION
The TextMate grammars for inline templates and inline styles ended the string at the first occurrence of the delimiter, so an escaped delimiter (e.g. \`) terminated the highlighting prematurely and the rest of the template was no longer highlighted as HTML.

Escape sequences are now consumed before delegating to the HTML/CSS grammars, so escaped delimiters no longer end the string. Also removes the stray pipes from the string delimiter character class, which unintentionally matched a literal '|'.

Fixes #65493

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: #65493

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
