### PR TITLE
fix(devtools): improve manifest check for extension version retrieval

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -144,7 +144,7 @@ export class DevToolsTabsComponent {
       }
     });
 
-    if (typeof chrome !== 'undefined' && chrome.runtime !== undefined) {
+    if (typeof chrome !== 'undefined' && typeof chrome.runtime?.getManifest === 'function') {
       this.extensionVersion.set(chrome.runtime.getManifest().version);
     }
   }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.spec.ts
@@ -65,6 +65,25 @@ describe('DevtoolsTabsComponent', () => {
     expect(comp).toBeTruthy();
   });
 
+  it('uses the development version when the extension manifest API is unavailable', () => {
+    const globalObject = globalThis as typeof globalThis & {chrome?: unknown};
+    const originalChrome = globalObject.chrome;
+    Object.defineProperty(globalObject, 'chrome', {
+      configurable: true,
+      value: {runtime: {}},
+    });
+
+    try {
+      const fixture = TestBed.createComponent(DevToolsTabsComponent);
+      expect(fixture.componentInstance['extensionVersion']()).toBe('dev-build');
+    } finally {
+      Object.defineProperty(globalObject, 'chrome', {
+        configurable: true,
+        value: originalChrome,
+      });
+    }
+  });
+
   it('toggles inspector flag', () => {
     expect(comp.inspectorRunning()).toBe(false);
     comp.toggleInspectorState();


### PR DESCRIPTION
Resolves browser error while running pnpm devtools:devserver

<img width="1728" height="943" alt="Screenshot 2026-09-06 at 14 45 01" src="https://github.com/user-attachments/assets/431ee0cf-3458-4e98-b642-8e669f34ed8d" />
