### PR TITLE
fix(common): let NgOptimizedImage pass a [srcset] binding through when srcset optimization is disabled

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -391,8 +391,10 @@ export class NgOptimizedImage implements OnInit, OnChanges {
 
   /**
    * Value of the `srcset` attribute if set on the host `<img>` element.
-   * This input is exclusively read to assert that `srcset` is not set in conflict
-   * with `ngSrcset` and that images don't start to load until a lazy loading strategy is set.
+   * This input is read to assert that `srcset` is not set in conflict with `ngSrcset` and that
+   * images don't start to load until a lazy loading strategy is set. When `disableOptimizedSrcset`
+   * is set, this value is also written back to the host element's `srcset` attribute (otherwise a
+   * `[srcset]` binding would be captured by this input and never reach the DOM).
    * @internal
    */
   @Input() srcset?: string;
@@ -692,6 +694,10 @@ export class NgOptimizedImage implements OnInit, OnChanges {
 
     if (rewrittenSrcset) {
       this.setHostAttribute('srcset', rewrittenSrcset);
+    } else if (this.disableOptimizedSrcset && this.srcset) {
+      // A `[srcset]` binding is captured by the `srcset` input rather than reaching the DOM. When
+      // the user opted out of optimized srcset generation, pass their value through unchanged.
+      this.setHostAttribute('srcset', this.srcset);
     }
     return rewrittenSrcset;
   }

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -2585,6 +2585,22 @@ describe('Image directive', () => {
         const img = nativeElement.querySelector('img')!;
         expect(img.getAttribute('srcset')).toBeNull();
       });
+
+      it('should pass a `[srcset]` binding through to the DOM when "disableOptimizedSrcset" is set', async () => {
+        // https://github.com/angular/angular/issues/49335
+        setupTestingModule({imageLoader});
+
+        const template = `
+      <img ngSrc="img" width="100" height="50" disableOptimizedSrcset
+           [srcset]="'https://example.com/a.png 1x, https://example.com/b.png 2x'">
+    `;
+        const fixture = createTestComponent(template);
+        await fixture.whenStable();
+        const img = (fixture.nativeElement as HTMLElement).querySelector('img')!;
+        expect(img.getAttribute('srcset')).toBe(
+          'https://example.com/a.png 1x, https://example.com/b.png 2x',
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
NgOptimizedImage declares a `srcset` input, so a `[srcset]="..."` binding is captured by the directive and never reaches the `<img>` element. The directive only reads that input for a conflict check, so with `disableOptimizedSrcset` the image ended up with no `srcset` at all. The only way to set one was `[attr.srcset]`.

Now, when `disableOptimizedSrcset` is set and the directive isn't generating its own srcset, the value from the `[srcset]` binding is written back to the element.

Fixes #49335