### PR TITLE
docs(forms): close the unterminated code fences in the compatForm docs

### DIFF
--- a/packages/forms/signals/compat/src/api/compat_form.ts
+++ b/packages/forms/signals/compat/src/api/compat_form.ts
@@ -75,6 +75,7 @@ export function compatForm<TModel>(model: WritableSignal<TModel>): FieldTree<TMo
  * });
  *
  * nameForm.last().value(); // lastName, not FormControl
+ * ```
  *
  * @param model A writable signal that contains the model data for the form. The resulting field
  * structure will match the shape of the model and any changes to the form data will be written to
@@ -114,6 +115,7 @@ export function compatForm<TModel>(
  * });
  *
  * nameForm.last().value(); // lastName, not FormControl
+ * ```
  *
  * @param model A writable signal that contains the model data for the form. The resulting field
  * structure will match the shape of the model and any changes to the form data will be written to


### PR DESCRIPTION
On https://angular.dev/api/forms/signals/compat/compatForm the three overloads share the same code example, but only the first one is syntax highlighted. The other two render as flat grey text.

The two later overloads are missing the closing ``` in their JSDoc, so the code fence never terminates and shiki can't highlight it. Adding the two missing lines fixes both.
