### PR TITLE
docs: correct openFiles entries that point at missing files

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/05-inputs/config.json
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/config.json
@@ -3,5 +3,9 @@
   "type": "editor",
   "answerSrc": "../06-property-binding/src",
   "answerRootDir": "../06-property-binding/",
-  "openFiles": ["src/app/housing-location/housing-location.ts", "src/app/home/home.ts","src/app/housinglocations.ts"]
+  "openFiles": [
+    "src/app/housing-location/housing-location.ts",
+    "src/app/home/home.ts",
+    "src/app/housinglocation.ts"
+  ]
 }

--- a/adev/src/content/tutorials/signals/steps/5-component-communication-with-signals/config.json
+++ b/adev/src/content/tutorials/signals/steps/5-component-communication-with-signals/config.json
@@ -1,10 +1,5 @@
 {
-  "openFiles": [
-    "src/app/app.ts",
-    "src/app/product-card.ts",
-    "src/app/quantity-selector.ts",
-    "src/app/app.css"
-  ],
+  "openFiles": ["src/app/app.ts", "src/app/product-card.ts", "src/app/app.css"],
   "type": "editor",
   "title": "Passing data to components with input signals"
 }


### PR DESCRIPTION
Two tutorial steps list a file in `openFiles` that does not exist, and a missing entry is dropped without complaint. `first-app/05-inputs` asks for `housinglocations.ts` when the file is `housinglocation.ts`; since `hiddenFiles` is everything not in `openFiles`, the interface that step teaches was marked hidden rather than opened.
`signals/5-component-communication-with-signals` asks for `quantity-selector.ts`, which exists in neither `src` nor `answer`. Every openFiles entry in the tutorials now resolves.
