### PR TITLE
fix(docs-infra): keep the collapsed code state when a code block is r…

### DIFF
--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
@@ -21,7 +21,7 @@
         [class.docs-example-code-toggle__show]="!showCode()"
         [attr.aria-checked]="showCode()"
         [attr.aria-label]="showCode() ? 'Hide code' : 'Show code'"
-        (click)="showCode.set(!showCode())"
+        (click)="toggleCodeVisibility()"
         [matTooltip]="showCode() ? 'Hide code' : 'Show code'"
         matTooltipPosition="above"
       >

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
@@ -116,6 +116,15 @@ export class ExampleViewer {
     this.setCodeLinesVisibility();
   }
 
+  toggleCodeVisibility(): void {
+    const showCode = !this.showCode();
+    this.showCode.set(showCode);
+
+    if (showCode) {
+      afterNextRender(() => this.setCodeLinesVisibility(), {injector: this.injector});
+    }
+  }
+
   copyLink(): void {
     // Reconstruct the URL using `origin + pathname` so we drop any pre-existing hash.
     const fullUrl =


### PR DESCRIPTION
Click Hide code then Show code on one, and it comes back showing the entire file, with the expand button still offering to expand it. 

Hiding destroys the block's DOM, and nothing reapplied the line trimming when it
was rebuilt. The fix reapplies it after the block renders again, keeping whichever
state you were in: collapsed comes back collapsed, expanded comes back expanded.

https://angular.dev/guide/forms/signals/validation#the-schema-function

Before: 

https://github.com/user-attachments/assets/016a6e22-307f-432f-9a06-06545f8ce575

After:

https://github.com/user-attachments/assets/cefe7492-8599-4d1e-8da5-9481629171fd

