### PR TITLE
fix(core): wait for app stability before cleaning up dehydrated views

### DIFF
--- a/packages/core/src/defer/triggering.ts
+++ b/packages/core/src/defer/triggering.ts
@@ -498,12 +498,31 @@ export async function triggerHydrationForBlockQueue(
     replayQueuedEventsFn(hydrationQueue);
   }
 
+  // `cleanupHydratedDeferBlocks` -> `cleanupDehydratedViews` walks all LViews
+  // registered with ApplicationRef and removes dehydrated views that aren't
+  // associated with a defer block. This is only safe once the app is stable.
+  // There may still be other pending tasks that need one of those views before
+  // they get a chance to hydrate it.
+  //
+  // This block's task is removed above, but other tasks may still be pending.
+  // Wait for those before treating any remaining dehydrated views as orphaned.
+  //
+  // Don't wait if there are no other pending tasks. Calling `whenStable()`
+  // creates another subscription to the stability signal, which can move this
+  // cleanup to a later microtask than callers already waiting on
+  // `appRef.whenStable()`. Keeping this path synchronous preserves the existing
+  // behavior when the app is already stable.
+  const appRef = injector.get(ApplicationRef);
+  if (pendingTasks.hasPendingTasks) {
+    await appRef.whenStable();
+  }
+
   // Cleanup after hydration of all affected defer blocks.
   cleanupHydratedDeferBlocks(
     dehydratedBlockRegistry.get(lastBlockName),
     hydrationQueue,
     dehydratedBlockRegistry,
-    injector.get(ApplicationRef),
+    appRef,
   );
 }
 

--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -25,7 +25,9 @@ import {
   ɵresetIncrementalHydrationEnabledWarnedForTests as resetIncrementalHydrationEnabledWarnedForTests,
   signal,
   ɵTimerScheduler as TimerScheduler,
+  ViewChild,
   ViewChildren,
+  ViewContainerRef,
   ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR,
 } from '@angular/core';
 
@@ -2939,6 +2941,91 @@ describe('platform-server partial hydration integration', () => {
       expect(contract.instance!.cleanUp).not.toHaveBeenCalled();
       expect(registry.cleanup).toHaveBeenCalledTimes(1);
     });
+
+    it(
+      'should not remove a still-pending dehydrated view (e.g. from a plain ' +
+        'ViewContainerRef.createComponent() call guarded by PendingTasks) when an ' +
+        'unrelated @defer block on the same page hydrates first',
+      async () => {
+        // Represents content created dynamically via `ViewContainerRef.createComponent()`
+        // -- NOT a `@defer` block -- so its dehydrated view carries no `DEFER_BLOCK_ID`.
+        @Component({
+          selector: 'dynamic-cmp',
+          template: `<p id="dynamic-content">Dynamically created</p>`,
+        })
+        class DynamicCmp {}
+
+        @Component({
+          selector: 'app',
+          template: `
+            @defer (hydrate on immediate) {
+              <p id="defer-content">defer block</p>
+            }
+            <ng-template #container />
+          `,
+        })
+        class SimpleComponent {
+          @ViewChild('container', {read: ViewContainerRef, static: true})
+          container!: ViewContainerRef;
+
+          private readonly pendingTasks = inject(PendingTasks);
+
+          ngAfterViewInit() {
+            // Mirrors a real dynamic-component loader: creation is guarded by
+            // `PendingTasks` (so SSR waits for it), but the creation itself is
+            // genuinely async (e.g. behind a lazy-loaded chunk) on the client --
+            // giving the unrelated @defer block above time to hydrate and run
+            // its cleanup first.
+            this.pendingTasks.run(async () => {
+              await dynamicImportOf(DynamicCmp, 101);
+              this.container.createComponent(DynamicCmp);
+            });
+          }
+        }
+
+        const appId = 'custom-app-id';
+        const providers = [{provide: APP_ID, useValue: appId}];
+        const hydrationFeatures = () => [withIncrementalHydration()];
+
+        const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain('<p id="dynamic-content">Dynamically created</p>');
+        expect(ssrContents).toContain('<p id="defer-content">defer block</p>');
+
+        // Internal cleanup before we do server->client transition in this test.
+        resetTViewsFor(SimpleComponent, DynamicCmp);
+
+        ////////////////////////////////
+        const doc = getDocument();
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+          envProviders: [...providers, {provide: PLATFORM_ID, useValue: 'browser'}],
+          hydrationFeatures,
+        });
+
+        appRef.tick();
+
+        // Let the @defer (hydrate on immediate) block finish hydrating -- its
+        // completion triggers a GLOBAL `cleanupDehydratedViews` sweep over every
+        // LView on the page -- well before our own PendingTasks-guarded dynamic
+        // component creation resolves (that's still ~101ms away).
+        await timeout(20);
+
+        // BUG: `dynamic-content` was never claimed or replaced by anything at
+        // this point -- our own creation logic hasn't run yet. It should still
+        // be exactly the server-rendered content sitting untouched in the DOM.
+        // Before the fix, the @defer block's cleanup sweep incorrectly deletes
+        // it here because it carries no DEFER_BLOCK_ID, well before the code
+        // that's actually supposed to claim it ever gets a chance to run.
+        expect(doc.getElementById('dynamic-content')).not.toBeNull();
+
+        await allPendingDynamicImports();
+        appRef.tick();
+        await appRef.whenStable();
+
+        expect(doc.getElementById('dynamic-content')).not.toBeNull();
+      },
+    );
   });
 
   describe('Router', () => {


### PR DESCRIPTION
This fixes a production crash seen on pages that dynamically create non-defer components:

    TypeError: Cannot set properties of null (setting '__ngContext__')
    ...
    at locateOrCreateElementNodeImpl

The crash was traced to `triggerHydrationForBlockQueue()`. When a `@defer` block finishes hydrating, it removes its own `PendingTasks` entry and immediately calls `cleanupHydratedDeferBlocks()` -> `cleanupDehydratedViews()`. That cleanup walks all LViews registered with `ApplicationRef` and removes dehydrated views that aren't associated with a defer block. This isn't safe while other async hydration work is still pending.

For example, a dynamically created component can have its own `PendingTasks` entry while its `ViewContainerRef.createComponent()` call is still waiting to run. If an unrelated defer block finishes first, its cleanup can remove that component's dehydrated view before the component gets a chance to claim it. The later creation then sees stale hydration state and can fail with the crash above.

This was reproduced with a test in `incremental_hydration_spec.ts` that combines an immediately hydrated `@defer` block with an unrelated `PendingTasks`-guarded `ViewContainerRef.createComponent()` whose creation is delayed until after the defer block hydrates. The test fails with the original code and passes with this fix.

The fix waits for `ApplicationRef.whenStable()` before running the cleanup, but only when there are other pending tasks. This keeps the usual case synchronous while making sure cleanup doesn't run while other hydration work is still in progress.

The wait is intentionally conditional. An unconditional `whenStable()` introduces another subscription to the shared stability signal. Because this subscription is created after this function removes its own pending task, callers that are already waiting on `whenStable()` can resume one microtask before this cleanup does. That changes the existing timing and breaks the `immediate` and `should create an IntersectionObserver...` tests. Checking `hasPendingTasks` first avoids creating that extra subscription when there is nothing else to wait for, preserving the existing behavior.