### PR TITLE
ci: remove shared primitives pullapprove group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -302,7 +302,7 @@ groups:
     conditions:
       - >
         contains_any_globs(files
-            .exclude('.pullapprove.yml') 
+            .exclude('.pullapprove.yml')
             .exclude('tools/manual_api_docs/blocks/*.md')
             .exclude('tools/manual_api_docs/elements/*.md')
             .exclude('.agent/**/*.md'),
@@ -484,23 +484,9 @@ groups:
         - ~thePunderWoman # Jessica Janiuk
         - ~AndrewKushnir # Andrew Kushnir
         - atscott # Andrew Scott
-
-  # External team required reviews
-  primitives-shared:
-    <<: *defaults
-    conditions:
-      - >
-        contains_any_globs(files.exclude('packages/core/primitives/**/*spec.ts'), [
-          'packages/core/primitives/**/{*,.*}',
-        ])
-    reviewers:
-      users:
-        - csmick # Cameron Smick
-        - mturco # Matt Turco
-        - iteriani # Thomas Nguyen
-        - tbondwilkinson # Tom Wilkinson
         - rahatarmanahmed # Rahat Ahmed
         - e-cline # Ethan Cline
+        - rockymeza # Rocky Meza
 
   ####################################################################################
   # Override managed result groups


### PR DESCRIPTION
This group is no longer necessary as responsibilities for that are now spread amongst teams more equally.
