### PR TITLE
fix(common): titlecase words that start with a supplementary-plane letter

### DIFF
--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -89,10 +89,26 @@ export class TitleCasePipe implements PipeTransform {
     if (value == null) return null;
     assertPipeArgument(TitleCasePipe, value);
 
-    return value.replace(
-      unicodeWordMatch,
-      (txt) => txt[0].toUpperCase() + txt.slice(1).toLowerCase(),
-    );
+    return value.replace(unicodeWordMatch, (txt) => {
+      // `txt` is a single matched word, e.g. "hello". The goal: upper-case its first
+      // letter and lower-case the rest -> "Hello".
+      //
+      // Why not just `txt[0]`? A JavaScript string is a list of 16-bit units. Most
+      // characters are one unit, but characters outside the common range - some
+      // scripts such as Deseret or Adlam, and emoji - are stored as two units (a
+      // "surrogate pair"). `txt[0]` would hand back only the first half of such a
+      // character, which is meaningless on its own.
+      //
+      // `codePointAt(0)` returns the whole first character, whether it's one unit or
+      // two (it can't be undefined here - the regex only matches when there's at
+      // least one character). A value above 0xFFFF means that character used two
+      // units, so we skip 2 units rather than 1 to get the rest of the word.
+      const firstCodePoint = txt.codePointAt(0)!;
+      const headLength = firstCodePoint > 0xffff ? 2 : 1;
+      return (
+        String.fromCodePoint(firstCodePoint).toUpperCase() + txt.slice(headLength).toLowerCase()
+      );
+    });
   }
 }
 

--- a/packages/common/test/pipes/case_conversion_pipes_spec.ts
+++ b/packages/common/test/pipes/case_conversion_pipes_spec.ts
@@ -108,6 +108,32 @@ describe('TitleCasePipe', () => {
     expect(pipe.transform('éric')).toEqual('Éric');
   });
 
+  it('should titlecase words that start with a supplementary-plane letter', () => {
+    // Deseret small long I (U+10428) -> Deseret capital long I (U+10400), tail lowered.
+    expect(pipe.transform('\u{10428}word')).toEqual('\u{10400}word');
+    // Already a Deseret capital: first char kept, rest lowered.
+    expect(pipe.transform('\u{10400}WORD')).toEqual('\u{10400}word');
+    // Mixed: a lowercase astral start is cased up, an already-capital one is kept.
+    expect(pipe.transform('\u{10428}ello \u{10412}ye')).toEqual('\u{10400}ello \u{10412}ye');
+    // Adlam small alif (U+1E922) -> Adlam capital alif (U+1E900).
+    expect(pipe.transform('\u{1E922}nnabujel')).toEqual('\u{1E900}nnabujel');
+  });
+
+  it('should leave a caseless supplementary-plane first letter unchanged', () => {
+    // Mathematical bold small a (U+1D41A) has no case mapping.
+    expect(pipe.transform('\u{1D41A}bc')).toEqual('\u{1D41A}bc');
+  });
+
+  it('should keep the existing behavior for length-changing case mappings', () => {
+    expect(pipe.transform('ﬁ')).toEqual('FI'); // ﬁ ligature
+    expect(pipe.transform('ß')).toEqual('SS'); // ß
+  });
+
+  it('should split words on a no-break space but not on a zero-width space', () => {
+    expect(pipe.transform('one\u00a0two')).toEqual('One\u00a0Two');
+    expect(pipe.transform('one\u200btwo')).toEqual('One\u200btwo');
+  });
+
   it('should handle numbers at the beginning of words', () => {
     expect(pipe.transform('frodo was 1st and bilbo was 2nd')).toEqual(
       'Frodo Was 1st And Bilbo Was 2nd',


### PR DESCRIPTION
`TitleCasePipe` upper-cases the first character of each matched word with
`txt[0]` and rebuilds the rest with `txt.slice(1)`. Both work on UTF-16 code
units. A letter outside the Basic Multilingual Plane (e.g. Deseret, Adlam) is
stored as two code units — a surrogate pair — so `txt[0]` is only its leading
surrogate. `toUpperCase()` leaves an unpaired surrogate as-is and `slice(1)`
cuts one unit too early, so the first letter of such a word is never
capitalized.

Read the first character with `codePointAt(0)` instead, upper-case it via
`String.fromCodePoint()`, and slice the tail past the right number of code
units (2 for a supplementary-plane code point, 1 otherwise). Output is
identical for every BMP input, including length-changing case mappings such as
`ﬁ` and `ß`.

The `unicodeWordMatch` regex is unchanged — this commit only changes how the
matched first character is cased.