### PR TITLE
docs: highlight the search tutorial @for block as Angular

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/13-search/README.md
+++ b/adev/src/content/tutorials/first-app/steps/13-search/README.md
@@ -46,7 +46,7 @@ The `Home` already contains an input field that you will use to capture input fr
 
 1. The last template update is to the `@for` directive. Update the `@for` to iterate over values from the `filteredLocationList` array.
 
-   <docs-code header="Update the @for template directive in home.ts" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.ts" visibleLines="[17,19]" language="html"/>
+   <docs-code language="angular-ts" header="Update the @for template directive in home.ts" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.ts" visibleLines="[17,19]"/>
 
 </docs-step>
 


### PR DESCRIPTION
The block quotes a `.ts` file but declares `language="html"`, and shiki's HTML grammar does not know Angular control flow, so the whole `@for` line renders unstyled. Use `angular-ts`, matching the other blocks in the tutorial.

https://angular.dev/tutorials/first-app/13-search#:~:text=The%20last%20template%20update%20is%20to%20the

Before:
<img width="1041" height="282" alt="image" src="https://github.com/user-attachments/assets/ce23f071-b64b-4b9a-9913-2570a5788766" />

After:
<img width="1011" height="265" alt="image" src="https://github.com/user-attachments/assets/4ef42f30-edbc-47f1-a8ab-65fd0c66d32b" />
