### PR TITLE
fix(common): honor CSS scroll-margin when scrolling to an anchor

### DIFF
--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -168,10 +168,15 @@ export class BrowserViewportScroller implements ViewportScroller {
     const left = rect.left + this.window.pageXOffset;
     const top = rect.top + this.window.pageYOffset;
     const offset = this.offset();
+    // Also honor the element's CSS `scroll-margin`, the way the browser does when scrolling to a
+    // native fragment target. `scroll-padding` on the scroll container is not accounted for.
+    const style = this.window.getComputedStyle(el);
+    const scrollMarginTop = parseFloat(style.scrollMarginTop) || 0;
+    const scrollMarginLeft = parseFloat(style.scrollMarginLeft) || 0;
     this.window.scrollTo({
       ...options,
-      left: left - offset[0],
-      top: top - offset[1],
+      left: left - offset[0] - scrollMarginLeft,
+      top: top - offset[1] - scrollMarginTop,
     });
   }
 }

--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -128,6 +128,37 @@ describe('BrowserViewportScroller', () => {
       cleanup();
     });
 
+    it('should honor the element `scroll-margin-top`', () => {
+      // https://github.com/angular/angular/issues/55383
+      const {anchorNode, cleanup} = createTallElement();
+      anchorNode.id = anchor;
+      anchorNode.style.scrollMarginTop = '40px';
+      document.body.style.paddingBottom = '5000px';
+
+      scroller.scrollToAnchor(anchor);
+
+      // The element ends up 40px below the viewport top, matching native fragment scrolling.
+      expect(Math.round(anchorNode.getBoundingClientRect().top)).toBe(40);
+
+      document.body.style.paddingBottom = '';
+      cleanup();
+    });
+
+    it('should combine `scroll-margin-top` with the configured offset', () => {
+      const {anchorNode, cleanup} = createTallElement();
+      anchorNode.id = anchor;
+      anchorNode.style.scrollMarginTop = '40px';
+      document.body.style.paddingBottom = '5000px';
+      scroller.setOffset([0, 80]);
+
+      scroller.scrollToAnchor(anchor);
+
+      expect(Math.round(anchorNode.getBoundingClientRect().top)).toBe(120);
+
+      document.body.style.paddingBottom = '';
+      cleanup();
+    });
+
     it('should honor the scroll offset when smooth scrolling', async () => {
       // Ensure the scroll behavior is smooth for this test, as the bug only occurred with smooth scrolling.
       document.documentElement.style.scrollBehavior = 'smooth';


### PR DESCRIPTION
BrowserViewportScroller.scrollToElement only subtracted the offset
configured via setOffset(), ignoring the element's CSS scroll-margin.
Native fragment navigation (clicking an `<a>` element with an href
fragment) does take scroll-margin into account, so the router's anchor
scrolling landed the target flush at the top even when scroll-margin-top
was set to clear a sticky header.

Read the element's computed scroll-margin-top / scroll-margin-left and
subtract them too, on top of the configured offset. scroll-padding on
the scroll container is still not accounted for.

Fixes https://github.com/angular/angular/issues/55383