### PR TITLE
docs: fix the docregion marker in the apache config example

### DIFF
--- a/adev/src/content/examples/i18n/doc-files/apache2.conf
+++ b/adev/src/content/examples/i18n/doc-files/apache2.conf
@@ -1,4 +1,4 @@
-# docregion
+# #docregion
 <VirtualHost *:80>
     ServerName localhost
     DocumentRoot /www/data


### PR DESCRIPTION
The marker was written `# docregion`, but the hash matcher expects `# #docregion`, one hash for the comment and one for the marker. It was not recognised, so it was never stripped and rendered as the first line of the Apache config on https://angular.dev/guide/i18n/deploy.

The sibling `nginx.conf`, shown on the same page, already has the correct form.


Before:

<img width="886" height="386" alt="Screenshot 2026-09-07 at 10 40 37" src="https://github.com/user-attachments/assets/efd05e7e-b15b-4c7d-a1fb-8ce796960de0" />

After:

<img width="852" height="340" alt="Screenshot 2026-09-07 at 10 40 31" src="https://github.com/user-attachments/assets/c617260d-54e8-4d94-94c6-8f71a44af8b3" />