### PR TITLE
fix(forms): avoid custom control constraint input collisions

### DIFF
--- a/adev/src/content/guide/forms/signals/custom-controls.md
+++ b/adev/src/content/guide/forms/signals/custom-controls.md
@@ -182,14 +182,14 @@ NOTE: `disabledReasons` is an array of `DisabledReason` objects. Each object has
 
 Receive validation constraint values from the form:
 
-| Property    | Purpose                                              |
-| ----------- | ---------------------------------------------------- |
-| `required`  | Whether the field is required                        |
-| `min`       | Minimum numeric value (`undefined` if no constraint) |
-| `max`       | Maximum numeric value (`undefined` if no constraint) |
-| `minLength` | Minimum string length (undefined if no constraint)   |
-| `maxLength` | Maximum string length (undefined if no constraint)   |
-| `pattern`   | Array of regular expression patterns to match        |
+| Property             | Purpose                                              |
+| -------------------- | ---------------------------------------------------- |
+| `required`           | Whether the field is required                        |
+| `formFieldMin`       | Minimum value (`undefined` if no constraint)         |
+| `formFieldMax`       | Maximum value (`undefined` if no constraint)         |
+| `formFieldMinLength` | Minimum string length (`undefined` if no constraint) |
+| `formFieldMaxLength` | Maximum string length (`undefined` if no constraint) |
+| `pattern`            | Array of regular expression patterns to match        |
 
 #### Field metadata
 
@@ -478,7 +478,7 @@ orderForm.amount().reset();
 
 Controls display validation state but don't perform validation. Validation happens in the form schema - your control receives `invalid()` and `errors()` signals from the FormField directive and displays them (as shown in the StatefulInput example above).
 
-The FormField directive also passes validation constraint values like `required`, `min`, `max`, `minLength`, `maxLength`, and `pattern`. Your control can use these to enhance the UI:
+The FormField directive also passes validation constraint values like `required`, `formFieldMin`, `formFieldMax`, `formFieldMinLength`, `formFieldMaxLength`, and `pattern`. Your control can use these to enhance the UI. The `formField` prefix makes the four native-like constraints explicit opt-ins and leaves common component inputs such as `min` and `max` available for other purposes.
 
 ```ts
 export class NumberInput implements FormValueControl<number> {
@@ -486,12 +486,12 @@ export class NumberInput implements FormValueControl<number> {
 
   // Constraint values from schema validation rules
   required = input<boolean>(false);
-  min = input<number | undefined>(undefined);
-  max = input<number | undefined>(undefined);
+  formFieldMin = input<number | undefined>(undefined);
+  formFieldMax = input<number | undefined>(undefined);
 }
 ```
 
-When you add `min()` and `max()` validation rules to the schema, the FormField directive passes these values to your control. Use them to apply HTML5 attributes or show constraint hints in your template.
+When you add `min()` and `max()` validation rules to the schema, the FormField directive passes these values to your control's `formFieldMin` and `formFieldMax` inputs. Use them to apply HTML5 attributes or show constraint hints in your template.
 
 IMPORTANT: Don't implement validation logic in your control. Define validation rules in the form schema and let your control display the results:
 

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -251,12 +251,12 @@ export interface FormUiControl<TValue> {
     readonly disabledReasons?: InputSignal<readonly WithOptionalFieldTree<DisabledReason>[]> | InputSignalWithTransform<readonly WithOptionalFieldTree<DisabledReason>[], unknown>;
     readonly errors?: InputSignal<readonly ValidationError.WithOptionalFieldTree[]> | InputSignalWithTransform<readonly ValidationError.WithOptionalFieldTree[], unknown>;
     focus?(options?: FocusOptions): void;
+    readonly formFieldMax?: InputSignal<NonNullable<TValue> | undefined> | InputSignalWithTransform<NonNullable<TValue> | undefined, unknown>;
+    readonly formFieldMaxLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
+    readonly formFieldMin?: InputSignal<NonNullable<TValue> | undefined> | InputSignalWithTransform<NonNullable<TValue> | undefined, unknown>;
+    readonly formFieldMinLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
     readonly hidden?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
     readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly max?: InputSignal<NonNullable<TValue> | undefined> | InputSignalWithTransform<NonNullable<TValue> | undefined, unknown>;
-    readonly maxLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
-    readonly min?: InputSignal<NonNullable<TValue> | undefined> | InputSignalWithTransform<NonNullable<TValue> | undefined, unknown>;
-    readonly minLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
     readonly name?: InputSignal<string> | InputSignalWithTransform<string, unknown>;
     readonly pattern?: InputSignal<readonly RegExp[]> | InputSignalWithTransform<readonly RegExp[], unknown>;
     readonly pending?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;

--- a/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
@@ -431,6 +431,100 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(0);
     });
 
+    it('should not treat native constraint names as form bindings on custom controls', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, input, model, signal} from '@angular/core';
+          import {FormField, form} from '@angular/forms/signals';
+
+          type Range = readonly [number, number];
+          type DayLike = {day?: number; month?: number; year?: number};
+
+          @Component({selector: 'range-control', template: ''})
+          class RangeControl {
+            readonly value = model.required<Range>();
+            readonly min = input(0);
+            readonly max = input(100);
+            readonly minLength = input<DayLike | null>(null);
+            readonly maxLength = input<DayLike | null>(null);
+          }
+
+          @Component({
+            imports: [FormField, RangeControl],
+            template: '<range-control [formField]="field" [min]="0" [max]="100"/>',
+          })
+          class TestCmp {
+            readonly field = form(signal<Range>([20, 80]));
+          }
+        `,
+      );
+
+      expect(env.driveDiagnostics()).toEqual([]);
+    });
+
+    it('should type-check opted-in custom control constraint inputs', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, input, model, signal} from '@angular/core';
+          import {FormField, form} from '@angular/forms/signals';
+
+          @Component({selector: 'custom-control', template: ''})
+          class CustomControl {
+            readonly value = model.required<string>();
+            readonly formFieldMinLength = input<{value: number}>({value: 0});
+          }
+
+          @Component({
+            imports: [FormField, CustomControl],
+            template: '<custom-control [formField]="field"/>',
+          })
+          class TestCmp {
+            readonly field = form(signal('value'));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      if (diags.length === 1) {
+        expect(extractMessage(diags[0])).toBe(
+          `Type 'number | undefined' is not assignable to type '{ value: number; }'.`,
+        );
+      }
+    });
+
+    it('should type-check opted-in constraint inputs on directives attached to custom controls', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, Directive, input, model, signal} from '@angular/core';
+          import {FormField, form} from '@angular/forms/signals';
+
+          @Directive({selector: '[constraints]'})
+          class Constraints {
+            readonly formFieldMax = input.required<number | undefined>();
+          }
+
+          @Component({selector: 'custom-control', template: ''})
+          class CustomControl {
+            readonly value = model.required<number>();
+          }
+
+          @Component({
+            imports: [FormField, Constraints, CustomControl],
+            template: '<custom-control constraints [formField]="field"/>',
+          })
+          class TestCmp {
+            readonly field = form(signal(1));
+          }
+        `,
+      );
+
+      expect(env.driveDiagnostics()).toEqual([]);
+    });
+
     it('should report unsupported property bindings on a field', () => {
       env.write(
         'test.ts',
@@ -515,11 +609,11 @@ runInEachFileSystem(() => {
           @Component({selector: 'custom-control', template: ''})
           export class CustomControl implements FormValueControl<number> {
             readonly value = model<number>(0);
-            readonly max = input<number | undefined>(1);
+            readonly formFieldMax = input<number | undefined>(1);
           }
 
           @Component({
-            template: '<custom-control [formField]="f" [max]="2"/>',
+            template: '<custom-control [formField]="f" [formFieldMax]="2"/>',
             imports: [FormField, CustomControl]
           })
           export class Comp {
@@ -531,7 +625,7 @@ runInEachFileSystem(() => {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
       expect(extractMessage(diags[0])).toBe(
-        `Binding to '[max]' is not allowed on nodes using the '[formField]' directive`,
+        `Binding to '[formFieldMax]' is not allowed on nodes using the '[formField]' directive`,
       );
     });
 

--- a/packages/compiler/src/typecheck/ops/directive_constructor.ts
+++ b/packages/compiler/src/typecheck/ops/directive_constructor.ts
@@ -39,6 +39,7 @@ export class TcbDirectiveCtorOp extends TcbOp {
     private node: DirectiveOwner,
     private dir: TcbDirectiveMetadata,
     private customFormControlType: CustomFormControlType | null,
+    private usesCustomControlConstraintInputs: boolean,
     private directiveIndex?: number,
   ) {
     super();
@@ -64,11 +65,12 @@ export class TcbDirectiveCtorOp extends TcbOp {
       span = this.node.startSourceSpan || this.node.sourceSpan;
       boundAttrs = getBoundAttributes(this.dir, this.node);
 
-      if (this.customFormControlType !== null) {
+      if (this.customFormControlType !== null || this.usesCustomControlConstraintInputs) {
         const additionalBindings = expandBoundAttributesForField(
           this.dir,
           this.node,
           this.customFormControlType,
+          this.usesCustomControlConstraintInputs,
         );
 
         if (additionalBindings !== null) {

--- a/packages/compiler/src/typecheck/ops/inputs.ts
+++ b/packages/compiler/src/typecheck/ops/inputs.ts
@@ -55,6 +55,7 @@ export class TcbDirectiveInputsOp extends TcbOp {
     private dir: TcbDirectiveMetadata,
     private isFormControl: boolean = false,
     private customFormControlType: CustomFormControlType | null,
+    private usesCustomControlConstraintInputs: boolean,
   ) {
     super();
   }
@@ -79,6 +80,7 @@ export class TcbDirectiveInputsOp extends TcbOp {
         this.dir,
         this.node,
         this.customFormControlType,
+        this.usesCustomControlConstraintInputs,
       );
 
       if (additionalBindings !== null) {

--- a/packages/compiler/src/typecheck/ops/scope.ts
+++ b/packages/compiler/src/typecheck/ops/scope.ts
@@ -778,8 +778,16 @@ export class Scope {
   ): void {
     const nodeIsFormControl = isFormControl(allDirectiveMatches);
     const customFormControlType = nodeIsFormControl ? getCustomFieldDirectiveType(dir) : null;
-
-    const directiveOp = this.getDirectiveOp(dir, node, customFormControlType, directiveIndex);
+    const usesCustomControlConstraintInputs =
+      nodeIsFormControl &&
+      allDirectiveMatches.some((match) => getCustomFieldDirectiveType(match) !== null);
+    const directiveOp = this.getDirectiveOp(
+      dir,
+      node,
+      customFormControlType,
+      usesCustomControlConstraintInputs,
+      directiveIndex,
+    );
     const dirIndex = this.opQueue.push(directiveOp) - 1;
     dirMap.set(dir, dirIndex);
 
@@ -796,7 +804,15 @@ export class Scope {
     }
 
     this.opQueue.push(
-      new TcbDirectiveInputsOp(this.tcb, this, node, dir, nodeIsFormControl, customFormControlType),
+      new TcbDirectiveInputsOp(
+        this.tcb,
+        this,
+        node,
+        dir,
+        nodeIsFormControl,
+        customFormControlType,
+        usesCustomControlConstraintInputs,
+      ),
     );
   }
 
@@ -804,6 +820,7 @@ export class Scope {
     dir: TcbDirectiveMetadata,
     node: DirectiveOwner,
     customFieldType: CustomFormControlType | null,
+    usesCustomControlConstraintInputs: boolean,
     directiveIndex?: number,
   ): TcbOp {
     if (!dir.isGeneric) {
@@ -814,7 +831,15 @@ export class Scope {
       // For generic directives, we use a type constructor to infer types. If a directive requires
       // an inline type constructor, then inlining must be available to use the
       // `TcbDirectiveCtorOp`. If not we, we fallback to using `any` – see below.
-      return new TcbDirectiveCtorOp(this.tcb, this, node, dir, customFieldType, directiveIndex);
+      return new TcbDirectiveCtorOp(
+        this.tcb,
+        this,
+        node,
+        dir,
+        customFieldType,
+        usesCustomControlConstraintInputs,
+        directiveIndex,
+      );
     }
 
     // If inlining is not available, then we give up on inferring the generic params, and use
@@ -1002,7 +1027,7 @@ export class Scope {
       const directiveOpMap = new Map<TcbDirectiveMetadata, number>();
 
       for (const directive of directives) {
-        const directiveOp = this.getDirectiveOp(directive, node, null);
+        const directiveOp = this.getDirectiveOp(directive, node, null, false);
         directiveOpMap.set(directive, this.opQueue.push(directiveOp) - 1);
       }
 

--- a/packages/compiler/src/typecheck/ops/signal_forms.ts
+++ b/packages/compiler/src/typecheck/ops/signal_forms.ts
@@ -29,8 +29,8 @@ import type {Scope} from './scope';
 /** Possible types of custom form control directives. */
 export type CustomFormControlType = 'value' | 'checkbox';
 
-/** Names of the input fields on custom controls. */
-const formControlInputFields = [
+/** Names shared by the field state and custom control inputs. */
+const commonFormControlInputFields = [
   // Should be kept in sync with the `FormUiControl` bindings,
   // defined in `packages/forms/signals/src/api/control.ts`.
   'errors',
@@ -43,17 +43,25 @@ const formControlInputFields = [
   'pending',
   'readonly',
   'touched',
-  'max',
-  'maxLength',
-  'min',
-  'minLength',
   'pattern',
   'required',
 ];
 
+/** Native constraint properties controlled by the field directive. */
+const nativeFormControlConstraintFields = ['max', 'maxLength', 'min', 'minLength'];
+
+/** Explicit custom control inputs which opt into receiving native-like constraints. */
+const customFormControlConstraintInputs = [
+  {inputName: 'formFieldMax', fieldPropertyName: 'max'},
+  {inputName: 'formFieldMaxLength', fieldPropertyName: 'maxLength'},
+  {inputName: 'formFieldMin', fieldPropertyName: 'min'},
+  {inputName: 'formFieldMinLength', fieldPropertyName: 'minLength'},
+];
+
 /** Names of input fields to which users aren't allowed to bind when using a `field` directive. */
 export const customFormControlBannedInputFields = new Set([
-  ...formControlInputFields,
+  ...commonFormControlInputFields,
+  ...customFormControlConstraintInputs.map(({inputName}) => inputName),
   'value',
   'checked',
 ]);
@@ -74,7 +82,8 @@ const formControlOptionalFields = new Set([
 export class TcbNativeFieldOp extends TcbOp {
   /** Bindings that aren't supported on signal form fields. */
   protected readonly unsupportedBindingFields = new Set([
-    ...formControlInputFields,
+    ...commonFormControlInputFields,
+    ...nativeFormControlConstraintFields,
     'value',
     'checked',
     'maxlength',
@@ -250,6 +259,7 @@ export function expandBoundAttributesForField(
   directive: TcbDirectiveMetadata,
   node: Template | Element | Component | Directive,
   customFormControlType: CustomFormControlType | null,
+  usesCustomControlConstraintInputs: boolean,
 ): TcbBoundAttribute[] | null {
   const fieldBinding = node.inputs.find(
     (input) => input.type === BindingType.Property && input.name === 'formField',
@@ -287,7 +297,7 @@ export function expandBoundAttributesForField(
     boundInputs.push(primaryInput);
   }
 
-  for (const name of formControlInputFields) {
+  for (const name of commonFormControlInputFields) {
     const input = getSyntheticFieldBoundInput(
       directive,
       name,
@@ -299,6 +309,38 @@ export function expandBoundAttributesForField(
     if (input !== null) {
       boundInputs ??= [];
       boundInputs.push(input);
+    }
+  }
+
+  if (usesCustomControlConstraintInputs) {
+    for (const {inputName, fieldPropertyName} of customFormControlConstraintInputs) {
+      const input = getSyntheticFieldBoundInput(
+        directive,
+        inputName,
+        fieldPropertyName,
+        fieldBinding,
+        customFormControlType,
+      );
+
+      if (input !== null) {
+        boundInputs ??= [];
+        boundInputs.push(input);
+      }
+    }
+  } else {
+    for (const name of nativeFormControlConstraintFields) {
+      const input = getSyntheticFieldBoundInput(
+        directive,
+        name,
+        name,
+        fieldBinding,
+        customFormControlType,
+      );
+
+      if (input !== null) {
+        boundInputs ??= [];
+        boundInputs.push(input);
+      }
     }
   }
 

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -83,37 +83,34 @@ export interface FormUiControl<TValue> {
    * An input to receive the min value for the field. If implemented, the `Field` directive will
    * automatically bind the min value from the bound field to this input.
    */
-  readonly min?:
+  readonly formFieldMin?:
     | InputSignal<NonNullable<TValue> | undefined>
     | InputSignalWithTransform<NonNullable<TValue> | undefined, unknown>;
   /**
    * An input to receive the min length for the field. If implemented, the `Field` directive will
    * automatically bind the min length from the bound field to this input.
    */
-  readonly minLength?:
-    | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+  readonly formFieldMinLength?:
+    InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
   /**
    * An input to receive the max value for the field. If implemented, the `Field` directive will
    * automatically bind the max value from the bound field to this input.
    */
-  readonly max?:
+  readonly formFieldMax?:
     | InputSignal<NonNullable<TValue> | undefined>
     | InputSignalWithTransform<NonNullable<TValue> | undefined, unknown>;
   /**
    * An input to receive the max length for the field. If implemented, the `Field` directive will
    * automatically bind the max length from the bound field to this input.
    */
-  readonly maxLength?:
-    | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+  readonly formFieldMaxLength?:
+    InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
   /**
    * An input to receive the value patterns for the field. If implemented, the `Field` directive
    * will automatically bind the value patterns from the bound field to this input.
    */
   readonly pattern?:
-    | InputSignal<readonly RegExp[]>
-    | InputSignalWithTransform<readonly RegExp[], unknown>;
+    InputSignal<readonly RegExp[]> | InputSignalWithTransform<readonly RegExp[], unknown>;
   /**
    * An output to emit when the user finishes interacting with the control, marking the field as
    * touched. Emit this in response to the native `blur` event (when focus leaves the control), not

--- a/packages/forms/signals/src/directive/bindings.ts
+++ b/packages/forms/signals/src/directive/bindings.ts
@@ -13,59 +13,71 @@ import type {ReadonlyFieldState} from '../api/types';
  */
 export type ControlBindingKey = string & {__brand: 'ControlBindingKey'};
 
+export interface ControlBinding {
+  fieldStateKey: BoundFieldStateKey;
+  customControlInput: ControlBindingKey;
+  nativeProperty: ControlBindingKey;
+}
+
 /**
- * A map of field state properties to control binding name.
+ * A map of field state properties to their custom control and native binding names.
  *
  * This excludes `controlValue` whose corresponding control binding name differs between control
  * types.
  *
- * The control binding name can be used for inputs or attributes (since DOM attributes are case
- * insensitive).
+ * The custom control and native names differ for constraint bindings so that custom controls must
+ * explicitly opt into receiving them without reserving common component input names.
  */
 const FIELD_STATE_KEY_TO_CONTROL_BINDING = {
-  disabled: 'disabled' as ControlBindingKey,
-  disabledReasons: 'disabledReasons' as ControlBindingKey,
-  dirty: 'dirty' as ControlBindingKey,
-  errors: 'errors' as ControlBindingKey,
-  hidden: 'hidden' as ControlBindingKey,
-  invalid: 'invalid' as ControlBindingKey,
-  max: 'max' as ControlBindingKey,
-  maxLength: 'maxLength' as ControlBindingKey,
-  min: 'min' as ControlBindingKey,
-  minLength: 'minLength' as ControlBindingKey,
-  name: 'name' as ControlBindingKey,
-  pattern: 'pattern' as ControlBindingKey,
-  pending: 'pending' as ControlBindingKey,
-  readonly: 'readonly' as ControlBindingKey,
-  required: 'required' as ControlBindingKey,
-  touched: 'touched' as ControlBindingKey,
-} as const satisfies {[K in keyof ReadonlyFieldState<unknown>]?: ControlBindingKey};
+  disabled: binding('disabled'),
+  disabledReasons: binding('disabledReasons'),
+  dirty: binding('dirty'),
+  errors: binding('errors'),
+  hidden: binding('hidden'),
+  invalid: binding('invalid'),
+  max: binding('formFieldMax', 'max'),
+  maxLength: binding('formFieldMaxLength', 'maxLength'),
+  min: binding('formFieldMin', 'min'),
+  minLength: binding('formFieldMinLength', 'minLength'),
+  name: binding('name'),
+  pattern: binding('pattern'),
+  pending: binding('pending'),
+  readonly: binding('readonly'),
+  required: binding('required'),
+  touched: binding('touched'),
+} as const satisfies {
+  [K in keyof ReadonlyFieldState<unknown>]?: Omit<ControlBinding, 'fieldStateKey'>;
+};
 
-/**
- * Inverts `FIELD_STATE_KEY_TO_CONTROL_BINDING` to look up the minified name of the corresponding
- * field state property from its control binding name.
- */
-const CONTROL_BINDING_TO_FIELD_STATE_KEY = /* @__PURE__ */ (() => {
-  const map = {} as Record<ControlBindingKey, keyof typeof FIELD_STATE_KEY_TO_CONTROL_BINDING>;
-  for (const key of Object.keys(FIELD_STATE_KEY_TO_CONTROL_BINDING) as Array<
-    keyof typeof FIELD_STATE_KEY_TO_CONTROL_BINDING
-  >) {
-    map[FIELD_STATE_KEY_TO_CONTROL_BINDING[key]] = key;
-  }
-  return map;
-})();
+type BoundFieldStateKey = keyof typeof FIELD_STATE_KEY_TO_CONTROL_BINDING;
+
+function binding(
+  customControlInput: string,
+  nativeProperty = customControlInput,
+): Omit<ControlBinding, 'fieldStateKey'> {
+  return {
+    customControlInput: customControlInput as ControlBindingKey,
+    nativeProperty: nativeProperty as ControlBindingKey,
+  };
+}
 
 export function readFieldStateBindingValue(
   fieldState: ReadonlyFieldState<unknown>,
-  key: ControlBindingKey,
+  binding: ControlBinding,
 ): unknown {
-  const property = CONTROL_BINDING_TO_FIELD_STATE_KEY[key];
-  return fieldState[property]?.();
+  return fieldState[binding.fieldStateKey]?.();
 }
 
-/** The keys of {@link FIELD_STATE_KEY_TO_CONTROL_BINDING} */
-export const CONTROL_BINDING_NAMES = /* @__PURE__ */ (() =>
-  Object.values(FIELD_STATE_KEY_TO_CONTROL_BINDING))() as Array<ControlBindingKey>;
+/** The bindings represented by {@link FIELD_STATE_KEY_TO_CONTROL_BINDING}. */
+export const CONTROL_BINDINGS = /* @__PURE__ */ (() =>
+  (
+    Object.keys(FIELD_STATE_KEY_TO_CONTROL_BINDING) as Array<
+      keyof typeof FIELD_STATE_KEY_TO_CONTROL_BINDING
+    >
+  ).map((fieldStateKey) => ({
+    fieldStateKey,
+    ...FIELD_STATE_KEY_TO_CONTROL_BINDING[fieldStateKey],
+  })))() as ControlBinding[];
 
 export function createBindings<TKey extends string>(): {[K in TKey]?: unknown} {
   return {};

--- a/packages/forms/signals/src/directive/control_custom.ts
+++ b/packages/forms/signals/src/directive/control_custom.ts
@@ -10,7 +10,7 @@ import type {ɵControlDirectiveHost as ControlDirectiveHost} from '@angular/core
 import type {FormField, FormFieldBindingOptions} from './form_field';
 import {
   bindingUpdated,
-  CONTROL_BINDING_NAMES,
+  CONTROL_BINDINGS,
   type ControlBindingKey,
   createBindings,
   readFieldStateBindingValue,
@@ -36,24 +36,32 @@ export function customControlCreate(
     }
 
     // Bind remaining field state properties.
-    for (const name of CONTROL_BINDING_NAMES) {
+    for (const binding of CONTROL_BINDINGS) {
+      const {customControlInput, nativeProperty} = binding;
       let value: unknown;
-      if (name === 'errors') {
+      if (customControlInput === 'errors') {
         value = parent.errors();
       } else {
-        value = readFieldStateBindingValue(state, name);
+        value = readFieldStateBindingValue(state, binding);
       }
-      if (bindingUpdated(bindings, name, value)) {
-        host.setInputOnDirectives(name, value);
+      if (bindingUpdated(bindings, customControlInput, value)) {
+        host.setInputOnDirectives(customControlInput, value);
 
         // If the host node is a native control, we can bind field state properties to native
         // properties for any that weren't defined as inputs on the custom control.
-        if (parent.elementAcceptsNativeProperty(name) && !host.customControlHasInput(name)) {
-          const domValue = formatDateForMinMax(name, value, parent.nativeFormElement.type);
+        if (
+          parent.elementAcceptsNativeProperty(nativeProperty) &&
+          !host.customControlHasInput(customControlInput)
+        ) {
+          const domValue = formatDateForMinMax(
+            nativeProperty,
+            value,
+            parent.nativeFormElement.type,
+          );
           setNativeDomProperty(
             parent.renderer,
             parent.nativeFormElement,
-            name,
+            nativeProperty,
             domValue as string | number | boolean | undefined,
           );
         }

--- a/packages/forms/signals/src/directive/control_cva.ts
+++ b/packages/forms/signals/src/directive/control_cva.ts
@@ -19,7 +19,7 @@ import {reactiveErrorsToSignalErrors} from '../compat/validation_errors';
 import {type ValidationError} from '../api/rules';
 import {
   bindingUpdated,
-  CONTROL_BINDING_NAMES,
+  CONTROL_BINDINGS,
   type ControlBindingKey,
   createBindings,
   readFieldStateBindingValue,
@@ -96,8 +96,9 @@ export function cvaControlCreate(
       untracked(() => parent.controlValueAccessor!.writeValue(controlValue));
     }
 
-    for (const name of CONTROL_BINDING_NAMES) {
-      const value = readFieldStateBindingValue(fieldState, name);
+    for (const binding of CONTROL_BINDINGS) {
+      const name = binding.nativeProperty;
+      const value = readFieldStateBindingValue(fieldState, binding);
       if (bindingUpdated(bindings, name, value)) {
         const propertyWasSet = host.setInputOnDirectives(name, value);
         if (name === 'disabled' && parent.controlValueAccessor!.setDisabledState) {

--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -14,7 +14,7 @@ import type {ValidationError} from '../api/rules';
 import {createParser} from '../util/parser';
 import {
   bindingUpdated,
-  CONTROL_BINDING_NAMES,
+  CONTROL_BINDINGS,
   createBindings,
   readFieldStateBindingValue,
   type ControlBindingKey,
@@ -99,8 +99,9 @@ export function nativeControlCreate(
   return () => {
     const state = parent.state();
 
-    for (const name of CONTROL_BINDING_NAMES) {
-      const value = readFieldStateBindingValue(state, name);
+    for (const binding of CONTROL_BINDINGS) {
+      const name = binding.nativeProperty;
+      const value = readFieldStateBindingValue(state, binding);
       if (bindingUpdated(bindings, name, value)) {
         host.setInputOnDirectives(name, value);
         if (parent.elementAcceptsNativeProperty(name)) {

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -2463,7 +2463,7 @@ describe('field directive', () => {
         })
         class CustomControl implements FormValueControl<Date> {
           readonly value = model.required<Date>();
-          readonly max = input<Date>();
+          readonly formFieldMax = input<Date>();
         }
 
         @Component({
@@ -2480,7 +2480,47 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().max()).toEqual(new Date('2026-12-31'));
+        expect(component.customControl().formFieldMax()).toEqual(new Date('2026-12-31'));
+      });
+
+      it('should not bind max to a custom control without explicit opt-in', () => {
+        @Component({selector: 'custom-control', template: ''})
+        class CustomControl implements FormValueControl<number> {
+          readonly value = model(0);
+          readonly unrelatedMax = input(100, {alias: 'max'});
+        }
+
+        @Component({
+          imports: [FormField, CustomControl],
+          template: `<custom-control [formField]="f" />`,
+        })
+        class TestCmp {
+          readonly f = form(signal(5), (p) => max(p, 10));
+          readonly customControl = viewChild.required(CustomControl);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        expect(fixture.componentInstance.customControl().unrelatedMax()).toBe(100);
+      });
+
+      it('should bind max to a custom control with explicit opt-in', () => {
+        @Component({selector: 'custom-control', template: ''})
+        class CustomControl implements FormValueControl<number> {
+          readonly value = model(0);
+          readonly formFieldMax = input<number | undefined>();
+        }
+
+        @Component({
+          imports: [FormField, CustomControl],
+          template: `<custom-control [formField]="f" />`,
+        })
+        class TestCmp {
+          readonly f = form(signal(5), (p) => max(p, 10));
+          readonly customControl = viewChild.required(CustomControl);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        expect(fixture.componentInstance.customControl().formFieldMax()).toBe(10);
       });
 
       it('should validate max on native text input', async () => {
@@ -2566,14 +2606,18 @@ describe('field directive', () => {
         @Directive()
         class CustomControlDir implements FormValueControl<number> {
           readonly value = model(0);
-          readonly max = input<number>();
+          readonly formFieldMax = input<number>();
         }
 
         @Component({
           selector: 'custom-control',
           template: '',
           hostDirectives: [
-            {directive: CustomControlDir, inputs: ['max', 'value'], outputs: ['valueChange']},
+            {
+              directive: CustomControlDir,
+              inputs: ['formFieldMax', 'value'],
+              outputs: ['valueChange'],
+            },
           ],
         })
         class CustomControl {}
@@ -2592,10 +2636,10 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().max()).toBe(10);
+        expect(component.customControl().formFieldMax()).toBe(10);
 
         act(() => component.max.set(5));
-        expect(component.customControl().max()).toBe(5);
+        expect(component.customControl().formFieldMax()).toBe(5);
       });
 
       it('should bind to a custom control when composed as a host directive', () => {
@@ -2606,7 +2650,7 @@ describe('field directive', () => {
         })
         class CustomControl implements FormValueControl<number> {
           readonly value = model(0);
-          readonly max = input<number>();
+          readonly formFieldMax = input<number>();
         }
 
         @Component({
@@ -2623,17 +2667,17 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().max()).toBe(10);
+        expect(component.customControl().formFieldMax()).toBe(10);
 
         act(() => component.max.set(5));
-        expect(component.customControl().max()).toBe(5);
+        expect(component.customControl().formFieldMax()).toBe(5);
       });
 
       it('should bind to custom control', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<number> {
           readonly value = model(0);
-          readonly max = input<number>();
+          readonly formFieldMax = input<number>();
         }
 
         @Component({
@@ -2650,10 +2694,10 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().max()).toBe(10);
+        expect(component.customControl().formFieldMax()).toBe(10);
 
         act(() => component.max.set(5));
-        expect(component.customControl().max()).toBe(5);
+        expect(component.customControl().formFieldMax()).toBe(5);
       });
 
       it('should bind to native control host of custom control without input', () => {
@@ -2707,7 +2751,7 @@ describe('field directive', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<number> {
           readonly value = model(0);
-          readonly max = input<number | undefined>();
+          readonly formFieldMax = input<number | undefined>();
         }
 
         @Component({
@@ -2724,16 +2768,16 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().max()).toBe(10);
+        expect(component.customControl().formFieldMax()).toBe(10);
 
         act(() => component.field.set(component.f.y));
-        expect(component.customControl().max()).toBeUndefined();
+        expect(component.customControl().formFieldMax()).toBeUndefined();
       });
 
       it('should bind to directive input on native control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly max = input.required<number | undefined>();
+          readonly max = input<number | undefined>();
         }
 
         @Component({
@@ -2760,7 +2804,7 @@ describe('field directive', () => {
       it('should bind to directive input on custom control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly max = input.required<number | undefined>();
+          readonly formFieldMax = input<number | undefined>();
         }
 
         @Component({selector: 'input[custom]', template: ``})
@@ -2784,11 +2828,11 @@ describe('field directive', () => {
         const dir = fixture.componentInstance.dir();
         const element = fixture.nativeElement.querySelector('input') as HTMLInputElement;
 
-        expect(dir.max()).toBe(10);
+        expect(dir.formFieldMax()).toBe(10);
         expect(element.max).toBe('10');
 
         act(() => fixture.componentInstance.max.set(5));
-        expect(dir.max()).toBe(5);
+        expect(dir.formFieldMax()).toBe(5);
         expect(element.max).toBe('5');
       });
     });
@@ -2910,7 +2954,7 @@ describe('field directive', () => {
         })
         class CustomControl implements FormValueControl<Date> {
           readonly value = model.required<Date>();
-          readonly min = input<Date>();
+          readonly formFieldMin = input<Date>();
         }
 
         @Component({
@@ -2927,7 +2971,7 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().min()).toEqual(new Date('2026-01-01'));
+        expect(component.customControl().formFieldMin()).toEqual(new Date('2026-01-01'));
       });
 
       it('should validate min on native text input', async () => {
@@ -3013,14 +3057,18 @@ describe('field directive', () => {
         @Directive()
         class CustomControlDir implements FormValueControl<number> {
           readonly value = model(0);
-          readonly min = input<number>();
+          readonly formFieldMin = input<number>();
         }
 
         @Component({
           selector: 'custom-control',
           template: '',
           hostDirectives: [
-            {directive: CustomControlDir, inputs: ['min', 'value'], outputs: ['valueChange']},
+            {
+              directive: CustomControlDir,
+              inputs: ['formFieldMin', 'value'],
+              outputs: ['valueChange'],
+            },
           ],
         })
         class CustomControl {}
@@ -3039,10 +3087,10 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().min()).toBe(10);
+        expect(component.customControl().formFieldMin()).toBe(10);
 
         act(() => component.min.set(5));
-        expect(component.customControl().min()).toBe(5);
+        expect(component.customControl().formFieldMin()).toBe(5);
       });
 
       it('should bind to a custom control when composed as a host directive', () => {
@@ -3053,7 +3101,7 @@ describe('field directive', () => {
         })
         class CustomControl implements FormValueControl<number> {
           readonly value = model(0);
-          readonly min = input<number>();
+          readonly formFieldMin = input<number>();
         }
 
         @Component({
@@ -3070,17 +3118,17 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().min()).toBe(10);
+        expect(component.customControl().formFieldMin()).toBe(10);
 
         act(() => component.min.set(5));
-        expect(component.customControl().min()).toBe(5);
+        expect(component.customControl().formFieldMin()).toBe(5);
       });
 
       it('should bind to custom control', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<number> {
           readonly value = model(0);
-          readonly min = input<number>();
+          readonly formFieldMin = input<number>();
         }
 
         @Component({
@@ -3097,10 +3145,10 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().min()).toBe(10);
+        expect(component.customControl().formFieldMin()).toBe(10);
 
         act(() => component.min.set(5));
-        expect(component.customControl().min()).toBe(5);
+        expect(component.customControl().formFieldMin()).toBe(5);
       });
 
       it('should bind to native control host of custom control without input', () => {
@@ -3154,7 +3202,7 @@ describe('field directive', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<number> {
           readonly value = model(0);
-          readonly min = input<number | undefined>();
+          readonly formFieldMin = input<number | undefined>();
         }
 
         @Component({
@@ -3171,16 +3219,16 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().min()).toBe(10);
+        expect(component.customControl().formFieldMin()).toBe(10);
 
         act(() => component.field.set(component.f.y));
-        expect(component.customControl().min()).toBeUndefined();
+        expect(component.customControl().formFieldMin()).toBeUndefined();
       });
 
       it('should bind to directive input on native control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly min = input.required<number | undefined>();
+          readonly min = input<number | undefined>();
         }
 
         @Component({
@@ -3207,7 +3255,7 @@ describe('field directive', () => {
       it('should bind to directive input on custom control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly min = input.required<number | undefined>();
+          readonly formFieldMin = input<number | undefined>();
         }
 
         @Component({selector: 'input[custom]', template: ``})
@@ -3231,11 +3279,11 @@ describe('field directive', () => {
         const dir = fixture.componentInstance.dir();
         const element = fixture.nativeElement.querySelector('input') as HTMLInputElement;
 
-        expect(dir.min()).toBe(10);
+        expect(dir.formFieldMin()).toBe(10);
         expect(element.min).toBe('10');
 
         act(() => fixture.componentInstance.min.set(5));
-        expect(dir.min()).toBe(5);
+        expect(dir.formFieldMin()).toBe(5);
         expect(element.min).toBe('5');
       });
     });
@@ -3265,14 +3313,18 @@ describe('field directive', () => {
         @Directive()
         class CustomControlDir implements FormValueControl<string> {
           readonly value = model('');
-          readonly maxLength = input<number>();
+          readonly formFieldMaxLength = input<number>();
         }
 
         @Component({
           selector: 'custom-control',
           template: '',
           hostDirectives: [
-            {directive: CustomControlDir, inputs: ['maxLength', 'value'], outputs: ['valueChange']},
+            {
+              directive: CustomControlDir,
+              inputs: ['formFieldMaxLength', 'value'],
+              outputs: ['valueChange'],
+            },
           ],
         })
         class CustomControl {}
@@ -3291,10 +3343,10 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().maxLength()).toBe(10);
+        expect(component.customControl().formFieldMaxLength()).toBe(10);
 
         act(() => component.maxLength.set(5));
-        expect(component.customControl().maxLength()).toBe(5);
+        expect(component.customControl().formFieldMaxLength()).toBe(5);
       });
 
       it('should bind to a custom control when composed as a host directive', () => {
@@ -3305,7 +3357,7 @@ describe('field directive', () => {
         })
         class CustomControl implements FormValueControl<string> {
           readonly value = model('');
-          readonly maxLength = input<number>();
+          readonly formFieldMaxLength = input<number>();
         }
 
         @Component({
@@ -3322,17 +3374,17 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().maxLength()).toBe(10);
+        expect(component.customControl().formFieldMaxLength()).toBe(10);
 
         act(() => component.maxLength.set(5));
-        expect(component.customControl().maxLength()).toBe(5);
+        expect(component.customControl().formFieldMaxLength()).toBe(5);
       });
 
       it('should bind to custom control', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
           readonly value = model('');
-          readonly maxLength = input<number>();
+          readonly formFieldMaxLength = input<number>();
         }
 
         @Component({
@@ -3349,10 +3401,10 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().maxLength()).toBe(10);
+        expect(component.customControl().formFieldMaxLength()).toBe(10);
 
         act(() => component.maxLength.set(5));
-        expect(component.customControl().maxLength()).toBe(5);
+        expect(component.customControl().formFieldMaxLength()).toBe(5);
       });
 
       it('should bind to native control host of custom control without input', () => {
@@ -3440,7 +3492,7 @@ describe('field directive', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
           readonly value = model('');
-          readonly maxLength = input<number | undefined>();
+          readonly formFieldMaxLength = input<number | undefined>();
         }
 
         @Component({
@@ -3457,16 +3509,16 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().maxLength()).toBe(10);
+        expect(component.customControl().formFieldMaxLength()).toBe(10);
 
         act(() => component.field.set(component.f.y));
-        expect(component.customControl().maxLength()).toBe(undefined);
+        expect(component.customControl().formFieldMaxLength()).toBe(undefined);
       });
 
       it('should bind to directive input on native control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly maxLength = input.required<number | undefined>();
+          readonly maxLength = input<number | undefined>();
         }
 
         @Component({
@@ -3493,7 +3545,7 @@ describe('field directive', () => {
       it('should bind to directive input on custom control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly maxLength = input.required<number | undefined>();
+          readonly formFieldMaxLength = input<number | undefined>();
         }
 
         @Component({selector: 'input[custom]', template: ``})
@@ -3517,11 +3569,11 @@ describe('field directive', () => {
         const dir = fixture.componentInstance.dir();
         const element = fixture.nativeElement.querySelector('input') as HTMLInputElement;
 
-        expect(dir.maxLength()).toBe(10);
+        expect(dir.formFieldMaxLength()).toBe(10);
         expect(element.maxLength).toBe(10);
 
         act(() => fixture.componentInstance.maxLength.set(5));
-        expect(dir.maxLength()).toBe(5);
+        expect(dir.formFieldMaxLength()).toBe(5);
         expect(element.maxLength).toBe(5);
       });
     });
@@ -3547,18 +3599,44 @@ describe('field directive', () => {
         expect(element.minLength).toBe(15);
       });
 
+      it('should not write minLength to an unrelated custom control input', () => {
+        type DayLike = {day?: number};
+
+        @Component({selector: 'custom-control', template: ''})
+        class CustomControl implements FormValueControl<string> {
+          readonly value = model('');
+          readonly unrelatedMinLength = input<DayLike | null>({day: 1}, {alias: 'minLength'});
+        }
+
+        @Component({
+          imports: [FormField, CustomControl],
+          template: `<custom-control [formField]="f" />`,
+        })
+        class TestCmp {
+          readonly f = form(signal('value'), (p) => minLength(p, 3));
+          readonly customControl = viewChild.required(CustomControl);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        expect(fixture.componentInstance.customControl().unrelatedMinLength()).toEqual({day: 1});
+      });
+
       it('should bind to a custom control host directive', () => {
         @Directive()
         class CustomControlDir implements FormValueControl<string> {
           readonly value = model('');
-          readonly minLength = input<number>();
+          readonly formFieldMinLength = input<number>();
         }
 
         @Component({
           selector: 'custom-control',
           template: '',
           hostDirectives: [
-            {directive: CustomControlDir, inputs: ['minLength', 'value'], outputs: ['valueChange']},
+            {
+              directive: CustomControlDir,
+              inputs: ['formFieldMinLength', 'value'],
+              outputs: ['valueChange'],
+            },
           ],
         })
         class CustomControl {}
@@ -3577,10 +3655,10 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().minLength()).toBe(10);
+        expect(component.customControl().formFieldMinLength()).toBe(10);
 
         act(() => component.minLength.set(5));
-        expect(component.customControl().minLength()).toBe(5);
+        expect(component.customControl().formFieldMinLength()).toBe(5);
       });
 
       it('should bind to a custom control when composed as a host directive', () => {
@@ -3591,7 +3669,7 @@ describe('field directive', () => {
         })
         class CustomControl implements FormValueControl<string> {
           readonly value = model('');
-          readonly minLength = input<number>();
+          readonly formFieldMinLength = input<number>();
         }
 
         @Component({
@@ -3608,17 +3686,17 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().minLength()).toBe(10);
+        expect(component.customControl().formFieldMinLength()).toBe(10);
 
         act(() => component.minLength.set(5));
-        expect(component.customControl().minLength()).toBe(5);
+        expect(component.customControl().formFieldMinLength()).toBe(5);
       });
 
       it('should bind to custom control', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
           readonly value = model('');
-          readonly minLength = input<number>();
+          readonly formFieldMinLength = input<number>();
         }
 
         @Component({
@@ -3635,10 +3713,10 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().minLength()).toBe(10);
+        expect(component.customControl().formFieldMinLength()).toBe(10);
 
         act(() => component.minLength.set(5));
-        expect(component.customControl().minLength()).toBe(5);
+        expect(component.customControl().formFieldMinLength()).toBe(5);
       });
 
       it('should bind to native control host of custom control without input', () => {
@@ -3708,7 +3786,7 @@ describe('field directive', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
           readonly value = model('');
-          readonly minLength = input<number | undefined>();
+          readonly formFieldMinLength = input<number | undefined>();
         }
 
         @Component({
@@ -3725,16 +3803,16 @@ describe('field directive', () => {
 
         const fixture = act(() => TestBed.createComponent(TestCmp));
         const component = fixture.componentInstance;
-        expect(component.customControl().minLength()).toBe(10);
+        expect(component.customControl().formFieldMinLength()).toBe(10);
 
         act(() => component.field.set(component.f.y));
-        expect(component.customControl().minLength()).toBeUndefined();
+        expect(component.customControl().formFieldMinLength()).toBeUndefined();
       });
 
       it('should bind to directive input on native control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly minLength = input.required<number | undefined>();
+          readonly minLength = input<number | undefined>();
         }
 
         @Component({
@@ -3761,7 +3839,7 @@ describe('field directive', () => {
       it('should bind to directive input on custom control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly minLength = input.required<number | undefined>();
+          readonly formFieldMinLength = input<number | undefined>();
         }
 
         @Component({selector: 'input[custom]', template: ``})
@@ -3785,11 +3863,11 @@ describe('field directive', () => {
         const dir = fixture.componentInstance.dir();
         const element = fixture.nativeElement.querySelector('input') as HTMLInputElement;
 
-        expect(dir.minLength()).toBe(10);
+        expect(dir.formFieldMinLength()).toBe(10);
         expect(element.minLength).toBe(10);
 
         act(() => fixture.componentInstance.minLength.set(5));
-        expect(dir.minLength()).toBe(5);
+        expect(dir.formFieldMinLength()).toBe(5);
         expect(element.minLength).toBe(5);
       });
     });
@@ -4009,8 +4087,8 @@ describe('field directive', () => {
         readonly pending = input(false);
         readonly dirty = input(false);
         readonly touched = input(false);
-        readonly minLength = input<number | undefined>(1);
-        readonly maxLength = input<number | undefined>(5);
+        readonly formFieldMinLength = input<number | undefined>(1);
+        readonly formFieldMaxLength = input<number | undefined>(5);
       }
 
       @Component({
@@ -4055,12 +4133,16 @@ describe('field directive', () => {
       @Component({selector: 'custom-control', template: ``})
       class CustomControl implements FormValueControl<number> {
         readonly value = model(0);
-        readonly min = input<number | undefined, unknown>(undefined, {transform: numberAttribute});
-        readonly max = input<number | undefined, unknown>(undefined, {transform: numberAttribute});
-        readonly minLength = input<number | undefined, unknown>(undefined, {
+        readonly formFieldMin = input<number | undefined, unknown>(undefined, {
           transform: numberAttribute,
         });
-        readonly maxLength = input<number | undefined, unknown>(undefined, {
+        readonly formFieldMax = input<number | undefined, unknown>(undefined, {
+          transform: numberAttribute,
+        });
+        readonly formFieldMinLength = input<number | undefined, unknown>(undefined, {
+          transform: numberAttribute,
+        });
+        readonly formFieldMaxLength = input<number | undefined, unknown>(undefined, {
           transform: numberAttribute,
         });
       }

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -1078,7 +1078,7 @@ describe('ControlValueAccessor', () => {
       it('should bind to directive input', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly max = input.required<number | string | undefined>();
+          readonly max = input<number | string | undefined>();
         }
 
         @Component({
@@ -1128,7 +1128,7 @@ describe('ControlValueAccessor', () => {
       it('should bind to directive input', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly maxLength = input.required<number | undefined>();
+          readonly maxLength = input<number | undefined>();
         }
 
         @Component({
@@ -1178,7 +1178,7 @@ describe('ControlValueAccessor', () => {
       it('should bind to directive input', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly min = input.required<number | string | undefined>();
+          readonly min = input<number | string | undefined>();
         }
 
         @Component({
@@ -1228,7 +1228,7 @@ describe('ControlValueAccessor', () => {
       it('should bind to directive input', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly minLength = input.required<number | undefined>();
+          readonly minLength = input<number | undefined>();
         }
 
         @Component({


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Signal Forms treats any custom-control inputs named `min`, `max`, `minLength`, or `maxLength` as form constraint inputs. This can produce template type errors for unrelated component APIs and can overwrite those inputs at runtime.

Issue Number: #70600

## What is the new behavior?

Custom controls explicitly opt into constraint synchronization through `formFieldMin`, `formFieldMax`, `formFieldMinLength`, and `formFieldMaxLength`. Ordinary inputs using the native names remain component-owned. Native controls and CVAs keep their existing native property names, and all other Signal Forms state inputs remain strictly checked.

Compiler and runtime regression tests cover both the name-collision case and the explicit opt-in path.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Custom controls that intentionally receive these four constraints must rename their inputs to the corresponding `formField*` names.

## Other information

Verified with the focused Signal Forms compiler tests, Chromium web tests, and the Forms public API golden test.