### PR TITLE
build(zone.js): fix release PR URL and filter changelog to zone.js scope

### DIFF
--- a/packages/zone.js/DEVELOPER.md
+++ b/packages/zone.js/DEVELOPER.md
@@ -34,8 +34,7 @@ Run all checks (lint/format/browser test/test-node):
 
 Please make sure you pass all following checks before commit
 
-- pnpm gulp lint (tslint)
-- pnpm gulp format (prettier)
+- pnpm lint (tslint and format)
 - pnpm promisetest (promise a+ test)
 - pnpm bazel test //packages/zone.js/... (all tests)
 
@@ -53,14 +52,7 @@ pnpm webdriver-test
 
 ## Releasing
 
-Releasing `zone.js` is a two step process.
-
-1. Create a PR which updates the changelog, and get it merged using normal merge process.
-2. Once the PR is merged check out the merge SHA of the PR and release `zone.js` from that SHA and tag it.
-
-### Automated Release
-
-You can use the automated release script which handles both steps (run from the root of the repo):
+Releasing `zone.js` is handled via the release script (run from the root of the repo):
 
 ```bash
 pnpm zonejs:release
@@ -68,55 +60,7 @@ pnpm zonejs:release
 
 Follow the interactive prompts to either create a PR or cut a release.
 
----
+Releasing is a two step process:
 
-### Manual Release (Legacy)
-
-#### 1. Creating a PR for release
-
-```
-rm -rf node_modules && pnpm install
-export PREVIOUS_ZONE_TAG=`git tag -l 'zone.js-0.15.*' | tail -n1`
-export VERSION=`(cd packages/zone.js; npm version patch --no-git-tag-version)`
-export VERSION=${VERSION#v}
-export TAG="zone.js-${VERSION}"
-echo "Releasing zone.js version ${TAG}. Last release was ${PREVIOUS_ZONE_TAG}."
-pnpm gulp changelog:zonejs
-```
-
-Inspect the `packages/zone.js/CHANGELOG.md` for any issues and than commit it with this command.
-
-Create a dry run build to make sure everything is ready.
-
-```
-pnpm bazel build //packages/zone.js:npm_package --workspace_status_command="echo STABLE_PROJECT_VERSION $VERSION"
-```
-
-If everything looks good, commit the changes and push them to your origin to create a PR.
-
-```
-git checkout -b "release_${TAG}"
-git add packages/zone.js/CHANGELOG.md packages/zone.js/package.json
-git commit -m "release: cut the ${TAG} release"
-git push origin "release_${TAG}"
-```
-
-#### 2. Cutting a release
-
-Check out the SHA on main which has the changelog commit of the zone.js
-
-```
-git fetch upstream
-git checkout upstream/main
-rm -rf node_modules && pnpm install
-export VERSION=`(node -e "console.log(require('./packages/zone.js/package.json').version)")`
-export TAG="zone.js-${VERSION}"
-export SHA=`git log upstream/main --oneline -n 1000 | grep "release: cut the ${TAG} release" | cut -f 1 -d " "`
-echo "Releasing '$VERSION' which will be tagged as '$TAG' from SHA '$SHA'."
-git checkout ${SHA}
-npm login --registry https://wombat-dressing-room.appspot.com
-pnpm bazel build //packages/zone.js:npm_package --config=release --workspace_status_command="echo STABLE_PROJECT_VERSION $VERSION"
-npm publish dist/bin/packages/zone.js/npm_package --access public --tag latest
-git tag ${TAG} ${SHA}
-git push upstream ${TAG}
-```
+1. **Create a PR for release**: updates the version in `packages/zone.js/package.json`, generates the `packages/zone.js/CHANGELOG.md` with all changes since the last zone.js release, runs a dry-run build, creates and pushes the release branch, and provides a PR link.
+2. **Cut a release (publish)**: once the PR is merged, check out the merged release commit, build the package with release config, publish to npm, and tag and push the `zone.js-<version>` release tag.

--- a/packages/zone.js/tools/release.mts
+++ b/packages/zone.js/tools/release.mts
@@ -85,7 +85,6 @@ async function createPrWorkflow(): Promise<void> {
   await updatingPackageJsonVersion(newVersion);
 
   // Generate changelog
-  // pnpm gulp changelog:zonejs
   console.log(chalk.blue('Generating changelog...'));
   await execAndStream('pnpm', ['gulp', 'changelog:zonejs'], {
     env: {
@@ -124,11 +123,14 @@ async function createPrWorkflow(): Promise<void> {
   console.log(chalk.blue(`Pushing to ${forkRemote}...`));
   await exec(`git push ${forkRemote} "${releaseBranch}"`);
 
-  console.log(
-    chalk.yellow(
-      `Please create a pull request by visiting: https://github.com/angular/angular/pull/new/${releaseBranch}`,
-    ),
-  );
+  const {stdout: remoteUrl} = await exec(`git remote get-url ${forkRemote}`);
+  const {owner, repo} = getRepoDetails(remoteUrl);
+  const prUrl =
+    owner === 'angular'
+      ? `https://github.com/angular/angular/compare/main...${releaseBranch}`
+      : `https://github.com/angular/angular/compare/main...${owner}:${repo}:${releaseBranch}`;
+
+  console.log(chalk.yellow(`Please create a pull request by visiting: ${prUrl}`));
 
   const continueToPublish = await select({
     message: 'Do you want to continue to the publish step once the PR is merged?',
@@ -177,7 +179,7 @@ async function cutReleaseWorkflow(): Promise<void> {
   console.log(chalk.blue(`Looking for release commit for ${tagName}...`));
   const commitMessagePattern = `release: cut the ${tagName} release`;
   const {stdout: sha} = await exec(
-    `git log FETCH_HEAD --oneline -n 1000 | grep "${commitMessagePattern}" | cut -f 1 -d " "`,
+    `git log FETCH_HEAD --grep="^${commitMessagePattern}" --format=format:%H -n 1`,
   );
 
   const trimmedSha = sha.trim();
@@ -230,7 +232,7 @@ async function cutReleaseWorkflow(): Promise<void> {
 async function cleanAndInstall() {
   console.log(chalk.blue('Cleaning and installing dependencies...'));
   await exec('git clean -dxf');
-  await execAndStream('pnpm', ['install', , '--frozen-lockfile']);
+  await execAndStream('pnpm', ['install', '--frozen-lockfile']);
 }
 
 async function checkCleanWorkingDirectory(): Promise<void> {
@@ -374,7 +376,7 @@ async function getForkRemoteName(): Promise<string> {
 }
 
 function getRepoDetails(remoteUrl: string): {owner: string; repo: string} {
-  const match = remoteUrl.trim().match(/github\.com[/:]([\w-]+)\/([\w-]+)/);
+  const match = remoteUrl.trim().match(/github\.com[/:]([\w-]+)\/([\w-]+?)(?:\.git)?$/);
   return {
     owner: match ? match[1] : 'angular',
     repo: match ? match[2] : 'angular',

--- a/tools/gulp-tasks/changelog-zonejs.js
+++ b/tools/gulp-tasks/changelog-zonejs.js
@@ -19,14 +19,19 @@ module.exports = (gulp) => () => {
       conventionalChangelog(
         {
           preset: 'angular',
+          tagPrefix: 'zone.js-',
         },
         {linkCompare: true, previousTag: ptag, currentTag: tag, version: version},
         {
-          // Ignore commits that have a different scope than `zone.js`.
-          extendedRegexp: true,
-          grep: '^((feat|fix|perf)\\(zone\\.js\\)|revert:.*\\(zone\\.js\\))',
           from: ptag,
           to: 'HEAD',
+        },
+        undefined,
+        {
+          transform: (commit) => {
+            if (commit.scope !== 'zone.js') return undefined;
+            return commit;
+          },
         },
       ),
     )


### PR DESCRIPTION
In recent conventional-changelog version updates, the underlying @conventional-changelog/git-client dropped support for the raw `grep` and `extendedRegexp` options, causing all monorepo commits to be included in the zone.js changelog. Additionally, without `tagPrefix: 'zone.js-'`, conventional-changelog treated monorepo release tags as release boundaries, generating changelog sections for every intermediate monorepo release.

This change:
- Configures `tagPrefix: 'zone.js-'` and filters commits by `scope === 'zone.js'` via `writerOpts.transform` in the gulp changelog task.
- Fixes the PR creation link in the release script to use the cross-fork compare URL format on GitHub.
- Fixes the release commit SHA lookup in `cutReleaseWorkflow`.
- Updates zone.js release documentation.
