### PR TITLE
docs(animations): stop the query() usage notes truncating at a code sample

### DIFF
--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -1231,7 +1231,7 @@ export function useAnimation(
  * Tokens can be merged into a combined query selector string. For example:
  *
  * ```ts
- *  query(':self, .record:enter, .record:leave, @subTrigger', [...])
+ *  query('@subTrigger, :self, .record:enter, .record:leave', [...])
  * ```
  *
  * The `query()` function collects multiple elements and works internally by using


### PR DESCRIPTION
https://angular.dev/api/animations/query cuts off mid-sentence, inside the first
code sample in Usage Notes.

That sample contains `@subTrigger`, and TypeScript's JSDoc parser reads a space
followed by `@word` as a new tag, even inside a code fence. So it splits the
comment there and everything after is dropped.

Two sections go missing, plus the anchor that two links point at. Moving
`@subTrigger` to the front of the selector puts it after a quote instead of a
space, which the parser ignores. Order in a selector list doesn't matter.

https://angular.dev/api/animations/query

Before:

https://github.com/user-attachments/assets/7177da90-81c0-4929-acc8-e5e2f2318c7f

After:

https://github.com/user-attachments/assets/368adc5e-4032-4497-82a3-3025d4628e6e
