### PR TITLE
fix(docs-infra): correct example viewer tab state and line numbering

### DIFF
--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
@@ -5,6 +5,7 @@
         #codeTabs
         animationDuration="0ms"
         mat-stretch-tabs="false"
+        [selectedIndex]="selectedTabIndex()"
         (selectedTabChange)="onTabIndexChange($event.index)"
       >
         @for (tab of tabs(); track tab) {

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.spec.ts
@@ -166,6 +166,147 @@ describe('ExampleViewer', () => {
     expect(hiddenLine).toBeNull();
   });
 
+  it('keeps the expand control after switching tabs while expanded', async () => {
+    const collapsible = {
+      name: 'example.ts',
+      sanitizedContent:
+        '<pre><code><div class="line">one</div><div class="line">two</div></code></pre>',
+      visibleLinesRange: '1',
+    };
+
+    componentRef.setInput(
+      'metadata',
+      getMetadata({files: [collapsible, {name: 'example.css', sanitizedContent: ''}]}),
+    );
+
+    await component.renderExample();
+    await fixture.whenStable();
+
+    expect(component.expandable()).toBeTrue();
+
+    component.toggleExampleVisibility();
+    await fixture.whenStable();
+
+    const tabGroup = await loader.getHarness(MatTabGroupHarness);
+    await (await tabGroup.getTabs())[1].select();
+    await fixture.whenStable();
+    await (await tabGroup.getTabs())[0].select();
+    await fixture.whenStable();
+
+    expect(component.expandable()).toBeTrue();
+  });
+
+  it('hides only the lines outside the visible range, and adds no gap within one range', async () => {
+    componentRef.setInput(
+      'metadata',
+      getMetadata({
+        files: [
+          {
+            name: 'example.ts',
+            sanitizedContent:
+              '<pre><code><div class="line">one</div><div class="line">two</div><div class="line">three</div></code></pre>',
+            visibleLinesRange: '2,3',
+          },
+        ],
+      }),
+    );
+
+    await component.renderExample();
+    await fixture.whenStable();
+
+    const lines = fixture.debugElement
+      .queryAll(By.css('.line'))
+      .map((line) => (line.nativeElement as HTMLElement).className);
+
+    expect(lines).toEqual(['line hidden', 'line', 'line']);
+  });
+
+  it('hides the line numbers that pair with the hidden lines', async () => {
+    const numbered = (n: number, text: string) =>
+      `<span class="shiki-ln-number">${n}</span><div class="line">${text}</div>`;
+
+    componentRef.setInput(
+      'metadata',
+      getMetadata({
+        files: [
+          {
+            name: 'example.ts',
+            sanitizedContent: `<pre><code>${numbered(1, 'one')}${numbered(2, 'two')}${numbered(3, 'three')}</code></pre>`,
+            visibleLinesRange: '2,3',
+          },
+        ],
+      }),
+    );
+
+    await component.renderExample();
+    await fixture.whenStable();
+
+    const visibleNumbers = fixture.debugElement
+      .queryAll(By.css('.shiki-ln-number'))
+      .filter((el) => !(el.nativeElement as HTMLElement).classList.contains('hidden'))
+      .map((el) => (el.nativeElement as HTMLElement).textContent);
+
+    expect(visibleNumbers).toEqual(['2', '3']);
+  });
+
+  it('restores the selected tab and its collapsed lines after hiding and reshowing the code', async () => {
+    componentRef.setInput(
+      'metadata',
+      getMetadata({
+        files: [
+          {name: 'example.ts', sanitizedContent: ''},
+          {
+            name: 'example.css',
+            sanitizedContent:
+              '<pre><code><div class="line">one</div><div class="line">two</div></code></pre>',
+            visibleLinesRange: '2',
+          },
+        ],
+      }),
+    );
+
+    await component.renderExample();
+    await fixture.whenStable();
+
+    const tabGroup = await loader.getHarness(MatTabGroupHarness);
+    await (await tabGroup.getTabs())[1].select();
+    await fixture.whenStable();
+
+    component.toggleCodeVisibility();
+    await fixture.whenStable();
+    component.toggleCodeVisibility();
+    await fixture.whenStable();
+
+    expect(
+      await (await (await loader.getHarness(MatTabGroupHarness)).getSelectedTab()).getLabel(),
+    ).toBe('CSS');
+    const lines = fixture.debugElement
+      .queryAll(By.css('.line'))
+      .map((line) => (line.nativeElement as HTMLElement).className);
+    expect(lines).toEqual(['line hidden', 'line']);
+  });
+
+  it('offers no expand control when the range covers the whole file', async () => {
+    componentRef.setInput(
+      'metadata',
+      getMetadata({
+        files: [
+          {
+            name: 'example.ts',
+            sanitizedContent:
+              '<pre><code><div class="line">one</div><div class="line">two</div></code></pre>',
+            visibleLinesRange: '1,2',
+          },
+        ],
+      }),
+    );
+
+    await component.renderExample();
+    await fixture.whenStable();
+
+    expect(component.expandable()).toBeFalse();
+  });
+
   it('should set exampleComponent when metadata contains path and preview is true', async () => {
     exampleContentSpy.loadPreview.and.resolveTo(ExampleComponent);
     componentRef.setInput(

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
@@ -69,6 +69,7 @@ export class ExampleViewer {
   readonly expandable = signal<boolean>(false);
   readonly expanded = signal<boolean>(false);
   readonly snippetCode = signal<Snippet | undefined>(undefined);
+  readonly selectedTabIndex = signal<number>(0);
   readonly showCode = signal<boolean>(true);
   readonly tabs = computed(() =>
     this.exampleMetadata()?.files.map((file) => ({
@@ -101,10 +102,7 @@ export class ExampleViewer {
           `example-${this.exampleMetadata()?.id.toString()!}`,
         );
 
-        const lines = this.getHiddenCodeLines();
-        const lineNumbers = this.getHiddenCodeLineNumbers();
-
-        this.expandable.set(lines.length > 0 || lineNumbers.length > 0);
+        this.updateExpandable();
       },
       {injector: this.injector},
     );
@@ -137,8 +135,25 @@ export class ExampleViewer {
   }
 
   protected onTabIndexChange(index: number): void {
+    this.selectedTabIndex.set(index);
     this.snippetCode.set(this.exampleMetadata()?.files[index]);
-    this.setCodeLinesVisibility();
+
+    afterNextRender(
+      () => {
+        this.setCodeLinesVisibility();
+        this.updateExpandable();
+      },
+      {injector: this.injector},
+    );
+  }
+
+  // A file is expandable when its range hides lines. While the block is expanded nothing is
+  // hidden, so trust the presence of a range instead of the rendered state.
+  private updateExpandable(): void {
+    this.expandable.set(
+      !!this.snippetCode()?.visibleLinesRange &&
+        (this.expanded() || this.getHiddenCodeLines().length > 0),
+    );
   }
 
   private getFileExtension(name: string): string {
@@ -197,13 +212,13 @@ export class ExampleViewer {
     for (const [index, line] of lines.entries()) {
       if (!linesToDisplay.includes(index + 1)) {
         line.classList.add(HIDDEN_CLASS_NAME);
-      } else if (!linesToDisplay.includes(index - 1)) {
+      } else if (!linesToDisplay.includes(index)) {
         appendGapBefore.push(line);
       }
     }
 
     for (const [index, lineNumber] of lineNumbers.entries()) {
-      if (!linesToDisplay.includes(index)) {
+      if (!linesToDisplay.includes(index + 1)) {
         lineNumber.classList.add(HIDDEN_CLASS_NAME);
       }
     }

--- a/adev/shared-docs/styles/_resets.scss
+++ b/adev/shared-docs/styles/_resets.scss
@@ -304,7 +304,7 @@
           active-label-text-color: transparent,
           label-text-font: 'InterTight, sans-serif',
           label-text-tracking: -0.00875rem,
-          label-text-size: 0.8125rem,
+          label-text-size: 0.875rem,
         )
       );
 


### PR DESCRIPTION
@JeanMeche as I mentioned in https://github.com/angular/angular/pull/70508#issuecomment-5508523149, here are the other issues I found in the same component (Example-viewer). Six more issues.

### 1. Selected tab is lost, and desyncs from the code

Pick a tab, hide the code, show it again: the strip highlights the _first_ file while the code below is still the one you chose.

https://angular.dev/guide/animations/enter-and-leave, select `enter.css`, Hide code, Show code

The tab group is recreated by `@if (showCode())` with no `[selectedIndex]`, so it resets to 0 while `snippetCode` survives.

Before:

https://github.com/user-attachments/assets/f0b7c64c-3d32-48ee-afee-81924994885b

After:

https://github.com/user-attachments/assets/d3fa7a93-97ca-4b17-af1c-b5b73f8994e6


### 2. Switching tabs shows the whole file

Selecting a file that should be collapsed renders all of it, nothing hidden.

https://angular.dev/guide/i18n/prepare, click the `app.component.ts` tab

`onTabIndexChange` set the new file then queried the DOM immediately, before the incoming HTML had rendered, so it measured the outgoing tab. Same root cause as #70508.

Before:

https://github.com/user-attachments/assets/798446b3-4fef-460c-be08-2ac631f59a04

After:

https://github.com/user-attachments/assets/81e69704-1292-4731-8fc8-e610e22e88c3


### 3. No expand button on a collapsed tab

Same tab as above: even with the collapse applied, there was no expand control to reveal the 24 hidden lines. `expandable` was computed once at startup from the first tab, and never recomputed.

It is now derived from the file's `visibleLinesRange` in both paths, rather than from counting hidden DOM nodes. Counting the DOM is wrong whenever the block is expanded: nothing is hidden then, so the button would unmount permanently on the next tab switch.


### 4. Line numbers off by one

Eight rows of code, seven numbers, the gutter starting at 4 where the code starts at 3. The first rows lose their number cell, so the two-column layout collapses for them.

/kitchen-sink  "A styled code example"

The gutter tested `includes(index)` while the code tested `includes(index + 1)`.

Before:

<img width="856" height="573" alt="image" src="https://github.com/user-attachments/assets/4c3c6f07-c77c-4ef4-a214-6697cb46c9d3" />

After:

<img width="865" height="577" alt="image" src="https://github.com/user-attachments/assets/2def4e75-d800-4340-8144-ba985f02390a" />


### 5. A "..." marker drawn inside consecutive lines

The marker means "lines hidden here". It was drawn between lines that are adjacent in the file.

https://angular.dev/tutorials/first-app/13-search, step 3, the `@for` block

The check for "is the previous line hidden" tested `index - 1`; a line at index `i` is line `i + 1`, so its predecessor is `index`.

Before:

<img width="1098" height="299" alt="Screenshot 2026-09-03 at 01 40 55" src="https://github.com/user-attachments/assets/66e215aa-ba62-4424-8ff3-e9999e444459" />

After:

<img width="1143" height="281" alt="Screenshot 2026-09-03 at 01 41 14" src="https://github.com/user-attachments/assets/b2b9dcbe-6189-4a62-bf39-db3861c68592" />


### 6. Tab label smaller than the code beside it

https://angular.dev/guide/animations/enter-and-leave, any viewer with tabs

The example viewer's tab label was `0.8125rem` against `0.875rem` code, from a viewer-specific override. Now matches.

Before:

<img width="935" height="332" alt="Screenshot 2026-09-03 at 01 42 22" src="https://github.com/user-attachments/assets/72cccffa-3bfb-4ca8-b520-1f70939ccb47" />

<img width="565" height="301" alt="Screenshot 2026-09-03 at 01 42 39" src="https://github.com/user-attachments/assets/c2754eb8-d3ea-4ade-bdb7-def073544ccc" />

After:

<img width="585" height="342" alt="Screenshot 2026-09-03 at 01 42 51" src="https://github.com/user-attachments/assets/c23dc38a-077f-4d8b-bd54-4bdf2bcb8f64" />
