### PR TITLE
test(docs-infra): run the orphaned shared-docs pipes specs

### DIFF
--- a/adev/shared-docs/pipes/BUILD.bazel
+++ b/adev/shared-docs/pipes/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -29,4 +29,21 @@ ng_project(
         "//adev/shared-docs/interfaces",
         "//adev/shared-docs/utils",
     ],
+)
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(
+        ["*.spec.ts"],
+    ),
+    deps = [
+        ":lib",
+        "//adev/shared-docs/interfaces",
+    ],
+)
+
+zoneless_web_test_suite(
+    name = "test",
+    deps = [":test_lib"],
 )


### PR DESCRIPTION
`relative-link.pipe.spec.ts` and `is-active-navigation-item.pipe.spec.ts` arrived with this package's BUILD file in #57132, but no test target came with them and `lib` excludes `**/*.spec.ts`, so nothing has ever compiled them. `bazel query` reports both as not declared in the package.

They pass unmodified. `getRelativeUrl` has no other coverage in the repo, and both pipes are used by the search dialog, the navigation list and the not found page.