### PR TITLE
build: narrow the preview exclusions for two example apps

### DIFF
--- a/adev/src/content/examples/BUILD.bazel
+++ b/adev/src/content/examples/BUILD.bazel
@@ -16,9 +16,12 @@ copy_to_bin(
             "i18n/**",  # @angular/localize/init not available in docs app
             "elements/**",  # @angular/elements not available in docs app
             "service-worker-getting-started/**",  # @angular/service-worker not available in docs app
-            # TODO: The following examples have broken code that does not compile, fix them and remove them from this list.
-            "reactive-forms/**",
-            "form-validation/**",
+            # Partial snapshots quoted by the guides. Each shares the final template of
+            # the component it precedes, which references members it does not have yet.
+            "form-validation/src/app/reactive/actor-form-reactive.component.1.ts",
+            "form-validation/src/app/reactive/actor-form-reactive.component.2.ts",
+            "reactive-forms/src/app/profile-editor/profile-editor.component.1.ts",
+            "reactive-forms/src/app/profile-editor/profile-editor.component.2.ts",
         ],
     ),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
`reactive-forms` and `form-validation` were excluded from `embeddable` in full, with a TODO to fix them. The examples are fine; four partial snapshots quoted by the guides are not, since each shares the final template of the component it precedes, which references members it does not have yet. Excluding those four files clears all 30 errors and puts 23 app files back in the preview pool, so both guides' final components can be previewed for the first time.