### PR TITLE
fix(forms): mark control as dirty before setting its value in FVC interop

### DIFF
--- a/packages/forms/signals/test/web/reactive_fvc.spec.ts
+++ b/packages/forms/signals/test/web/reactive_fvc.spec.ts
@@ -553,6 +553,33 @@ describe('FormControlName with FVC', () => {
     expect(fixture.componentInstance.form.controls.name.value).toBe('from-fvc');
   });
 
+  it('should report the form as dirty inside valueChanges when the FVC writes a value', () => {
+    @Component({
+      template: `
+        <form [formGroup]="form">
+          <my-fvc-input formControlName="name" />
+        </form>
+      `,
+      imports: [MyFvcInput, ReactiveFormsModule],
+    })
+    class TestCmp {
+      form = new FormGroup({
+        name: new FormControl('initial'),
+      });
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const form = fixture.componentInstance.form;
+
+    const dirtyDuringValueChanges: boolean[] = [];
+    form.valueChanges.subscribe(() => dirtyDuringValueChanges.push(form.dirty));
+
+    const fvc = fixture.debugElement.query(By.directive(MyFvcInput)).componentInstance;
+    act(() => fvc.value.set('from-fvc'));
+
+    expect(dirtyDuringValueChanges).toEqual([true]);
+  });
+
   it('should fall back to CVA when no FVC pattern is present', () => {
     @Component({
       template: `

--- a/packages/forms/src/directives/ng_control.ts
+++ b/packages/forms/src/directives/ng_control.ts
@@ -231,8 +231,8 @@ export abstract class NgControl extends AbstractControlDirective {
     // (e.g., FormControlDirective's form input hasn't been bound)
     host.listenToCustomControlModel((value) => {
       // TODO: is there a case where this input has not yet been set?
-      this.control?.setValue(value, {emitModelToViewChange: false});
       this.control?.markAsDirty();
+      this.control?.setValue(value, {emitModelToViewChange: false});
       this.viewToModelUpdate(value);
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added
- [x] Documentation is not required for this bug fix

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

When a `FormValueControl` writes a value through the reactive forms interop, `ngControlCreate` calls `setValue()` first and `markAsDirty()` afterwards. `setValue()` emits `valueChanges`, so a subscriber that reads `dirty` sees `false`, and the control only becomes dirty once the emission is over. The `ControlValueAccessor` path does the opposite in `updateControl()`: it marks the control dirty first, then sets the value.

That makes the two ways of binding a custom control with `formControlName` behave differently, so swapping a CVA for an FVC silently changes what a `valueChanges` subscriber observes.

Issue Number: #70554

## What is the new behavior?

The interop marks the control dirty before setting its value, matching `updateControl()`. A `valueChanges` subscriber now sees `dirty === true` for both kinds of control.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
