### PR TITLE
docs: add CommonModule guidance to AI best practices

### DIFF
--- a/packages/core/resources/best-practices.md
+++ b/packages/core/resources/best-practices.md
@@ -34,6 +34,7 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - When not using Signal Forms, prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead
 - Do NOT use `ngStyle`, use `style` bindings instead
+- Do NOT import `CommonModule`, import only the directives and pipes the template uses, such as `AsyncPipe` or `DatePipe`
 - When using external templates/styles, use paths relative to the component TS file.
 
 ## State Management


### PR DESCRIPTION
Clarifies that CommonModule should not be imported wholesale when narrower
imports can be used instead.