### PR TITLE
fix(common): parse hash-prefixed URLs in the AngularJS $location shim

### DIFF
--- a/packages/common/upgrade/src/location_shim.ts
+++ b/packages/common/upgrade/src/location_shim.ts
@@ -421,10 +421,18 @@ export class $locationShim {
     let pathUrl: string | undefined;
     if (url.startsWith('/')) {
       pathUrl = url;
+    } else if (url.startsWith('#')) {
+      // Hash strategy: the app URL comes in `#`-prefixed, e.g. `#/user/123`
+      pathUrl = url.substring(1);
     } else {
       // Remove protocol & hostname if URL starts with it
       pathUrl = this.stripBaseUrl(this.getServerBase(), url);
+      // Hash strategy leaves a `#` right after the server base, e.g. `http://host.com/#/user/123`
+      if (pathUrl?.startsWith('#')) {
+        pathUrl = pathUrl.substring(1);
+      }
     }
+
     if (typeof pathUrl === 'undefined') {
       throw new Error(`Invalid url "${url}", missing path prefix "${this.getServerBase()}".`);
     }

--- a/packages/common/upgrade/test/upgrade.spec.ts
+++ b/packages/common/upgrade/test/upgrade.spec.ts
@@ -8,7 +8,7 @@
 
 import {inject, TestBed} from '@angular/core/testing';
 import {UpgradeModule} from '@angular/upgrade/static';
-import {CommonModule} from '../../index';
+import {CommonModule, Location} from '../../index';
 
 import {$locationShim} from '../src/location_shim';
 
@@ -743,6 +743,67 @@ describe('$location.onChange()', () => {
     $location.url('/newUrl');
     mock$rootScope.runWatchers();
     expect(error.message).toBe('Handle error');
+  });
+});
+
+describe('$location with HashLocationStrategy (useHash: true)', () => {
+  let $location: $locationShim;
+  let location: Location;
+  let upgradeModule: UpgradeModule;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        LocationUpgradeTestModule.config({useHash: true, startUrl: 'http://host.com/'}),
+      ],
+      providers: [UpgradeModule],
+    });
+
+    upgradeModule = TestBed.inject(UpgradeModule);
+    upgradeModule.$injector = {get: injectorFactory()};
+  });
+
+  beforeEach(inject([$locationShim, Location], (loc: $locationShim, ngLocation: Location) => {
+    $location = loc;
+    location = ngLocation;
+  }));
+
+  it('should parse a bare hash-prefixed URL', () => {
+    $location.$$parse('#/foo');
+
+    expect($location.path()).toBe('/foo');
+    expect($location.absUrl()).toBe('http://host.com/foo');
+  });
+
+  it('should keep the search params and fragment of a hash-prefixed URL', () => {
+    $location.$$parse('#/foo?a=b&c=d#section');
+
+    expect($location.path()).toBe('/foo');
+    expect($location.search()).toEqual({a: 'b', c: 'd'});
+    expect($location.hash()).toBe('section');
+  });
+
+  it('should parse a hash-prefixed URL that still has the server base', () => {
+    // The shape of `PlatformLocation.href` when the app boots on a deep link.
+    $location.$$parse('http://host.com/#/user/123');
+
+    expect($location.path()).toBe('/user/123');
+  });
+
+  it('should still reject a URL pointing at a different server', () => {
+    expect(() => $location.$$parse('http://other.server.org/#/path')).toThrowError(
+      'Invalid url "http://other.server.org/#/path", missing path prefix "http://host.com/".',
+    );
+  });
+
+  it('should follow a navigation made through the Angular Location service', () => {
+    // `Location.go()` (what the Router calls) hands the shim a `#`-prefixed URL via
+    // `onUrlChange`. This used to throw `Invalid url "#/foo", missing path prefix`.
+    expect(() => location.go('/foo')).not.toThrow();
+
+    expect($location.path()).toBe('/foo');
+    expect($location.absUrl()).toBe('http://host.com/foo');
   });
 });
 


### PR DESCRIPTION
When LocationUpgradeModule is set up with useHash: true, the $location shim gets URLs that start with a "#" (like "#/foo"). This happens on startup from PlatformLocation.href, and on every navigation because the Angular Location service reports the URL through onUrlChange with the "#" still on it.

The shim's $$parse only knew how to deal with a plain "/path" or a full "http://host/path" URL, so anything starting with "#" blew up with 'Invalid url "#/", missing path prefix ...' and routing never started.

Now $$parse drops a leading "#" (either on its own or right after the server base) before it parses the rest, so hash mode works. Path mode is not affected since those URLs never start with "#".

Fixes #31882
Fixes #34600