### PR TITLE
fix(core): defer afterRenderEffect sequences registered while hooks run

### DIFF
--- a/packages/core/src/render3/after_render/manager.ts
+++ b/packages/core/src/render3/after_render/manager.ts
@@ -139,7 +139,13 @@ export class AfterRenderImpl {
   }
 
   addSequence(sequence: AfterRenderSequence): void {
-    this.sequences.add(sequence);
+    if (this.executing) {
+      // Defer registrations made while hooks are running. Otherwise the sequence could start
+      // in the current pass with its earlier phases already skipped. See #61715.
+      this.deferredRegistrations.add(sequence);
+    } else {
+      this.sequences.add(sequence);
+    }
     // Trigger an `ApplicationRef.tick()` if one is not already pending/running, because we have a
     // new render hook that needs to run.
     this.scheduler.notify(NotificationSource.RenderHook);

--- a/packages/core/test/acceptance/after_render_effect_spec.ts
+++ b/packages/core/test/acceptance/after_render_effect_spec.ts
@@ -9,7 +9,10 @@
 import {
   afterNextRender,
   ApplicationRef,
+  Component,
   computed,
+  createComponent,
+  EnvironmentInjector,
   PLATFORM_ID,
   provideZonelessChangeDetection,
   signal,
@@ -364,5 +367,45 @@ describe('afterRenderEffect', () => {
     counter.set(1);
     appRef.tick();
     expect(log).toEqual(['earlyRead: 1', 'earlyRead: 0', 'write: 0']);
+  });
+
+  it('runs all phases in order for a sequence registered while hooks are executing', async () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    const environmentInjector = TestBed.inject(EnvironmentInjector);
+
+    @Component({template: ''})
+    class Inner {
+      constructor() {
+        afterRenderEffect({
+          earlyRead: () => {
+            log.push('inner earlyRead');
+            return 'from earlyRead';
+          },
+          write: (value) => {
+            log.push(`inner write: ${typeof value === 'function' ? value() : value}`);
+          },
+        });
+      }
+    }
+
+    // The `write` hook creates and change-detects a component that registers its own effect.
+    // This mirrors a custom element connecting during a render phase. See #61715.
+    afterNextRender(
+      {
+        write: () => {
+          const ref = createComponent(Inner, {environmentInjector});
+          appRef.attachView(ref.hostView);
+          ref.changeDetectorRef.detectChanges();
+        },
+      },
+      {injector: appRef.injector},
+    );
+
+    appRef.tick();
+    await appRef.whenStable();
+
+    // `earlyRead` must run before `write`, and pass its result to `write`.
+    expect(log).toEqual(['inner earlyRead', 'inner write: from earlyRead']);
   });
 });


### PR DESCRIPTION
`AfterRenderImpl.addSequence` added the sequence straight to `sequences` without checking whether hooks were already running. If a view was change-detected from inside a render hook (for example, when a custom element connects to the DOM during a render phase), its `afterRenderEffect` sequence could be added mid-pass. The phase loop would then run its later phases in the current pass and skip the earlier ones, so `earlyRead` could run a tick after `write`. This also shifted the phase callback arguments and eventually caused `TypeError: fn is not a function` when the view was destroyed.

Defer these registrations to the next pass, like `register` already does for sequences registered outside a view.

Fixes https://github.com/angular/angular/issues/61715