### PR TITLE
docs: update examples to use the Service decorator

### DIFF
--- a/adev/src/content/examples/form-validation/src/app/shared/actors.service.ts
+++ b/adev/src/content/examples/form-validation/src/app/shared/actors.service.ts
@@ -1,10 +1,10 @@
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {delay} from 'rxjs/operators';
 
 const ROLES = ['Hamlet', 'Ophelia', 'Romeo', 'Juliet'];
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class ActorsService {
   isRoleTaken(role: string): Observable<boolean> {
     const isTaken = ROLES.includes(role);

--- a/adev/src/content/examples/form-validation/src/app/shared/role.directive.ts
+++ b/adev/src/content/examples/form-validation/src/app/shared/role.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, forwardRef, inject, Injectable} from '@angular/core';
+import {Directive, forwardRef, inject, Service} from '@angular/core';
 import {
   AsyncValidator,
   AbstractControl,
@@ -10,7 +10,7 @@ import {ActorsService} from './actors.service';
 import {Observable, of} from 'rxjs';
 
 // #docregion async-validator
-@Injectable({providedIn: 'root'})
+@Service()
 export class UniqueRoleValidator implements AsyncValidator {
   private readonly actorsService = inject(ActorsService);
 

--- a/adev/src/content/examples/schematics-for-libraries/projects/my-lib/schematics/my-service/files/__name@dasherize__.service.ts.template
+++ b/adev/src/content/examples/schematics-for-libraries/projects/my-lib/schematics/my-service/files/__name@dasherize__.service.ts.template
@@ -1,10 +1,8 @@
 // #docregion template
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Service()
 export class <%= classify(name) %>Service {
   private http = inject(HttpClient);
 }

--- a/adev/src/content/examples/schematics-for-libraries/projects/my-lib/src/lib/my-lib.service.ts
+++ b/adev/src/content/examples/schematics-for-libraries/projects/my-lib/src/lib/my-lib.service.ts
@@ -1,6 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class MyLibService {}

--- a/adev/src/content/examples/service-worker-getting-started/src/app/check-for-update.service.ts
+++ b/adev/src/content/examples/service-worker-getting-started/src/app/check-for-update.service.ts
@@ -1,9 +1,9 @@
-import {ApplicationRef, inject, Injectable} from '@angular/core';
+import {ApplicationRef, inject, Service} from '@angular/core';
 import {SwUpdate} from '@angular/service-worker';
 import {concat, interval} from 'rxjs';
 import {first} from 'rxjs/operators';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class CheckForUpdateService {
   private appRef = inject(ApplicationRef);
   private updates = inject(SwUpdate);

--- a/adev/src/content/examples/service-worker-getting-started/src/app/handle-unrecoverable-state.service.ts
+++ b/adev/src/content/examples/service-worker-getting-started/src/app/handle-unrecoverable-state.service.ts
@@ -1,10 +1,10 @@
-import {inject, Injectable} from '@angular/core';
+import {inject, Service} from '@angular/core';
 import {SwUpdate} from '@angular/service-worker';
 
 function notifyUser(message: string): void {}
 
 // #docregion sw-unrecoverable-state
-@Injectable({providedIn: 'root'})
+@Service()
 export class HandleUnrecoverableStateService {
   private updates = inject(SwUpdate);
   constructor() {

--- a/adev/src/content/examples/service-worker-getting-started/src/app/log-update.service.ts
+++ b/adev/src/content/examples/service-worker-getting-started/src/app/log-update.service.ts
@@ -1,8 +1,8 @@
-import {inject, Injectable} from '@angular/core';
+import {inject, Service} from '@angular/core';
 import {SwUpdate, VersionReadyEvent} from '@angular/service-worker';
 
 // #docregion sw-update
-@Injectable({providedIn: 'root'})
+@Service()
 export class LogUpdateService {
   private updates = inject(SwUpdate);
   constructor() {

--- a/adev/src/content/examples/service-worker-getting-started/src/app/prompt-update.service.ts
+++ b/adev/src/content/examples/service-worker-getting-started/src/app/prompt-update.service.ts
@@ -1,5 +1,5 @@
 // #docplaster
-import {inject, Injectable} from '@angular/core';
+import {inject, Service} from '@angular/core';
 // #docregion sw-replicate-available
 import {filter, map} from 'rxjs/operators';
 // #enddocregion sw-replicate-available
@@ -10,7 +10,7 @@ function promptUser(event: VersionReadyEvent): boolean {
 }
 
 // #docregion sw-version-ready
-@Injectable({providedIn: 'root'})
+@Service()
 export class PromptUpdateService {
   constructor() {
     const swUpdate = inject(SwUpdate);

--- a/adev/src/content/guide/di/dependency-injection-context.md
+++ b/adev/src/content/guide/di/dependency-injection-context.md
@@ -36,10 +36,8 @@ const canActivateTeam: CanActivateFn = (
 If you need to run a function within an injection context without already being in one, you can use `runInInjectionContext`.
 This requires access to an injector, such as the `EnvironmentInjector`:
 
-```ts {highlight: [9], header:"hero.service.ts"}
-@Injectable({
-  providedIn: 'root',
-})
+```ts {highlight: [7], header:"hero.service.ts"}
+@Service()
 export class HeroService {
   private environmentInjector = inject(EnvironmentInjector);
 
@@ -72,9 +70,7 @@ You can then call this helper **from an injection context** (constructor, field 
 import {Component, inject} from '@angular/core';
 import {injectNativeElement} from './dom-helpers';
 
-@Component({
-  /* … */
-})
+@Component({/* … */})
 export class PreviewCard {
   readonly hostEl = injectNativeElement<HTMLElement>(); // Field initializer runs in an injection context.
 

--- a/adev/src/content/guide/testing/services.md
+++ b/adev/src/content/guide/testing/services.md
@@ -35,7 +35,7 @@ describe('Calculator', () => {
 
   beforeEach(() => {
     // Injects the Calculator service which is available to Angular
-    // because the service uses `providedIn: 'root'`
+    // because the service uses `@Service`
     service = TestBed.inject(Calculator);
   });
 


### PR DESCRIPTION
Use the new `@Service` decorator in documentation examples to reflect the recommended way of declaring root-provided services.

