### PR TITLE
feat(router): make route resources reactive and support parallel depe…

### DIFF
--- a/adev/src/content/guide/routing/data-fetching-with-resources.md
+++ b/adev/src/content/guide/routing/data-fetching-with-resources.md
@@ -4,16 +4,16 @@ The Angular Router integrates with Angular Signals through the `resources` route
 
 ## Why use route resources?
 
-Route resources offer several advantages over traditional [data resolvers](/guide/routing/data-resolvers):
+Route resources integrate the Angular Router directly with Angular Signals and `Resource` APIs, offering significant advantages over traditional [data resolvers](/guide/routing/data-resolvers):
 
-- **Parallel execution**: Route resources run concurrently across all matched routes, eliminating the sequential waterfall delays of resolvers.
-- **Non-blocking data loading**: Use `nonBlocking()` to activate the route immediately and render loading skeletons or UI states while data loads in the background.
-- **Reload without renavigation**: Call `.reload()` on individual resources or update signal parameters to refresh data without triggering a full route navigation, rerun guards, or re-match routes.
-- **Reactive data fetching**: Resources integrate directly with Angular Signals, automatically re-evaluating when signal dependencies change and exposing reactive status signals like `isLoading()` and `error()`.
+- **Parallel execution without waterfalls**: Resources across all matched routes execute concurrently. Even when child routes depend on data from parent routes, reactive coordination eliminates traditional sequential network waterfalls.
+- **Automatic, fine-grained change tracking**: Resources subscribe directly to the exact signal properties they read (such as `ctx.params()['id']` or `ctx.queryParams()['tab']`). Navigating between URLs only re-evaluates resources whose specific dependencies changed, with zero manual dependency arrays or cache invalidation keys.
+- **Non-blocking data loading**: Unlike resolvers which strictly block navigation, you can wrap resources with `nonBlocking()` to activate the route immediately and render loading skeletons or progressive UI states.
+- **Reload without renavigation**: Call `.reload()` on individual resources or update signal dependencies to refresh data without triggering full route navigations, running route guards, or re-matching routes.
 
-## Setup
+## Enabling route resources
 
-To enable this feature, provide `withRouterResources()` to your router configuration:
+To enable route resources, provide `withRouterResources()` to your router configuration:
 
 ```ts
 import {provideRouter, withComponentInputBinding, withRouterResources} from '@angular/router';
@@ -23,9 +23,11 @@ bootstrapApplication(App, {
 });
 ```
 
-You can then define resources in your `Route` definitions and access them directly as component inputs.
+TIP: Enable `withComponentInputBinding()` so the router can bind resolved resources directly to component inputs.
 
-The `resources` function runs in an injection context, allowing you to use `inject()` to access services, API clients, or stores directly inside the route definition.
+## Defining route resources
+
+You define resources on a route using the `resources` function. The function runs in an injection context, allowing you to use `inject()` to access services, API clients, or stores directly inside the route definition.
 
 ```angular-ts
 import {Component, inject, input, resource} from '@angular/core';
@@ -57,21 +59,15 @@ export class UserProfile {
 }
 ```
 
-TIP: Notice we map the exact primitive ID we need in `params: () => ctx.params()['id']`. Passing the entire parameters object (e.g. `params: () => ctx.params()`) can cause unnecessary resource reloads during navigations. Because the router generates a new object identity for the parameters on navigation, the resource will trigger a refetch even if the specific `id` value you care about hasn't changed.
+### The ResourceContext
 
-### Parallel execution (avoiding waterfalls)
+The `resources` function receives a `ResourceContext` providing:
 
-Traditional data resolvers execute sequentially from parent routes to child routes. If a parent route resolver takes 200ms and a child route resolver takes 300ms, the navigation is blocked for 500ms total.
+- Route signals: `params`, `queryParams`, `fragment`, and `data`.
+- `resources`: A `Signal<ResourceResult>` containing resources defined on or inherited by the route.
+- `routeConfig`: The matched route configuration object (`Route | null`).
 
-In contrast, all route resources across the entire matched route hierarchy execute concurrently during navigation. In the same scenario, navigation completes in 300ms (the time of the slowest resource), eliminating network waterfalls.
-
-TIP: If a resource depends on data from another resource, you can compose the requests within a single resource's loader function, or chain dependent resources using [`chain()`](/guide/signals/resource#chaining-resources).
-
-### ResourceContext
-
-The `resources` function receives a `ResourceContext` providing access to route signals (such as `params`, `queryParams`, and `data`) as well as the static `snapshot`.
-
-### Resource implementations and async configuration
+### Supported resource implementations
 
 The `resources` map supports any Angular `Resource` implementation (such as `resource()`, `rxResource()`, or custom resources).
 
@@ -109,37 +105,134 @@ resources: async (ctx) => {
 },
 ```
 
-## Reloading resources without renavigation
+## Fine-grained change tracking with signals
 
-With traditional data resolvers, refetching data requires triggering a route navigation (such as navigating with `onSameUrlNavigation: 'reload'`), which re-evaluates all route guards, resolvers, and route matching logic.
+Route resources leverage Angular Signals to track dependencies automatically at the property level.
 
-With route resources, you can reload data without renavigating:
+When you access a route parameter or query parameter within a resource's `params` computation, Angular establishes a fine-grained reactive dependency:
 
-1. **Programmatic reload**: Call `.reload()` directly on the `Resource` instance.
-2. **Reactive reload**: If a resource's `params` computation reads signals (such as an application filter or state signal), updating those signals automatically re-triggers the resource loader.
+```ts
+resources: (ctx) => ({
+  products: resource({
+    // Only subscribes to the 'category' query parameter
+    params: () => ctx.queryParams()['category'],
+    loader: ({params: category}) => fetchProducts(category),
+  }),
+}),
+```
 
-When using `withComponentInputBinding()`, blocking resources bind only their unwrapped value directly to component inputs. If you need to interact with the underlying `Resource` instance (for example, to trigger a manual `.reload()` or inspect status signals), access it through `ActivatedRoute` or `ActivatedRouteSnapshot`:
+Because `ctx.queryParams()['category']` reads only the `'category'` property:
+
+- If a navigation updates an unrelated query parameter (such as `?sort=desc` or `?page=2`), the `'category'` property remains unchanged.
+- The resource automatically recognizes that its dependency did not change and does not refetch.
+
+You do not need to maintain manual dependency arrays, configure query keys, or write custom cache-invalidation logic. Angular's reactive graph automatically tracks the exact data dependencies.
+
+TIP: Always read specific properties directly (such as `ctx.params()['id']` or `ctx.queryParams()['category']`) rather than returning the entire parameters object (such as `ctx.params()`). If you return the entire object, the router creates a new object reference on every navigation, which triggers a refetch even if individual parameter values did not change.
+
+## Parallel execution without waterfalls
+
+Traditional data resolvers execute sequentially from parent routes to child routes. If a parent route resolver takes 200ms and a child route resolver takes 300ms, the navigation is blocked for 500ms total.
+
+In contrast, route resources across the entire matched route hierarchy execute concurrently during navigation. In that same scenario, navigation completes in 300ms (the time of the slowest resource), eliminating network waterfalls.
+
+### Reactive coordination for dependent resources
+
+Nested routes frequently require data from a parent route before loading child data. In traditional routing architectures, this forces a sequential waterfall: the child loader cannot even be called until the parent loader finishes.
+
+With route resources, all setup functions and independent loaders across all route levels initialize concurrently. When a child resource depends on a parent resource, it coordinates reactively through Signals:
+
+```ts
+const routes: Routes = [
+  {
+    path: 'user/:id',
+    resources: (ctx) => ({
+      user: resource({
+        params: () => ctx.params()['id'],
+        loader: ({params: id}) => fetchUser(id),
+      }),
+    }),
+    children: [
+      {
+        path: 'details',
+        component: UserDetails,
+        resources: (ctx) => ({
+          details: resource({
+            // Retains the loading state while the parent resource resolves
+            params: ({chain}) => chain(ctx.resources()['user']).role,
+            loader: ({params: role}) => fetchRoleDetails(role),
+          }),
+        }),
+      },
+    ],
+  },
+];
+```
+
+In this architecture:
+
+1. Both the parent route and child route run their `resources` setup functions concurrently.
+2. The parent `user` resource immediately begins fetching user data.
+3. The child `details` resource chains off the parent resource with `chain(ctx.resources()['user'])`, keeping the child in a `loading` state while the parent is in flight.
+4. The instant the parent `user` resource emits its resolved value, the child's `params` computation receives the result and triggers `fetchRoleDetails(role)`.
+
+This reactive coordination gives you the best of both worlds: independent resources load concurrently without waiting, and dependent resources start fetching as soon as their prerequisite data is available, with zero manual orchestration.
+
+TIP: Within the same route, you can also compose requests inside a single resource's loader or use [`chain()`](/guide/signals/resource#chaining-resources).
+
+## Resource inheritance
+
+Resources defined on ancestor routes are always inherited down the route tree to all descendant routes.
+
+Child routes and components can access inherited ancestor resources through:
+
+- In route configuration, child resources can read ancestor resources via `ctx.resources()`.
+- With `withComponentInputBinding()`, child components receive inherited resources directly as inputs.
+- Through `ActivatedRoute` or `ActivatedRouteSnapshot`, you can inspect ancestor resources using `route.resources`.
+
+For example, consider a nested project management view:
 
 ```angular-ts
-import {Component, inject, input} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
+const routes: Routes = [
+  {
+    path: 'projects/:projectId',
+    resources: (ctx) => ({
+      project: resource({
+        params: () => ctx.params()['projectId'],
+        loader: ({params: id}) => fetchProject(id),
+      }),
+    }),
+    children: [
+      {
+        path: 'tasks/:taskId',
+        component: TaskDetail,
+        resources: (ctx) => ({
+          task: resource({
+            params: () => ctx.params()['taskId'],
+            loader: ({params: id}) => fetchTask(id),
+          }),
+        }),
+      },
+    ],
+  },
+];
 
 @Component({
   template: `
-    <p>User: {{ user().name }}</p>
-    <button (click)="refreshUser()">Refresh</button>
+    <h1>Project: {{ project().name }}</h1>
+    <h2>Task: {{ task().title }}</h2>
   `,
 })
-export class UserProfile {
-  user = input.required<User>();
-  private userResource = inject(ActivatedRoute).resources?.['user'];
+export class TaskDetail {
+  // Inherited from the parent 'projects/:projectId' route
+  project = input.required<Project>();
 
-  refreshUser() {
-    // Reloads only this specific resource without renavigating the route
-    this.userResource?.reload();
-  }
+  // Bound from the route's own resource
+  task = input.required<Task>();
 }
 ```
+
+The `TaskDetail` component receives both the parent `project` resource and its own `task` resource directly as inputs.
 
 ## Blocking and non-blocking resources
 
@@ -219,6 +312,38 @@ const routes: Routes = [
     },
   },
 ];
+```
+
+## Reloading resources without renavigation
+
+With traditional data resolvers, refetching data requires triggering a route navigation (such as navigating with `onSameUrlNavigation: 'reload'`), which re-evaluates all route guards, resolvers, and route matching logic.
+
+With route resources, you can reload data without renavigating:
+
+1. **Programmatic reload**: Call `.reload()` directly on the `Resource` instance.
+2. **Reactive reload**: If a resource's `params` computation reads signals (such as an application filter or state signal), updating those signals automatically re-triggers the resource loader.
+
+When using `withComponentInputBinding()`, blocking resources bind only their unwrapped value directly to component inputs. If you need to interact with the underlying `Resource` instance (for example, to trigger a manual `.reload()` or inspect status signals), access it through `ActivatedRoute` or `ActivatedRouteSnapshot`:
+
+```angular-ts
+import {Component, inject, input} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+
+@Component({
+  template: `
+    <p>User: {{ user().name }}</p>
+    <button (click)="refreshUser()">Refresh</button>
+  `,
+})
+export class UserProfile {
+  user = input.required<User>();
+  private userResource = inject(ActivatedRoute).resources?.['user'];
+
+  refreshUser() {
+    // Reloads only this specific resource without renavigating the route
+    this.userResource?.reload();
+  }
+}
 ```
 
 ## Transitional states during pending navigations

--- a/adev/src/content/guide/routing/read-route-state.md
+++ b/adev/src/content/guide/routing/read-route-state.md
@@ -30,7 +30,7 @@ The `ActivatedRoute` can provide different information about the route. Some com
 | `data`        | An `Observable` that contains the `data` object provided for the route. Also contains any resolved values from the resolve guard. |
 | `params`      | An `Observable` that contains the required and optional parameters specific to the route.                                         |
 | `queryParams` | An `Observable` that contains the query parameters available to all routes.                                                       |
-| `resources`   | An optional record of `Resource` instances defined on the route (when `withRouterResources` is enabled).                          |
+| `resources`   | An optional record of `Resource` instances defined on or inherited by the route (when `withRouterResources` is enabled).          |
 
 Check out the [`ActivatedRoute` API docs](/api/router/ActivatedRoute) for a complete list of what you can access with in the route.
 

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -672,7 +672,6 @@ export interface ResourceContext {
     fragment: Signal<string | null>;
     params: Signal<Params>;
     queryParams: Signal<Params>;
-    snapshot: ActivatedRouteSnapshot;
 }
 
 // @public

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -672,6 +672,7 @@ export interface ResourceContext {
     fragment: Signal<string | null>;
     params: Signal<Params>;
     queryParams: Signal<Params>;
+    resources: Signal<ResourceResult>;
 }
 
 // @public

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -516,7 +516,7 @@ export class RoutedComponentInputBinder {
             ...queryParams,
             ...params,
             ...data,
-            ...(activatedRoute.resources || {}),
+            ...activatedRoute?.resources,
           };
           // Get the first result from the data subscription synchronously so it's available to
           // the component as soon as possible (and doesn't require a second change detection).

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -61,13 +61,6 @@ export interface ResourceContext {
    * @developerPreview 22.2
    */
   data: Signal<Record<string, any>>;
-  /**
-   * The static activated route snapshot for this navigation.
-   * Useful for reading initial static configuration statically without
-   * reacting to future parameter changes on reused routes.
-   * @developerPreview 22.2
-   */
-  snapshot: ActivatedRouteSnapshot;
 }
 
 /**

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -61,6 +61,13 @@ export interface ResourceContext {
    * @developerPreview 22.2
    */
   data: Signal<Record<string, any>>;
+  /**
+   * Inherited resources from ancestor routes.
+   * Updates reactively as ancestor route resource setup functions complete.
+   *
+   * @developerPreview 22.2
+   */
+  resources: Signal<ResourceResult>;
 }
 
 /**

--- a/packages/router/src/operators/setup_and_run_resources.ts
+++ b/packages/router/src/operators/setup_and_run_resources.ts
@@ -6,11 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {
+  computed,
   createEnvironmentInjector,
-  runInInjectionContext,
-  Resource,
-  effect,
   DestroyRef,
+  effect,
+  EnvironmentInjector,
+  Resource,
+  runInInjectionContext,
+  signal,
+  ɵWritable as Writable,
 } from '@angular/core';
 import {OperatorFunction, pipe} from 'rxjs';
 import {ResourceContext, ResourceResult} from '../models';
@@ -24,6 +28,18 @@ import {
   SOURCE_RESOURCE_SYMBOL,
 } from '../router_resource';
 import {switchTap} from './switch_tap';
+
+function initializeRouteResources(route: ActivatedRoute): void {
+  if (route._resourceContextSignal !== undefined) {
+    return;
+  }
+  const writableRoute = route as Writable<ActivatedRoute>;
+  writableRoute._ownResourcesSignal = signal<ResourceResult>({});
+  writableRoute._resourceContextSignal = computed(() => ({
+    ...route.parent?._resourceContextSignal?.(),
+    ...writableRoute._ownResourcesSignal!(),
+  }));
+}
 
 export function setupAndRunResources(
   abortSignal: AbortSignal,
@@ -41,6 +57,12 @@ export function setupAndRunResources(
         const route = stateNode.value;
         if (route) {
           initializeActivatedRoute(route);
+          if (
+            route.routeConfig?.resources !== undefined ||
+            route.parent?._resourceContextSignal !== undefined
+          ) {
+            initializeRouteResources(route);
+          }
           processRoute(
             route,
             newlyCreatedRoutes,
@@ -57,9 +79,27 @@ export function setupAndRunResources(
 
       traverse(targetRouterState._root);
 
-      return Promise.all(resourceSetupPromises).then(() => Promise.all(blockingResourcePromises));
+      return Promise.all(resourceSetupPromises).then(() => {
+        finalizeResources(targetRouterState._root);
+        return Promise.all(blockingResourcePromises);
+      });
     }),
   );
+}
+
+function finalizeResources(stateNode: TreeNode<ActivatedRoute>): void {
+  const route = stateNode.value;
+  if (route && route._resourceContextSignal) {
+    const resources = route._resourceContextSignal();
+    route.resources = resources;
+    if (route.snapshot) {
+      (route.snapshot as Writable<ActivatedRouteSnapshot>).resources = resources;
+    }
+    (route._futureSnapshot as Writable<ActivatedRouteSnapshot>).resources = resources;
+  }
+  for (const childState of stateNode.children) {
+    finalizeResources(childState);
+  }
 }
 
 function processRoute(
@@ -98,6 +138,7 @@ async function setupNewRouterResources(
 
   let childInjector = route._localInjector;
   if (!childInjector) {
+    // TODO: Consider providing ActivatedRoute to the resource injector.
     childInjector = createEnvironmentInjector([], parentInjector);
     route._localInjector = childInjector; // Attach to route for cleanup
   }
@@ -107,39 +148,32 @@ async function setupNewRouterResources(
     queryParams: route.queryParamsSignal,
     fragment: route.fragmentSignal,
     data: route.dataSignal,
+    resources: route._resourceContextSignal!,
   };
 
   const resourceResultRaw = runInInjectionContext(childInjector, () => resourcesFn(context));
-  let resourceResult: ResourceResult;
-  if (resourceResultRaw instanceof Promise) {
-    resourceResult = await resourceResultRaw;
-    // Bail out if the router cancelled the navigation (and destroyed our injector!)
-    // while we were waiting.
-    if (abortSignal.aborted) return;
-  } else {
-    resourceResult = resourceResultRaw as ResourceResult;
-  }
-
-  if (!resourceResult) return;
+  const resourceResult =
+    resourceResultRaw instanceof Promise ? await resourceResultRaw : resourceResultRaw;
+  if (abortSignal.aborted || !resourceResult) return;
 
   const wrappedResult: ResourceResult = {};
-  for (const [key, res] of Object.entries(resourceResult)) {
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  runInInjectionContext(childInjector, () => {
+    for (const [key, res] of Object.entries(resourceResult)) {
       if (
-        !res ||
-        typeof res !== 'object' ||
-        typeof (res as Partial<Resource<unknown>>).snapshot !== 'function'
+        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        (!res ||
+          typeof res !== 'object' ||
+          typeof (res as Partial<Resource<unknown>>).snapshot !== 'function')
       ) {
         throw new Error(
           `Invalid resource returned for key "${key}". Expected a Resource, but got ${res === null ? 'null' : typeof res}.`,
         );
       }
+      wrappedResult[key] = routerResource(res);
     }
+  });
 
-    wrappedResult[key] = runInInjectionContext(childInjector, () => routerResource(res));
-  }
-
-  route.resources = route._futureSnapshot.resources = snapshot.resources = wrappedResult;
+  route._ownResourcesSignal?.set(wrappedResult);
   setupBlocking(route, wrappedResult, blockingResourcePromises, abortSignal);
 }
 
@@ -150,23 +184,22 @@ function updateExistingResources(
 ) {
   // This route is reused. We must eagerly update the resource context signals
   // so that resources can react and fetch new data during the pending navigation.
-  const currentResources = route.snapshot?.resources;
-  if (!currentResources) {
+  const ownResources = route._ownResourcesSignal?.();
+  if (!ownResources || Object.keys(ownResources).length === 0) {
     return;
   }
 
-  Object.values(currentResources).forEach((r) => {
+  for (const r of Object.values(ownResources)) {
     const underlyingRes = (r as InternalRouterResource)[SOURCE_RESOURCE_SYMBOL];
     if (underlyingRes.status() === 'error') {
       // If a resource previously failed and the route is reused identically,
       // the parameter signals won't change, meaning the internal effect won't automatically refetch.
       // We must manually trigger a reload to ensure the new navigation attempts a retry.
-      (underlyingRes as unknown as {reload?: () => boolean}).reload?.();
+      (underlyingRes as InternalRouterResource).reload?.();
     }
-  });
+  }
 
-  route._futureSnapshot.resources = currentResources;
-  setupBlocking(route, currentResources, blockingResourcePromises, abortSignal);
+  setupBlocking(route, ownResources, blockingResourcePromises, abortSignal);
 }
 
 function setupBlocking(
@@ -179,52 +212,53 @@ function setupBlocking(
   const childInjector = route._localInjector;
   if (!childInjector || !resourceResult) return;
 
-  for (const r of Object.values(resourceResult)) {
-    const res = r as InternalRouterResource;
-    if (res[BLOCKING_SYMBOL] === false) {
-      continue;
+  for (const res of Object.values(resourceResult)) {
+    const internalRes = res as InternalRouterResource;
+    if (internalRes[BLOCKING_SYMBOL] !== false) {
+      blockingResourcePromises.push(waitForResource(internalRes, childInjector, abortSignal));
     }
-    const promise = new Promise<void>((resolve, reject) => {
-      const underlyingRes = res[SOURCE_RESOURCE_SYMBOL];
-      let isDestroyed = false;
-      let unregisterOnDestroy: (() => void) | undefined;
-
-      const cleanup = () => {
-        isDestroyed = true;
-        blockingEffect.destroy();
-        unregisterOnDestroy?.();
-        abortSignal.removeEventListener('abort', onAbort);
-      };
-
-      const onAbort = () => {
-        cleanup();
-        resolve();
-      };
-
-      abortSignal.addEventListener('abort', onAbort, {once: true});
-
-      const blockingEffect = effect(
-        () => {
-          if (isDestroyed) {
-            return;
-          }
-          const status = underlyingRes.status();
-          if (status === 'error') {
-            cleanup();
-            reject(underlyingRes.error());
-          } else if (!underlyingRes.isLoading()) {
-            cleanup();
-            resolve();
-          }
-        },
-        {injector: childInjector, manualCleanup: true},
-      );
-
-      unregisterOnDestroy = childInjector.get(DestroyRef).onDestroy(() => {
-        cleanup();
-        resolve();
-      });
-    });
-    blockingResourcePromises.push(promise);
   }
+}
+
+function waitForResource(
+  resource: InternalRouterResource,
+  injector: EnvironmentInjector,
+  abortSignal: AbortSignal,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const underlyingRes = resource[SOURCE_RESOURCE_SYMBOL];
+    let isDestroyed = false;
+    let cleanup: (() => void) | undefined;
+
+    const onDone = () => {
+      cleanup?.();
+      resolve();
+    };
+
+    abortSignal.addEventListener('abort', onDone, {once: true});
+
+    const blockingEffect = effect(
+      () => {
+        if (isDestroyed) return;
+        const status = underlyingRes.status();
+        if (status === 'error') {
+          cleanup?.();
+          reject(underlyingRes.error());
+        } else if (!underlyingRes.isLoading()) {
+          cleanup?.();
+          resolve();
+        }
+      },
+      {injector, manualCleanup: true},
+    );
+
+    const unregisterDestroy = injector.get(DestroyRef).onDestroy(onDone);
+
+    cleanup = () => {
+      isDestroyed = true;
+      blockingEffect.destroy();
+      unregisterDestroy();
+      abortSignal.removeEventListener('abort', onDone);
+    };
+  });
 }

--- a/packages/router/src/operators/setup_and_run_resources.ts
+++ b/packages/router/src/operators/setup_and_run_resources.ts
@@ -107,7 +107,6 @@ async function setupNewRouterResources(
     queryParams: route.queryParamsSignal,
     fragment: route.fragmentSignal,
     data: route.dataSignal,
-    snapshot: route._futureSnapshot,
   };
 
   const resourceResultRaw = runInInjectionContext(childInjector, () => resourcesFn(context));

--- a/packages/router/src/router_resource.ts
+++ b/packages/router/src/router_resource.ts
@@ -88,22 +88,18 @@ export function routerResource<T>(source: Resource<T>): Resource<T> & {reload():
   res[BLOCKING_SYMBOL] =
     (source as unknown as InternalRouterResource<T>)[BLOCKING_SYMBOL] !== false;
 
-  if (typeof (source as any).reload === 'function') {
-    res.reload = function (): boolean {
-      // If the resource is currently frozen (e.g., during an active navigation transition
-      // or while recovering from a cancelled navigation), we reject manual reload requests.
-      // Triggering a reload during an active navigation (where the resource may already be
-      // reactively loading new parameters behind the scenes) would disrupt the router's resource
-      // tracking for the transition. Similarly, during a rollback recovery, the router is
-      // already managing the resource reload to restore the previous state.
-      if (frozenSnapshot() !== null) {
-        return false;
-      }
-      return (source as any).reload();
-    };
-  } else {
-    res.reload = () => false;
-  }
+  res.reload = function (): boolean {
+    // If the resource is currently frozen (e.g., during an active navigation transition
+    // or while recovering from a cancelled navigation), we reject manual reload requests.
+    // Triggering a reload during an active navigation (where the resource may already be
+    // reactively loading new parameters behind the scenes) would disrupt the router's resource
+    // tracking for the transition. Similarly, during a rollback recovery, the router is
+    // already managing the resource reload to restore the previous state.
+    if (frozenSnapshot() !== null) {
+      return false;
+    }
+    return (source as any).reload?.() ?? false;
+  };
 
   return res;
 }
@@ -201,12 +197,13 @@ export function createResourceOutletBindingEffects(
   const createdEffects: EffectRef[] = [];
   const handledKeys: string[] = [];
   const mirror = route.component ? reflectComponentType(route.component) : null;
-  if (!mirror) {
+  const resources = route.resources;
+  if (!mirror || !resources) {
     return {createdEffects, handledKeys};
   }
 
   for (const {templateName} of mirror.inputs) {
-    const resource = route.resources?.[templateName];
+    const resource = resources[templateName];
     if (!resource || !(resource as InternalRouterResource)[BLOCKING_SYMBOL]) {
       continue;
     }

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -166,17 +166,18 @@ export class ActivatedRoute {
   // ===== Resource integration ======
   // =================================
 
-  // Note for framework developers: Unlike `data` and `params`, the `resources` property
-  // is assigned once when the route is first initialized and its reference remains stable
-  // for the entire lifetime of the `ActivatedRoute` instance. Do NOT replace or swap this
-  // reference during pending navigations or route reuse, as doing so breaks reactivity
-  // for components subscribed to the underlying resource signals.
+  /** @internal */
+  _ownResourcesSignal?: WritableSignal<ResourceResult>;
+  /** @internal */
+  _resourceContextSignal?: Signal<ResourceResult>;
+
   /**
-   * A map of resources for this route.
+   * A map of resources for this route, including resources inherited from ancestor routes.
    *
    * @developerPreview 22.2
    */
   resources?: ResourceResult;
+
   /** @internal */
   _localInjector?: EnvironmentInjector;
   /** @internal */
@@ -241,7 +242,7 @@ export class ActivatedRoute {
 
   /** The parent of this route in the router state tree. */
   get parent(): ActivatedRoute | null {
-    return this._routerState.parent(this);
+    return this._routerState?.parent(this) ?? null;
   }
 
   /** The first child of this route in the router state tree. */
@@ -397,8 +398,10 @@ export class ActivatedRouteSnapshot {
   _queryParamMap?: ParamMap;
   /** @internal */
   readonly _environmentInjector: EnvironmentInjector;
+
   /**
-   * The result of running the route's resources function.
+   * The result of running the route's resources function, including resources
+   * inherited from ancestor routes.
    * @developerPreview 22.2
    */
   resources?: ResourceResult;
@@ -460,7 +463,7 @@ export class ActivatedRouteSnapshot {
 
   /** The parent of this route in the router state tree */
   get parent(): ActivatedRouteSnapshot | null {
-    return this._routerState.parent(this);
+    return this._routerState?.parent(this) ?? null;
   }
 
   /** The first child of this route in the router state tree */

--- a/packages/router/test/router_resource_spec.ts
+++ b/packages/router/test/router_resource_spec.ts
@@ -12,9 +12,14 @@ import {
   EnvironmentProviders,
   EnvironmentInjector,
   inject,
+  Injector,
+  Input,
+  input,
   resource,
   Resource,
+  ResourceParamsStatus,
   ResourceStatus,
+  runInInjectionContext,
   Signal,
   signal,
   ɵpromiseWithResolvers as promiseWithResolvers,
@@ -27,6 +32,8 @@ import {
   withNavigationErrorHandler,
   RedirectCommand,
   withRouterResources,
+  withComponentInputBinding,
+  withRouterConfig,
   nonBlocking,
   ActivatedRoute,
   Route,
@@ -47,12 +54,16 @@ async function setupRouter(routes: Route[], ...features: RouterFeatures[]) {
   return {harness, router};
 }
 
-type ActivatedRouteInternal = ActivatedRoute & {
-  resources?: {[key: string]: Resource<unknown>};
-};
+type ActivatedRouteInternal = ActivatedRoute;
 
 @Component({template: ''})
 class TargetCmp {}
+
+@Component({template: ''})
+class InputBindingCmp {
+  @Input() user: any;
+  @Input() extra: any;
+}
 
 describe('Router resources integration', () => {
   useAutoTick();
@@ -130,7 +141,6 @@ describe('Router resources integration', () => {
       ]);
 
       await harness.navigateByUrl('/test');
-      await harness.fixture.whenStable();
 
       const route = router.routerState.root.firstChild as ActivatedRouteInternal;
       const resourceRef = route?.resources?.['data'] as any;
@@ -165,7 +175,6 @@ describe('Router resources integration', () => {
       // 2. Now resolve the blocking resource loader
       loaderDeferred.resolve('resolved data');
       await navPromise;
-      await harness.fixture.whenStable();
 
       expect(router.url).toBe('/test');
       const route = router.routerState.root.firstChild as ActivatedRouteInternal;
@@ -200,7 +209,6 @@ describe('Router resources integration', () => {
 
       // Supersede with navigation to /second
       await harness.navigateByUrl('/second');
-      await harness.fixture.whenStable();
 
       expect(router.url).toBe('/second');
 
@@ -239,7 +247,6 @@ describe('Router resources integration', () => {
 
       // Supersede with navigation to /second
       await harness.navigateByUrl('/second');
-      await harness.fixture.whenStable();
 
       expect(router.url).toBe('/second');
 
@@ -315,7 +322,6 @@ describe('Router resources integration', () => {
       ]);
 
       await harness.navigateByUrl('/parent/componentless/child');
-      await harness.fixture.whenStable();
       await timeout(20);
 
       const parentRoute = router.routerState.root.firstChild!;
@@ -442,7 +448,6 @@ describe('Router resources integration', () => {
 
       // 1. Initial navigation succeeds
       await harness.navigateByUrl('/test/1');
-      await harness.fixture.whenStable();
       expect(router.url).toBe('/test/1');
 
       const resourceRef = (router.routerState.root.firstChild as ActivatedRouteInternal)
@@ -458,39 +463,82 @@ describe('Router resources integration', () => {
       // 3. Retry the identical route with same parameters using onSameUrlNavigation: 'reload'
       shouldError = false;
       await router.navigateByUrl('/test/1', {onSameUrlNavigation: 'reload'});
-      await harness.fixture.whenStable();
 
       expect(router.url).toBe('/test/1'); // Succeeded!
       expect(resourceRef.status()).toBe('resolved');
       expect(resourceRef.value()).toBe('1');
     });
 
-    it('should block navigation when a resource has a defaultValue until loading is complete', async () => {
-      const loaderDeferred = promiseWithResolvers<string>();
+    it('should block navigation when reloading an existing resource that already has a value', async () => {
+      let loaderPromise = promiseWithResolvers<string>();
 
       const {harness, router} = await setupRouter([
         {
-          path: 'test',
+          path: 'test/:id',
           component: TargetCmp,
-          resources: () => ({
-            user: resource({
-              defaultValue: 'default-user',
-              loader: async () => loaderDeferred.promise,
+          resources: (ctx) => ({
+            data: resource({
+              params: () => ctx.params()['id'],
+              loader: async () => loaderPromise.promise,
             }),
           }),
         },
       ]);
 
-      const nav = harness.navigateByUrl('/test');
+      // 1. Initial load
+      loaderPromise.resolve('val-1');
+      await harness.navigateByUrl('/test/1');
+      expect(router.url).toBe('/test/1');
+
+      const resourceRef = (router.routerState.root.firstChild as ActivatedRouteInternal)
+        ?.resources?.['data'] as any;
+      expect(resourceRef.value()).toBe('val-1');
+
+      // 2. Navigate to /test/2: resets loaderPromise
+      loaderPromise = promiseWithResolvers<string>();
+      const nav = harness.navigateByUrl('/test/2');
+      await timeout();
+
+      // Navigation is blocked on loading even though resource previously had a value
+      expect(router.url).toBe('/test/1');
+
+      loaderPromise.resolve('val-2');
+      await nav;
+
+      expect(router.url).toBe('/test/2');
+      expect(resourceRef.value()).toBe('val-2');
+    });
+
+    it('should block navigation when a resource has a defaultValue until loading is complete', async () => {
+      const loaderDeferred = promiseWithResolvers<string>();
+
+      const {harness, router} = await setupRouter(
+        [
+          {
+            path: 'test',
+            component: InputBindingCmp,
+            resources: () => ({
+              user: resource({
+                defaultValue: 'default-user',
+                loader: async () => loaderDeferred.promise,
+              }),
+            }),
+          },
+        ],
+        withComponentInputBinding(),
+      );
+
+      const nav = harness.navigateByUrl('/test', InputBindingCmp);
       await timeout();
 
       // Navigation is blocked on loading even though the resource has a defaultValue
       expect(router.url).not.toBe('/test');
 
       loaderDeferred.resolve('loaded-user');
-      await nav;
+      const cmp = await nav;
 
       expect(router.url).toBe('/test');
+      expect(cmp.user).toBe('loaded-user');
 
       const resourceRef = (router.routerState.root.firstChild as ActivatedRouteInternal)
         ?.resources?.['user'] as any;
@@ -542,7 +590,6 @@ describe('Router resources integration', () => {
 
       // Navigate without query params -> params() is undefined -> resource is idle
       await harness.navigateByUrl('/search');
-      await harness.fixture.whenStable();
 
       expect(router.url).toBe('/search');
       const resourceRef = (router.routerState.root.firstChild as ActivatedRouteInternal)
@@ -571,7 +618,6 @@ describe('Router resources integration', () => {
       ]);
 
       await harness.navigateByUrl('/test');
-      await harness.fixture.whenStable();
       const resourceRef = (router.routerState.root.firstChild as ActivatedRouteInternal)
         ?.resources?.['data'] as any;
 
@@ -612,7 +658,6 @@ describe('Router resources integration', () => {
       // Fail next navigation
       canActivate = false;
       await harness.navigateByUrl('/test/2');
-      await harness.fixture.whenStable();
 
       // The navigation is cancelled so the resource should retain the old value without loading flicker.
       expect(resourceRef.value()).toBe('1');
@@ -697,7 +742,6 @@ describe('Router resources integration', () => {
 
       p3.resolve('loaded-3');
       await nav3;
-      await harness.fixture.whenStable();
 
       const resourceRef = (router.routerState.root.firstChild as ActivatedRouteInternal)
         ?.resources?.['data'] as any;
@@ -728,7 +772,6 @@ describe('Router resources integration', () => {
       // Settle initial state
       loader.resolve('1');
       await harness.navigateByUrl('/target/1');
-      await harness.fixture.whenStable();
 
       const resourceRef = (router.routerState.root.firstChild as ActivatedRouteInternal)
         ?.resources?.['data'] as any;
@@ -747,7 +790,6 @@ describe('Router resources integration', () => {
 
       loader.resolve('3');
       await nav2;
-      await harness.fixture.whenStable();
 
       expect(resourceRef.isLoading()).toBe(false);
       expect(resourceRef.value()).toBe('3');
@@ -838,7 +880,6 @@ describe('Router resources integration', () => {
       expect(resourceRef.value()).toBeUndefined();
 
       await nav;
-      await harness.fixture.whenStable();
 
       expect(resourceRef.isLoading()).toBe(false);
       expect(resourceRef.value()).toBe('rx loaded 123');
@@ -934,7 +975,6 @@ describe('Router resources integration', () => {
         // Resolve user
         resolveUser({id: 'u1', teamId: 't42'});
         await nav;
-        await harness.fixture.whenStable();
 
         expect(router.url).toBe('/user-team');
         const resources = (router.routerState.root.firstChild as ActivatedRouteInternal)
@@ -998,16 +1038,300 @@ describe('Router resources integration', () => {
         // Resolve child
         resolveChild({role: 'admin', permissions: ['read', 'write']});
         await nav;
-        await harness.fixture.whenStable();
 
         expect(router.url).toBe('/user/1/details');
         const parentRoute = router.routerState.root.firstChild as ActivatedRouteInternal;
         const childRoute = parentRoute.firstChild as ActivatedRouteInternal;
-        expect(parentRoute.resources?.['user'].value()).toEqual({id: '1', role: 'admin'});
-        expect(childRoute.resources?.['details'].value()).toEqual({
+        expect(parentRoute.resources!['user'].value()).toEqual({id: '1', role: 'admin'});
+        expect(childRoute.resources!['details'].value()).toEqual({
           role: 'admin',
           permissions: ['read', 'write'],
         });
+      });
+
+      it('should handle parallel dependent resources where parent setup takes longer than child', async () => {
+        const parentSetupDeferred = promiseWithResolvers<void>();
+        const parentLoaderDeferred = promiseWithResolvers<{id: string; role: string}>();
+        const childLoaderDeferred = promiseWithResolvers<string[]>();
+
+        const {harness, router} = await setupRouter([
+          {
+            path: 'user',
+            resources: async () => {
+              const injector = inject(Injector);
+              // Parent setup is async and delayed
+              await parentSetupDeferred.promise;
+              return runInInjectionContext(injector, () => ({
+                user: resource({
+                  loader: () => parentLoaderDeferred.promise,
+                }),
+              }));
+            },
+            children: [
+              {
+                path: 'roles',
+                component: TargetCmp,
+                resources: (ctx) => ({
+                  roles: resource({
+                    params: ({chain}) => {
+                      const user = ctx.resources()['user'];
+                      if (!user) {
+                        throw ResourceParamsStatus.LOADING;
+                      }
+                      return (chain(user) as any).role;
+                    },
+                    loader: async () => {
+                      return childLoaderDeferred.promise;
+                    },
+                  }),
+                }),
+              },
+            ],
+          },
+        ]);
+
+        const nav = harness.navigateByUrl('/user/roles');
+        await timeout(10);
+
+        // Navigation is blocked: parent setup hasn't finished yet
+        expect(router.url).not.toBe('/user/roles');
+
+        // 1. Resolve parent setup function
+        parentSetupDeferred.resolve();
+        await timeout(10);
+
+        // Navigation is still blocked: parent loader is running
+        expect(router.url).not.toBe('/user/roles');
+
+        // 2. Resolve parent loader
+        parentLoaderDeferred.resolve({id: '123', role: 'admin'});
+        await timeout(10);
+
+        // Navigation is still blocked: child loader received role='admin' and is now running
+        expect(router.url).not.toBe('/user/roles');
+
+        // 3. Resolve child loader
+        childLoaderDeferred.resolve(['read', 'write', 'admin']);
+        await nav;
+
+        expect(router.url).toBe('/user/roles');
+        const parentRoute = router.routerState.root.firstChild!;
+        const childRoute = parentRoute.firstChild!;
+
+        expect(parentRoute.resources!['user'].value()).toEqual({id: '123', role: 'admin'});
+        expect(childRoute.resources!['user'].value()).toEqual({id: '123', role: 'admin'});
+        expect(childRoute.resources!['roles'].value()).toEqual(['read', 'write', 'admin']);
+      });
+    });
+
+    describe('Resource inheritance', () => {
+      it('should inherit resources from parent routes to child routes', async () => {
+        const {harness, router} = await setupRouter([
+          {
+            path: 'parent',
+            resources: () => ({
+              parentData: resource({loader: async () => 'parent-value'}),
+            }),
+            children: [
+              {
+                path: 'child',
+                component: TargetCmp,
+                resources: () => ({
+                  childData: resource({loader: async () => 'child-value'}),
+                }),
+              },
+            ],
+          },
+        ]);
+
+        await harness.navigateByUrl('/parent/child');
+
+        const parentRoute = router.routerState.root.firstChild!;
+        const childRoute = parentRoute.firstChild!;
+
+        expect(parentRoute.resources!['parentData'].value()).toBe('parent-value');
+        expect(parentRoute.resources!['childData']).toBeUndefined();
+
+        expect(childRoute.resources!['parentData'].value()).toBe('parent-value');
+        expect(childRoute.resources!['childData'].value()).toBe('child-value');
+        expect(childRoute.snapshot.resources!['parentData'].value()).toBe('parent-value');
+        expect(childRoute.snapshot.resources!['childData'].value()).toBe('child-value');
+      });
+
+      it('should inherit resources to child routes without own resources config', async () => {
+        const {harness, router} = await setupRouter([
+          {
+            path: 'parent',
+            resources: () => ({
+              parentData: resource({loader: async () => 'parent-value'}),
+            }),
+            children: [
+              {
+                path: 'child',
+                component: TargetCmp,
+              },
+            ],
+          },
+        ]);
+
+        await harness.navigateByUrl('/parent/child');
+
+        const parentRoute = router.routerState.root.firstChild!;
+        const childRoute = parentRoute.firstChild!;
+
+        expect(childRoute.resources!['parentData'].value()).toBe('parent-value');
+        expect(childRoute.snapshot.resources!['parentData'].value()).toBe('parent-value');
+      });
+
+      it('should allow child resources to override inherited parent resources with the same key', async () => {
+        const {harness, router} = await setupRouter([
+          {
+            path: 'parent',
+            resources: () => ({
+              shared: resource({loader: async () => 'parent-shared'}),
+            }),
+            children: [
+              {
+                path: 'child',
+                component: TargetCmp,
+                resources: () => ({
+                  shared: resource({loader: async () => 'child-shared'}),
+                }),
+              },
+            ],
+          },
+        ]);
+
+        await harness.navigateByUrl('/parent/child');
+
+        const parentRoute = router.routerState.root.firstChild!;
+        const childRoute = parentRoute.firstChild!;
+
+        expect(parentRoute.resources!['shared'].value()).toBe('parent-shared');
+        expect(childRoute.resources!['shared'].value()).toBe('child-shared');
+      });
+
+      it('should always inherit resources from parent routes regardless of paramsInheritanceStrategy emptyOnly', async () => {
+        const {harness, router} = await setupRouter(
+          [
+            {
+              path: 'parent',
+              component: TargetCmp,
+              resources: () => ({
+                data: resource({loader: async () => 'parent-data'}),
+              }),
+              children: [
+                {
+                  path: 'non-empty-child',
+                  component: TargetCmp,
+                },
+                {
+                  path: '',
+                  component: TargetCmp,
+                },
+              ],
+            },
+            {
+              path: 'componentless',
+              resources: () => ({
+                data: resource({loader: async () => 'comp-data'}),
+              }),
+              children: [
+                {
+                  path: 'sub',
+                  component: TargetCmp,
+                },
+              ],
+            },
+          ],
+          withRouterConfig({paramsInheritanceStrategy: 'emptyOnly'}),
+        );
+
+        // 1. Non-empty path child of a component route STILL inherits resources
+        await harness.navigateByUrl('/parent/non-empty-child');
+        const parentRoute = router.routerState.root.firstChild!;
+        const nonEmptyChild = parentRoute.firstChild!;
+        expect(nonEmptyChild.resources!['data'].value()).toBe('parent-data');
+
+        // 2. Empty path child inherits resources
+        await harness.navigateByUrl('/parent');
+        const emptyChild = parentRoute.firstChild!;
+        expect(emptyChild.resources!['data'].value()).toBe('parent-data');
+
+        // 3. Child of componentless route inherits resources
+        await harness.navigateByUrl('/componentless/sub');
+        const compRoute = router.routerState.root.firstChild!;
+        const subRoute = compRoute.firstChild!;
+        expect(subRoute.resources!['data'].value()).toBe('comp-data');
+      });
+
+      it('should leave resources undefined on routes that do not configure or inherit resources', async () => {
+        const {harness, router} = await setupRouter([
+          {
+            path: 'no-resources',
+            component: TargetCmp,
+          },
+        ]);
+
+        await harness.navigateByUrl('/no-resources');
+
+        const route = router.routerState.root.firstChild!;
+        expect(route.resources).toBeUndefined();
+        expect(route.snapshot.resources).toBeUndefined();
+      });
+
+      it('should bind inherited blocking and non-blocking resources to component inputs', async () => {
+        const {harness} = await setupRouter(
+          [
+            {
+              path: 'parent',
+              resources: () => ({
+                user: resource({loader: async () => ({name: 'Alice'})}),
+                extra: nonBlocking(resource({loader: async () => 'extra-info'})),
+              }),
+              children: [
+                {
+                  path: 'child',
+                  component: InputBindingCmp,
+                },
+              ],
+            },
+          ],
+          withComponentInputBinding(),
+        );
+
+        const cmpInstance = await harness.navigateByUrl('/parent/child', InputBindingCmp);
+
+        // Blocking resource binds unwrapped value directly
+        expect(cmpInstance.user).toEqual({name: 'Alice'});
+        // Non-blocking resource binds Resource instance
+        expect(cmpInstance.extra.value()).toBe('extra-info');
+      });
+
+      it('should pass routeConfig and reactive resources to ResourceContext without snapshot', async () => {
+        let receivedContext: any = null;
+
+        const {harness} = await setupRouter([
+          {
+            path: 'meta',
+            component: TargetCmp,
+            title: 'Meta Page',
+            resources: (ctx) => {
+              receivedContext = ctx;
+              return {
+                data: nonBlocking(resource({loader: async () => 'ok'})),
+              };
+            },
+          },
+        ]);
+
+        await harness.navigateByUrl('/meta');
+
+        expect(receivedContext).not.toBeNull();
+        expect(receivedContext.routeConfig?.path).toBe('meta');
+        expect(receivedContext.routeConfig?.title).toBe('Meta Page');
+        expect(typeof receivedContext.resources).toBe('function');
+        expect(receivedContext.snapshot).toBeUndefined();
       });
     });
   });


### PR DESCRIPTION
…ndent loading

Makes `ActivatedRoute.resources` and `ActivatedRouteSnapshot.resources` signals (`Signal<ResourceResult> | undefined`) to enable reactive resource inheritance and parallel execution of dependent resources.

Previously, `resources` was defined as a static map resolved at navigation time with no inheritance between parent and child routes. This prevented child route resources from depending on parent route resources without introducing sequential waterfalls: if a child resource read `ctx.resources()`, it would read static data and fail to react when a parent resource completed its fetch. By converting `resources` to a signal, child resources can reactively read parent resources (`params: () => ctx.resources()['parent']?.value()`), automatically initiating their own fetch the moment the parent resolves without blocking setup or requiring sequential execution.

This change also addresses several key design requirements:

- Synchronous pre-pass initialization: Because route setup functions can be asynchronous, child routes could attempt to read `ctx.resources()` before a parent's setup function had even created the resources property. A synchronous top-down pre-pass (`initializeResourceTree`) creates the signals and computed inheritance links across all matched routes before any setup functions execute. This ensures that all routes have stable, readable signals from the start.

- Resource inheritance: Prior to this change, no inheritance was done for route resources. Adds resource inheritance down the route tree, intentionally not using `paramsInheritanceStrategy`. Unlike URL parameters, route resources represent data that descendant routes and components naturally depend on (similar to route `data` inheritance). Because resources are reactive signals, child routes can inherit and coordinate with parent resources without introducing sequential waterfall delays.

- Documentation reorganization: Previously, core architectural topics such as fine-grained signal tracking, parallel execution, and resource inheritance were nested under the "Setup" heading. The guide has been restructured into a clear, logical flow: enabling the feature, defining resources and their context, fine-grained signal reactivity, parallel dependent execution, inheritance, blocking/non-blocking modes, and in-place reloading.
