### PR TITLE
fix(upgrade): delay linking projected AngularJS nodes

### DIFF
--- a/packages/upgrade/src/common/src/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/src/downgrade_component_adapter.ts
@@ -28,9 +28,11 @@ import {
 } from '@angular/core';
 
 import {
+  element as angularElement,
   IAttributes,
   IAugmentedJQuery,
   ICompileService,
+  ILinkFn,
   INgModelController,
   IParseService,
   IScope,
@@ -48,6 +50,7 @@ export class DowngradeComponentAdapter {
   private inputChangeCount: number = 0;
   private inputChanges: SimpleChanges = {};
   private componentScope: IScope;
+  private projectableNodesLinkFns: ILinkFn[] = [];
 
   constructor(
     private element: IAugmentedJQuery,
@@ -66,20 +69,15 @@ export class DowngradeComponentAdapter {
   }
 
   compileContents(): Node[][] {
-    const compiledProjectableNodes: Node[][] = [];
-    const projectableNodes: Node[][] = this.groupProjectableNodes();
-    const linkFns = projectableNodes.map((nodes) => this.$compile(nodes));
+    // `$compile()` may replace root nodes (e.g. `ng-if` replaces its element with a comment).
+    // Wrapping each group ensures that these replacements are reflected in the nodes passed to
+    // Angular for projection.
+    const projectableNodes = this.groupProjectableNodes().map((nodes) => angularElement(nodes));
+    this.projectableNodesLinkFns = projectableNodes.map((nodes) => this.$compile(nodes));
 
     this.element.empty!();
 
-    linkFns.forEach((linkFn) => {
-      linkFn(this.scope, (clone: Node[]) => {
-        compiledProjectableNodes.push(clone);
-        this.element.append!(clone);
-      });
-    });
-
-    return compiledProjectableNodes;
+    return projectableNodes;
   }
 
   createComponentAndSetup(
@@ -183,7 +181,10 @@ export class DowngradeComponentAdapter {
     }
 
     // Invoke `ngOnChanges()` and Change Detection (when necessary)
-    const detectChanges = () => changeDetector.detectChanges();
+    const detectChanges = () => {
+      changeDetector.detectChanges();
+      this.linkProjectableNodes();
+    };
     const prototype = this.component.prototype;
     this.implementsOnChanges = !!(prototype && (<OnChanges>prototype).ngOnChanges);
 
@@ -221,6 +222,17 @@ export class DowngradeComponentAdapter {
         const appRef = this.parentInjector.get<ApplicationRef>(ApplicationRef);
         appRef.attachView(componentRef.hostView);
       });
+    }
+  }
+
+  private linkProjectableNodes(): void {
+    // AngularJS structural directives need their root markers to have a parent before linking.
+    // Angular creates embedded views containing projection slots during change detection, so link
+    // the projected nodes only after the component has completed its first change detection.
+    const linkFns = this.projectableNodesLinkFns;
+    this.projectableNodesLinkFns = [];
+    for (const linkFn of linkFns) {
+      linkFn(this.scope);
     }
   }
 

--- a/packages/upgrade/static/test/integration/content_projection_spec.ts
+++ b/packages/upgrade/static/test/integration/content_projection_spec.ts
@@ -27,7 +27,7 @@ import {
   withEachNg1Version,
 } from '../../../src/common/test/helpers/common_test_helpers';
 
-import {bootstrap} from './static_test_helpers';
+import {$apply, bootstrap} from './static_test_helpers';
 
 withEachNg1Version(() => {
   describe('content projection', () => {
@@ -109,6 +109,42 @@ withEachNg1Version(() => {
 
       bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
         expect(multiTrim(document.body.textContent)).toBe('ng2-a( 123 )ng2-b( 456 )ng2-c( 789 )');
+      });
+    }));
+
+    it('should project root AngularJS structural directives into an Angular embedded view', waitForAsync(() => {
+      @Component({
+        selector: 'ng2',
+        template: '<div *ngIf="true"><ng-content></ng-content></div>',
+        standalone: false,
+      })
+      class Ng2Component {}
+
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        declarations: [Ng2Component],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
+
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2', downgradeComponent({component: Ng2Component}))
+        .run(($rootScope: angular.IRootScopeService) => {
+          $rootScope['show'] = true;
+        });
+
+      const element = html('<ng2><div ng-if="show">projected content</div></ng2>');
+
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(element.textContent).toBe('projected content');
+
+        $apply(upgrade, 'show = false');
+        expect(element.textContent).toBe('');
+
+        $apply(upgrade, 'show = true');
+        expect(element.textContent).toBe('projected content');
       });
     }));
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (not applicable: no public API or documented behavior changes)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Projected AngularJS content is linked before the downgraded Angular component renders its projection slots. If a root AngularJS structural directive such as `ng-if` is projected into an Angular embedded view, its marker has no parent during the first digest and the initial content cannot be inserted.

Fixes #16685

## What is the new behavior?

Root replacements produced by AngularJS compilation are passed to Angular as the projectable nodes, while AngularJS linking is deferred until after the component's first change detection. This preserves the existing input and lifecycle timing while ensuring projected structural directive markers are attached before linking.

The regression test covers initial rendering and subsequent toggling of a root `ng-if` across AngularJS 1.5 through 1.8 in Chromium and Firefox.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated with:

- `pnpm bazel test //packages/upgrade/src/common/test //packages/upgrade/static/test`
- `pnpm bazel test //packages/upgrade/...`
- `pnpm tslint`
- `pnpm ng-dev format changed --check`
