### PR TITLE
feat(common): support default locale in DATE_PIPE_DEFAULT_OPTIONS

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -156,6 +156,8 @@ export interface DatePipeConfig {
     // (undocumented)
     dateFormat?: string;
     // (undocumented)
+    locale?: string;
+    // (undocumented)
     timezone?: string;
 }
 

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -30,6 +30,8 @@ export const DATE_PIPE_DEFAULT_TIMEZONE = new InjectionToken<string>(
  * will use the 'mediumDate' as a value.
  * - `timezone`: configures the default timezone. If not provided, the `DatePipe` will
  * use the end-user's local system timezone.
+ * - `locale`: configures the default locale. If not provided, the `DatePipe` will
+ * use the value of `LOCALE_ID` (which is `en-US` by default).
  *
  * @see {@link DatePipeConfig}
  *
@@ -51,6 +53,13 @@ export const DATE_PIPE_DEFAULT_TIMEZONE = new InjectionToken<string>(
  * ```ts
  * providers: [
  *   {provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone: '-1200'}}
+ * ]
+ * ```
+ *
+ * Override the default locale by providing a value using the token:
+ * ```ts
+ * providers: [
+ *   {provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {locale: 'fr'}}
  * ]
  * ```
  */
@@ -240,7 +249,9 @@ export class DatePipe implements PipeTransform {
    * the `timezone` property). If the token is not configured, the end-user's local system
    * timezone is used as a value.
    * @param locale A locale code for the locale format rules to use.
-   * When not supplied, uses the value of `LOCALE_ID`, which is `en-US` by default.
+   * When not supplied, the `DatePipe` looks for the value using the
+   * `DATE_PIPE_DEFAULT_OPTIONS` injection token (and reads the `locale` property).
+   * If the token is not configured, uses the value of `LOCALE_ID`, which is `en-US` by default.
    * See [Setting your app locale](guide/i18n/locale-id).
    *
    * @see {@link DATE_PIPE_DEFAULT_OPTIONS}
@@ -272,7 +283,8 @@ export class DatePipe implements PipeTransform {
       const _format = format ?? this.defaultOptions?.dateFormat ?? DEFAULT_DATE_FORMAT;
       const _timezone =
         timezone ?? this.defaultOptions?.timezone ?? this.defaultTimezone ?? undefined;
-      return formatDate(value, _format, locale || this.locale, _timezone);
+      const _locale = locale || this.defaultOptions?.locale || this.locale;
+      return formatDate(value, _format, _locale, _timezone);
     } catch (error) {
       throw invalidPipeArgumentError(DatePipe, (error as Error).message);
     }

--- a/packages/common/src/pipes/date_pipe_config.ts
+++ b/packages/common/src/pipes/date_pipe_config.ts
@@ -17,6 +17,7 @@
 export interface DatePipeConfig {
   dateFormat?: string;
   timezone?: string;
+  locale?: string;
 }
 
 /**

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -11,13 +11,17 @@ import {TestBed} from '@angular/core/testing';
 import {DATE_PIPE_DEFAULT_OPTIONS, DatePipe} from '../../index';
 import localeEn from '../../locales/en';
 import localeEnExtra from '../../locales/extra/en';
+import localeFr from '../../locales/fr';
 
 describe('DatePipe', () => {
   const isoStringWithoutTime = '2015-01-01';
   let pipe: DatePipe;
   let date: Date;
 
-  beforeAll(() => ɵregisterLocaleData(localeEn, localeEnExtra));
+  beforeAll(() => {
+    ɵregisterLocaleData(localeEn, localeEnExtra);
+    ɵregisterLocaleData(localeFr);
+  });
   afterAll(() => ɵunregisterLocaleData());
 
   beforeEach(() => {
@@ -208,6 +212,69 @@ describe('DatePipe', () => {
 
       const content = fixture.nativeElement.textContent;
       expect(content).toBe('Jan 10, 2017');
+    });
+
+    it('should use default locale provided in DATE_PIPE_DEFAULT_OPTIONS when no locale is passed explicitly', async () => {
+      @Component({
+        selector: 'test-component',
+        imports: [DatePipe],
+        template: "{{ value | date:'fullDate' }}",
+      })
+      class TestComponent {
+        value = '2017-01-11T10:14:39+0000';
+      }
+
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+        providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {locale: 'fr'}}],
+      });
+      const fixture = TestBed.createComponent(TestComponent);
+      await fixture.whenStable();
+
+      const content = fixture.nativeElement.textContent;
+      expect(content).toBe('mercredi 11 janvier 2017');
+    });
+
+    it('should override default locale when locale is passed explicitly', async () => {
+      @Component({
+        selector: 'test-component',
+        imports: [DatePipe],
+        template: "{{ value | date:'fullDate':'':'en-US' }}",
+      })
+      class TestComponent {
+        value = '2017-01-11T10:14:39+0000';
+      }
+
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+        providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {locale: 'fr'}}],
+      });
+      const fixture = TestBed.createComponent(TestComponent);
+      await fixture.whenStable();
+
+      const content = fixture.nativeElement.textContent;
+      expect(content).toBe('Wednesday, January 11, 2017');
+    });
+
+    it('should fallback to global LOCALE_ID when no default locale is configured', async () => {
+      @Component({
+        selector: 'test-component',
+        imports: [DatePipe],
+        template: "{{ value | date:'fullDate' }}",
+      })
+      class TestComponent {
+        value = '2017-01-11T10:14:39+0000';
+      }
+
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+        providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {dateFormat: 'fullDate'}}],
+      });
+      const fixture = TestBed.createComponent(TestComponent);
+      await fixture.whenStable();
+
+      const content = fixture.nativeElement.textContent;
+      expect(content).toBe('Wednesday, January 11, 2017');
     });
   });
 


### PR DESCRIPTION
Adds support for configuring a default locale globally/locally for DatePipe instances via the DATE_PIPE_DEFAULT_OPTIONS injection token.

Closes #70488

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the `DatePipe` allows overriding format and timezone defaults globally using the `DATE_PIPE_DEFAULT_OPTIONS` injection token. However, there is no way to globally set a default locale specifically for the `DatePipe`. Developers have to pass the locale explicitly to every `date` pipe template invocation or change the global `LOCALE_ID` token, which affects all other locale-sensitive formatting globally.

Issue Number: #70470

## What is the new behavior?

This PR introduces support for configuring a default `locale` property in `DATE_PIPE_DEFAULT_OPTIONS`. If no locale is explicitly passed to the `date` pipe in the template, the pipe falls back to using the default locale provided by the token, before falling back to the global `LOCALE_ID`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
