### PR TITLE
refactor(docs-infra): validate api/cdk and api/aria links

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/renderer.mts
+++ b/adev/shared-docs/pipeline/shared/marked/renderer.mts
@@ -75,10 +75,6 @@ export class AdevDocsRenderer extends Renderer {
       route.startsWith('#') || // Anchor link within the same page
       route.startsWith('mailto:') || // Should we have a regex to exclude any protocol?
       route.startsWith('playground') ||
-      // TODO: Extract routes from the CDK as well
-      route.startsWith('api/cdk') ||
-      // TODO: Extract routes from Aria as well
-      route.startsWith('api/aria') ||
       route.startsWith('tutorials') ||
       route.startsWith('extended-diagnostics')
     ) {


### PR DESCRIPTION
`isKnownRoute` exempted both families behind TODOs waiting on route extraction for those packages. That extraction had already landed when the TODOs were written in #66254: cdk pages since #60853 and aria pages since the cross-repo workflow. `defined-routes.json` carries 70 `api/cdk` and 39 `api/aria` routes today, and all 45 such link targets in the guides resolve, so the build stays green without the exemptions.

The gap was not theoretical. `guide/aria/select.md` and `guide/aria/multiselect.md` linked `api/cdk/overlay/CdkConnectedOverlay`, which has never been a route, and it shipped as a 404 for six months. Link validation landed four months into that and said nothing, because of this exemption. It took a user filing #68914 and an outside contributor fixing it in #68915.