### PR TITLE
fix(forms): prevent date inputs from being marked dirty on init

### DIFF
--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {
+  untracked,
   type ɵControlDirectiveHost as ControlDirectiveHost,
   type Signal,
   type WritableSignal,
@@ -31,6 +32,19 @@ import {
 } from './native';
 import {observeSelectMutations} from './select';
 
+/**
+ * Compares two control values, treating `Date`s for the same instant as equal.
+ *
+ * Date-like inputs are read through `valueAsDate`, which returns a fresh `Date` on every access, so
+ * identity comparison alone would report a change even when the input was never touched.
+ */
+function controlValuesEqual(a: unknown, b: unknown): boolean {
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  return Object.is(a, b);
+}
+
 export function nativeControlCreate(
   host: ControlDirectiveHost,
   parent: FormField<unknown>,
@@ -40,6 +54,13 @@ export function nativeControlCreate(
   validityMonitor: InputValidityMonitor,
 ): () => void {
   let updateMode = false;
+  // While true, a write that leaves the value untouched must not dirty the field.
+  //
+  // A native validity change isn't necessarily a user edit: the browser runs the `:valid` /
+  // `:invalid` animation as soon as the input is rendered, which would otherwise dirty every
+  // date-like field on load (#69632). Syncs that clear a parse error are exempt, because a parse
+  // error can only exist in response to the user typing something the input couldn't parse.
+  let dirtyOnlyIfValueChanged = false;
   const input = parent.nativeFormElement;
 
   // TODO: (perf) ok to always create this?
@@ -47,7 +68,15 @@ export function nativeControlCreate(
     // Read from the model value
     () => parent.state().value(),
     // Write to the buffered "control value"
-    (rawValue: unknown) => parent.state().controlValue.set(rawValue),
+    (rawValue: unknown) => {
+      const state = parent.state();
+      if (dirtyOnlyIfValueChanged && controlValuesEqual(untracked(state.controlValue), rawValue)) {
+        return;
+      }
+      // Outside of `dirtyOnlyIfValueChanged` we intentionally write even when the value is
+      // unchanged, so that re-entering the same value still dirties the field.
+      state.controlValue.set(rawValue);
+    },
     // Our parse function doesn't care about the raw value that gets passed in,
     // It just reads the newly parsed value directly off the input element.
     (_rawValue: unknown) => getNativeControlValue(input, parent.state().value, validityMonitor),
@@ -66,7 +95,16 @@ export function nativeControlCreate(
 
   // TODO: move extraction to first update pass?
   if (isInput(input) && inputRequiresValidityTracking(input)) {
-    validityMonitor.watchValidity(parent.destroyRef, input, () => parser.setRawValue(undefined));
+    validityMonitor.watchValidity(parent.destroyRef, input, () => {
+      // Resolving a parse error is always a user edit, so let those syncs dirty the field even
+      // when the parsed value is unchanged.
+      dirtyOnlyIfValueChanged = untracked(parser.errors).length === 0;
+      try {
+        parser.setRawValue(undefined);
+      } finally {
+        dirtyOnlyIfValueChanged = false;
+      }
+    });
   }
 
   parent.registerAsBinding();

--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -90,7 +90,13 @@ export function nativeControlCreate(
     setNativeControlValue(input, value);
   };
   // Pass undefined as the raw value since the parse function doesn't care about it.
-  host.listenToDom('input', () => parser.setRawValue(undefined));
+  host.listenToDom('input', () => {
+    // An `input` event is the definitive signal of user interaction, so dirty the field up front.
+    // Parsing may fail — typing `e` into a number input, or an incomplete date — in which case no
+    // value reaches `controlValue` and nothing else would mark the field as edited.
+    parent.state().markAsDirty();
+    parser.setRawValue(undefined);
+  });
   host.listenToDom('blur', () => parent.state().markAsTouched());
 
   // TODO: move extraction to first update pass?

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -5510,6 +5510,273 @@ describe('field directive', () => {
       expect(cmp.f().value()).toBe('');
     });
 
+    it('should mark the field dirty when native UI clears the date to null without input event', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="date" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal('2024-01-01'));
+      }
+
+      const validityMonitor = configureTestValidityMonitor();
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // 1. Start with a valid date, pristine.
+      expect(cmp.f().value()).toBe('2024-01-01');
+      expect(cmp.f().dirty()).toBe(false);
+
+      // 2. Transition to bad input state (parse error; value/controlValue unchanged).
+      act(() => {
+        validityMonitor.setInputState(input, '', true);
+      });
+      expect(cmp.f().errors()).toEqual([jasmine.objectContaining({kind: 'parse'})]);
+      // Bad input didn't change the value, so still pristine.
+      expect(cmp.f().dirty()).toBe(false);
+
+      // 3. Native UI clears the date to empty WITHOUT an `input` event
+      //    (only the validity-monitor callback fires).
+      act(() => {
+        validityMonitor.setInputState(input, '', false);
+      });
+
+      // 4. Value is cleared and, because the value actually changed, the field is dirty.
+      expect(cmp.f().errors()).toEqual([]);
+      expect(cmp.f().value()).toBe('');
+      expect(cmp.f().dirty()).toBe(true);
+    });
+
+    it('should mark the field dirty when a parse error is cleared without changing the value', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="date" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(''));
+      }
+
+      const validityMonitor = configureTestValidityMonitor();
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      expect(cmp.f().dirty()).toBe(false);
+
+      // The user types a date the input can't parse. The model value never leaves `''`.
+      act(() => validityMonitor.setInputState(input, '', true));
+      expect(cmp.f().errors()).toEqual([jasmine.objectContaining({kind: 'parse'})]);
+      expect(cmp.f().dirty()).toBe(false);
+
+      // Clearing that bad input resolves the parse error without changing the value. It is still a
+      // user edit, so the field is dirtied.
+      act(() => validityMonitor.setInputState(input, '', false));
+      expect(cmp.f().errors()).toEqual([]);
+      expect(cmp.f().value()).toBe('');
+      expect(cmp.f().dirty()).toBe(true);
+    });
+
+    it('should not be dirty when the initial validity animation fires on load', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="date" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(''), (p) => {
+          required(p, {message: 'required field'});
+        });
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const field = fix.componentInstance.f;
+
+      expect(field().dirty()).toBe(false);
+      expect(field().touched()).toBe(false);
+
+      // The browser runs the `:valid` / `:invalid` animation as soon as the input is rendered. An
+      // empty required date renders as `:invalid`, so `ng-invalid` fires without any interaction.
+      act(() => {
+        input.dispatchEvent(
+          new AnimationEvent('animationstart', {animationName: 'ng-invalid', bubbles: true}),
+        );
+      });
+
+      expect(field().dirty()).toBe(false);
+      expect(field().touched()).toBe(false);
+    });
+
+    it('should not be dirty when the initial validity animation fires on a Date model', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="date" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal<Date | null>(new Date('2024-01-01T00:00:00.000Z')));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const field = fix.componentInstance.f;
+
+      expect(input.value).toBe('2024-01-01');
+      expect(field().dirty()).toBe(false);
+
+      // `valueAsDate` hands back a new `Date` on every read, so the sync triggered by the initial
+      // animation must compare the instant rather than the object identity.
+      act(() => {
+        input.dispatchEvent(
+          new AnimationEvent('animationstart', {animationName: 'ng-valid', bubbles: true}),
+        );
+      });
+
+      expect(field().dirty()).toBe(false);
+      expect(field().value()).toEqual(new Date('2024-01-01T00:00:00.000Z'));
+    });
+
+    // The initial `:valid` / `:invalid` animation fires for every input type we track validity on,
+    // not just `date`, so none of them may dirty their field on load. See #69632.
+    //
+    // The types are spelled out statically: a template built by interpolating the type into a
+    // template literal is not statically analyzable, so the compiler would emit the raw
+    // `type="${type}"` text and the browser would silently fall back to a `text` input.
+    it('should not be dirty when the initial validity animation fires on any date-like input', () => {
+      @Component({
+        imports: [FormField],
+        template: `
+          <input type="date" [formField]="f.date" />
+          <input type="datetime-local" [formField]="f.datetimeLocal" />
+          <input type="month" [formField]="f.month" />
+          <input type="time" [formField]="f.time" />
+          <input type="week" [formField]="f.week" />
+        `,
+      })
+      class TestCmp {
+        f = form(signal({date: '', datetimeLocal: '', month: '', time: '', week: ''}));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const cmp = fix.componentInstance as TestCmp;
+      const inputs = Array.from(
+        (fix.nativeElement as HTMLElement).querySelectorAll('input'),
+      ) as HTMLInputElement[];
+      const fields = [cmp.f.date, cmp.f.datetimeLocal, cmp.f.month, cmp.f.time, cmp.f.week];
+
+      // Guards against the interpolation trap described above. This reads the attribute rather
+      // than `input.type` because browsers report `text` for types they don't implement (Firefox
+      // does so for `month` and `week`), which would make the assertion browser-dependent.
+      expect(inputs.map((i) => i.getAttribute('type'))).toEqual([
+        'date',
+        'datetime-local',
+        'month',
+        'time',
+        'week',
+      ]);
+      expect(fields.map((field) => field().dirty())).toEqual([false, false, false, false, false]);
+
+      act(() => {
+        for (const input of inputs) {
+          input.dispatchEvent(
+            new AnimationEvent('animationstart', {animationName: 'ng-invalid', bubbles: true}),
+          );
+        }
+      });
+
+      expect(fields.map((field) => field().dirty())).toEqual([false, false, false, false, false]);
+      expect(cmp.f().value()).toEqual({
+        date: '',
+        datetimeLocal: '',
+        month: '',
+        time: '',
+        week: '',
+      });
+    });
+
+    it('should not be dirty when the initial validity animation fires on a null model', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="date" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal<Date | null>(null));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const field = fix.componentInstance.f;
+
+      expect(input.value).toBe('');
+      expect(field().dirty()).toBe(false);
+
+      act(() => {
+        input.dispatchEvent(
+          new AnimationEvent('animationstart', {animationName: 'ng-invalid', bubbles: true}),
+        );
+      });
+
+      expect(field().dirty()).toBe(false);
+      expect(field().value()).toBe(null);
+    });
+
+    it('should not be dirty when the initial validity animation fires on a numeric model', () => {
+      const timestamp = Date.UTC(2024, 0, 1);
+
+      @Component({
+        imports: [FormField],
+        template: `<input type="date" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(timestamp));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const field = fix.componentInstance.f;
+
+      expect(input.value).toBe('2024-01-01');
+      expect(field().dirty()).toBe(false);
+
+      act(() => {
+        input.dispatchEvent(
+          new AnimationEvent('animationstart', {animationName: 'ng-valid', bubbles: true}),
+        );
+      });
+
+      expect(field().dirty()).toBe(false);
+      expect(field().value()).toBe(timestamp);
+    });
+
+    it('should still be dirtied by a real edit to a date input', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="date" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal('2024-01-01'));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const field = fix.componentInstance.f;
+
+      // The load-time animation must not mask a subsequent genuine edit.
+      act(() => {
+        input.dispatchEvent(
+          new AnimationEvent('animationstart', {animationName: 'ng-valid', bubbles: true}),
+        );
+      });
+      expect(field().dirty()).toBe(false);
+
+      act(() => {
+        input.value = '2024-06-15';
+        input.dispatchEvent(new Event('input'));
+      });
+
+      expect(field().dirty()).toBe(true);
+      expect(field().value()).toBe('2024-06-15');
+    });
+
     it('should re-evaluate validity and value when native UI clears time input without input event', () => {
       @Component({
         imports: [FormField],

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -5528,13 +5528,14 @@ describe('field directive', () => {
       expect(cmp.f().value()).toBe('2024-01-01');
       expect(cmp.f().dirty()).toBe(false);
 
-      // 2. Transition to bad input state (parse error; value/controlValue unchanged).
+      // 2. Transition to bad input state. This clears the native value, so an `input` event fires
+      //    and the field is dirtied even though the parse failed and the model value is unchanged.
       act(() => {
         validityMonitor.setInputState(input, '', true);
       });
       expect(cmp.f().errors()).toEqual([jasmine.objectContaining({kind: 'parse'})]);
-      // Bad input didn't change the value, so still pristine.
-      expect(cmp.f().dirty()).toBe(false);
+      expect(cmp.f().value()).toBe('2024-01-01');
+      expect(cmp.f().dirty()).toBe(true);
 
       // 3. Native UI clears the date to empty WITHOUT an `input` event
       //    (only the validity-monitor callback fires).
@@ -5574,6 +5575,32 @@ describe('field directive', () => {
       act(() => validityMonitor.setInputState(input, '', false));
       expect(cmp.f().errors()).toEqual([]);
       expect(cmp.f().value()).toBe('');
+      expect(cmp.f().dirty()).toBe(true);
+    });
+
+    it('should mark the field dirty when the user types a value that fails to parse', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="number" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal<number | null>(5));
+      }
+
+      const validityMonitor = configureTestValidityMonitor();
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      expect(input.value).toBe('5');
+      expect(cmp.f().dirty()).toBe(false);
+
+      // Typing `e` into a number input empties `value` and flags `badInput`, so the parse fails
+      // and no value ever reaches the model. The user still edited the field.
+      act(() => validityMonitor.setInputState(input, '', true));
+
+      expect(cmp.f().errors()).toEqual([jasmine.objectContaining({kind: 'parse'})]);
+      expect(cmp.f().value()).toBe(5);
       expect(cmp.f().dirty()).toBe(true);
     });
 


### PR DESCRIPTION
Signal Forms inputs that require validity tracking were being marked `dirty()` on component initialization, before any user interaction. This caused validation error  messages and invalid/valid styling to appear immediately on load.

Fix: #69632

Issue Number: #69632