### PR TITLE
fix(core): apply SkipSelf to only the starting node in embedded views

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -1003,6 +1003,10 @@ function lookupTokenUsingEmbeddedInjector<T>(
       return nodeInjectorValue;
     }
 
+    // The injector of the node we started from has been checked at this point, so everything
+    // we look at from here on is a parent and must not be skipped by the `SkipSelf` flag.
+    flags &= ~InternalInjectFlags.SkipSelf;
+
     // Has an explicit type due to a TS bug: https://github.com/microsoft/TypeScript/issues/33191
     let parentTNode: TElementNode | TContainerNode | null = currentTNode.parent;
 
@@ -1015,11 +1019,7 @@ function lookupTokenUsingEmbeddedInjector<T>(
         const embeddedViewInjectorValue = (embeddedViewInjector as BackwardsCompatibleInjector).get(
           token,
           NOT_FOUND as T | {},
-          // The `SkipSelf` flag is intended for the current injection context (the child component).
-          // When we delegate to the embedded view injector, we are effectively traversing to a
-          // parent/fallback scope, so the "Self" has already been skipped. We must strip the
-          // flag to ensure the embedded view injector can resolve tokens from itself.
-          flags & ~InternalInjectFlags.SkipSelf,
+          flags,
         );
         if (embeddedViewInjectorValue !== NOT_FOUND) {
           return embeddedViewInjectorValue;

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -6066,6 +6066,51 @@ describe('di', () => {
       expect(fixture.componentInstance.menu.tokenValue).toBeNull();
     });
 
+    it('should skip only the current node with @SkipSelf when providing an injection token through an embedded view injector', () => {
+      @Directive({
+        selector: 'menu',
+        providers: [{provide: token, useValue: 'hello from menu'}],
+        standalone: false,
+      })
+      class Menu {}
+
+      @Directive({
+        selector: 'menu-item',
+        providers: [{provide: token, useValue: 'hello from menu item'}],
+        standalone: false,
+      })
+      class MenuItem {
+        constructor(@Inject(token) @SkipSelf() public tokenValue: string) {}
+      }
+
+      @Component({
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <menu>
+              <menu-item></menu-item>
+            </menu>
+          </ng-template>
+        `,
+        standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(MenuItem) menuItem!: MenuItem;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, MenuTrigger, Menu, MenuItem]});
+      const injector = Injector.create({providers: [{provide: token, useValue: 'hello'}]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(injector);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.menuItem.tokenValue).toBe('hello from menu');
+    });
+
     it('should be able to provide an injection token to a nested template through a custom injector', () => {
       @Directive({
         selector: 'menu',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #70547

Resolving a token through an embedded view injector walks the nodes one at a time and forces the `Self` flag on each node injector lookup. A lookup that also carries `SkipSelf` can never match, because `SkipSelf` first moves the search to the parent injector and `Self` then stops it from going there. So every node between the injection point and the view boundary was skipped, not just the starting one, and the token was resolved from the custom injector instead of the nearest parent node.

## What is the new behavior?

`SkipSelf` is cleared once the starting node has been checked, so only that node is skipped and the remaining nodes are searched normally.

That also makes the flag strip at the embedded view injector redundant, since `SkipSelf` is already cleared before that call on every iteration, so it goes away along with the comment explaining it. It was added in a7e8abbb7e, which fixed the same symptom for the injector itself but not for the nodes in between.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The new spec in `di_spec.ts` fails on current `main` with `Expected 'hello' to be 'hello from menu'`, which is the reported symptom: the value comes from the custom injector rather than the parent node.
