### PR TITLE
WebMCP annotations

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -2139,6 +2139,7 @@ export interface WebMcpClient {
 
 // @public
 export interface WebMcpToolDescriptor<InputSchema extends JsonSchemaForInference> {
+    annotations?: Annotations;
     description: string;
     execute: WebMcpToolExecute<InputSchema>;
     inputSchema: InputSchema;

--- a/packages/core/src/webmcp/types.ts
+++ b/packages/core/src/webmcp/types.ts
@@ -22,7 +22,7 @@ import type {
 /**
  * The client context of a given WebMCP tool execution.
  *
- * @experimental
+ * @experimental 22.0
  */
 export interface Client {
   // Mostly empty for now until we have more clarity of what this will contain.
@@ -43,7 +43,7 @@ export interface Client {
  * @param client The client context invoking the tool.
  * @returns The result of executing the tool which will be serialized and provided back
  *     to the connected agent. This is typically just a raw `string`.
- * @experimental
+ * @experimental 22.0
  */
 export type Execute<InputSchema extends JsonSchemaForInference> = (
   args: InferArgsFromInputSchema<InputSchema>,
@@ -57,9 +57,30 @@ export interface ToolRegistrationOptions {
 }
 
 /**
+ * Annotations for a WebMCP tool which describe its behavior.
+ *
+ * @experimental 22.2
+ */
+export interface Annotations {
+  /**
+   * A hint that the tool will not modify user-visible state (e.g. it will not trigger
+   * a navigation, mutate the DOM, or alter data stored on a backend). Agents may be
+   * more likely to use tools which are explicitly declared read-only as they are
+   * safer against potential misuse.
+   */
+  readOnlyHint?: boolean;
+
+  /**
+   * A hint that the tool will return untrusted content from the perspective of the
+   * author of the tool.
+   */
+  untrustedContentHint?: boolean;
+}
+
+/**
  * Describes and implements a specific WebMCP tool for an agent to invoke.
  *
- * @experimental
+ * @experimental 22.0
  */
 export interface ToolDescriptor<InputSchema extends JsonSchemaForInference> {
   /** The unique name of this tool. */
@@ -76,6 +97,9 @@ export interface ToolDescriptor<InputSchema extends JsonSchemaForInference> {
 
   /** The callback function which implements this tool. */
   execute: Execute<InputSchema>;
+
+  /** Optional annotations describing the tool's behavior and safety properties. */
+  annotations?: Annotations;
 }
 
 /** The `window.document.modelContext` object for imperatively registering WebMCP tools. */

--- a/packages/core/test/webmcp/declare_tool_spec.ts
+++ b/packages/core/test/webmcp/declare_tool_spec.ts
@@ -62,6 +62,36 @@ describe('declareExperimentalWebMcpTool', () => {
     });
   });
 
+  it('should pass tool annotations to registerTool', async () => {
+    const execute = jasmine.createSpy<Execute<JsonSchemaForInference>>('execute');
+    const modelContext = (globalThis.document as any).modelContext;
+    const registerSpy = spyOn(modelContext, 'registerTool').and.callThrough();
+
+    await declareExperimentalWebMcpTool(
+      {
+        name: 'annotatedTool',
+        description: 'A tool with annotations',
+        inputSchema: {type: 'object', properties: {}},
+        execute,
+        annotations: {
+          readOnlyHint: true,
+          untrustedContentHint: true,
+        },
+      },
+      Injector.create({providers: []}),
+    );
+
+    expect(registerSpy).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        annotations: {
+          readOnlyHint: true,
+          untrustedContentHint: true,
+        },
+      }),
+      jasmine.anything(),
+    );
+  });
+
   it('should throw if the tool is already registered', async () => {
     const injector = Injector.create({providers: []});
 

--- a/packages/forms/signals/src/webmcp/registration.ts
+++ b/packages/forms/signals/src/webmcp/registration.ts
@@ -55,6 +55,15 @@ async function initWebMcpForm(
       name: options.name,
       description: options.description,
       inputSchema,
+      annotations: {
+        // Forms are assumed to implicitly mutate the DOM (otherwise how would a user interact with them?)
+        // and therefore are _never_ read-only.
+        readOnlyHint: false,
+
+        // Response text is currently hard-coded by the framework and trusted or derived from application
+        // errors which are considered trusted.
+        untrustedContentHint: false,
+      },
       execute: async (args: Record<string, unknown>) => {
         // Populate the form with changes from the agent.
         node.value.set(args);

--- a/packages/forms/signals/test/web/webmcp.spec.ts
+++ b/packages/forms/signals/test/web/webmcp.spec.ts
@@ -40,6 +40,9 @@ describe('Signal Forms WebMCP Integration', () => {
         },
       });
 
+      const modelContext = (globalThis.document as any).modelContext;
+      const registerSpy = spyOn(modelContext, 'registerTool').and.callThrough();
+
       TestBed.runInInjectionContext(() => {
         form(model, {
           experimentalWebMcpTool: {
@@ -49,6 +52,16 @@ describe('Signal Forms WebMCP Integration', () => {
         });
       });
       await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(registerSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          annotations: {
+            readOnlyHint: false,
+            untrustedContentHint: false,
+          },
+        }),
+        jasmine.anything(),
+      );
 
       const registeredTools = globalThis.navigator.modelContextTesting!.listTools();
       expect(registeredTools[0].name).toBe('testFormTool');


### PR DESCRIPTION
This adds support for annotations to Angular's experimental WebMCP support.

`annotations` is a newly supported option for `declareExperimentalWebMcpTool` and passes through whatever value it is given.

Implicit WebMCP tools in signal forms always set `{readOnlyHint: false, untrustedContentHint: false}` and are not configurable as those are the only options which make logical sense in the context of a user-visible form. See the second commit for more details on that front.

See: https://webmachinelearning.github.io/webmcp/#annotations

/cc @kulikowski