### PR TITLE
feat(router): support waitFor option in nonBlocking

### DIFF
--- a/packages/router/src/operators/setup_and_run_resources.ts
+++ b/packages/router/src/operators/setup_and_run_resources.ts
@@ -13,7 +13,7 @@ import {
   DestroyRef,
 } from '@angular/core';
 import {OperatorFunction, pipe} from 'rxjs';
-import {ResourceContext, ResourceResult} from '../models';
+import {RedirectCommand, ResourceContext, ResourceResult} from '../models';
 import {NavigationTransition} from '../navigation_transition';
 import {ActivatedRoute, ActivatedRouteSnapshot, initializeActivatedRoute} from '../router_state';
 import {TreeNode} from '../utils/tree';
@@ -21,6 +21,7 @@ import {
   BLOCKING_SYMBOL,
   hasValueOrResolved,
   InternalRouterResource,
+  NonBlockingOptions,
   routerResource,
   SOURCE_RESOURCE_SYMBOL,
 } from '../router_resource';
@@ -183,9 +184,13 @@ function setupBlocking(
 
   for (const r of Object.values(resourceResult)) {
     const res = r as InternalRouterResource;
-    if (res[BLOCKING_SYMBOL] === false) {
+    const blockingConfig = res[BLOCKING_SYMBOL];
+    if (blockingConfig === false) {
       continue;
     }
+
+    const waitForPromise = (blockingConfig as NonBlockingOptions)?.waitFor;
+
     const promise = new Promise<void>((resolve, reject) => {
       const underlyingRes = res[SOURCE_RESOURCE_SYMBOL];
       let isDestroyed = false;
@@ -205,6 +210,14 @@ function setupBlocking(
 
       abortSignal.addEventListener('abort', onAbort, {once: true});
 
+      if (waitForPromise) {
+        const done = () => {
+          cleanup();
+          resolve();
+        };
+        waitForPromise.then(done, done);
+      }
+
       const blockingEffect = effect(
         () => {
           if (isDestroyed) {
@@ -213,7 +226,12 @@ function setupBlocking(
           const status = underlyingRes.status();
           if (status === 'error') {
             cleanup();
-            reject(underlyingRes.error());
+            const error = underlyingRes.error();
+            if (waitForPromise && !(error instanceof RedirectCommand)) {
+              resolve();
+            } else {
+              reject(error);
+            }
           } else if (hasValueOrResolved(underlyingRes)) {
             cleanup();
             resolve();

--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -12,5 +12,5 @@ export {loadChildren as ɵloadChildren} from './router_config_loader';
 export {ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
 export {afterNextNavigation as ɵafterNextNavigation} from './utils/navigations';
 export {withRouterResources as ɵwithRouterResources} from './provide_router';
-export {nonBlocking as ɵnonBlocking} from './router_resource';
+export {nonBlocking as ɵnonBlocking, NonBlockingOptions as ɵNonBlockingOptions} from './router_resource';
 export {ResourceContext as ɵResourceContext, ResourceResult as ɵResourceResult} from './models';

--- a/packages/router/src/router_resource.ts
+++ b/packages/router/src/router_resource.ts
@@ -49,21 +49,35 @@ export function hasValueOrResolved(res: Resource<unknown>): boolean {
 }
 
 /**
+ * Options for configuring non-blocking router resources.
+ * @developerPreview
+ */
+export interface NonBlockingOptions {
+  /**
+   * A `Promise` that holds navigation until it settles, after which the navigation
+   * completes and the resource continues loading in the background.
+   */
+  waitFor?: Promise<unknown>;
+}
+
+export type BlockingConfig = boolean | NonBlockingOptions;
+
+/**
  * @internal
  */
 export interface InternalRouterResource<T = unknown> extends Resource<T> {
   [SOURCE_RESOURCE_SYMBOL]: Resource<T>;
-  [BLOCKING_SYMBOL]?: boolean;
+  [BLOCKING_SYMBOL]?: BlockingConfig;
   reload(): boolean;
 }
 
 /**
  * Marks a resource as non-blocking. The Router will NOT wait for this resource to resolve
- * before completing the navigation.
- * @experimental
+ * before completing the navigation, unless a `waitFor` promise is specified.
+ * @developerPreview
  */
-export function nonBlocking<T, R extends Resource<T>>(res: R): R {
-  (res as unknown as InternalRouterResource<T>)[BLOCKING_SYMBOL] = false;
+export function nonBlocking<T, R extends Resource<T>>(res: R, options?: NonBlockingOptions): R {
+  (res as unknown as InternalRouterResource<T>)[BLOCKING_SYMBOL] = options ?? false;
   return res;
 }
 
@@ -85,8 +99,8 @@ export function routerResource<T>(source: Resource<T>): Resource<T> & {reload():
   const res = resourceFromSnapshots(snapshotSignal) as unknown as InternalRouterResource<T>;
 
   res[SOURCE_RESOURCE_SYMBOL] = source;
-  res[BLOCKING_SYMBOL] =
-    (source as unknown as InternalRouterResource<T>)[BLOCKING_SYMBOL] !== false;
+  const sourceBlocking = (source as unknown as InternalRouterResource<T>)[BLOCKING_SYMBOL];
+  res[BLOCKING_SYMBOL] = sourceBlocking !== undefined ? sourceBlocking : true;
 
   if (typeof (source as any).reload === 'function') {
     res.reload = function (): boolean {
@@ -208,7 +222,7 @@ export function createResourceOutletBindingEffects(
 
   for (const {templateName} of mirror.inputs) {
     const resource = route.resources?.[templateName];
-    if (!resource || !(resource as InternalRouterResource)[BLOCKING_SYMBOL]) {
+    if (!resource || (resource as InternalRouterResource)[BLOCKING_SYMBOL] !== true) {
       continue;
     }
 

--- a/packages/router/test/router_resource_spec.ts
+++ b/packages/router/test/router_resource_spec.ts
@@ -10,6 +10,8 @@ import {
   Component,
   computed,
   EnvironmentProviders,
+  Input,
+  input,
   resource,
   Resource,
   ResourceStatus,
@@ -23,6 +25,7 @@ import {
   Router,
   NavigationError,
   withNavigationErrorHandler,
+  withComponentInputBinding,
   RedirectCommand,
   ɵwithRouterResources as withRouterResources,
   ɵnonBlocking as nonBlocking,
@@ -535,6 +538,223 @@ describe('Router resources integration', () => {
         ?.resources?.['data'] as any;
       expect(resourceRef.status()).toBe('idle');
       expect(resourceRef.value()).toBeUndefined();
+    });
+  });
+
+  describe('nonBlocking with waitFor', () => {
+    it('should complete navigation immediately when resource resolves before waitFor resolves', async () => {
+      const deferredResource = promiseWithResolvers<string>();
+      const deferredWait = promiseWithResolvers<void>();
+
+      const {harness, router} = await setupRouter([
+        {
+          path: 'test',
+          component: TargetCmp,
+          resources: () => ({
+            data: nonBlocking(
+              resource({
+                loader: async () => deferredResource.promise,
+              }),
+              {waitFor: deferredWait.promise},
+            ),
+          }),
+        },
+      ]);
+
+      let completed = false;
+      const navPromise = harness.navigateByUrl('/test').then(() => {
+        completed = true;
+      });
+
+      await timeout(10);
+      expect(completed).toBe(false);
+      expect(router.url).toBe('/');
+
+      // Resolve resource before waitFor
+      deferredResource.resolve('early loaded');
+      await navPromise;
+
+      expect(completed).toBe(true);
+      expect(router.url).toBe('/test');
+      const route = router.routerState.root.firstChild as ActivatedRouteInternal;
+      const resourceRef = route?.resources?.['data'] as any;
+      expect(resourceRef.value()).toBe('early loaded');
+      expect(resourceRef.isLoading()).toBe(false);
+    });
+
+    it('should complete navigation when waitFor resolves before resource finishes', async () => {
+      const deferredResource = promiseWithResolvers<string>();
+      const deferredWait = promiseWithResolvers<void>();
+
+      const {harness, router} = await setupRouter([
+        {
+          path: 'test',
+          component: TargetCmp,
+          resources: () => ({
+            data: nonBlocking(
+              resource({
+                loader: async () => deferredResource.promise,
+              }),
+              {waitFor: deferredWait.promise},
+            ),
+          }),
+        },
+      ]);
+
+      let completed = false;
+      const navPromise = router.navigateByUrl('/test').then(() => {
+        completed = true;
+      });
+
+      await timeout(10);
+      expect(completed).toBe(false);
+      expect(router.url).toBe('/');
+
+      // Resolve waitFor while resource is still pending
+      deferredWait.resolve();
+      await navPromise;
+
+      expect(completed).toBe(true);
+      expect(router.url).toBe('/test');
+
+      const route = router.routerState.root.firstChild as ActivatedRouteInternal;
+      const resourceRef = route?.resources?.['data'] as any;
+      expect(resourceRef.isLoading()).toBe(true);
+      expect(resourceRef.value()).toBeUndefined();
+
+      // Resource resolves later in the background
+      deferredResource.resolve('late loaded');
+      await harness.fixture.whenStable();
+
+      expect(resourceRef.isLoading()).toBe(false);
+      expect(resourceRef.value()).toBe('late loaded');
+    });
+
+    it('should complete navigation when waitFor rejects and resource is still loading', async () => {
+      const deferredResource = promiseWithResolvers<string>();
+      const deferredWait = promiseWithResolvers<void>();
+      deferredWait.promise.catch(() => {});
+
+      const {harness, router} = await setupRouter([
+        {
+          path: 'test',
+          component: TargetCmp,
+          resources: () => ({
+            data: nonBlocking(
+              resource({
+                loader: async () => deferredResource.promise,
+              }),
+              {waitFor: deferredWait.promise},
+            ),
+          }),
+        },
+      ]);
+
+      const navPromise = router.navigateByUrl('/test');
+
+      // Reject waitFor
+      deferredWait.reject(new Error('wait error'));
+      await navPromise;
+
+      expect(router.url).toBe('/test');
+      const route = router.routerState.root.firstChild as ActivatedRouteInternal;
+      const resourceRef = route?.resources?.['data'] as any;
+      expect(resourceRef.isLoading()).toBe(true);
+
+      deferredResource.resolve('data');
+      await harness.fixture.whenStable();
+      expect(resourceRef.value()).toBe('data');
+    });
+
+    it('should complete navigation and expose error when resource throws before waitFor', async () => {
+      const deferredWait = promiseWithResolvers<void>();
+
+      const {harness, router} = await setupRouter([
+        {
+          path: 'test',
+          component: TargetCmp,
+          resources: () => ({
+            data: nonBlocking(
+              resource({
+                loader: async () => {
+                  throw new Error('Load failed');
+                },
+              }),
+              {waitFor: deferredWait.promise},
+            ),
+          }),
+        },
+      ]);
+
+      await harness.navigateByUrl('/test');
+
+      expect(router.url).toBe('/test');
+      const route = router.routerState.root.firstChild as ActivatedRouteInternal;
+      const resourceRef = route?.resources?.['data'] as any;
+      expect(resourceRef.error()?.message).toBe('Load failed');
+      expect(resourceRef.isLoading()).toBe(false);
+    });
+
+    it('should redirect when resource throws RedirectCommand before waitFor resolves', async () => {
+      const deferredWait = promiseWithResolvers<void>();
+
+      const {harness, router} = await setupRouter([
+        {
+          path: 'test',
+          component: TargetCmp,
+          resources: () => ({
+            data: nonBlocking(
+              resource({
+                loader: async () => {
+                  throw new RedirectCommand(TestBed.inject(Router).parseUrl('/redirected'));
+                },
+              }),
+              {waitFor: deferredWait.promise},
+            ),
+          }),
+        },
+        {
+          path: 'redirected',
+          component: TargetCmp,
+        },
+      ]);
+
+      await harness.navigateByUrl('/test');
+
+      expect(router.url).toBe('/redirected');
+    });
+
+    it('should bind the Resource instance to component inputs when nonBlocking with waitFor is used', async () => {
+      @Component({
+        template: '',
+        standalone: false,
+      })
+      class InputTargetCmp {
+        @Input() result?: Resource<string>;
+      }
+
+      const {harness, router} = await setupRouter(
+        [
+          {
+            path: 'test',
+            component: InputTargetCmp,
+            resources: () => ({
+              result: nonBlocking(
+                resource({
+                  loader: async () => 'bound resource value',
+                }),
+                {waitFor: timeout(100)},
+              ),
+            }),
+          },
+        ],
+        withComponentInputBinding(),
+      );
+
+      const activatedCmp = await harness.navigateByUrl('/test', InputTargetCmp);
+
+      expect(typeof activatedCmp.result).toBe('object');
+      expect(activatedCmp.result?.value()).toBe('bound resource value');
     });
   });
 


### PR DESCRIPTION
Allow passing an options bag to nonBlocking with a waitFor Promise option. The router will hold navigation until either the resource resolves or the waitFor Promise settles. Thrown RedirectCommand errors during the wait period will immediately cancel and redirect the navigation.
