### PR TITLE
test(core): reduce `fakeAsync` usage in tests 

### DIFF
--- a/packages/core/test/acceptance/authoring/BUILD.bazel
+++ b/packages/core/test/acceptance/authoring/BUILD.bazel
@@ -14,7 +14,6 @@ TEST_DEPS = [
     "//packages/platform-browser:platform-browser",
     "//packages/core/primitives/signals:signals",
     "//:node_modules/rxjs",
-    "//packages/core/test/animation_utils",
     "//packages/private/testing",
 ]
 

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -43,7 +43,7 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '../../src/core';
-import {ComponentFixture, fakeAsync, TestBed} from '../../testing';
+import {ComponentFixture, TestBed} from '../../testing';
 
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MockResourceLoader} from './resource_loader_mock';
@@ -145,217 +145,217 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
     });
 
     describe('expressions', () => {
-      it('should support literals', fakeAsync(() => {
+      it('should support literals', () => {
         expect(_bindAndCheckSimpleValue(10)).toEqual(['id=10']);
-      }));
+      });
 
-      it('should strip quotes from literals', fakeAsync(() => {
+      it('should strip quotes from literals', () => {
         expect(_bindAndCheckSimpleValue('"str"')).toEqual(['id=str']);
-      }));
+      });
 
-      it('should support newlines in literals', fakeAsync(() => {
+      it('should support newlines in literals', () => {
         expect(_bindAndCheckSimpleValue('"a\n\nb"')).toEqual(['id=a\n\nb']);
-      }));
+      });
 
-      it('should support + operations', fakeAsync(() => {
+      it('should support + operations', () => {
         expect(_bindAndCheckSimpleValue('10 + 2')).toEqual(['id=12']);
-      }));
+      });
 
-      it('should support - operations', fakeAsync(() => {
+      it('should support - operations', () => {
         expect(_bindAndCheckSimpleValue('10 - 2')).toEqual(['id=8']);
-      }));
+      });
 
-      it('should support * operations', fakeAsync(() => {
+      it('should support * operations', () => {
         expect(_bindAndCheckSimpleValue('10 * 2')).toEqual(['id=20']);
-      }));
+      });
 
-      it('should support / operations', fakeAsync(() => {
+      it('should support / operations', () => {
         expect(_bindAndCheckSimpleValue('10 / 2')).toEqual([`id=5`]);
-      }));
+      });
 
-      it('should support % operations', fakeAsync(() => {
+      it('should support % operations', () => {
         expect(_bindAndCheckSimpleValue('11 % 2')).toEqual(['id=1']);
-      }));
+      });
 
-      it('should support == operations on identical', fakeAsync(() => {
+      it('should support == operations on identical', () => {
         expect(_bindAndCheckSimpleValue('1 == 1')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support != operations', fakeAsync(() => {
+      it('should support != operations', () => {
         expect(_bindAndCheckSimpleValue('1 != 1')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support == operations on coerceible', fakeAsync(() => {
+      it('should support == operations on coerceible', () => {
         expect(_bindAndCheckSimpleValue('1 == true')).toEqual([`id=true`]);
-      }));
+      });
 
-      it('should support === operations on identical', fakeAsync(() => {
+      it('should support === operations on identical', () => {
         expect(_bindAndCheckSimpleValue('1 === 1')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support !== operations', fakeAsync(() => {
+      it('should support !== operations', () => {
         expect(_bindAndCheckSimpleValue('1 !== 1')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support === operations on coerceible', fakeAsync(() => {
+      it('should support === operations on coerceible', () => {
         expect(_bindAndCheckSimpleValue('1 === true')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support true < operations', fakeAsync(() => {
+      it('should support true < operations', () => {
         expect(_bindAndCheckSimpleValue('1 < 2')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support false < operations', fakeAsync(() => {
+      it('should support false < operations', () => {
         expect(_bindAndCheckSimpleValue('2 < 1')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support false > operations', fakeAsync(() => {
+      it('should support false > operations', () => {
         expect(_bindAndCheckSimpleValue('1 > 2')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support true > operations', fakeAsync(() => {
+      it('should support true > operations', () => {
         expect(_bindAndCheckSimpleValue('2 > 1')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support true <= operations', fakeAsync(() => {
+      it('should support true <= operations', () => {
         expect(_bindAndCheckSimpleValue('1 <= 2')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support equal <= operations', fakeAsync(() => {
+      it('should support equal <= operations', () => {
         expect(_bindAndCheckSimpleValue('2 <= 2')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support false <= operations', fakeAsync(() => {
+      it('should support false <= operations', () => {
         expect(_bindAndCheckSimpleValue('2 <= 1')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support true >= operations', fakeAsync(() => {
+      it('should support true >= operations', () => {
         expect(_bindAndCheckSimpleValue('2 >= 1')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support equal >= operations', fakeAsync(() => {
+      it('should support equal >= operations', () => {
         expect(_bindAndCheckSimpleValue('2 >= 2')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support false >= operations', fakeAsync(() => {
+      it('should support false >= operations', () => {
         expect(_bindAndCheckSimpleValue('1 >= 2')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support true && operations', fakeAsync(() => {
+      it('should support true && operations', () => {
         expect(_bindAndCheckSimpleValue('true && true')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support false && operations', fakeAsync(() => {
+      it('should support false && operations', () => {
         expect(_bindAndCheckSimpleValue('true && false')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support true || operations', fakeAsync(() => {
+      it('should support true || operations', () => {
         expect(_bindAndCheckSimpleValue('true || false')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support false || operations', fakeAsync(() => {
+      it('should support false || operations', () => {
         expect(_bindAndCheckSimpleValue('false || false')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support negate', fakeAsync(() => {
+      it('should support negate', () => {
         expect(_bindAndCheckSimpleValue('!true')).toEqual(['id=false']);
-      }));
+      });
 
-      it('should support double negate', fakeAsync(() => {
+      it('should support double negate', () => {
         expect(_bindAndCheckSimpleValue('!!true')).toEqual(['id=true']);
-      }));
+      });
 
-      it('should support true conditionals', fakeAsync(() => {
+      it('should support true conditionals', () => {
         expect(_bindAndCheckSimpleValue('1 < 2 ? 1 : 2')).toEqual(['id=1']);
-      }));
+      });
 
-      it('should support false conditionals', fakeAsync(() => {
+      it('should support false conditionals', () => {
         expect(_bindAndCheckSimpleValue('1 > 2 ? 1 : 2')).toEqual(['id=2']);
-      }));
+      });
 
-      it('should support keyed access to a list item', fakeAsync(() => {
+      it('should support keyed access to a list item', () => {
         expect(_bindAndCheckSimpleValue('["foo", "bar"][0]')).toEqual(['id=foo']);
-      }));
+      });
 
-      it('should support keyed access to a map item', fakeAsync(() => {
+      it('should support keyed access to a map item', () => {
         expect(_bindAndCheckSimpleValue('{"foo": "bar"}["foo"]')).toEqual(['id=bar']);
-      }));
+      });
 
-      it('should report all changes on the first run including uninitialized values', fakeAsync(() => {
+      it('should report all changes on the first run including uninitialized values', () => {
         expect(_bindAndCheckSimpleValue('value', Uninitialized)).toEqual(['id=null']);
-      }));
+      });
 
-      it('should report all changes on the first run including null values', fakeAsync(() => {
+      it('should report all changes on the first run including null values', () => {
         const ctx = _bindSimpleValue('a', TestData);
         ctx.componentInstance.a = null;
         ctx.detectChanges(false);
         expect(renderLog.log).toEqual(['id=null']);
-      }));
+      });
 
-      it('should support simple chained property access', fakeAsync(() => {
+      it('should support simple chained property access', () => {
         const ctx = _bindSimpleValue('address.city', Person);
         ctx.componentInstance.name = 'Victor';
         ctx.componentInstance.address = new Address('Grenoble');
         ctx.detectChanges(false);
         expect(renderLog.log).toEqual(['id=Grenoble']);
-      }));
+      });
 
       describe('safe navigation operator', () => {
-        it('should support reading properties of nulls', fakeAsync(() => {
+        it('should support reading properties of nulls', () => {
           const ctx = _bindSimpleValue('address?.city', Person);
           ctx.componentInstance.address = null!;
           ctx.detectChanges(false);
           expect(renderLog.log).toEqual(['id=undefined']);
-        }));
+        });
 
-        it('should support calling methods on nulls', fakeAsync(() => {
+        it('should support calling methods on nulls', () => {
           const ctx = _bindSimpleValue('address?.toString()', Person);
           ctx.componentInstance.address = null!;
           ctx.detectChanges(false);
           expect(renderLog.log).toEqual(['id=undefined']);
-        }));
+        });
 
-        it('should support reading properties on non nulls', fakeAsync(() => {
+        it('should support reading properties on non nulls', () => {
           const ctx = _bindSimpleValue('address?.city', Person);
           ctx.componentInstance.address = new Address('MTV');
           ctx.detectChanges(false);
           expect(renderLog.log).toEqual(['id=MTV']);
-        }));
+        });
 
-        it('should support calling methods on non nulls', fakeAsync(() => {
+        it('should support calling methods on non nulls', () => {
           const ctx = _bindSimpleValue('address?.toString()', Person);
           ctx.componentInstance.address = new Address('MTV');
           ctx.detectChanges(false);
           expect(renderLog.log).toEqual(['id=MTV']);
-        }));
+        });
 
-        it('should support short-circuting safe navigation', fakeAsync(() => {
+        it('should support short-circuting safe navigation', () => {
           const ctx = _bindSimpleValue('value?.address.city', PersonHolder);
           ctx.componentInstance.value = null!;
           ctx.detectChanges(false);
           expect(renderLog.log).toEqual(['id=undefined']);
-        }));
+        });
 
-        it('should support nested short-circuting safe navigation', fakeAsync(() => {
+        it('should support nested short-circuting safe navigation', () => {
           const ctx = _bindSimpleValue('value.value?.address.city', PersonHolderHolder);
           ctx.componentInstance.value = new PersonHolder();
           ctx.detectChanges(false);
           expect(renderLog.log).toEqual(['id=undefined']);
-        }));
+        });
 
-        it('should support chained short-circuting safe navigation', fakeAsync(() => {
+        it('should support chained short-circuting safe navigation', () => {
           const ctx = _bindSimpleValue('value?.value?.address.city', PersonHolderHolder);
           ctx.detectChanges(false);
           expect(renderLog.log).toEqual(['id=undefined']);
-        }));
+        });
 
-        it('should support short-circuting array index operations', fakeAsync(() => {
+        it('should support short-circuting array index operations', () => {
           const ctx = _bindSimpleValue('value?.phones[0]', PersonHolder);
           ctx.detectChanges(false);
           expect(renderLog.log).toEqual(['id=undefined']);
-        }));
+        });
 
-        it('should still throw if right-side would throw', fakeAsync(() => {
+        it('should still throw if right-side would throw', () => {
           expect(() => {
             const ctx = _bindSimpleValue('value?.address.city', PersonHolder);
             const person = new Person();
@@ -363,30 +363,30 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             ctx.componentInstance.value = person;
             ctx.detectChanges(false);
           }).toThrow();
-        }));
+        });
       });
 
-      it('should support method calls', fakeAsync(() => {
+      it('should support method calls', () => {
         const ctx = _bindSimpleValue('sayHi("Jim")', Person);
         ctx.detectChanges(false);
         expect(renderLog.log).toEqual(['id=Hi, Jim']);
-      }));
+      });
 
-      it('should support function calls', fakeAsync(() => {
+      it('should support function calls', () => {
         const ctx = _bindSimpleValue('a()(99)', TestData);
         ctx.componentInstance.a = () => (a: any) => a;
         ctx.detectChanges(false);
         expect(renderLog.log).toEqual(['id=99']);
-      }));
+      });
 
-      it('should support chained method calls', fakeAsync(() => {
+      it('should support chained method calls', () => {
         const ctx = _bindSimpleValue('address.toString()', Person);
         ctx.componentInstance.address = new Address('MTV');
         ctx.detectChanges(false);
         expect(renderLog.log).toEqual(['id=MTV']);
-      }));
+      });
 
-      it('should support NaN', fakeAsync(() => {
+      it('should support NaN', () => {
         const ctx = _bindSimpleValue('age', Person);
         ctx.componentInstance.age = NaN;
         ctx.detectChanges(false);
@@ -396,9 +396,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
 
         ctx.detectChanges(false);
         expect(renderLog.log).toEqual([]);
-      }));
+      });
 
-      it('should do simple watching', fakeAsync(() => {
+      it('should do simple watching', () => {
         const ctx = _bindSimpleValue('name', Person);
         ctx.componentInstance.name = 'misko';
 
@@ -413,28 +413,28 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         ctx.componentInstance.name = 'Misko';
         ctx.detectChanges(false);
         expect(renderLog.log).toEqual(['id=Misko']);
-      }));
+      });
 
-      it('should support literal array made of literals', fakeAsync(() => {
+      it('should support literal array made of literals', () => {
         const ctx = _bindSimpleValue('[1, 2]');
         ctx.detectChanges(false);
         expect(renderLog.loggedValues).toEqual([[1, 2]]);
-      }));
+      });
 
-      it('should support empty literal array', fakeAsync(() => {
+      it('should support empty literal array', () => {
         const ctx = _bindSimpleValue('[]');
         ctx.detectChanges(false);
         expect(renderLog.loggedValues).toEqual([[]]);
-      }));
+      });
 
-      it('should support literal array made of expressions', fakeAsync(() => {
+      it('should support literal array made of expressions', () => {
         const ctx = _bindSimpleValue('[1, a]', TestData);
         ctx.componentInstance.a = 2;
         ctx.detectChanges(false);
         expect(renderLog.loggedValues).toEqual([[1, 2]]);
-      }));
+      });
 
-      it('should not recreate literal arrays unless their content changed', fakeAsync(() => {
+      it('should not recreate literal arrays unless their content changed', () => {
         const ctx = _bindSimpleValue('[1, a]', TestData);
         ctx.componentInstance.a = 2;
         ctx.detectChanges(false);
@@ -446,28 +446,28 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           [1, 2],
           [1, 3],
         ]);
-      }));
+      });
 
-      it('should support literal maps made of literals', fakeAsync(() => {
+      it('should support literal maps made of literals', () => {
         const ctx = _bindSimpleValue('{z: 1}');
         ctx.detectChanges(false);
         expect(renderLog.loggedValues[0]['z']).toEqual(1);
-      }));
+      });
 
-      it('should support empty literal map', fakeAsync(() => {
+      it('should support empty literal map', () => {
         const ctx = _bindSimpleValue('{}');
         ctx.detectChanges(false);
         expect(renderLog.loggedValues).toEqual([{}]);
-      }));
+      });
 
-      it('should support literal maps made of expressions', fakeAsync(() => {
+      it('should support literal maps made of expressions', () => {
         const ctx = _bindSimpleValue('{z: a}');
         ctx.componentInstance.a = 1;
         ctx.detectChanges(false);
         expect(renderLog.loggedValues[0]['z']).toEqual(1);
-      }));
+      });
 
-      it('should not recreate literal maps unless their content changed', fakeAsync(() => {
+      it('should not recreate literal maps unless their content changed', () => {
         const ctx = _bindSimpleValue('{z: a}');
         ctx.componentInstance.a = 1;
         ctx.detectChanges(false);
@@ -478,76 +478,76 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         expect(renderLog.loggedValues.length).toBe(2);
         expect(renderLog.loggedValues[0]['z']).toEqual(1);
         expect(renderLog.loggedValues[1]['z']).toEqual(2);
-      }));
+      });
 
-      it('should ignore empty bindings', fakeAsync(() => {
+      it('should ignore empty bindings', () => {
         const ctx = _bindSimpleProp('[id]', TestData);
         ctx.componentInstance.a = 'value';
         ctx.detectChanges(false);
 
         expect(renderLog.log).toEqual([]);
-      }));
+      });
 
-      it('should support interpolation', fakeAsync(() => {
+      it('should support interpolation', () => {
         const ctx = _bindSimpleProp('id="B{{a}}A"', TestData);
         ctx.componentInstance.a = 'value';
         ctx.detectChanges(false);
 
         expect(renderLog.log).toEqual(['id=BvalueA']);
-      }));
+      });
 
-      it('should output empty strings for null values in interpolation', fakeAsync(() => {
+      it('should output empty strings for null values in interpolation', () => {
         const ctx = _bindSimpleProp('id="B{{a}}A"', TestData);
         ctx.componentInstance.a = null;
         ctx.detectChanges(false);
 
         expect(renderLog.log).toEqual(['id=BA']);
-      }));
+      });
 
-      it('should escape values in literals that indicate interpolation', fakeAsync(() => {
+      it('should escape values in literals that indicate interpolation', () => {
         expect(_bindAndCheckSimpleValue('"$"')).toEqual(['id=$']);
-      }));
+      });
 
-      it('should read locals', fakeAsync(() => {
+      it('should read locals', () => {
         const ctx = createCompFixture(
           '<ng-template testLocals let-local="someLocal">{{local}}</ng-template>',
         );
         ctx.detectChanges(false);
 
         expect(renderLog.log).toEqual(['{{someLocalValue}}']);
-      }));
+      });
 
       describe('pipes', () => {
-        it('should use the return value of the pipe', fakeAsync(() => {
+        it('should use the return value of the pipe', () => {
           const ctx = _bindSimpleValue('name | countingPipe', Person);
           ctx.componentInstance.name = 'bob';
           ctx.detectChanges(false);
           expect(renderLog.loggedValues).toEqual(['bob state:0']);
-        }));
+        });
 
-        it('should support arguments in pipes', fakeAsync(() => {
+        it('should support arguments in pipes', () => {
           const ctx = _bindSimpleValue('name | multiArgPipe:"one":address.city', Person);
           ctx.componentInstance.name = 'value';
           ctx.componentInstance.address = new Address('two');
           ctx.detectChanges(false);
           expect(renderLog.loggedValues).toEqual(['value one two default']);
-        }));
+        });
 
-        it('should associate pipes right-to-left', fakeAsync(() => {
+        it('should associate pipes right-to-left', () => {
           const ctx = _bindSimpleValue('name | multiArgPipe:"a":"b" | multiArgPipe:0:1', Person);
           ctx.componentInstance.name = 'value';
           ctx.detectChanges(false);
           expect(renderLog.loggedValues).toEqual(['value a b default 0 1 default']);
-        }));
+        });
 
-        it('should support calling pure pipes with different number of arguments', fakeAsync(() => {
+        it('should support calling pure pipes with different number of arguments', () => {
           const ctx = _bindSimpleValue('name | multiArgPipe:"a":"b" | multiArgPipe:0:1:2', Person);
           ctx.componentInstance.name = 'value';
           ctx.detectChanges(false);
           expect(renderLog.loggedValues).toEqual(['value a b default 0 1 2']);
-        }));
+        });
 
-        it('should do nothing when no change', fakeAsync(() => {
+        it('should do nothing when no change', () => {
           const ctx = _bindSimpleValue('"Megatron" | identityPipe', Person);
 
           ctx.detectChanges(false);
@@ -558,9 +558,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           ctx.detectChanges(false);
 
           expect(renderLog.log).toEqual([]);
-        }));
+        });
 
-        it('should call pure pipes only if the arguments change', fakeAsync(() => {
+        it('should call pure pipes only if the arguments change', () => {
           const ctx = _bindSimpleValue('name | countingPipe', Person);
           // change from undefined -> null
           ctx.componentInstance.name = null!;
@@ -582,9 +582,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           expect(renderLog.loggedValues).toEqual(['null state:0', 'bob state:1', 'bart state:2']);
           ctx.detectChanges(false);
           expect(renderLog.loggedValues).toEqual(['null state:0', 'bob state:1', 'bart state:2']);
-        }));
+        });
 
-        it('should call pure pipes that are used multiple times only when the arguments change', fakeAsync(() => {
+        it('should call pure pipes that are used multiple times only when the arguments change', () => {
           const ctx = createCompFixture(
             `<div [id]="name | countingPipe"></div><div [id]="age | countingPipe"></div>` +
               '<div *ngFor="let x of [1,2]" [id]="address.city | countingPipe"></div>',
@@ -616,20 +616,20 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'mtv state:0',
             '11 state:1',
           ]);
-        }));
+        });
 
-        it('should call impure pipes on each change detection run', fakeAsync(() => {
+        it('should call impure pipes on each change detection run', () => {
           const ctx = _bindSimpleValue('name | countingImpurePipe', Person);
           ctx.componentInstance.name = 'bob';
           ctx.detectChanges(false);
           expect(renderLog.loggedValues).toEqual(['bob state:0']);
           ctx.detectChanges(false);
           expect(renderLog.loggedValues).toEqual(['bob state:0', 'bob state:1']);
-        }));
+        });
       });
 
       describe('event expressions', () => {
-        it('should support field assignments', fakeAsync(() => {
+        it('should support field assignments', () => {
           const ctx = _bindSimpleProp('(event)="b=a=$event"');
           const childEl = ctx.debugElement.children[0];
           const evt = 'EVENT';
@@ -637,34 +637,34 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
 
           expect(ctx.componentInstance.a).toEqual(evt);
           expect(ctx.componentInstance.b).toEqual(evt);
-        }));
+        });
 
-        it('should support keyed assignments', fakeAsync(() => {
+        it('should support keyed assignments', () => {
           const ctx = _bindSimpleProp('(event)="a[0]=$event"');
           const childEl = ctx.debugElement.children[0];
           ctx.componentInstance.a = ['OLD'];
           const evt = 'EVENT';
           childEl.triggerEventHandler('event', evt);
           expect(ctx.componentInstance.a).toEqual([evt]);
-        }));
+        });
 
-        it('should support chains', fakeAsync(() => {
+        it('should support chains', () => {
           const ctx = _bindSimpleProp('(event)="a=a+1; a=a+1;"');
           const childEl = ctx.debugElement.children[0];
           ctx.componentInstance.a = 0;
           childEl.triggerEventHandler('event', 'EVENT');
           expect(ctx.componentInstance.a).toEqual(2);
-        }));
+        });
 
-        it('should support empty literals', fakeAsync(() => {
+        it('should support empty literals', () => {
           const ctx = _bindSimpleProp('(event)="a=[{},[]]"');
           const childEl = ctx.debugElement.children[0];
           childEl.triggerEventHandler('event', 'EVENT');
 
           expect(ctx.componentInstance.a).toEqual([{}, []]);
-        }));
+        });
 
-        xit('should throw when trying to assign to a local', fakeAsync(() => {
+        xit('should throw when trying to assign to a local', () => {
           expect(() => {
             _bindSimpleProp('(event)="$event=1"');
           }).toThrowError(
@@ -672,20 +672,20 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
               'Cannot assign value (.*) to template variable (.*). Template variables are read-only.',
             ),
           );
-        }));
+        });
 
-        it('should support short-circuiting', fakeAsync(() => {
+        it('should support short-circuiting', () => {
           const ctx = _bindSimpleProp('(event)="true ? a = a + 1 : a = a + 1"');
           const childEl = ctx.debugElement.children[0];
           ctx.componentInstance.a = 0;
           childEl.triggerEventHandler('event', 'EVENT');
           expect(ctx.componentInstance.a).toEqual(1);
-        }));
+        });
       });
     });
 
     describe('RendererFactory', () => {
-      it('should call the begin and end methods on the renderer factory when change detection is called', fakeAsync(() => {
+      it('should call the begin and end methods on the renderer factory when change detection is called', () => {
         const ctx = createCompFixture('<div testDirective [a]="42"></div>');
         const rf = TestBed.inject(RendererFactory2);
         // TODO: @JiaLiPassion, need to wait @types/jasmine to fix the
@@ -699,31 +699,31 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         ctx.detectChanges(false);
         expect(rf.begin).toHaveBeenCalled();
         expect(rf.end).toHaveBeenCalled();
-      }));
+      });
     });
 
     describe('change notification', () => {
       describe('updating directives', () => {
-        it('should happen without invoking the renderer', fakeAsync(() => {
+        it('should happen without invoking the renderer', () => {
           const ctx = createCompFixture('<div testDirective [a]="42"></div>');
           ctx.detectChanges(false);
           expect(renderLog.log).toEqual([]);
           expect(queryDirs(ctx.debugElement, TestDirective)[0].a).toEqual(42);
-        }));
+        });
       });
 
       describe('reading directives', () => {
-        it('should read directive properties', fakeAsync(() => {
+        it('should read directive properties', () => {
           const ctx = createCompFixture(
             '<div testDirective [a]="42" ref-dir="testDirective" [id]="dir.a"></div>',
           );
           ctx.detectChanges(false);
           expect(renderLog.loggedValues).toEqual([42]);
-        }));
+        });
       });
 
       describe('ngOnChanges', () => {
-        it('should notify the directive when a group of records changes', fakeAsync(() => {
+        it('should notify the directive when a group of records changes', () => {
           const ctx = createCompFixture(
             '<div [testDirective]="\'aName\'" [a]="1" [b]="2"></div><div [testDirective]="\'bName\'" [a]="4"></div>',
           );
@@ -739,7 +739,7 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'a': new SimpleChange(undefined, 4, true),
             'name': new SimpleChange(undefined, 'bName', true),
           });
-        }));
+        });
       });
     });
 
@@ -759,7 +759,7 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
       }
 
       describe('ngOnInit', () => {
-        it('should be called after ngOnChanges', fakeAsync(() => {
+        it('should be called after ngOnChanges', () => {
           const ctx = createCompFixture('<div testDirective="dir"></div>');
           expect(directiveLog.filter(['ngOnInit', 'ngOnChanges'])).toEqual([]);
 
@@ -774,9 +774,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           ctx.detectChanges(false);
 
           expect(directiveLog.filter(['ngOnInit'])).toEqual([]);
-        }));
+        });
 
-        it('should only be called only once', fakeAsync(() => {
+        it('should only be called only once', () => {
           const ctx = createCompFixture('<div testDirective="dir"></div>');
 
           ctx.detectChanges(false);
@@ -795,9 +795,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           ctx.detectChanges(false);
 
           expect(directiveLog.filter(['ngOnInit'])).toEqual([]);
-        }));
+        });
 
-        it('should not call ngOnInit again if it throws', fakeAsync(() => {
+        it('should not call ngOnInit again if it throws', () => {
           const ctx = createCompFixture('<div testDirective="dir" throwOn="ngOnInit"></div>');
 
           let errored = false;
@@ -821,11 +821,11 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             throw new Error('Second detectChanges() should not have called ngOnInit.');
           }
           expect(directiveLog.filter(['ngOnInit'])).toEqual([]);
-        }));
+        });
       });
 
       describe('ngDoCheck', () => {
-        it('should be called after ngOnInit', fakeAsync(() => {
+        it('should be called after ngOnInit', () => {
           const ctx = createCompFixture('<div testDirective="dir"></div>');
 
           ctx.detectChanges(false);
@@ -833,9 +833,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'dir.ngOnInit',
             'dir.ngDoCheck',
           ]);
-        }));
+        });
 
-        it('should be called on every detectChanges run, except for checkNoChanges', fakeAsync(() => {
+        it('should be called on every detectChanges run, except for checkNoChanges', () => {
           const ctx = createCompFixture('<div testDirective="dir"></div>');
 
           ctx.detectChanges(false);
@@ -854,11 +854,11 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           ctx.detectChanges(false);
 
           expect(directiveLog.filter(['ngDoCheck'])).toEqual(['dir.ngDoCheck']);
-        }));
+        });
       });
 
       describe('ngAfterContentInit', () => {
-        it('should be called after processing the content children but before the view children', fakeAsync(() => {
+        it('should be called after processing the content children but before the view children', () => {
           const ctx = createCompWithContentAndViewChild();
           ctx.detectChanges(false);
 
@@ -870,9 +870,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'viewChild.ngDoCheck',
             'viewChild.ngAfterContentInit',
           ]);
-        }));
+        });
 
-        it('should only be called only once', fakeAsync(() => {
+        it('should only be called only once', () => {
           const ctx = createCompFixture('<div testDirective="dir"></div>');
 
           ctx.detectChanges(false);
@@ -891,9 +891,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           ctx.detectChanges(false);
 
           expect(directiveLog.filter(['ngAfterContentInit'])).toEqual([]);
-        }));
+        });
 
-        it('should not call ngAfterContentInit again if it throws', fakeAsync(() => {
+        it('should not call ngAfterContentInit again if it throws', () => {
           const ctx = createCompFixture(
             '<div testDirective="dir" throwOn="ngAfterContentInit"></div>',
           );
@@ -918,11 +918,11 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             throw new Error('Second detectChanges() should not have run detection.');
           }
           expect(directiveLog.filter(['ngAfterContentInit'])).toEqual([]);
-        }));
+        });
       });
 
       describe('ngAfterContentChecked', () => {
-        it('should be called after the content children but before the view children', fakeAsync(() => {
+        it('should be called after the content children but before the view children', () => {
           const ctx = createCompWithContentAndViewChild();
 
           ctx.detectChanges(false);
@@ -935,9 +935,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'viewChild.ngDoCheck',
             'viewChild.ngAfterContentChecked',
           ]);
-        }));
+        });
 
-        it('should be called on every detectChanges run, except for checkNoChanges', fakeAsync(() => {
+        it('should be called on every detectChanges run, except for checkNoChanges', () => {
           const ctx = createCompFixture('<div testDirective="dir"></div>');
 
           ctx.detectChanges(false);
@@ -960,9 +960,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           expect(directiveLog.filter(['ngAfterContentChecked'])).toEqual([
             'dir.ngAfterContentChecked',
           ]);
-        }));
+        });
 
-        it('should be called in reverse order so the child is always notified before the parent', fakeAsync(() => {
+        it('should be called in reverse order so the child is always notified before the parent', () => {
           const ctx = createCompFixture(
             '<div testDirective="parent"><div testDirective="child"></div></div><div testDirective="sibling"></div>',
           );
@@ -974,11 +974,11 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'parent.ngAfterContentChecked',
             'sibling.ngAfterContentChecked',
           ]);
-        }));
+        });
       });
 
       describe('ngAfterViewInit', () => {
-        it('should be called after processing the view children', fakeAsync(() => {
+        it('should be called after processing the view children', () => {
           const ctx = createCompWithContentAndViewChild();
 
           ctx.detectChanges(false);
@@ -991,9 +991,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'viewChild.ngAfterViewInit',
             'parent.ngAfterViewInit',
           ]);
-        }));
+        });
 
-        it('should only be called only once', fakeAsync(() => {
+        it('should only be called only once', () => {
           const ctx = createCompFixture('<div testDirective="dir"></div>');
 
           ctx.detectChanges(false);
@@ -1012,9 +1012,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           ctx.detectChanges(false);
 
           expect(directiveLog.filter(['ngAfterViewInit'])).toEqual([]);
-        }));
+        });
 
-        it('should not call ngAfterViewInit again if it throws', fakeAsync(() => {
+        it('should not call ngAfterViewInit again if it throws', () => {
           const ctx = createCompFixture(
             '<div testDirective="dir" throwOn="ngAfterViewInit"></div>',
           );
@@ -1039,11 +1039,11 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             throw new Error('Second detectChanges() should not have run detection.');
           }
           expect(directiveLog.filter(['ngAfterViewInit'])).toEqual([]);
-        }));
+        });
       });
 
       describe('ngAfterViewChecked', () => {
-        it('should be called after processing the view children', fakeAsync(() => {
+        it('should be called after processing the view children', () => {
           const ctx = createCompWithContentAndViewChild();
 
           ctx.detectChanges(false);
@@ -1056,9 +1056,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'viewChild.ngAfterViewChecked',
             'parent.ngAfterViewChecked',
           ]);
-        }));
+        });
 
-        it('should be called on every detectChanges run, except for checkNoChanges', fakeAsync(() => {
+        it('should be called on every detectChanges run, except for checkNoChanges', () => {
           const ctx = createCompFixture('<div testDirective="dir"></div>');
 
           ctx.detectChanges(false);
@@ -1077,9 +1077,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           ctx.detectChanges(false);
 
           expect(directiveLog.filter(['ngAfterViewChecked'])).toEqual(['dir.ngAfterViewChecked']);
-        }));
+        });
 
-        it('should be called in reverse order so the child is always notified before the parent', fakeAsync(() => {
+        it('should be called in reverse order so the child is always notified before the parent', () => {
           const ctx = createCompFixture(
             '<div testDirective="parent"><div testDirective="child"></div></div><div testDirective="sibling"></div>',
           );
@@ -1091,20 +1091,20 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'parent.ngAfterViewChecked',
             'sibling.ngAfterViewChecked',
           ]);
-        }));
+        });
       });
 
       describe('ngOnDestroy', () => {
-        it('should be called on view destruction', fakeAsync(() => {
+        it('should be called on view destruction', () => {
           const ctx = createCompFixture('<div testDirective="dir"></div>');
           ctx.detectChanges(false);
 
           ctx.destroy();
 
           expect(directiveLog.filter(['ngOnDestroy'])).toEqual(['dir.ngOnDestroy']);
-        }));
+        });
 
-        it('should be called after processing the content and view children', fakeAsync(() => {
+        it('should be called after processing the content and view children', () => {
           TestBed.overrideComponent(AnotherComponent, {
             set: new Component({
               selector: 'other-cmp',
@@ -1127,9 +1127,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'viewChild.ngOnDestroy',
             'parent.ngOnDestroy',
           ]);
-        }));
+        });
 
-        it('should be called in reverse order so the child is always notified before the parent', fakeAsync(() => {
+        it('should be called in reverse order so the child is always notified before the parent', () => {
           const ctx = createCompFixture(
             '<div testDirective="parent"><div testDirective="child"></div></div><div testDirective="sibling"></div>',
           );
@@ -1142,27 +1142,27 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'parent.ngOnDestroy',
             'sibling.ngOnDestroy',
           ]);
-        }));
+        });
 
-        it('should deliver synchronous events to parent', fakeAsync(() => {
+        it('should deliver synchronous events to parent', () => {
           const ctx = createCompFixture('<div (destroy)="a=$event" onDestroyDirective></div>');
 
           ctx.detectChanges(false);
           ctx.destroy();
 
           expect(ctx.componentInstance.a).toEqual('destroyed');
-        }));
+        });
 
-        it('should call ngOnDestroy on pipes', fakeAsync(() => {
+        it('should call ngOnDestroy on pipes', () => {
           const ctx = createCompFixture('{{true | pipeWithOnDestroy }}');
 
           ctx.detectChanges(false);
           ctx.destroy();
 
           expect(directiveLog.filter(['ngOnDestroy'])).toEqual(['pipeWithOnDestroy.ngOnDestroy']);
-        }));
+        });
 
-        it('should call ngOnDestroy on an injectable class', fakeAsync(() => {
+        it('should call ngOnDestroy on an injectable class', () => {
           TestBed.overrideDirective(TestDirective, {set: {providers: [InjectableWithLifecycle]}});
 
           const ctx = createCompFixture('<div testDirective="dir"></div>', TestComponent);
@@ -1177,12 +1177,12 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             'dir.ngOnDestroy',
             'injectable.ngOnDestroy',
           ]);
-        }));
+        });
       });
     });
 
     describe('enforce no new changes', () => {
-      it('should throw when a record gets changed after it has been checked', fakeAsync(() => {
+      it('should throw when a record gets changed after it has been checked', () => {
         @Directive({
           selector: '[changed]',
           standalone: false,
@@ -1198,9 +1198,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         ctx.componentInstance.b = 1;
         const errMsgRegExp = /Previous value: 'undefined'\. Current value: '1'/g;
         expect(() => ctx.checkNoChanges()).toThrowError(errMsgRegExp);
-      }));
+      });
 
-      it('should throw when a record gets changed after the first change detection pass', fakeAsync(() => {
+      it('should throw when a record gets changed after the first change detection pass', () => {
         @Directive({
           selector: '[changed]',
           standalone: false,
@@ -1219,7 +1219,7 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         ctx.componentInstance.b = 2;
         const errMsgRegExp = /Previous value: '1'\. Current value: '2'/g;
         expect(() => ctx.checkNoChanges()).toThrowError(errMsgRegExp);
-      }));
+      });
 
       it('should allow view to be created in a cd hook', () => {
         const ctx = createCompFixture('<div *gh9882>{{ a }}</div>', TestData);
@@ -1228,24 +1228,24 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         expect(ctx.nativeElement.innerText).toEqual('1');
       });
 
-      it('should not throw when two arrays are structurally the same', fakeAsync(() => {
+      it('should not throw when two arrays are structurally the same', () => {
         const ctx = _bindSimpleValue('a', TestData);
         ctx.componentInstance.a = ['value'];
         ctx.detectChanges(false);
         ctx.componentInstance.a = ['value'];
         expect(() => ctx.checkNoChanges()).not.toThrow();
-      }));
+      });
 
-      it('should not break the next run', fakeAsync(() => {
+      it('should not break the next run', () => {
         const ctx = _bindSimpleValue('a', TestData);
         ctx.componentInstance.a = 'value';
         expect(() => ctx.checkNoChanges()).toThrow();
 
         ctx.detectChanges();
         expect(renderLog.loggedValues).toEqual(['value']);
-      }));
+      });
 
-      it('should not break the next run (view engine and ivy)', fakeAsync(() => {
+      it('should not break the next run (view engine and ivy)', () => {
         const ctx = _bindSimpleValue('a', TestData);
 
         ctx.detectChanges();
@@ -1256,11 +1256,11 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
 
         ctx.detectChanges();
         expect(renderLog.loggedValues).toEqual(['value']);
-      }));
+      });
     });
 
     describe('mode', () => {
-      it('Detached', fakeAsync(() => {
+      it('Detached', () => {
         const ctx = createCompFixture('<comp-with-ref></comp-with-ref>');
         const cmp: CompWithRef = queryDirs(ctx.debugElement, CompWithRef)[0];
         cmp.value = 'hello';
@@ -1269,9 +1269,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         ctx.detectChanges();
 
         expect(renderLog.log).toEqual([]);
-      }));
+      });
 
-      it('Detached should disable OnPush', fakeAsync(() => {
+      it('Detached should disable OnPush', () => {
         const ctx = createCompFixture('<push-cmp [value]="value"></push-cmp>');
         ctx.componentInstance.value = 0;
         ctx.detectChanges();
@@ -1284,9 +1284,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         ctx.detectChanges();
 
         expect(renderLog.log).toEqual([]);
-      }));
+      });
 
-      it('Detached view can be checked locally', fakeAsync(() => {
+      it('Detached view can be checked locally', () => {
         const ctx = createCompFixture('<wrap-comp-with-ref></wrap-comp-with-ref>');
         const cmp: CompWithRef = queryDirs(ctx.debugElement, CompWithRef)[0];
         cmp.value = 'hello';
@@ -1300,9 +1300,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         cmp.changeDetectorRef.detectChanges();
 
         expect(renderLog.log).toEqual(['{{hello}}']);
-      }));
+      });
 
-      it('Reattaches', fakeAsync(() => {
+      it('Reattaches', () => {
         const ctx = createCompFixture('<comp-with-ref></comp-with-ref>');
         const cmp: CompWithRef = queryDirs(ctx.debugElement, CompWithRef)[0];
 
@@ -1318,9 +1318,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
         ctx.detectChanges();
 
         expect(renderLog.log).toEqual(['{{hello}}']);
-      }));
+      });
 
-      it('Reattaches in the original cd mode', fakeAsync(() => {
+      it('Reattaches in the original cd mode', () => {
         const ctx = createCompFixture('<push-cmp></push-cmp>');
         const cmp: PushComp = queryDirs(ctx.debugElement, PushComp)[0];
         cmp.changeDetectorRef.detach();
@@ -1335,7 +1335,7 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
 
         ctx.detectChanges();
         expect(cmp.renderCount).toBe(count);
-      }));
+      });
     });
 
     describe('nested view recursion', () => {

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -51,7 +51,7 @@ import {QueryList} from '../../src/linker/query_list';
 import {TemplateRef} from '../../src/linker/template_ref';
 import {ViewContainerRef} from '../../src/linker/view_container_ref';
 import {EmbeddedViewRef} from '../../src/linker/view_ref';
-import {fakeAsync, getTestBed, TestBed, tick, waitForAsync} from '../../testing';
+import {getTestBed, TestBed, waitForAsync} from '../../testing';
 
 import {stringify} from '../../src/util/stringify';
 
@@ -589,13 +589,13 @@ describe('integration tests', function () {
       });
 
       if (getDOM().supportsDOMEvents) {
-        it('should allow to destroy a component from within a host event handler', fakeAsync(() => {
+        it('should allow to destroy a component from within a host event handler', async () => {
           TestBed.configureTestingModule({declarations: [MyComp, [[PushCmpWithHostEvent]]]});
           const template = '<push-cmp-with-host-event></push-cmp-with-host-event>';
           TestBed.overrideComponent(MyComp, {set: {template}});
           const fixture = TestBed.createComponent(MyComp);
 
-          tick();
+          await fixture.whenStable();
           fixture.detectChanges();
 
           const cmpEl = fixture.debugElement.children[0];
@@ -603,7 +603,7 @@ describe('integration tests', function () {
           cmp.ctxCallback = (_: any) => fixture.destroy();
 
           expect(() => cmpEl.triggerEventHandler('click', <Event>{})).not.toThrow();
-        }));
+        });
       }
 
       it('should be checked when an event is fired', () => {
@@ -663,7 +663,7 @@ describe('integration tests', function () {
         expect(cmp.prop).toEqual('two');
       });
 
-      it('should be checked when an async pipe requests a check', fakeAsync(() => {
+      it('should be checked when an async pipe requests a check', async () => {
         TestBed.configureTestingModule({
           declarations: [MyComp, PushCmpWithAsyncPipe],
           imports: [CommonModule],
@@ -672,7 +672,7 @@ describe('integration tests', function () {
         TestBed.overrideComponent(MyComp, {set: {template}});
         const fixture = TestBed.createComponent(MyComp);
 
-        tick();
+        await fixture.whenStable();
 
         const cmp: PushCmpWithAsyncPipe = fixture.debugElement.children[0].references!['cmp'];
         fixture.detectChanges();
@@ -683,11 +683,11 @@ describe('integration tests', function () {
         expect(cmp.numberOfChecks).toEqual(1);
 
         cmp.resolve(2);
-        tick();
+        await fixture.whenStable();
 
         fixture.detectChanges();
         expect(cmp.numberOfChecks).toEqual(2);
-      }));
+      });
     });
 
     it('should create a component that injects an @Host', () => {
@@ -2030,7 +2030,7 @@ describe('integration tests', function () {
     });
 
     if (getDOM().supportsDOMEvents) {
-      it('should support event decorators', fakeAsync(() => {
+      it('should support event decorators', async () => {
         TestBed.configureTestingModule({
           declarations: [MyComp, DirectiveWithPropDecorators],
           schemas: [NO_ERRORS_SCHEMA],
@@ -2039,15 +2039,15 @@ describe('integration tests', function () {
         TestBed.overrideComponent(MyComp, {set: {template}});
         const fixture = TestBed.createComponent(MyComp);
 
-        tick();
+        await fixture.whenStable();
 
         const emitter = fixture.debugElement.children[0].injector.get(DirectiveWithPropDecorators);
         emitter.fireEvent('fired !');
 
-        tick();
+        await fixture.whenStable();
 
         expect(fixture.componentInstance.ctxProp()).toEqual('called');
-      }));
+      });
 
       it('should support host listener decorators', () => {
         TestBed.configureTestingModule({

--- a/packages/core/test/linker/query_list_spec.ts
+++ b/packages/core/test/linker/query_list_spec.ts
@@ -9,7 +9,6 @@
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {QueryList} from '../../src/linker/query_list';
 import {iterateListLike} from '../../src/util/iterable';
-import {fakeAsync, tick} from '../../testing';
 
 describe('QueryList', () => {
   let queryList: QueryList<string>;
@@ -160,7 +159,7 @@ describe('QueryList', () => {
 
   if (getDOM().supportsDOMEvents) {
     describe('simple observable interface', () => {
-      it('should fire callbacks on change', fakeAsync(() => {
+      it('should fire callbacks on change', () => {
         let fires = 0;
         queryList.changes.subscribe({
           next: (_) => {
@@ -169,17 +168,15 @@ describe('QueryList', () => {
         });
 
         queryList.notifyOnChanges();
-        tick();
 
         expect(fires).toEqual(1);
 
         queryList.notifyOnChanges();
-        tick();
 
         expect(fires).toEqual(2);
-      }));
+      });
 
-      it('should provides query list as an argument', fakeAsync(() => {
+      it('should provides query list as an argument', () => {
         let recorded!: QueryList<string>;
         queryList.changes.subscribe({
           next: (v: QueryList<string>) => {
@@ -189,10 +186,9 @@ describe('QueryList', () => {
 
         queryList.reset(['one']);
         queryList.notifyOnChanges();
-        tick();
 
         expect(recorded).toBe(queryList);
-      }));
+      });
     });
   }
 });

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -36,7 +36,7 @@ import {
   ViewContainerRef,
   provideZoneChangeDetection,
 } from '../../src/core';
-import {fakeAsync, inject, TestBed, tick} from '../../testing';
+import {inject, TestBed} from '../../testing';
 import {BrowserModule, By, platformBrowser} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
 
@@ -88,7 +88,7 @@ describe('regressions', () => {
       expect(CountingPipe.calls).toBe(1);
     });
 
-    it('should only update the bound property when using asyncPipe - #15205', fakeAsync(() => {
+    it('should only update the bound property when using asyncPipe - #15205', async () => {
       @Component({
         template: '<div myDir [a]="p | async" [b]="2"></div>',
         standalone: false,
@@ -130,12 +130,12 @@ describe('regressions', () => {
       dir.setterCalls = {};
       dir.changes = {};
 
-      tick();
+      await fixture.whenStable();
       fixture.detectChanges();
 
       expect(dir.setterCalls).toEqual({'a': 1});
       expect(Object.keys(dir.changes)).toEqual(['a']);
-    }));
+    });
 
     it('should only evaluate methods once - #10639', () => {
       TestBed.configureTestingModule({declarations: [MyCountingComp]});

--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -35,7 +35,7 @@ import {
   ViewContainerRef,
 } from '../../src/core';
 import {ERROR_DETAILS_PAGE_BASE_URL} from '../../src/error_details_base_url';
-import {ComponentFixture, fakeAsync, TestBed} from '../../testing';
+import {ComponentFixture, TestBed} from '../../testing';
 
 @Directive({
   selector: '[simpleDirective]',
@@ -822,22 +822,22 @@ describe('View injector', () => {
       );
     });
 
-    it('should instantiate directives that depend on other directives', fakeAsync(() => {
+    it('should instantiate directives that depend on other directives', () => {
       TestBed.configureTestingModule({declarations: [SimpleDirective, NeedsDirective]});
       const el = createComponent('<div simpleDirective><div needsDirective></div></div>');
       const d = el.children[0].children[0].injector.get(NeedsDirective);
 
       expect(d).toBeInstanceOf(NeedsDirective);
       expect(d.dependency).toBeInstanceOf(SimpleDirective);
-    }));
+    });
 
-    it('should throw when a dependency cannot be resolved', fakeAsync(() => {
+    it('should throw when a dependency cannot be resolved', () => {
       TestBed.configureTestingModule({declarations: [NeedsService]});
 
       expect(() => createComponent('<div needsService></div>')).toThrowError(
         /NG0201: No provider found for `service`\./,
       );
-    }));
+    });
 
     it('should inject null when an optional dependency cannot be resolved', () => {
       TestBed.configureTestingModule({declarations: [OptionallyNeedsDirective]});


### PR DESCRIPTION

Use async/await where needed. Share the frame helper and remove unused dependencies.
