### PR TITLE
fix(core): don't fail NgModule checks for a pipe that extends a base class

### DIFF
--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -306,17 +306,32 @@ function verifySemanticsOfNgModuleDef(
     }
   }
 
+  /**
+   * Checks that a directive declared in the module actually has a selector.
+   *
+   * This does the following:
+   * 1. Reads the directive definition off the type. This also finds a definition that the type
+   *    inherited from a base class.
+   * 2. Skips the check if the type is really a component or a pipe. Components don't need a
+   *    selector, and a pipe can inherit a directive definition from an abstract base class (for
+   *    example a base class that only adds a lifecycle hook) - that inherited definition belongs
+   *    to the base class, not to the pipe.
+   * 3. Otherwise, if the directive has a definition but no selectors, adds an error telling the
+   *    user to add one.
+   */
   function verifyDirectivesHaveSelector(type: Type<any>): void {
     type = resolveForwardRef(type);
     const def = getDirectiveDef(type);
-    if (!getComponentDef(type) && def && def.selectors.length == 0) {
+    if (!getComponentDef(type) && !getPipeDef(type) && def && def.selectors.length == 0) {
       errors.push(`Directive ${stringifyForError(type)} has no selector, please add it!`);
     }
   }
 
   function verifyNotStandalone(type: Type<any>, moduleType: NgModuleType): void {
     type = resolveForwardRef(type);
-    const def = getComponentDef(type) || getDirectiveDef(type) || getPipeDef(type);
+    // Check the pipe def first: a pipe that extends an abstract directive base class also has
+    // an (inherited) directive def, and we want the pipe's own `standalone` flag here.
+    const def = getPipeDef(type) || getComponentDef(type) || getDirectiveDef(type);
     if (def?.standalone) {
       const location = `"${stringifyForError(moduleType)}" NgModule`;
       errors.push(generateStandaloneInDeclarationsError(type, location));

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1384,6 +1384,41 @@ describe('integration tests', function () {
       expect(() => TestBed.createComponent(MyComp)).not.toThrowError();
     });
 
+    it('should not throw when a declared pipe extends an abstract directive base class', () => {
+      // https://github.com/angular/angular/issues/36427
+      // An abstract base class with a lifecycle hook is compiled as a selector-less
+      // directive. A pipe that extends it inherits that directive def, which used to trip
+      // the "has no selector" (and later the "is standalone") NgModule checks.
+      @Directive({standalone: false})
+      abstract class NonStandaloneBase implements OnDestroy {
+        ngOnDestroy() {}
+      }
+
+      @Pipe({name: 'nonStandalonePipe', standalone: false})
+      class NonStandalonePipe extends NonStandaloneBase implements PipeTransform {
+        transform(value: unknown): unknown {
+          return value;
+        }
+      }
+
+      @Directive()
+      abstract class StandaloneBase implements OnDestroy {
+        ngOnDestroy() {}
+      }
+
+      @Pipe({name: 'standaloneDefaultPipe', standalone: false})
+      class StandaloneDefaultPipe extends StandaloneBase implements PipeTransform {
+        transform(value: unknown): unknown {
+          return value;
+        }
+      }
+
+      TestBed.configureTestingModule({
+        declarations: [MyComp, NonStandalonePipe, StandaloneDefaultPipe],
+      });
+      expect(() => TestBed.createComponent(MyComp)).not.toThrowError();
+    });
+
     it('should throw when using directives with empty string selector', () => {
       @Directive({
         selector: '',


### PR DESCRIPTION
When an abstract base class has something like a lifecycle hook, Angular compiles it as a directive with no selector. If a pipe extends that base class, the pipe picks up the base class's directive definition through normal class inheritance.

The NgModule dev-mode checks then got confused by that inherited definition and reported the pipe as a broken directive:

  - "Directive SomePipe has no selector, please add it!"
  - or, if the base class was a default (standalone) abstract directive, "SomePipe is marked as standalone and can't be declared..."

Both only happened in tests (TestBed), not when running the app.

Now the selector check and the standalone check both look at the pipe's own definition and ignore a directive definition that only came from a base class.

Fixes #36427