### PR TITLE
refactor(core): move @defer hydrate trigger registration inside binding check

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -307,14 +307,13 @@ export function ɵɵdeferHydrateWhen(rawValue: unknown) {
 
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
-  // TODO(incremental-hydration): audit all defer instructions to reduce unnecessary work by
-  // moving function calls inside their relevant control flow blocks
   const bindingIndex = nextBindingIndex();
-  const tView = getTView();
-  const hydrateTriggers = getHydrateTriggers(tView, tNode);
-  hydrateTriggers.set(DeferBlockTrigger.When, null);
 
   if (bindingUpdated(lView, bindingIndex, rawValue)) {
+    const tView = getTView();
+    const hydrateTriggers = getHydrateTriggers(tView, tNode);
+    hydrateTriggers.set(DeferBlockTrigger.When, null);
+
     if (typeof ngServerMode !== 'undefined' && ngServerMode) {
       // We are on the server and SSR for defer blocks is enabled.
       triggerDeferBlock(TriggerType.Hydrate, lView, tNode);

--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -338,6 +338,33 @@ describe('platform-server partial hydration integration', () => {
         // which contains parent id (which is not needed for top-level blocks).
         expect(ssrContents).toContain('"__nghDeferData__":{"d0":{"r":1,"s":2}}}');
       });
+
+      it('should serialize blocks whose only hydrate trigger is `hydrate when`', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            @defer (hydrate when shouldHydrate) {
+              Hello world!
+            } @placeholder {
+              <span>Placeholder</span>
+            }
+          `,
+        })
+        class SimpleComponent {
+          shouldHydrate = false;
+        }
+
+        const appId = 'custom-app-id';
+        const providers = [{provide: APP_ID, useValue: appId}];
+
+        const html = await ssr(SimpleComponent, {
+          envProviders: providers,
+        });
+
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain('"__nghDeferData__":{"d0":{"r":1,"s":2}}}');
+      });
     });
 
     describe('basic hydration behavior', () => {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
Resolves the TODO(incremental-hydration) in the same function. An audit of the remaining defer instructions found no other sites: 20 run in the create block, and ɵɵdeferWhen/ɵɵdeferPrefetchWhen already keep their lookups inside the guard

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe: