### PR TITLE
fix(devtools): safely handle foreign root elements in feature detection and discovery

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/component-tree/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/component-tree/BUILD.bazel
@@ -35,6 +35,7 @@ ts_test_library(
         ":get-roots",
         "//:node_modules/@angular/core",
         "//:node_modules/jasmine",
+        "//devtools/projects/ng-devtools-backend/src/lib/directive-forest:core-enums",
     ],
 )
 

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/component-tree/component-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/component-tree/component-tree.spec.ts
@@ -13,10 +13,12 @@ import {
   InjectionToken,
 } from '@angular/core';
 import {
+  getDirectiveCdStrategy,
   getInjectorFromElementNode,
   getRootElements,
   serializeProviderRecord,
 } from './component-tree';
+import {ChangeDetectionStrategy, Framework} from '../core-enums';
 
 type Ng = ɵExternalCoreGlobalUtils;
 const NG_VERSION = 'ng-version';
@@ -181,6 +183,25 @@ describe('component-tree', () => {
       );
 
       expect(result.token).toBe('InjectionToken (FOO)');
+    });
+  });
+
+  describe('getDirectiveCdStrategy', () => {
+    it('returns change detection strategy when passed valid component', () => {
+      const ng: Partial<Ng> = {
+        getDirectiveMetadata: jasmine.createSpy('getDirectiveMetadata').and.returnValue({
+          framework: Framework.Angular,
+          changeDetection: ChangeDetectionStrategy.OnPush,
+        } as any),
+      };
+      (globalThis as any).ng = ng;
+
+      const result = getDirectiveCdStrategy({
+        instance: {},
+        name: 'Foo',
+        isElement: false,
+      });
+      expect(result).toBe('ng-on-push');
     });
   });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/component-tree/component-tree.ts
@@ -228,9 +228,9 @@ const enum DirectiveMetadataKey {
 // Gets directive metadata. For newer versions of Angular (v12+) it uses
 // the global `getDirectiveMetadata`. For prior versions of the framework
 // the method directly interacts with the directive/component definition.
-const getDirectiveMetadata = (dir: any): DirectiveMetadata => {
-  const getMetadata = ngDebugClient().getDirectiveMetadata!;
-  const metadata = getMetadata?.(dir);
+function getDirectiveMetadata(dir: any): DirectiveMetadata {
+  const getMetadata = ngDebugClient().getDirectiveMetadata;
+  const metadata = dir ? getMetadata?.(dir) : null;
   if (metadata) {
     const {framework} = metadata;
     switch (framework) {
@@ -287,9 +287,9 @@ const getDirectiveMetadata = (dir: any): DirectiveMetadata => {
     encapsulation: safelyGrabMetadata(DirectiveMetadataKey.ENCAPSULATION),
     changeDetection: safelyGrabMetadata(DirectiveMetadataKey.CHANGE_DETECTION),
   };
-};
+}
 
-export function getDirectiveCdStrategy(dir: any): ChangeDetection | undefined {
+export function getDirectiveCdStrategy(dir: ComponentInstanceType): ChangeDetection | undefined {
   const metadata = getDirectiveMetadata(dir.instance);
 
   switch (metadata.framework) {

--- a/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/ng-debug-api.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/ng-debug-api.spec.ts
@@ -114,6 +114,23 @@ describe('ng-debug-api', () => {
 
       expect(ngDebugRoutesApiIsSupported()).toBeFalse();
     });
+
+    it('should ignore elements where getComponent returns null (e.g. extension elements)', () => {
+      const foreignRoot = document.createElement('foreign-extension-app');
+      foreignRoot.setAttribute('ng-version', '0.0.0-PLACEHOLDER');
+      document.body.appendChild(foreignRoot);
+
+      try {
+        const fakeNg = fakeNgGlobal(Framework.Angular);
+        const originalGetComponent = fakeNg.getComponent!;
+        fakeNg.getComponent = (el) => (el === foreignRoot ? null : originalGetComponent(el));
+        (globalThis as any).ng = fakeNg;
+
+        expect(ngDebugProfilerApiIsSupported()).toBeTrue();
+      } finally {
+        foreignRoot.remove();
+      }
+    });
   });
 
   describe('ngDebugRoutesApiIsSupported', () => {
@@ -190,6 +207,23 @@ describe('ng-debug-api', () => {
 
       (globalThis as any).ng = fakeNgGlobal(Framework.ACX);
       expect(ngDebugSignalPropertiesInspectionApiIsSupported()).toBeFalse();
+    });
+
+    it('should ignore elements where getComponent returns null (e.g. extension elements)', () => {
+      const foreignRoot = document.createElement('foreign-extension-app');
+      foreignRoot.setAttribute('ng-version', '0.0.0-PLACEHOLDER');
+      document.body.appendChild(foreignRoot);
+
+      try {
+        const fakeNg = fakeNgGlobal(Framework.Angular);
+        const originalGetComponent = fakeNg.getComponent!;
+        fakeNg.getComponent = (el) => (el === foreignRoot ? null : originalGetComponent(el));
+        (globalThis as any).ng = fakeNg;
+
+        expect(ngDebugSignalPropertiesInspectionApiIsSupported()).toBeTrue();
+      } finally {
+        foreignRoot.remove();
+      }
     });
   });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/ng-debug-api.ts
@@ -58,7 +58,7 @@ export function ngDebugProfilerApiIsSupported(): boolean {
   // Temporary solution. Convert to an eligible API when available.
   // https://github.com/angular/angular/pull/60585#discussion_r2017047132
   // If there is a Wiz application, make Profiler API unavailable.
-  const roots = getAppRoots();
+  const roots = getAppRoots().filter((el) => ng.getComponent?.(el));
   return (
     !!roots.length &&
     !roots.some((el) => {
@@ -98,7 +98,7 @@ export function ngDebugSignalPropertiesInspectionApiIsSupported(): boolean {
   const ng = ngDebugClient();
 
   // If all apps are Angular, make the API available.
-  const roots = getAppRoots();
+  const roots = getAppRoots().filter((el) => ng.getComponent?.(el));
   return (
     !!roots.length &&
     roots.every((el) => {

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -304,6 +304,9 @@ export type DirectiveDebugMetadata =
 export function getDirectiveMetadata(
   directiveOrComponentInstance: any,
 ): AngularComponentDebugMetadata | AngularDirectiveDebugMetadata | null {
+  if (!directiveOrComponentInstance) {
+    return null;
+  }
   const {constructor} = directiveOrComponentInstance;
   if (!constructor) {
     throw new Error('Unable to find the instance constructor');

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -405,6 +405,11 @@ describe('discovery utils', () => {
       expect(metadata!.inputs).toEqual({a: 'b'});
       expect(metadata!.outputs).toEqual({c: 'd'});
     });
+
+    it('should return null when passed null or undefined', () => {
+      expect(getDirectiveMetadata(null)).toBeNull();
+      expect(getDirectiveMetadata(undefined)).toBeNull();
+    });
   });
 });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When DOM elements matching `[ng-version]` are present on the page that do not belong to the host Angular application (e.g. elements injected by Chrome extensions such as IP Protect, or third-party web components), Angular DevTools feature detection in `ng-debug-api.ts` assumes every root element is an Angular component managed by `window.ng`.

Because `ng.getComponent(el)` returns `null` for these foreign elements, DevTools calls `ng.getDirectiveMetadata(null)`. In `@angular/core`, `getDirectiveMetadata` attempts to destructure `{constructor}` from `null`, throwing an unhandled `TypeError: Cannot destructure property 'constructor' of 'directiveOrComponentInstance' as it is null.` during DevTools initialization, causing DevTools to crash and fail to connect.

## What is the new behavior?
1. In `ng-devtools-backend`:
   - `ngDebugProfilerApiIsSupported()` and `ngDebugSignalPropertiesInspectionApiIsSupported()` safely guard against `null` / `undefined` components returned by `ng.getComponent(el)`.
   - `getDirectiveMetadata` and `getDirectiveCdStrategy` in `component-tree.ts` defensively guard against null/undefined instances.
2. In `@angular/core`:
   - `getDirectiveMetadata` returns `null` when invoked with `null` or `undefined`, matching its return type signature and preventing unhandled `TypeError` exceptions.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```