### PR TITLE
docs: fix the visibleLines range on the ngFor tutorial step

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/README.md
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/README.md
@@ -27,7 +27,7 @@ In the `Home` there is only a single housing location. In this step, you will ad
 
 1. In `src/app/home/home.ts`, remove the `housingLocation` property from the `Home` class.
 1. Update the `Home` class to have a property called `housingLocationList`. Update your code to match the following code:
-   <docs-code language="angular-ts"  header="Add housingLocationList property in home.ts" path="adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.ts" visibleLines="26-131"/>
+   <docs-code language="angular-ts"  header="Add housingLocationList property in home.ts" path="adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.ts" visibleLines="[26,127]"/>
 
    IMPORTANT: Do not remove the `@Component` decorator, you will update that code in an upcoming step.
 


### PR DESCRIPTION
`visibleLines="26-131"` is not valid JSON, so `expandRangeStringValues` threw and returned an empty list. The rendered attribute was empty, and the viewer treats that as no range at all, so no ExampleViewer was created: https://angular.dev/tutorials/first-app/08-ngFor showed all 128 lines of `home.ts` with no collapse and no expand control, including the `@for` block the reader has not written yet.

The file is 128 lines and the property this step adds ends at 127. The sibling snippet on the same page already uses the `[start,end]` form.

https://angular.dev/tutorials/first-app/08-ngFor#:~:text=Add%20housingLocationList%20property%20in%20home.ts

Before:

<img width="728" height="734" alt="image" src="https://github.com/user-attachments/assets/d8cbaaf9-a04a-4182-accd-409160ec5309" />

After:

<img width="586" height="723" alt="image" src="https://github.com/user-attachments/assets/c0bf69c9-2b36-458d-8f08-f9b5ef929c82" />

