### PR TITLE
fix(docs-infra): render signal inputs and outputs using initializer s…

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/code-transforms.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/code-transforms.spec.mts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {formatExtendsClause, makeGenericsText} from '../../transforms/code-transforms.mjs';
+import {
+  formatExtendsClause,
+  getPropertyCodeLine,
+  isSignalInput,
+  isSignalModel,
+  isSignalOutput,
+  makeGenericsText,
+} from '../../transforms/code-transforms.mjs';
 
 describe('formatExtendsClause', () => {
   it('should return an empty string when extendsValue is undefined', () => {
@@ -87,5 +94,337 @@ describe('makeGenericsText', () => {
     expect(makeGenericsText(generics)).toBe(
       '<A extends string, B, C = number, D extends boolean = true>',
     );
+  });
+});
+
+describe('isSignalInput (string comparison)', () => {
+  it('returns true for an InputSignal-typed input member', () => {
+    const member = {
+      name: 'field',
+      type: 'InputSignal<Field<T>>',
+      memberTags: ['readonly', 'input'],
+      inputAlias: 'formField',
+      isRequiredInput: true,
+    } as any;
+    expect(isSignalInput(member)).toBe(true);
+  });
+
+  it('returns true for an InputSignalWithTransform-typed input member', () => {
+    const member = {
+      name: 'disabled',
+      type: 'InputSignalWithTransform<boolean, unknown>',
+      memberTags: ['input'],
+      inputAlias: 'disabled',
+      isRequiredInput: false,
+    } as any;
+    expect(isSignalInput(member)).toBe(true);
+  });
+
+  it('returns false for a decorator-based input (non-signal type)', () => {
+    const member = {
+      name: 'field',
+      type: 'Field<T>',
+      memberTags: ['input'],
+      inputAlias: 'formField',
+      isRequiredInput: false,
+    } as any;
+    expect(isSignalInput(member)).toBe(false);
+  });
+
+  it('returns false for an InputSignal-typed property that is not an input', () => {
+    const member = {
+      name: 'value',
+      type: 'InputSignal<V>',
+      memberTags: ['readonly'],
+    } as any;
+    expect(isSignalInput(member)).toBe(false);
+  });
+});
+
+describe('getPropertyCodeLine (signal inputs)', () => {
+  it('renders a required signal input with a differing alias', () => {
+    const member = {
+      name: 'field',
+      type: 'InputSignal<Field<T>>',
+      memberTags: ['readonly', 'input'],
+      inputAlias: 'formField',
+      isRequiredInput: true,
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(
+      `readonly field = input.required<Field<T>>({alias: 'formField'});`,
+    );
+  });
+
+  it('omits the alias argument when the alias matches the property name', () => {
+    const member = {
+      name: 'value',
+      type: 'InputSignal<V>',
+      memberTags: ['readonly', 'input'],
+      inputAlias: 'value',
+      isRequiredInput: true,
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`readonly value = input.required<V>();`);
+  });
+
+  it('renders an optional signal input using input()', () => {
+    const member = {
+      name: 'count',
+      type: 'InputSignal<number>',
+      memberTags: ['readonly', 'input'],
+      inputAlias: 'count',
+      isRequiredInput: false,
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`readonly count = input<number>();`);
+  });
+
+  it('renders an optional signal input with an alias', () => {
+    const member = {
+      name: 'count',
+      type: 'InputSignal<number>',
+      memberTags: ['input'],
+      inputAlias: 'itemCount',
+      isRequiredInput: false,
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`count = input<number>({alias: 'itemCount'});`);
+  });
+
+  it('unwraps InputSignalWithTransform to its inner type arguments', () => {
+    const member = {
+      name: 'disabled',
+      type: 'InputSignalWithTransform<boolean, unknown>',
+      memberTags: ['readonly', 'input'],
+      inputAlias: 'disabled',
+      isRequiredInput: false,
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`readonly disabled = input<boolean, unknown>();`);
+  });
+});
+
+describe('getPropertyCodeLine (decorator members unaffected)', () => {
+  it('still renders a decorator input with @Input(alias)', () => {
+    const member = {
+      name: 'field',
+      type: 'Field<T>',
+      memberTags: ['input'],
+      inputAlias: 'formField',
+      isRequiredInput: false,
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`@Input('formField') field: Field<T>;`);
+  });
+
+  it('still renders an output with @Output(alias)', () => {
+    const member = {
+      name: 'change',
+      type: 'EventEmitter<T>',
+      memberTags: ['output'],
+      outputAlias: 'valueChange',
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`@Output('valueChange') change: EventEmitter<T>;`);
+  });
+});
+
+describe('isSignalOutput (string comparison)', () => {
+  it('returns true for an OutputEmitterRef-typed output member', () => {
+    const member = {
+      name: 'nameChange',
+      type: 'OutputEmitterRef<string>',
+      memberTags: ['readonly', 'output'],
+      outputAlias: 'name',
+    } as any;
+    expect(isSignalOutput(member)).toBe(true);
+  });
+
+  it('returns false for a decorator-based output (EventEmitter)', () => {
+    const member = {
+      name: 'change',
+      type: 'EventEmitter<T>',
+      memberTags: ['output'],
+      outputAlias: 'valueChange',
+    } as any;
+    expect(isSignalOutput(member)).toBe(false);
+  });
+
+  it('returns false for an `outputFromObservable()` output typed as OutputRef', () => {
+    const member = {
+      name: 'change',
+      type: 'OutputRef<string>',
+      memberTags: ['readonly', 'output'],
+      outputAlias: 'change',
+    } as any;
+    expect(isSignalOutput(member)).toBe(false);
+  });
+
+  it('returns false for an OutputEmitterRef-typed property that is not an output', () => {
+    const member = {
+      name: 'emitter',
+      type: 'OutputEmitterRef<string>',
+      memberTags: ['readonly'],
+    } as any;
+    expect(isSignalOutput(member)).toBe(false);
+  });
+});
+
+describe('getPropertyCodeLine (signal outputs)', () => {
+  it('renders a signal output with a differing alias', () => {
+    const member = {
+      name: 'nameChange',
+      type: 'OutputEmitterRef<string>',
+      memberTags: ['readonly', 'output'],
+      outputAlias: 'name',
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(
+      `readonly nameChange = output<string>({alias: 'name'});`,
+    );
+  });
+
+  it('omits the alias argument when the alias matches the property name', () => {
+    const member = {
+      name: 'nameChange',
+      type: 'OutputEmitterRef<string>',
+      memberTags: ['readonly', 'output'],
+      outputAlias: 'nameChange',
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`readonly nameChange = output<string>();`);
+  });
+
+  it('renders a void output', () => {
+    const member = {
+      name: 'onClick',
+      type: 'OutputEmitterRef<void>',
+      memberTags: ['output'],
+      outputAlias: 'onClick',
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`onClick = output<void>();`);
+  });
+
+  it('keeps nested generics intact', () => {
+    const member = {
+      name: 'selected',
+      type: 'OutputEmitterRef<ReadonlyArray<Item<T>>>',
+      memberTags: ['readonly', 'output'],
+      outputAlias: 'selected',
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(
+      `readonly selected = output<ReadonlyArray<Item<T>>>();`,
+    );
+  });
+
+  it('still renders an `outputFromObservable()` output with @Output(...)', () => {
+    const member = {
+      name: 'change',
+      type: 'OutputRef<string>',
+      memberTags: ['readonly', 'output'],
+      outputAlias: 'valueChange',
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(
+      `readonly @Output('valueChange') change: OutputRef<string>;`,
+    );
+  });
+});
+
+describe('isSignalModel (string comparison)', () => {
+  it('returns true for a ModelSignal-typed member tagged as both input and output', () => {
+    const member = {
+      name: 'value',
+      type: 'ModelSignal<string>',
+      memberTags: ['readonly', 'input', 'output'],
+      inputAlias: 'value',
+      outputAlias: 'valueChange',
+      isRequiredInput: false,
+    } as any;
+    expect(isSignalModel(member)).toBe(true);
+  });
+
+  it('returns true when only one of the binding tags is present', () => {
+    const asInput = {
+      name: 'value',
+      type: 'ModelSignal<string>',
+      memberTags: ['readonly', 'input'],
+      inputAlias: 'value',
+    } as any;
+    const asOutput = {
+      name: 'value',
+      type: 'ModelSignal<string>',
+      memberTags: ['readonly', 'output'],
+      outputAlias: 'valueChange',
+    } as any;
+    expect(isSignalModel(asInput)).toBe(true);
+    expect(isSignalModel(asOutput)).toBe(true);
+  });
+
+  it('returns false for a ModelSignal-typed property that is neither an input nor an output', () => {
+    const member = {
+      name: 'value',
+      type: 'ModelSignal<string>',
+      memberTags: ['readonly'],
+    } as any;
+    expect(isSignalModel(member)).toBe(false);
+  });
+
+  it('returns false for a decorator-based two-way binding pair', () => {
+    const member = {
+      name: 'value',
+      type: 'string',
+      memberTags: ['input', 'output'],
+      inputAlias: 'value',
+      outputAlias: 'valueChange',
+      isRequiredInput: false,
+    } as any;
+    expect(isSignalModel(member)).toBe(false);
+  });
+});
+
+describe('getPropertyCodeLine (signal models)', () => {
+  it('renders an optional model using model()', () => {
+    const member = {
+      name: 'value',
+      type: 'ModelSignal<string>',
+      memberTags: ['readonly', 'input', 'output'],
+      inputAlias: 'value',
+      outputAlias: 'valueChange',
+      isRequiredInput: false,
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`readonly value = model<string>();`);
+  });
+
+  it('renders a required model using model.required()', () => {
+    const member = {
+      name: 'value',
+      type: 'ModelSignal<Field<T>>',
+      memberTags: ['readonly', 'input', 'output'],
+      inputAlias: 'value',
+      outputAlias: 'valueChange',
+      isRequiredInput: true,
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(`readonly value = model.required<Field<T>>();`);
+  });
+
+  it('passes only the input alias, since the output alias is derived from it', () => {
+    const member = {
+      name: 'value',
+      type: 'ModelSignal<string>',
+      memberTags: ['readonly', 'input', 'output'],
+      inputAlias: 'modelValue',
+      outputAlias: 'modelValueChange',
+      isRequiredInput: false,
+    } as any;
+    expect(getPropertyCodeLine(member)).toBe(
+      `readonly value = model<string>({alias: 'modelValue'});`,
+    );
+  });
+
+  it('drops both binding tags, so neither @Input() nor @Output() is rendered', () => {
+    const member = {
+      name: 'value',
+      type: 'ModelSignal<string>',
+      memberTags: ['input', 'output'],
+      inputAlias: 'value',
+      outputAlias: 'valueChange',
+      isRequiredInput: false,
+    } as any;
+    const line = getPropertyCodeLine(member);
+    expect(line).toBe(`value = model<string>();`);
+    expect(line).not.toContain('@Input');
+    expect(line).not.toContain('@Output');
   });
 });

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
@@ -366,8 +366,115 @@ function getCodeLine(member: MemberEntry): string {
   return getPropertyCodeLine(member as PropertyEntry);
 }
 
+/** Type-string prefix that identifies a signal-based model (`model()` / `model.required()`). */
+const SIGNAL_MODEL_TYPE_PREFIXES = ['ModelSignal<'];
+
+export function isSignalModel(member: PropertyEntry): boolean {
+  return (
+    (member.memberTags.includes(MemberTags.Input) ||
+      member.memberTags.includes(MemberTags.Output)) &&
+    SIGNAL_MODEL_TYPE_PREFIXES.some((prefix) => member.type?.startsWith(prefix))
+  );
+}
+
+/** Type-string prefixes that identify a signal-based input (`input()` / `input.required()`). */
+const SIGNAL_INPUT_TYPE_PREFIXES = ['InputSignal<', 'InputSignalWithTransform<'];
+
+/**
+ * Type-string prefixes that identify a signal-based output (`output()`).
+ *
+ * Only `OutputEmitterRef` is listed: `outputFromObservable()` is typed as the
+ * broader `OutputRef` and isn't declared with an `output()` initializer.
+ */
+const SIGNAL_OUTPUT_TYPE_PREFIXES = ['OutputEmitterRef<'];
+
+/**
+ * Detects a signal input (`input()` / `input.required()`) purely by string
+ * comparison on the resolved property type, since `PropertyEntry` carries no
+ * explicit `isSignal` flag.
+ */
+export function isSignalInput(member: PropertyEntry): boolean {
+  return (
+    member.memberTags.includes(MemberTags.Input) &&
+    SIGNAL_INPUT_TYPE_PREFIXES.some((prefix) => member.type?.startsWith(prefix))
+  );
+}
+
+/**
+ * Detects a signal output (`output()`) purely by string comparison on the
+ * resolved property type, since `PropertyEntry` carries no explicit `isSignal` flag.
+ */
+export function isSignalOutput(member: PropertyEntry): boolean {
+  return (
+    member.memberTags.includes(MemberTags.Output) &&
+    SIGNAL_OUTPUT_TYPE_PREFIXES.some((prefix) => member.type?.startsWith(prefix))
+  );
+}
+
+/**
+ * Extracts the type arguments from a signal binding type, e.g. `T` from
+ * `InputSignal<T>`, `T, W` from `InputSignalWithTransform<T, W>` and `T` from
+ * `OutputEmitterRef<T>`.
+ */
+function getSignalTypeArguments(type: string): string {
+  const start = type.indexOf('<');
+  const end = type.lastIndexOf('>');
+  return start !== -1 && end !== -1 ? type.slice(start + 1, end).trim() : type;
+}
+
+/**
+ * Renders a signal binding using the initializer form the source actually uses,
+ * e.g. `readonly field = input.required<Field<T>>({alias: 'formField'});`.
+ */
+function getSignalBindingCodeLine(
+  member: PropertyEntry,
+  bindingTag: MemberTags,
+  initializer: string,
+  alias: string | undefined,
+): string {
+  // Preserve the other tags (e.g. `readonly`) but drop the binding tag so we don't
+  // emit the misleading `@Input(...)` / `@Output(...)` decorator prefix.
+  const otherTags = getTags({
+    ...member,
+    memberTags: member.memberTags.filter((tag) => tag !== bindingTag),
+  });
+  const prefix = otherTags.length ? `${otherTags.join(SPACE)}${SPACE}` : '';
+  const args = alias && alias !== member.name ? `{alias: '${alias}'}` : '';
+
+  return `${prefix}${member.name} = ${initializer}<${getSignalTypeArguments(member.type)}>(${args});`;
+}
+
 /** Map getter, setter and property entry to text */
-function getPropertyCodeLine(member: PropertyEntry): string {
+export function getPropertyCodeLine(member: PropertyEntry): string {
+  if (isSignalModel(member)) {
+    // A model is both an input and an output. We need to strip both tags so they aren't rendered as decorators.
+    const memberWithoutTags = {
+      ...member,
+      memberTags: member.memberTags.filter(
+        (t) => t !== MemberTags.Input && t !== MemberTags.Output,
+      ),
+    };
+    return getSignalBindingCodeLine(
+      memberWithoutTags,
+      MemberTags.Input, // getSignalBindingCodeLine expects a tag to filter out, but we've already done it
+      member.isRequiredInput ? 'model.required' : 'model',
+      member.inputAlias,
+    );
+  }
+
+  if (isSignalInput(member)) {
+    return getSignalBindingCodeLine(
+      member,
+      MemberTags.Input,
+      member.isRequiredInput ? 'input.required' : 'input',
+      member.inputAlias,
+    );
+  }
+
+  if (isSignalOutput(member)) {
+    return getSignalBindingCodeLine(member, MemberTags.Output, 'output', member.outputAlias);
+  }
+
   const isOptional = isOptionalMember(member);
   const tags = getTags(member);
 


### PR DESCRIPTION
…yntax

The API reference rendered signal-based bindings with a hybrid line mixing decorator syntax and the signal type, e.g. `readonly @Input('formField') field: InputSignal<Field<T>>;` for a member declared as `readonly field = input.required<Field<T>>({alias: 'formField'});`. Signal bindings are never declared with `@Input()` / `@Output()`, so the rendered code did not match how the source is authored.

Signal inputs and outputs are now rendered in the initializer form the source uses:

  readonly field = input.required<Field<T>>({alias: 'formField'});
  readonly nameChange = output<string>({alias: 'name'});

`PropertyEntry` carries no `isSignal` flag, so the discriminator is the resolved property type: `InputSignal` / `InputSignalWithTransform` for inputs and `OutputEmitterRef` for outputs. `outputFromObservable()` is deliberately excluded — it is typed as the broader `OutputRef` and is not declared with an `output()` initializer. Decorator-based inputs and outputs continue to render with `@Input(...)` / `@Output(...)`.

## What is the current behavior?
https://angular.dev/api/forms/signals/FormRoot
https://angular.dev/api/forms/signals/FormField

## What is the new behavior?
<img width="1598" height="642" alt="image" src="https://github.com/user-attachments/assets/7c4ce3ae-0e24-445b-938e-0d73b3ae828d" />
<img width="1582" height="342" alt="image" src="https://github.com/user-attachments/assets/90db7fda-06f1-410a-ba20-840f2dd18545" />

