### PR TITLE
fix(platform-server): preserve WHATWG URL semantics for server xhr

### DIFF
--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -73,8 +73,7 @@ function relativeUrlsTransformerInterceptorFn(
   request: HttpRequest<unknown>,
   next: HttpHandlerFn,
 ): Observable<HttpEvent<unknown>> {
-  const trimmedUrl = request.url.trim();
-  if (URL_SCHEMA_REGEXP.test(trimmedUrl) && !HTTP_OR_HTTPS_NO_AUTHORITY_REGEXP.test(trimmedUrl)) {
+  if (URL_SCHEMA_REGEXP.test(request.url) && !HTTP_OR_HTTPS_NO_AUTHORITY_REGEXP.test(request.url)) {
     // URLs with a schema (and an authority for http(s)) should be left unchanged.
     return next(request);
   }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -1593,6 +1593,26 @@ class HiddenModule {}
           });
         });
 
+        it('should resolve unicode whitespace prefixed scheme URLs as relative paths on the same origin', async () => {
+          const urls = [
+            ['\u00A0http://attacker.example/collect', '%C2%A0'],
+            ['\uFEFFhttp://attacker.example/collect', '%EF%BB%BF'],
+          ];
+
+          ref.injector.get(NgZone).run(() => {
+            for (const [url, encodedWhitespace] of urls) {
+              http.get(url).subscribe((body) => {
+                expect(body).toEqual('success!');
+              });
+              mock
+                .expectOne(
+                  `http://localhost:4000/${encodedWhitespace}http://attacker.example/collect`,
+                )
+                .flush('success!');
+            }
+          });
+        });
+
         it('should resolve scheme URLs without authority as relative paths on the same origin', async () => {
           ref.injector.get(NgZone).run(() => {
             http.get('http:/localhost:9999/steal-a').subscribe((body) => {


### PR DESCRIPTION
Avoid String.prototype.trim() when classifying server request URLs because it strips Unicode whitespace that WHATWG URL parsing preserves as path data. This mismatch can cause xhr2 to send credentials to a different origin than the application approved.

Strip only leading ASCII URL whitespace during classification, preserve the existing ASCII behavior, and cover NBSP- and BOM-prefixed HTTP URLs.

Fixes #70540
