### PR TITLE
 fix(core): clean up old styles in HMR if REMOVE_STYLES_ON_COMPONENT_DESTROY is false

### DIFF
--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -7,9 +7,9 @@
  */
 
 import {computeMsgId} from '@angular/compiler';
-import {TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {clearTranslations, loadTranslations} from '@angular/localize';
-import {EVENT_MANAGER_PLUGINS} from '@angular/platform-browser';
+import {EVENT_MANAGER_PLUGINS, REMOVE_STYLES_ON_COMPONENT_DESTROY} from '@angular/platform-browser';
 import {isNode} from '@angular/private/testing';
 import {
   ChangeDetectionStrategy,
@@ -2372,6 +2372,54 @@ describe('hot module replacement', () => {
     // After HMR, dehydrated DOM nodes should have been cleaned up — no duplication.
     expect(childEl.innerHTML).not.toContain('SSR ghost');
     expectHTML(fixture.nativeElement, '<child-cmp><div>Replaced</div></child-cmp>');
+  });
+
+  it('should remove styles from a replaced component when style removal on destroy is disabled', () => {
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      template: 'Initial',
+      styles: '.hmr-old-style { color: red; }',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {}
+
+    @Component({
+      imports: [ChildCmp],
+      template: '<child-cmp/>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
+    class RootCmp {}
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: REMOVE_STYLES_ON_COMPONENT_DESTROY,
+          useValue: false,
+        },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+
+    const getStyleCount = (fixture: ComponentFixture<unknown>, cssContentMatcher: string) => {
+      return Array.from(
+        fixture.nativeElement.parentNode.parentNode.querySelectorAll('style'),
+      ).filter((style) => (style as HTMLStyleElement).innerText.includes(cssContentMatcher)).length;
+    };
+
+    expect(getStyleCount(fixture, '.hmr-old-style')).toBe(1);
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      styles: '.hmr-new-style { color: blue; }',
+    });
+    fixture.detectChanges();
+
+    expect(getStyleCount(fixture, '.hmr-old-style')).toBe(0);
+    expect(getStyleCount(fixture, '.hmr-new-style')).toBe(1);
   });
 
   // Testing utilities

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -296,6 +296,8 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
    * @param componentId ID of the component that is being replaced.
    */
   protected componentReplaced(componentId: string) {
+    const renderer = this.rendererByCompId.get(componentId);
+    renderer?.removeStylesHMR();
     this.rendererByCompId.delete(componentId);
   }
 }
@@ -680,6 +682,15 @@ class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
     if (!this.removeStylesOnCompDestroy) {
       return;
     }
+    this.removeStyles();
+  }
+
+  removeStylesHMR(): void {
+    if (!this.removeStylesOnCompDestroy) {
+      this.removeStyles();
+    }
+  }
+  removeStyles(): void {
     if (allLeavingAnimations.size === 0) {
       this.sharedStylesHost.removeStyles(this.styles, this.styleUrls);
     }


### PR DESCRIPTION
Issue Number: #62545 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


Removal of old style in HMR update relies on `destroy` method be called by `destroyLView`, which will skip the removal of style element if `REMOVE_STYLES_ON_COMPONENT_DESTROY` is false. Add additional style removal check inside `componentReplaced` during HMR update.
https://github.com/angular/angular/blob/9a58353b1b680f162a55969965ae6a90ae20316d/packages/platform-browser/src/dom/dom_renderer.ts#L679-L687

## What is the new behavior?
old component style will be removed inside `componentReplaced` during HMR update.
## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
