### PR TITLE
fix(compiler): infer KeyboardEvent for keydown.enter style event bindings

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1353,6 +1353,16 @@ describe('type check blocks', () => {
         );
         expect(block).toContain('($event: any): any => { (this).foo($event); }');
       });
+
+      it('should register "keydown.enter" style bindings with the underlying DOM event name', () => {
+        const block = tcb(`<div (keydown.enter)="foo($event)" (keyup.Enter)="foo($event)"></div>`);
+        expect(block).toContain(
+          '.addEventListener("keydown", ($event): any => { (this).foo($event); })',
+        );
+        expect(block).toContain(
+          '.addEventListener("keyup", ($event): any => { (this).foo($event); })',
+        );
+      });
     });
 
     describe('config.checkTypeOfDomReferences', () => {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -1389,6 +1389,59 @@ runInEachFileSystem(() => {
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
       });
+
+      it('should infer $event as KeyboardEvent for "keydown.enter" style bindings', () => {
+        // https://github.com/angular/angular/issues/40778
+        env.write(
+          'test.ts',
+          `
+          import {Component, NgModule} from '@angular/core';
+
+          @Component({
+            selector: 'test',
+            template: '<div (keydown.enter)="update($event)"></div>',
+            standalone: false,
+          })
+          class TestCmp {
+            update(data: string) {}
+          }
+
+          @NgModule({declarations: [TestCmp]})
+          class Module {}
+        `,
+        );
+        env.tsconfig({strictTemplates: true});
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toEqual(
+          `Argument of type 'KeyboardEvent' is not assignable to parameter of type 'string'.`,
+        );
+      });
+
+      it('should not error when a "keyup.Enter" handler expects a KeyboardEvent', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, NgModule} from '@angular/core';
+
+          @Component({
+            selector: 'test',
+            template: '<div (keyup.Enter)="update($event)"></div>',
+            standalone: false,
+          })
+          class TestCmp {
+            update(event: KeyboardEvent) {}
+          }
+
+          @NgModule({declarations: [TestCmp]})
+          class Module {}
+        `,
+        );
+        env.tsconfig({strictTemplates: true});
+
+        expect(env.driveDiagnostics().length).toBe(0);
+      });
     });
 
     it('should check basic usage of NgIf', () => {

--- a/packages/compiler/src/typecheck/ops/events.ts
+++ b/packages/compiler/src/typecheck/ops/events.ts
@@ -21,6 +21,24 @@ import {LocalSymbol} from './references';
 
 const EVENT_PARAMETER = '$event';
 
+/**
+ * Matches combined key event names handled by KeyEventsPlugin,
+ * such as `keydown.enter` or `keyup.control.shift.a`.
+ */
+const KEY_EVENT_NAME_RE = /^(keydown|keyup)\..+$/i;
+
+/**
+ * Returns the DOM event name used for `$event` type inference.
+ *
+ * Combined key events aren't real DOM events, so they aren't present
+ * in HTMLElementEventMap. Use the underlying event instead to infer
+ * KeyboardEvent.
+ */
+function domEventNameForTypeInference(eventName: string): string {
+  const match = KEY_EVENT_NAME_RE.exec(eventName);
+  return match ? match[1].toLowerCase() : eventName;
+}
+
 const enum EventParamType {
   /* Generates code to infer the type of `$event` based on how the listener is registered. */
   Infer,
@@ -232,7 +250,9 @@ export class TcbUnclaimedOutputsOp extends TcbOp {
           domEventAssertion,
         );
         const call = new TcbExpr(
-          `${propertyAccess.print()}(${TcbExpr.quoteAndEscape(output.name)}, ${handler.print()})`,
+          `${propertyAccess.print()}(${TcbExpr.quoteAndEscape(
+            domEventNameForTypeInference(output.name),
+          )}, ${handler.print()})`,
         );
         call.addParseSpanInfo(output.sourceSpan);
         this.scope.addStatement(call);


### PR DESCRIPTION
With strict DOM event type checking on, an event binding like (keydown.enter)="onEnter($event)" typed $event as the generic Event instead of KeyboardEvent. The type check block generates an addEventListener call using the full binding name, and "keydown.enter" is not a real DOM event (it's expanded at runtime by KeyEventsPlugin), so TypeScript had no entry for it and fell back to Event.

Now the type check block uses the underlying event name (keydown or keyup) for these bindings, so $event is inferred as KeyboardEvent. Only the name used for type inference changes; the handler itself is untouched. This also covers @HostListener('keydown.enter') when typeCheckHostBindings is enabled.

Fixes #40778