### PR TITLE
fix(docs-infra): don't render a return type on constructor signatures

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.mts
@@ -79,4 +79,22 @@ describe('renderable', () => {
       expect(anchor.getAttribute('href')).toBe(`#${id}`);
     }
   });
+
+  it('should not render a return type on constructor signatures', () => {
+    const httpRequest = entries.get('HttpRequest')!;
+    expect(httpRequest).toBeDefined();
+
+    const html = renderEntry(httpRequest);
+    const fragment = JSDOM.fragment(html);
+
+    const constructorLines = Array.from(fragment.querySelectorAll('.docs-code .line'))
+      .map((line) => line.textContent!.trim())
+      .filter((line) => line.startsWith('constructor('));
+
+    expect(constructorLines.length).toBeGreaterThan(0);
+    for (const line of constructorLines) {
+      // Constructors have no return type, the signature ends with the parameter list.
+      expect(line).toMatch(/\);$/);
+    }
+  });
 });

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
@@ -53,6 +53,8 @@ const INDENT = '  ';
 const SPACE = ' ';
 const LN_BREAK = '\n';
 const INDENTED_NEW_LINE = `${LN_BREAK}${INDENT}`;
+/** Name given to constructor entries by the docs extraction. */
+const CONSTRUCTOR_NAME = 'constructor';
 
 // Allows to generate links for code lines.
 interface CodeTableOfContentsData {
@@ -340,14 +342,15 @@ function getCodeTocData(members: MemberEntry[], isDeprecated: boolean): CodeTabl
     };
 
     if (isClassMethodEntry(curr)) {
+      const isConstructor = curr.name === CONSTRUCTOR_NAME;
       // class methods
       if (curr.signatures.length > 0) {
         curr.signatures.forEach((signature) => {
-          setTocData(signature, getMethodCodeLine(signature, curr.memberTags));
+          setTocData(signature, getMethodCodeLine(signature, curr.memberTags, isConstructor));
         });
       } else {
         // Constructors, methods on interfaces, Decorators
-        setTocData(curr, getMethodCodeLine(curr.implementation, curr.memberTags));
+        setTocData(curr, getMethodCodeLine(curr.implementation, curr.memberTags, isConstructor));
       }
     } else {
       // class props
@@ -375,12 +378,19 @@ function getPropertyCodeLine(member: PropertyEntry): string {
 }
 
 /** Map method entry to text */
-function getMethodCodeLine(member: FunctionSignatureMetadata, memberTags: MemberTags[]): string {
+function getMethodCodeLine(
+  member: FunctionSignatureMetadata,
+  memberTags: MemberTags[],
+  isConstructor = false,
+): string {
   const generics = makeGenericsText(member.generics);
+  // Constructors don't have a return type in TypeScript, so we omit it to keep the
+  // generated signature valid.
+  const returnType = isConstructor ? '' : `: ${member.returnType}`;
   return (
     `${memberTags.join(SPACE)}${memberTags.length ? ' ' : ''}${member.name}${generics}(` +
     `${member.params.map((param) => mapParamEntry(param)).join(`, `)}` +
-    `): ${member.returnType};`
+    `)${returnType};`
   );
 }
 


### PR DESCRIPTION
The API reference code block built every class member signature with a return type, so constructors were rendered as invalid TypeScript:

```
class ActivationStart {
    constructor(snapshot: ActivatedRouteSnapshot): ActivationStart;
}
```

Constructors are extracted as regular method entries whose return type is the class itself, so `getMethodCodeLine` now omits the return type when the member is a constructor, for both the single signature and the overloaded cases:

  ```
class ActivationStart {
    constructor(snapshot: ActivatedRouteSnapshot);
}
```

## What is the current behavior?
https://angular.dev/api/router/ActivationStart
