### PR TITLE
fix(docs-infra): keep an explicit theme choice when the OS scheme changes

### DIFF
--- a/adev/src/app/core/services/theme-manager.service.ts
+++ b/adev/src/app/core/services/theme-manager.service.ts
@@ -77,6 +77,9 @@ export class ThemeManager {
 
   private watchPreferredColorScheme() {
     window.matchMedia(PREFERS_COLOR_SCHEME_DARK).addEventListener('change', (event) => {
+      if (this.theme() !== 'auto') {
+        return;
+      }
       const preferredScheme = event.matches ? 'dark' : 'light';
       this.setThemeBodyClasses(preferredScheme);
     });


### PR DESCRIPTION
https://github.com/user-attachments/assets/226a027a-1e25-49e0-bbc9-0ecfd9979222

## Steps to reproduce

- Set macOS System Settings → Appearance to **Dark**
- Open https://angular.dev
- In the theme menu, pick **Dark** (matching your OS, so the next step is a single change)
- Switch System Settings → Appearance to **Light**

**Expected:** the site stays dark, since Dark was chosen explicitly.

**Actual:** the site turns light, and the theme menu still shows the checkmark on Dark.

Confirm in the console:

```js
localStorage.getItem('themePreference')   // "dark"   <- the stored choice
document.documentElement.className         // "docs-light-mode"  <- what was applied
```

Reloading restores Dark, until the OS changes again. Anyone using macOS **Auto** appearance hits this unprompted at sunrise and sunset.


After: 

https://github.com/user-attachments/assets/f842f9f9-133c-43dc-be05-8adf59937f47

