### PR TITLE
fix(docs-infra): make edit icon visible on gradient page headers

### DIFF
--- a/adev/shared-docs/styles/docs/_decorative-header.scss
+++ b/adev/shared-docs/styles/docs/_decorative-header.scss
@@ -82,6 +82,18 @@
       .docs-breadcrumb span {
         color: white !important;
       }
+
+      // The edit link sits on the gradient, where the default gray icon color
+      // doesn't have enough contrast.
+      .docs-page-title a {
+        docs-icon {
+          color: color-mix(in srgb, white 70%, transparent);
+        }
+
+        &:hover docs-icon {
+          color: #fff;
+        }
+      }
     }
 
     svg {


### PR DESCRIPTION
Color the icon white within the gradient header, keeping the muted to full contrast hover affordance used elsewhere.

## What is the current behavior?
<img width="1570" height="562" alt="image" src="https://github.com/user-attachments/assets/cbea52b4-1b89-466e-b448-13a0e1c4b794" />

## What is the new behavior?
<img width="1650" height="612" alt="image" src="https://github.com/user-attachments/assets/29de01c0-0340-457d-a650-a0b8ab2f14cb" />
