### PR TITLE
fix(docs-infra): remove space after decorator symbol

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.mts
@@ -34,16 +34,17 @@ export function replaceKeywordFromShikiHtml(
   shikiHtml: string,
   replaceWith: string,
 ): string {
+  const keywordElement = `<[^>]*>(?:${keyword})<\\/\\w+>`;
+
   return (
     shikiHtml
-      // remove the leading space of the element after the keyword
-      .replace(
-        new RegExp(`(<[^>]*>(?:${keyword})<\\/\\w+><[^>]*>)(\\s)(\\w+<\\/\\w+>)`, 'g'),
-        '$1$3',
-      )
+      // Linking an identifier causes Shiki to emit the space before it as a separate element.
+      .replace(new RegExp(`(${keywordElement})<[^>]*>\\s+<\\/\\w+>`, 'g'), '$1')
+      // Without a link, Shiki includes the space in the identifier's element instead.
+      .replace(new RegExp(`(${keywordElement}<[^>]*>)\\s+(?=[^<\\s]+<\\/\\w+>)`, 'g'), '$1')
       // Shiki requires the keywords (eg. function,interface) for highlighting signatures
       // here we are replacing it
-      .replace(new RegExp(`<[^>]*>(?:${keyword})<\\/\\w+>`, 'g'), replaceWith)
+      .replace(new RegExp(keywordElement, 'g'), replaceWith)
   );
 }
 

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/fake-entries.json
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/fake-entries.json
@@ -2,6 +2,24 @@
   "moduleName": "@angular/core",
   "entries": [
     {
+      "name": "Component",
+      "decoratorType": "class",
+      "entryType": "decorator",
+      "members": [
+        {
+          "name": "selector",
+          "type": "string | undefined",
+          "memberType": "property",
+          "memberTags": ["optional"],
+          "description": "The CSS selector that identifies this component in a template.",
+          "jsdocTags": []
+        }
+      ],
+      "description": "Decorator that marks a class as an Angular component.",
+      "jsdocTags": [],
+      "rawComment": ""
+    },
+    {
       "name": "NgTemplateOutlet",
       "isAbstract": false,
       "entryType": "directive",

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.mts
@@ -33,6 +33,7 @@ describe('renderable', () => {
     const symbols = Object.fromEntries([
       ['AfterRenderPhase', 'core'],
       ['afterRender', 'core'],
+      ['Component', 'core'],
       ['EmbeddedViewRef', 'core'],
       ['ChangeDetectionStrategy', 'core'],
       ['ChangeDetectorRef', 'core'],
@@ -78,5 +79,14 @@ describe('renderable', () => {
       const anchor = card.querySelector('h3 a.docs-anchor') as HTMLAnchorElement;
       expect(anchor.getAttribute('href')).toBe(`#${id}`);
     }
+  });
+
+  it('should render decorators without whitespace after the @ symbol', () => {
+    const component = entries.get('Component')!;
+    const html = renderEntry(component);
+    const fragment = JSDOM.fragment(html);
+    const api = fragment.querySelector('.docs-reference-api-section code')!;
+
+    expect(api.textContent).toContain('@Component({');
   });
 });


### PR DESCRIPTION
Handle the separate whitespace token emitted by Shiki when a decorator name is linked to its API reference.

## What is the current behavior?
See https://angular.dev/api/core/Component
<img width="827" height="708" alt="image" src="https://github.com/user-attachments/assets/0b9d173b-e562-486b-81a1-d1c0a7bec77a" />

## What is the new behavior?

<img width="842" height="734" alt="image" src="https://github.com/user-attachments/assets/df4e2bca-a068-4455-9d54-d0857789ea75" />
