### PR TITLE
docs(docs-infra): correct stale paths and routes in the tutorials README

### DIFF
--- a/adev/src/content/tutorials/README.md
+++ b/adev/src/content/tutorials/README.md
@@ -12,7 +12,7 @@ The tutorials content consists of the tutorial content, source code and configur
 
 The tutorial content must be located in a `README.md` file in the tutorial directory.
 
-Taking the `learn-angular` tutorial as an example, see: [`src/content/tutorials/learn-angular/intro/README.md`](/src/content/tutorials/learn-angular/intro/README.md)
+Taking the `learn-angular` tutorial as an example, see: [`adev/src/content/tutorials/learn-angular/intro/README.md`](/adev/src/content/tutorials/learn-angular/intro/README.md)
 
 ### Configuration: `config.json`
 
@@ -43,31 +43,31 @@ Taking the `learn-angular` tutorial as an example:
 
 ### Introduction
 
-[`src/content/tutorials/learn-angular/intro`](/src/content/tutorials/learn-angular/intro)
+[`adev/src/content/tutorials/learn-angular/intro`](/adev/src/content/tutorials/learn-angular/intro)
 
 is the introduction of the tutorial, which will live in the `/tutorials/learn-angular` route.
 
 ### Steps
 
-[`src/content/tutorials/learn-angular/steps`](/src/content/tutorials/learn-angular/steps) is the directory that contains the tutorial steps.
+[`adev/src/content/tutorials/learn-angular/steps`](/adev/src/content/tutorials/learn-angular/steps) is the directory that contains the tutorial steps.
 
 These are some examples from the `learn-angular` tutorial:
 
-- [`learn-angular/steps/1-components-in-angular`](/src/content/tutorials/learn-angular/steps/1-components-in-angular): The route will be `/tutorials/learn-angular/components-in-angular`
-- [`learn-angular/steps/2-updating-the-component-class`](/src/content/tutorials/learn-angular/steps/2-updating-the-component-class): The route will be `/tutorials/learn-angular/updating-the-component-class`
+- [`learn-angular/steps/1-components-in-angular`](/adev/src/content/tutorials/learn-angular/steps/1-components-in-angular): The route will be `/tutorials/learn-angular/1-components-in-angular`
+- [`learn-angular/steps/2-updating-the-component-class`](/adev/src/content/tutorials/learn-angular/steps/2-updating-the-component-class): The route will be `/tutorials/learn-angular/2-updating-the-component-class`
 
 Each step directory must start with a number followed by a hyphen, then followed by the step pathname.
 
 - The number denotes the step, defining which will be the previous and next step within a tutorial.
 - The hyphen is a delimiter :).
-- The pathname taken from the directory name defines the step URL.
+- The directory name, including the number and the hyphen, defines the step URL.
 
 ## Reserved tutorials directories
 
 ### `common`
 
 The common project is a complete Angular project that is reused by all tutorials. It contains all
-dependencies(`package.json`, `package-lock.json`), project configuration(`tsconfig.json`, `angular.json`) and main files to bootstrap the application(`index.html`, `main.ts`, `app.module.ts`).
+dependencies(`package.json`, `package-lock.json`), project configuration(`tsconfig.json`, `angular.json`) and main files to bootstrap the application(`index.html`, `main.ts`, `app.config.ts`).
 
 A common project is used for a variety of reasons:
 
@@ -79,30 +79,35 @@ A common project is used for a variety of reasons:
 - Provide a consistent environment for all tutorials.
 - Allow each tutorial to focus on the specific source code for what's being taught and not on the project setup.
 
-See [`src/content/tutorials/common`](/src/content/tutorials/common)
+See [`adev/shared-docs/pipeline/tutorials/common`](/adev/shared-docs/pipeline/tutorials/common)
+
+A tutorial can also provide its own `common` directory, whose files are applied on top of the shared common project for the intro and every step of that tutorial. See [`adev/src/content/tutorials/signals/common`](/adev/src/content/tutorials/signals/common) for an example.
 
 ### `playground`
 
 The playground contains the source code for the tutorials playground at `/playground`. It should not contain any content.
 
-See [`src/content/tutorials/playground`](/src/content/tutorials/playground)
+See [`adev/src/content/tutorials/playground`](/adev/src/content/tutorials/playground)
 
 ### `homepage`
 
 The homepage contains the source code for the homepage playground. It should not contain any content.
 
-See [`src/content/tutorials/homepage`](/src/content/tutorials/homepage)
+See [`adev/src/content/tutorials/homepage`](/adev/src/content/tutorials/homepage)
 
 ## Update dependencies
 
 To update the dependencies of all tutorials you can run the following script
 
 ```bash
-rm ./adev/src/content/tutorials/homepage/package-lock.json  ./adev/src/content/tutorials/first-app/common/package-lock.json ./adev/src/content/tutorials/learn-angular/common/package-lock.json ./adev/src/content/tutorials/playground/common/package-lock.json ./adev/src/content/tutorials/deferrable-views/common/package-lock.json
+rm ./adev/src/content/tutorials/homepage/package-lock.json  ./adev/src/content/tutorials/first-app/common/package-lock.json ./adev/src/content/tutorials/learn-angular/common/package-lock.json ./adev/src/content/tutorials/playground/common/package-lock.json ./adev/src/content/tutorials/deferrable-views/common/package-lock.json ./adev/src/content/tutorials/signals/common/package-lock.json ./adev/src/content/tutorials/signal-forms/common/package-lock.json ./adev/shared-docs/pipeline/tutorials/common/package-lock.json
 
 npm i --package-lock-only --prefix ./adev/src/content/tutorials/homepage
 npm i --package-lock-only --prefix ./adev/src/content/tutorials/first-app/common
 npm i --package-lock-only --prefix ./adev/src/content/tutorials/learn-angular/common
 npm i --package-lock-only --prefix ./adev/src/content/tutorials/playground/common
 npm i --package-lock-only --prefix ./adev/src/content/tutorials/deferrable-views/common
+npm i --package-lock-only --prefix ./adev/src/content/tutorials/signals/common
+npm i --package-lock-only --prefix ./adev/src/content/tutorials/signal-forms/common
+npm i --package-lock-only --prefix ./adev/shared-docs/pipeline/tutorials/common
 ```


### PR DESCRIPTION
A few things in the tutorials README no longer match the pipeline.

Eight links start with `/src/content/...`, which GitHub resolves from the repo root, so they 404. They need the `adev/` prefix.

The step examples say the route drops the leading number. It doesn't, the sitemap only has the numbered form.

The `common` section links to a directory removed in #53511, and mentions an `app.module.ts` the project doesn't have.

The update-dependencies script is missing three of the eight projects with a package-lock.json.

The README isn't rendered (`generate_guides` excludes it), so no page changes.
