### PR TITLE
refactor(core): expose onDestroy in DirectiveFixture

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -51,6 +51,7 @@ export enum DeferBlockState {
 export class DirectiveFixture<T> extends AbstractFixture<Element> {
     constructor(hostRef: ComponentRef<unknown>, directiveInstance: T);
     readonly directiveInstance: T;
+    onDestroy(callback: () => void): void;
 }
 
 // @public

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -3157,4 +3157,23 @@ describe('TestBed.createDirective', () => {
     expect(dir.moduleService.value).toBe('hello-module');
     expect(dir.dirService.value).toBe('hello-directive');
   });
+
+  it('should invoke destroy callbacks when the fixture is destroyed', () => {
+    const callbacks: string[] = [];
+
+    @Directive()
+    class Dir {
+      ngOnDestroy() {
+        callbacks.push('directive: ngOnDestroy');
+      }
+    }
+
+    const fixture = TestBed.createDirective(Dir, {tagName: 'div'});
+    fixture.onDestroy(() => callbacks.push('fixture: onDestroy'));
+    fixture.detectChanges();
+    expect(callbacks).toEqual([]);
+
+    fixture.destroy();
+    expect(callbacks).toEqual(['directive: ngOnDestroy', 'fixture: onDestroy']);
+  });
 });

--- a/packages/core/testing/src/fixture.ts
+++ b/packages/core/testing/src/fixture.ts
@@ -85,7 +85,7 @@ export abstract class AbstractFixture<E> {
   readonly changeDetectorRef: ChangeDetectorRef;
 
   /** @docs-private */
-  constructor(private readonly hostRef: ComponentRef<unknown>) {
+  constructor(protected readonly hostRef: ComponentRef<unknown>) {
     this.changeDetectorRef = hostRef.changeDetectorRef;
     this.debugElement = getDebugNode(hostRef.location.nativeElement) as DebugElement;
     this.nativeElement = hostRef.location.nativeElement;
@@ -313,5 +313,10 @@ export class DirectiveFixture<T> extends AbstractFixture<Element> {
   constructor(hostRef: ComponentRef<unknown>, directiveInstance: T) {
     super(hostRef);
     this.directiveInstance = directiveInstance;
+  }
+
+  /** Registers a callback that will be invoked when the fixture is destroyed. */
+  onDestroy(callback: () => void) {
+    this.hostRef.onDestroy(callback);
   }
 }


### PR DESCRIPTION
Exposes the `onDestroy` method from the host component in `DirectiveFixture`. We need this for harnesses in the CDK.