### PR TITLE
fix(docs-infra): recognise an alert that follows prose in the same paragraph

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-alert.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-alert.mts
@@ -34,9 +34,15 @@ const tokenMatcher = new RegExp(
   's',
 );
 
+const tokenStartMatcher = new RegExp(`\n(?:${alertSeverityLevels.join('|')}): `);
+
 export const docsAlertExtension: TokenizerAndRendererExtension = {
   name: 'docs-alert',
   level: 'inline',
+  start(src: string) {
+    const index = src.match(tokenStartMatcher)?.index;
+    return index === undefined ? undefined : index + 1;
+  },
   tokenizer(this: TokenizerThis, src: string): DocsAlertToken | undefined {
     const execMatch = tokenMatcher.exec(src);
     if (execMatch === null) {

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-alert/docs-alert.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-alert/docs-alert.md
@@ -17,4 +17,7 @@ IMPORTANT: Use Important for information that's crucial to comprehending the tex
 
 HELPFUL: Use Best practice to call out practices that are known to be successful or better than alternatives.
 
+Some prose that runs straight into the alert with no blank line.
+TIP: THIS TIP FOLLOWS PROSE ON THE NEXT LINE
+
 NOTE: THIS NOTE WITHOUT A LINE RETURN

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-alert/docs-alert.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-alert/docs-alert.spec.mts
@@ -35,6 +35,14 @@ describe('markdown to html', () => {
     expect(noteEl?.textContent?.trim()).toContain(`This is a multiline note`);
   });
 
+  it(`should handle an alert that follows prose in the same paragraph`, () => {
+    const tipEls = markdownDocument.querySelectorAll(`.docs-alert-tip`);
+
+    expect(tipEls[tipEls.length - 1]?.textContent?.trim()).toContain(
+      `THIS TIP FOLLOWS PROSE ON THE NEXT LINE`,
+    );
+  });
+
   it(`should handle alerts without a line return`, () => {
     const noteEl = markdownDocument.querySelector(`.docs-alert-note:last-of-type`);
 


### PR DESCRIPTION
`docs-alert` was the only marked extension in the pipeline without a `start` hook, so marked never cut `inlineText` short at an alert and swallowed any directive that was not at the start of the inline source. Writing the alert on its own line without a blank line before it left the literal text in the body.

On https://angular.dev/guide/http/testing two alerts render as boxes and a third shows as `IMPORTANT:` in the paragraph text. Also affects https://angular.dev/errors/NG3003 and the first step of the first app tutorial.

The same renderer handles JSDoc, so one API page changes too: https://angular.dev/api/upgrade/static/downgradeModule has three `NOTE:` continuation lines inside bullets that now render as alerts.

`docs-video` and `docs-pill` already declare `start` the same way.

https://angular.dev/guide/http/testing#configuring-httpclient-in-tests

Before:

<img width="845" height="374" alt="Screenshot 2026-09-07 at 19 15 13" src="https://github.com/user-attachments/assets/c2a0508f-021d-4bc2-9859-755cb5fd9950" />

After:

<img width="849" height="482" alt="Screenshot 2026-09-07 at 19 15 38" src="https://github.com/user-attachments/assets/0825db87-2f32-4876-a794-58e98eb55b3d" />