### PR TITLE
fix(router): stop adding tabindex to non-anchor elements with routerLink

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -806,7 +806,7 @@ export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHa
 
 // @public
 class RouterLink implements OnChanges, OnDestroy {
-    constructor(router: Router, route: ActivatedRoute, tabIndexAttribute: string | null | undefined, renderer: Renderer2, el: ElementRef, locationStrategy?: LocationStrategy | undefined);
+    constructor(router: Router, route: ActivatedRoute, el: ElementRef, locationStrategy?: LocationStrategy | undefined);
     browserUrl: i0.InputSignal<string | UrlTree | undefined>;
     set fragment(value: string | undefined);
     // (undocumented)
@@ -860,7 +860,7 @@ class RouterLink implements OnChanges, OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<RouterLink, "[routerLink]", never, { "target": { "alias": "target"; "required": false; }; "queryParams": { "alias": "queryParams"; "required": false; }; "fragment": { "alias": "fragment"; "required": false; }; "queryParamsHandling": { "alias": "queryParamsHandling"; "required": false; }; "state": { "alias": "state"; "required": false; }; "info": { "alias": "info"; "required": false; }; "relativeTo": { "alias": "relativeTo"; "required": false; }; "preserveFragment": { "alias": "preserveFragment"; "required": false; }; "skipLocationChange": { "alias": "skipLocationChange"; "required": false; }; "replaceUrl": { "alias": "replaceUrl"; "required": false; }; "browserUrl": { "alias": "browserUrl"; "required": false; "isSignal": true; }; "routerLink": { "alias": "routerLink"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<RouterLink, [null, null, { attribute: "tabindex"; }, null, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<RouterLink, never>;
 }
 export { RouterLink }
 export { RouterLink as RouterLinkWithHref }

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -8,7 +8,6 @@
 
 import {LocationStrategy} from '@angular/common';
 import {
-  Attribute,
   booleanAttribute,
   computed,
   Directive,
@@ -22,7 +21,6 @@ import {
   linkedSignal,
   OnChanges,
   OnDestroy,
-  Renderer2,
   ɵRuntimeError as RuntimeError,
   Service,
   signal,
@@ -70,6 +68,12 @@ export class ReactiveRouterState {
     this.path.set(this.serializer.serialize(new UrlTree(root)));
   }
 }
+
+// Whether `RouterLink` adds a `tabindex="0"` to non-anchor host elements. This was removed for the
+// public API (see #28345) because the element is put in the tab order without being made
+// keyboard-operable. It is retained inside Google via the marker below while callers migrate.
+// g3-only const ADD_TABINDEX_TO_NON_ANCHOR_ELEMENTS: boolean = true;
+const ADD_TABINDEX_TO_NON_ANCHOR_ELEMENTS: boolean = false; // 3p-only
 
 /**
  * @description
@@ -373,14 +377,20 @@ export class RouterLink implements OnChanges, OnDestroy {
   private readonly options = inject(ROUTER_CONFIGURATION, {optional: true});
   private readonly reactiveRouterState = inject(ReactiveRouterState);
 
+  // The value of the `tabindex` attribute as authored in the template, or `null` if not set. Only
+  // read when `ADD_TABINDEX_TO_NON_ANCHOR_ELEMENTS` is enabled (see the constructor).
+  private readonly tabIndexAttribute: string | null = null;
+
   constructor(
     private router: Router,
     private route: ActivatedRoute,
-    @Attribute('tabindex') private readonly tabIndexAttribute: string | null | undefined,
-    private readonly renderer: Renderer2,
     private readonly el: ElementRef,
     private locationStrategy?: LocationStrategy,
   ) {
+    if (ADD_TABINDEX_TO_NON_ANCHOR_ELEMENTS) {
+      this.tabIndexAttribute = inject(new HostAttributeToken('tabindex'), {optional: true});
+    }
+
     const tagName = el.nativeElement.tagName?.toLowerCase();
     this.isAnchorElement =
       tagName === 'a' ||
@@ -388,15 +398,13 @@ export class RouterLink implements OnChanges, OnDestroy {
       !!(
         // Avoid breaking in an SSR context where customElements might not
         // be defined.
+        typeof customElements === 'object' &&
+        // observedAttributes is an optional static property/getter on a
+        // custom element. The spec states that this must be an array of
+        // strings.
         (
-          typeof customElements === 'object' &&
-          // observedAttributes is an optional static property/getter on a
-          // custom element. The spec states that this must be an array of
-          // strings.
-          (
-            customElements.get(tagName) as {observedAttributes?: string[]} | undefined
-          )?.observedAttributes?.includes?.('href')
-        )
+          customElements.get(tagName) as {observedAttributes?: string[]} | undefined
+        )?.observedAttributes?.includes?.('href')
       );
 
     if (typeof ngDevMode !== 'undefined' && ngDevMode) {
@@ -423,10 +431,19 @@ export class RouterLink implements OnChanges, OnDestroy {
    * during instantiation.
    */
   private setTabIndexIfNotOnNativeEl(newTabIndex: string | null) {
-    if (this.tabIndexAttribute != null /* both `null` and `undefined` */ || this.isAnchorElement) {
+    if (
+      !ADD_TABINDEX_TO_NON_ANCHOR_ELEMENTS ||
+      this.tabIndexAttribute !== null ||
+      this.isAnchorElement
+    ) {
       return;
     }
-    this.applyAttributeValue('tabindex', newTabIndex);
+    const nativeElement = this.el.nativeElement as HTMLElement;
+    if (newTabIndex !== null) {
+      nativeElement.setAttribute('tabindex', newTabIndex);
+    } else {
+      nativeElement.removeAttribute('tabindex');
+    }
   }
 
   /** @docs-private */
@@ -523,16 +540,6 @@ export class RouterLink implements OnChanges, OnDestroy {
 
   /** @docs-private */
   ngOnDestroy(): any {}
-
-  private applyAttributeValue(attrName: string, attrValue: string | null) {
-    const renderer = this.renderer;
-    const nativeElement = this.el.nativeElement;
-    if (attrValue !== null) {
-      renderer.setAttribute(nativeElement, attrName, attrValue);
-    } else {
-      renderer.removeAttribute(nativeElement, attrName);
-    }
-  }
 
   /** @internal */
   _urlTree = computed(

--- a/packages/router/test/integration/router_links.spec.ts
+++ b/packages/router/test/integration/router_links.spec.ts
@@ -265,7 +265,7 @@ export function routerLinkIntegrationSpec() {
       expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
       const button = fixture.nativeElement.querySelector('button');
-      expect(button.getAttribute('tabindex')).toEqual('0');
+      expect(button.hasAttribute('tabindex')).toBeFalse();
       button.click();
       await advance(fixture);
 

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -13,7 +13,7 @@ import {Router, RouterLink, RouterModule, provideRouter} from '../index';
 import {RouterTestingHarness} from '../testing';
 
 describe('RouterLink', () => {
-  it('does not modify tabindex if already set on non-anchor element', async () => {
+  it('does not touch a tabindex set in the template on a non-anchor element', async () => {
     @Component({
       template: `<div [routerLink]="link" tabindex="1"></div>`,
       standalone: false,
@@ -73,19 +73,21 @@ describe('RouterLink', () => {
       (router.navigateByUrl as jasmine.Spy).calls.reset();
     });
 
-    it('null, removes tabIndex and does not navigate', async () => {
+    it('does not add a tabindex attribute', () => {
+      expect(link.hasAttribute('tabindex')).toBeFalse();
+    });
+
+    it('null, does not navigate', async () => {
       fixture.componentInstance.link.set(null);
       await fixture.whenStable();
-      expect(link.tabIndex).toEqual(-1);
 
       link.click();
       expect(router.navigateByUrl).not.toHaveBeenCalled();
     });
 
-    it('undefined, removes tabIndex and does not navigate', async () => {
+    it('undefined, does not navigate', async () => {
       fixture.componentInstance.link.set(undefined);
       await fixture.whenStable();
-      expect(link.tabIndex).toEqual(-1);
 
       link.click();
       expect(router.navigateByUrl).not.toHaveBeenCalled();


### PR DESCRIPTION
RouterLink automatically set `tabindex="0"` on any non-`<a>`/`<area>`
element it was applied to, with no way to opt out short of writing a
literal tabindex attribute in the template. It also made the element
focusable without making it keyboard-operable, since RouterLink only
listens for click events and never handled Enter/Space.

The behavior is now gated behind `ADD_TABINDEX_TO_NON_ANCHOR_ELEMENTS`,
which is `false` in the published package and kept `true` inside Google
(via a sync marker) while internal callers migrate off it. Because it is a
module-level `const`, bundlers fold it to `false` and drop the guarded
`setTabIndexIfNotOnNativeEl` body, so the published package carries none of
the tabindex logic.

To let the rest tree-shake with it:
- `Renderer2` is dropped. It was used only to write the tabindex
  attribute; that write now goes straight to the host element.
- `@Attribute('tabindex')` is replaced with a `HostAttributeToken`
  injected only inside the `ADD_TABINDEX_TO_NON_ANCHOR_ELEMENTS` branch of
  the constructor, so it is removed by the same fold.

The `RouterLink` constructor now takes `(router, route, el,
locationStrategy?)`.

BREAKING CHANGE: RouterLink no longer adds `tabindex="0"` to non-anchor
elements (e.g. `<div routerLink>`, `<button routerLink>`) by default. If
you need such an element to be part of the tab order, add `tabindex="0"`
to it directly in the template.

Fixes https://github.com/angular/angular/issues/28345