### PR TITLE
docs: use the remote-cache config in the bazel caching guide

### DIFF
--- a/contributing-docs/building-with-bazel.md
+++ b/contributing-docs/building-with-bazel.md
@@ -189,7 +189,7 @@ To enable remote caching for your build:
 5. Create a file called `.bazelrc.user` in the root directory of the workspace, and add the following content:
 
 ```
-build --config=angular-team --google_credentials=[ABSOLUTE_PATH_TO_SERVICE_KEY]
+build --config=remote-cache --google_credentials=[ABSOLUTE_PATH_TO_SERVICE_KEY]
 ```
 
 ## Diagnosing slow builds


### PR DESCRIPTION
`build --config=angular-team` has not existed since #31204 removed it from `.bazelrc` in June 2019. Following the guide writes that line into `.bazelrc.user`, after which `bazel build`, `test`, `info`, `cquery` and `clean` all fail with "Config value 'angular-team' is not defined in any .rc file", including invocations unrelated to caching.

`remote-cache` reads the same `storage.googleapis.com/angular-team-cache` bucket the removed config used, so an existing service account key still works. An explicit `--google_credentials` takes precedence over the config's `--google_default_credentials`, so the surrounding steps are unchanged.