### PR TITLE
test(devtools): run the orphaned supported-apis spec

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/BUILD.bazel
@@ -19,7 +19,7 @@ ng_project(
 
 ts_test_library(
     name = "ng-debug-api_test_lib",
-    srcs = ["ng-debug-api.spec.ts"],
+    srcs = glob(["*.spec.ts"]),
     deps = [
         ":ng-debug-api",
         "//:node_modules/@angular/core",

--- a/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/ng-debug-api.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/ng-debug-api.spec.ts
@@ -61,6 +61,7 @@ const fakeNgGlobal = (framework: Framework): Partial<Ng> => {
 describe('ng-debug-api', () => {
   afterEach(() => {
     delete (globalThis as any).ng;
+    document.body.replaceChildren();
   });
 
   describe('ngDebugDependencyInjectionApiIsSupported', () => {

--- a/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/supported-apis.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/shared/ng-debug-api/supported-apis.spec.ts
@@ -9,11 +9,38 @@
 import {getSupportedApis} from './supported-apis';
 
 describe('supported-apis', () => {
+  afterEach(() => {
+    delete (globalThis as any).ng;
+  });
+
   describe('getSupportedApis', () => {
-    it('should return supported APIs', () => {
+    it('should return every flag as false when no debug API is available', () => {
+      (globalThis as any).ng = {};
+
       const supported = getSupportedApis();
 
-      expect(supported).toBeTruthy();
+      expect(Object.keys(supported).sort()).toEqual([
+        'dependencyInjection',
+        'profiler',
+        'routes',
+        'signalPropertiesInspection',
+        'signals',
+        'transferState',
+      ]);
+      expect(Object.values(supported).every((value) => value === false)).toBeTrue();
+    });
+
+    it('should only report signals when the signal graph API is available', () => {
+      (globalThis as any).ng = {ɵgetSignalGraph: () => {}};
+
+      const supported = getSupportedApis();
+
+      expect(supported.signals).toBeTrue();
+      expect(supported.dependencyInjection).toBeFalse();
+      expect(supported.profiler).toBeFalse();
+      expect(supported.routes).toBeFalse();
+      expect(supported.signalPropertiesInspection).toBeFalse();
+      expect(supported.transferState).toBeFalse();
     });
   });
 });


### PR DESCRIPTION
`supported-apis.spec.ts` was added in #60585, in a commit that also edited the `ts_test_library` three lines below the `srcs` it was left out of. No revision of that BUILD file has ever listed it, so it has not run since March 2025. The target goes from 12 specs to 14.

Wiring it up alone would not have worked. Every `*IsSupported` helper calls `ngDebugClient()`, which throws when `window.ng` is undefined, and the old `expect(supported).toBeTruthy()` set no `ng` at all. It now stubs `ng` and checks the flag set and that each flag tracks its own debug API.

The `beforeEach` clears the DOM because `ng-debug-api.spec.ts` leaves an `[ng-version]` root behind for `getAppRoots()` to find under jasmine's random ordering.

`glob` matches the sibling `directive-forest/component-tree` target and keeps the next spec in this directory from being dropped the same way.