### PR TITLE
test(forms): remove redundant change detection configuration

### DIFF
--- a/packages/forms/signals/test/node/form_root.spec.ts
+++ b/packages/forms/signals/test/node/form_root.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
@@ -33,12 +33,6 @@ class TestCmp {
 }
 
 describe('FormRoot', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-  });
-
   it('should set novalidate on the form element', () => {
     const fixture = act(() => TestBed.createComponent(TestCmp));
     const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;

--- a/packages/forms/signals/test/web/compat_form.spec.ts
+++ b/packages/forms/signals/test/web/compat_form.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormControl} from '@angular/forms';
 import {compatForm} from '../../compat';
@@ -14,12 +14,6 @@ import {FormField} from '../../public_api';
 import {act} from '@angular/private/testing';
 
 describe('compatForm with [formField] directive', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-  });
-
   it('should bind compat form to input with [formField] directive', () => {
     @Component({
       imports: [FormField],

--- a/packages/forms/signals/test/web/debounce_async_validation_bug.spec.ts
+++ b/packages/forms/signals/test/web/debounce_async_validation_bug.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, debounced, resource, signal} from '@angular/core';
+import {Component, debounced, resource, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {form, FormField, validateAsync} from '../../public_api';
@@ -15,7 +15,6 @@ describe('debounced inside validateAsync bug', () => {
   it('should not throw a cycle error when using debounced in validateAsync factory', async () => {
     @Component({
       selector: 'debounce-bug',
-      changeDetection: ChangeDetectionStrategy.OnPush,
       template: ` <input [formField]="form.hello" /> `,
       imports: [FormField],
     })

--- a/packages/forms/signals/test/web/field_proxy.spec.ts
+++ b/packages/forms/signals/test/web/field_proxy.spec.ts
@@ -6,31 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  input,
-  provideZonelessChangeDetection,
-  signal,
-} from '@angular/core';
+import {Component, input, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {form, type FieldTree} from '../../public_api';
 import {act} from '@angular/private/testing';
 
 describe('field proxy', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-  });
-
   it('@for over array field should be reactive', () => {
     @Component({
       selector: 'iterate-field',
       template: `@for (i of f(); track i) {
         <p>hi</p>
       }`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class IterateFieldCmp {
       f = input.required<FieldTree<number[]>>();
@@ -42,7 +29,6 @@ describe('field proxy', () => {
         <button (click)="add()">add</button>
       `,
       imports: [IterateFieldCmp],
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class ParentCmp {
       f = form(signal([0]));

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -15,7 +15,6 @@ import {
   Input,
   input,
   model,
-  provideZonelessChangeDetection,
   resource,
   signal,
   viewChild,
@@ -58,12 +57,6 @@ import {
 import {act, actAsync} from '@angular/private/testing';
 
 describe('ControlValueAccessor', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-  });
-
   @Component({
     selector: 'custom-control',
     template: `

--- a/packages/forms/signals/test/web/signal_form_control_web.spec.ts
+++ b/packages/forms/signals/test/web/signal_form_control_web.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Injector, inject, provideZonelessChangeDetection, signal} from '@angular/core';
+import {Component, Injector, inject, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 import {disabled, FormField} from '@angular/forms/signals';
@@ -15,13 +15,6 @@ import {SignalFormControl} from '../../compat';
 import {act} from '@angular/private/testing';
 
 describe('SignalFormControl (web)', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-      imports: [ReactiveFormsModule, FormField],
-    });
-  });
-
   it('binds to formField directive', () => {
     @Component({
       imports: [ReactiveFormsModule, FormField],

--- a/packages/forms/test/ng_control_status_spec.ts
+++ b/packages/forms/test/ng_control_status_spec.ts
@@ -6,21 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, provideZonelessChangeDetection} from '@angular/core';
+import {Component} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule, Validators} from '../public_api';
 import {TestBed} from '@angular/core/testing';
 
 describe('status host binding classes', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({providers: [provideZonelessChangeDetection()]});
-  });
-
   it('work in OnPush components', async () => {
     @Component({
       selector: 'test-cmp',
       template: `<input type="text" [formControl]="control" />`,
       imports: [FormsModule, ReactiveFormsModule],
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class App {
       control = new FormControl('old value', [Validators.required]);

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -1653,7 +1653,6 @@ describe('value accessors', () => {
         @Component({
           selector: 'parent',
           template: '<child [ngModel]="value"></child>',
-          changeDetection: ChangeDetectionStrategy.OnPush,
           standalone: false,
         })
         class Parent {


### PR DESCRIPTION
`OnPush` is now the default change detection strategy, and tests run zoneless by default, so the explicit configuration is no longer needed.
 