### PR TITLE
fix(platform-server): avoid sourcemap corruption during domino path substitution

### DIFF
--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -49,7 +49,7 @@ ng_package(
     ],
     substitutions = {
         # Needed for the FESM files.
-        "\\./(.+)/third_party/domino/bundled-domino": "../third_party/domino/bundled-domino.mjs",
+        "(?<!\\.)\\./[a-zA-Z0-9_./-]+/third_party/domino/bundled-domino": "../third_party/domino/bundled-domino.mjs",
     },
     tags = [
         "release-with-framework",


### PR DESCRIPTION
The substitution regex `\./(.+)/third_party/domino/bundled-domino` was used to rewrite the relative execroot path emitted by Rollup for the domino external import into `../third_party/domino/bundled-domino.mjs`.

However, `ng_package` runs `text_replace` across all generated package files, including `.map` files which are serialized on a single line. The `\./` pattern unintentionally matched the `./` inside `"../../"` in the `sources` array, and the greedy `.+` wildcard matched across the rest of `sources` and the `"sourcesContent": [` declaration up to the domino import within the first source file's content. This corrupted `init.mjs.map` and `_server-chunk.mjs.map` by destroying `sourcesContent` and populating `sources` with raw file contents.

This commit updates the substitution regex to use a negative lookbehind `(?<!\.)` to prevent matching `../` sequences, and restricts the path characters to valid filesystem path characters `[a-zA-Z0-9_./-]+` rather than `.+`.

Fixes #70625