### PR TITLE
test(core): remove redundant change detection configuration

### DIFF
--- a/packages/core/rxjs-interop/test/to_signal_spec.ts
+++ b/packages/core/rxjs-interop/test/to_signal_spec.ts
@@ -305,7 +305,6 @@ describe('toSignal()', () => {
     it('should support `toSignal` as a class member initializer', () => {
       @Component({
         template: '{{counter()}}',
-        changeDetection: ChangeDetectionStrategy.OnPush,
         standalone: false,
       })
       class TestCmp {

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -900,7 +900,6 @@ describe('after render hooks', () => {
           selector: 'comp',
           standalone: false,
           template: `{{ outerHookCount() }}:{{ innerHookCount }}`,
-          changeDetection: ChangeDetectionStrategy.OnPush,
         })
         class Comp {
           injector = inject(Injector);
@@ -951,7 +950,6 @@ describe('after render hooks', () => {
         @Component({
           selector: 'inner',
           standalone: false,
-          changeDetection: ChangeDetectionStrategy.OnPush,
         })
         class Inner {
           constructor() {
@@ -965,7 +963,6 @@ describe('after render hooks', () => {
           selector: 'outer',
           standalone: false,
           template: '<inner></inner>',
-          changeDetection: ChangeDetectionStrategy.OnPush,
         })
         class Outer {
           changeDetectorRef = inject(ChangeDetectorRef);

--- a/packages/core/test/acceptance/animation_spec.ts
+++ b/packages/core/test/acceptance/animation_spec.ts
@@ -2309,20 +2309,6 @@ describe('Animation', () => {
 
   describe('animation queue timing', () => {
     it('should run animations with a fresh componentRef after destroy', fakeAsync(() => {
-      const animateStyles = `
-        .fade {
-          animation: fade-out 500ms;
-        }
-        @keyframes fade-out {
-          from {
-            opacity: 1;
-          }
-          to {
-            opacity: 0;
-          }
-        }
-      `;
-
       @Component({
         selector: 'app-control-panel',
         template: `
@@ -2333,7 +2319,6 @@ describe('Animation', () => {
             <p class="all-there-is">THIS SHOULD BE ALL THERE IS</p>
           }
         `,
-        changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class StepperComponent {
         readonly step = signal(0);
@@ -2342,7 +2327,6 @@ describe('Animation', () => {
       @Component({
         selector: 'app-dynamic',
         template: `<ng-container #dynamicComponent></ng-container>`,
-        changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class DynamicComponent implements AfterViewInit, OnDestroy {
         @ViewChild('dynamicComponent', {read: ViewContainerRef})
@@ -2579,7 +2563,6 @@ describe('Animation', () => {
             </div>
           </ng-template>
         `,
-        changeDetection: ChangeDetectionStrategy.OnPush,
         encapsulation: ViewEncapsulation.None,
       })
       class MenuComponent {

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -96,7 +96,6 @@ describe('CheckAlways components', () => {
     @Component({
       template: `<check-always />`,
       imports: [CheckAlwaysCmp],
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class OnPushParent {}
     const fixture = TestBed.createComponent(OnPushParent);
@@ -224,7 +223,6 @@ describe('OnPush components with signals', () => {
   it('marks view dirty', () => {
     @Component({
       template: `{{ value() }}{{ incrementTemplateExecutions() }}`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class OnPushCmp {
       numTemplateExecutions = 0;
@@ -254,7 +252,6 @@ describe('OnPush components with signals', () => {
   it("does not refresh a component when a signal notifies but isn't actually updated", () => {
     @Component({
       template: `{{ memo() }}{{ incrementTemplateExecutions() }}`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class OnPushCmp {
       numTemplateExecutions = 0;
@@ -288,7 +285,6 @@ describe('OnPush components with signals', () => {
     @Component({
       selector: 'child',
       template: `child`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class ChildReadingSignalCmp {
       constructor() {
@@ -302,7 +298,6 @@ describe('OnPush components with signals', () => {
         <!-- Template constructed to execute child component constructor in the update pass of a host component -->
         <ng-template [ngIf]="true"><child></child></ng-template>
       `,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       imports: [NgIf, ChildReadingSignalCmp],
     })
     class OnPushCmp {
@@ -350,7 +345,6 @@ describe('OnPush components with signals', () => {
         <!-- Template constructed to execute child component constructor in the update pass of a host component -->
         <ng-template [ngIf]="true"><with-input-setter [testInput]="'input'" /></ng-template>
       `,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       imports: [NgIf, WithInputSetter],
     })
     class OnPushCmp {
@@ -400,7 +394,6 @@ describe('OnPush components with signals', () => {
         <!-- Template constructed to execute child component constructor in the update pass of a host component -->
         <ng-template [ngIf]="true"><with-query-setter /></ng-template>
       `,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       imports: [NgIf, WithQuerySetter],
     })
     class OnPushCmp {
@@ -431,7 +424,6 @@ describe('OnPush components with signals', () => {
       template: `{{ incrementTemplateExecutions() }}`,
       selector: 'child',
       host: {'[class.blue]': 'useBlue()'},
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class MyCmp {
       useBlue = useBlue;
@@ -460,7 +452,6 @@ describe('OnPush components with signals', () => {
       template: `{{ incrementTemplateExecutions() }}`,
       selector: 'child',
       host: {'[class.blue]': 'useBlue()'},
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class ChildCmp {
       useBlue = signal(false);
@@ -474,7 +465,7 @@ describe('OnPush components with signals', () => {
 
     @Component({
       template: `<child />`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
+
       imports: [ChildCmp],
     })
     class ParentCmp {}
@@ -498,7 +489,6 @@ describe('OnPush components with signals', () => {
       template: ``,
       selector: 'child',
       host: {'[class.blue]': 'useBlue()'},
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class ChildCmp {
       useBlue = signal(false);
@@ -506,7 +496,7 @@ describe('OnPush components with signals', () => {
 
     @Component({
       template: `<child /> {{ parentSignalValue() }}`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
+
       imports: [ChildCmp],
       selector: 'parent',
     })
@@ -517,7 +507,7 @@ describe('OnPush components with signals', () => {
     // Wrapper component so we can effectively test ParentCmp being marked dirty
     @Component({
       template: `<parent />`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
+
       imports: [ParentCmp],
     })
     class TestWrapper {}
@@ -636,7 +626,6 @@ describe('OnPush components with signals', () => {
 
     @Component({
       template: '{{val()}}{{incrementChecks()}}',
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class App {
       val = val;
@@ -665,7 +654,6 @@ describe('OnPush components with signals', () => {
             @if (true) {}
             {{ val() }}
           `,
-          changeDetection: ChangeDetectionStrategy.OnPush,
         })
         class MyComp {
           val = signal('initial');
@@ -685,7 +673,6 @@ describe('OnPush components with signals', () => {
             {{ createEmbeddedView(template) }}
             {{ val() }}
           `,
-          changeDetection: ChangeDetectionStrategy.OnPush,
         })
         class MyComp {
           val = signal('initial');
@@ -706,7 +693,7 @@ describe('OnPush components with signals', () => {
     it('refreshes an embedded view in a component', () => {
       @Component({
         selector: 'signal-component',
-        changeDetection: ChangeDetectionStrategy.OnPush,
+
         imports: [NgIf],
         template: `<div *ngIf="true">{{ value() }}</div>`,
       })
@@ -724,7 +711,7 @@ describe('OnPush components with signals', () => {
     it('refreshes multiple embedded views in a component', () => {
       @Component({
         selector: 'signal-component',
-        changeDetection: ChangeDetectionStrategy.OnPush,
+
         imports: [NgFor],
         template: `<div *ngFor="let i of [1, 2, 3]">{{ value() }}</div>`,
       })
@@ -742,7 +729,7 @@ describe('OnPush components with signals', () => {
     it('refreshes entire component, including embedded views, when signal updates', () => {
       @Component({
         selector: 'signal-component',
-        changeDetection: ChangeDetectionStrategy.OnPush,
+
         imports: [NgIf],
         template: `
           {{ componentSignal() }}
@@ -772,7 +759,7 @@ describe('OnPush components with signals', () => {
     it('re-executes deep embedded template if signal updates', () => {
       @Component({
         selector: 'signal-component',
-        changeDetection: ChangeDetectionStrategy.OnPush,
+
         imports: [NgIf],
         template: `
           <div *ngIf="true">
@@ -798,7 +785,6 @@ describe('OnPush components with signals', () => {
 
     it('tracks signal updates if embedded view is change detected directly', () => {
       @Component({
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: ` <ng-template #template>{{ value() }}</ng-template> `,
       })
       class Test {
@@ -827,7 +813,6 @@ describe('OnPush components with signals', () => {
 
     it('tracks signal updates if embedded view is change detected directly before attaching', () => {
       @Component({
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: ` <ng-template #template>{{ value() }}</ng-template> `,
       })
       class Test {
@@ -861,7 +846,7 @@ describe('OnPush components with signals', () => {
   describe('shielded by non-dirty OnPush', () => {
     @Component({
       selector: 'signal-component',
-      changeDetection: ChangeDetectionStrategy.OnPush,
+
       template: `{{ value() }}`,
     })
     class SignalComponent {
@@ -877,7 +862,7 @@ describe('OnPush components with signals', () => {
       selector: 'on-push-parent',
       template: ` <signal-component></signal-component>
         {{ incrementChecks() }}`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
+
       imports: [SignalComponent],
     })
     class OnPushParent {

--- a/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
+++ b/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
@@ -44,7 +44,6 @@ describe('change detection for transplanted views', () => {
   describe('when declaration appears before insertion', () => {
     @Component({
       selector: 'onpush-insert-comp',
-      changeDetection: ChangeDetectionStrategy.OnPush,
       template: `
         OnPushInsertComp({{ greeting }})
         <div *ngIf="true">
@@ -119,7 +118,6 @@ describe('change detection for transplanted views', () => {
       selector: `onpush-declare-comp`,
       template: ` OnPushDeclareComp({{ name }})
         <ng-template #myTmpl let-greeting> {{ greeting }} {{ logName() }}! </ng-template>`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       standalone: false,
     })
     class OnPushDeclareComp extends DeclareComp {
@@ -137,7 +135,6 @@ describe('change detection for transplanted views', () => {
           {{ greeting }} {{ surname() }}{{ logExecutionContext() }}!
         </ng-template>
       `,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       standalone: false,
     })
     class SignalOnPushDeclareComp {
@@ -475,7 +472,6 @@ describe('change detection for transplanted views', () => {
       template: ` <div>Insertion({{ name }})</div>
         <ng-container [ngTemplateOutlet]="template" [ngTemplateOutletContext]="{$implicit: name}">
         </ng-container>`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       standalone: false,
     })
     class Insertion {
@@ -494,7 +490,6 @@ describe('change detection for transplanted views', () => {
           <div>TemplateContext({{ contextName }})</div>
         </ng-template>
       `,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       standalone: false,
     })
     class Declaration {
@@ -617,7 +612,6 @@ describe('change detection for transplanted views', () => {
     @Component({
       selector: 'on-push-insertion-host',
       template: `<check-always-insertion [template]="template"></check-always-insertion>`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       standalone: false,
     })
     class OnPushInsertionHost {
@@ -629,7 +623,6 @@ describe('change detection for transplanted views', () => {
         <ng-template #template>{{ value }}</ng-template>
         <on-push-insertion-host [template]="template"></on-push-insertion-host>
       `,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       standalone: false,
     })
     class OnPushDeclaration {
@@ -731,7 +724,6 @@ describe('change detection for transplanted views', () => {
     @Component({
       selector: 'triple',
       template: '<div *ngFor="let unused of [1,2,3]; template: template"></div>',
-      changeDetection: ChangeDetectionStrategy.OnPush,
       standalone: false,
     })
     class TripleTemplate {
@@ -883,7 +875,6 @@ describe('change detection for transplanted views', () => {
     @Component({
       selector: 'on-push-component',
       template: ` <ng-container #vc></ng-container> `,
-      changeDetection: ChangeDetectionStrategy.OnPush,
       standalone: false,
     })
     class OnPushComponent {
@@ -1036,7 +1027,6 @@ describe('change detection for transplanted views', () => {
       @Component({
         selector: 'insertion',
         template: `<ng-container #vc></ng-container>`,
-        changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class Insertion {
         @ViewChild('vc', {read: ViewContainerRef, static: true}) viewContainer!: ViewContainerRef;
@@ -1160,7 +1150,6 @@ describe('change detection for transplanted views', () => {
     @Component({
       selector: 'insertion',
       template: `<ng-container #vc></ng-container>`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class Insertion {
       @ViewChild('vc', {read: ViewContainerRef, static: true}) viewContainer!: ViewContainerRef;

--- a/packages/core/test/acceptance/control_flow_for_spec.ts
+++ b/packages/core/test/acceptance/control_flow_for_spec.ts
@@ -1297,7 +1297,6 @@ describe('control flow - for', () => {
       // prettier-ignore
       @Component({
         template: `@for (item of items; track item) {{{item}}|}`,
-        changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class TestComponent {
         items = new Proxy([1, 2, 3, 4, 5], {
@@ -1324,7 +1323,6 @@ describe('control flow - for', () => {
     // prettier-ignore
     @Component({
       template: `@for (item of items; track $index) {{{item}}|}`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class TestComponent {
       items = new Proxy(

--- a/packages/core/test/acceptance/create_component_spec.ts
+++ b/packages/core/test/acceptance/create_component_spec.ts
@@ -1141,7 +1141,6 @@ describe('createComponent', () => {
 
     it('should update view of component set with the onPush strategy after input change', () => {
       @Component({
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: 'Value: {{ value }}',
       })
       class DisplayOnPushComponent {

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -463,7 +463,6 @@ describe('@defer', () => {
       @Component({
         selector: 'simple-app',
         imports: [MyLazyCmp],
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: `
           @defer (on immediate) {
             <my-lazy-cmp />
@@ -485,7 +484,6 @@ describe('@defer', () => {
     it('should render when @defer-loaded component uses OnPush', async () => {
       @Component({
         selector: 'my-lazy-cmp',
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ foo }}',
       })
       class MyLazyCmp {
@@ -518,7 +516,6 @@ describe('@defer', () => {
     it('should render when both @defer-loaded and host component use OnPush', async () => {
       @Component({
         selector: 'my-lazy-cmp',
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ foo }}',
       })
       class MyLazyCmp {
@@ -528,7 +525,6 @@ describe('@defer', () => {
       @Component({
         selector: 'simple-app',
         imports: [MyLazyCmp],
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: `
           @defer (on immediate) {
             <my-lazy-cmp />
@@ -550,7 +546,6 @@ describe('@defer', () => {
     it('should render when both OnPush components used in other blocks (e.g. @placeholder)', async () => {
       @Component({
         selector: 'my-lazy-cmp',
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ foo }}',
       })
       class MyLazyCmp {
@@ -559,7 +554,6 @@ describe('@defer', () => {
 
       @Component({
         selector: 'another-lazy-cmp',
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ foo }}',
       })
       class AnotherLazyCmp {
@@ -569,7 +563,6 @@ describe('@defer', () => {
       @Component({
         selector: 'simple-app',
         imports: [MyLazyCmp, AnotherLazyCmp],
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: `
           @defer (when isVisible) {
             <my-lazy-cmp />

--- a/packages/core/test/acceptance/pipe_spec.ts
+++ b/packages/core/test/acceptance/pipe_spec.ts
@@ -674,7 +674,6 @@ describe('pipe', () => {
       let pipeChangeDetectorRef: ChangeDetectorRef | undefined;
 
       @Component({
-        changeDetection: ChangeDetectionStrategy.OnPush,
         selector: 'some-comp',
         template: 'Inner value: "{{displayValue}}"',
         standalone: false,
@@ -685,7 +684,6 @@ describe('pipe', () => {
       }
 
       @Component({
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: `
           <some-comp [value]="pipeValue | testPipe"></some-comp>
           Outer value: "{{ displayValue }}"
@@ -730,7 +728,6 @@ describe('pipe', () => {
       let pipeChangeDetectorRef: ChangeDetectorRef | undefined;
 
       @Component({
-        changeDetection: ChangeDetectionStrategy.OnPush,
         selector: 'some-comp',
         template: 'Inner value: "{{displayValue}}" <ng-content></ng-content>',
         standalone: false,
@@ -741,7 +738,6 @@ describe('pipe', () => {
       }
 
       @Component({
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: `
           <some-comp [value]="pipeValue | testPipe">
             <div>Hello</div>

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -1778,7 +1778,6 @@ describe('query logic', () => {
     it('should not throw when hydration metadata has no serialized container data', () => {
       @Component({
         template: `<div #foo></div>`,
-        changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class TestCmp {}
 

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -763,7 +763,6 @@ describe('bootstrap', () => {
       @Component({
         template: '',
         host: {'[class]': 'clazz'},
-        changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class HostBindingComp {
         clazz = 'initial';

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -1902,7 +1902,6 @@ class WrapCompWithRef {
   selector: 'push-cmp',
   template: '<div (event)="noop()" emitterDirective></div>{{value}}{{renderIncrement}}',
   host: {'(event)': 'noop()'},
-  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
 class PushComp {

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -2359,7 +2359,6 @@ class EventCmp {
   selector: 'push-cmp',
   inputs: ['prop'],
   host: {'(click)': 'true'},
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template:
     '{{field}}<div (click)="noop()"></div><div *ngIf="true" (click)="noop()"></div><event-cmp></event-cmp>',
   standalone: false,
@@ -2383,7 +2382,6 @@ class PushCmp {
 @Component({
   selector: 'push-cmp-with-ref',
   inputs: ['prop'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: '{{field}}',
   standalone: false,
 })
@@ -2410,7 +2408,6 @@ class PushCmpWithRef {
 @Component({
   selector: 'push-cmp-with-host-event',
   host: {'(click)': 'ctxCallback($event)'},
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: '',
   standalone: false,
 })
@@ -2420,7 +2417,6 @@ class PushCmpWithHostEvent {
 
 @Component({
   selector: 'push-cmp-with-async',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: '{{field | async}}',
   standalone: false,
 })

--- a/packages/core/test/render3/jit/declare_component_spec.ts
+++ b/packages/core/test/render3/jit/declare_component_spec.ts
@@ -306,7 +306,6 @@ describe('component declaration jit compilation', () => {
       version: '18.0.0',
       type: TestClass,
       template: '<div></div>',
-      changeDetection: ChangeDetectionStrategy.OnPush,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -349,7 +349,6 @@ describe('reactivity', () => {
 
       const source = signal('');
       @Component({
-        changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ data }}',
       })
       class TestCmp {
@@ -392,7 +391,6 @@ describe('reactivity', () => {
       }
 
       @Component({
-        changeDetection: ChangeDetectionStrategy.OnPush,
         providers: [Service],
         template: '{{ service.data }}',
       })
@@ -439,7 +437,6 @@ describe('reactivity', () => {
       @Component({
         imports: [Dir],
         template: `<ng-template dir let-data>{{ data }}</ng-template>`,
-        changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class TestCmp {}
 

--- a/packages/core/test/resource/BUILD.bazel
+++ b/packages/core/test/resource/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_project", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_project", "ng_web_test_suite", "zoneless_jasmine_test")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -16,7 +16,7 @@ ng_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "resource",
     data = [
         ":resource_lib",

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {timeout} from '@angular/private/testing';
 import {
   ApplicationRef,
   ɵCACHE_ACTIVE as CACHE_ACTIVE,
@@ -52,7 +53,7 @@ abstract class MockBackend<T, R> {
       entry.reject(reason);
     }
 
-    return flushMicrotasks();
+    return timeout();
   }
 
   async flush(): Promise<void> {
@@ -64,7 +65,7 @@ abstract class MockBackend<T, R> {
     this.pending.clear();
 
     await Promise.all(allPending);
-    await flushMicrotasks();
+    await timeout();
   }
 
   protected abstract prepareResponse(request: T): R;
@@ -132,7 +133,7 @@ describe('resource', () => {
     });
 
     TestBed.tick();
-    await flushMicrotasks();
+    await timeout();
 
     expect(prevStatus).toBe('idle');
   });
@@ -361,7 +362,7 @@ describe('resource', () => {
 
     // Resolve the first load.
     resolve[0]();
-    await flushMicrotasks();
+    await timeout();
 
     // The resource should still be loading. Ticking (triggering the 2nd effect)
     // should not change the loading status.
@@ -372,7 +373,7 @@ describe('resource', () => {
 
     // Resolve the second load.
     resolve[1]?.();
-    await flushMicrotasks();
+    await timeout();
 
     // We should see the resolved value.
     expect(res.status()).toBe('resolved');
@@ -1108,10 +1109,6 @@ describe('resource', () => {
   });
 });
 
-function flushMicrotasks(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 function extractError(fn: () => unknown): Error | undefined {
   try {
     fn();
@@ -1146,7 +1143,7 @@ describe('with TransferState', () => {
     expect(testResource.value()).toBe(123);
 
     // Should prevent loader from running
-    await flushMicrotasks();
+    await timeout();
     expect(testResource.value()).toBe(123);
   });
 
@@ -1162,7 +1159,7 @@ describe('with TransferState', () => {
 
     expect(testResource.status()).toBe('loading');
 
-    await flushMicrotasks();
+    await timeout();
 
     expect(testResource.status()).toBe('resolved');
     expect(testResource.value()).toBe(789);
@@ -1179,7 +1176,7 @@ describe('with TransferState', () => {
       injector: TestBed.inject(Injector),
     });
 
-    await flushMicrotasks();
+    await timeout();
 
     expect(testResource.status()).toBe('resolved');
     expect(testResource.value()).toBe(101112);

--- a/packages/core/test/signals/BUILD.bazel
+++ b/packages/core/test/signals/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ng_web_test_suite", "ts_project", "zoneless_jasmine_test")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -16,7 +16,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "signals",
     data = [
         ":signals_lib",


### PR DESCRIPTION
OnPush is now the default change detection strategy, so the explicit test configuration is no longer needed.

Updates outdated Bazel test targets to use the zoneless configuration.
