### PR TITLE
fix(docs-infra): highlight home page code for the resolved theme

### DIFF
--- a/adev/src/app/core/services/theme-manager.service.ts
+++ b/adev/src/app/core/services/theme-manager.service.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT, isPlatformBrowser} from '@angular/common';
-import {PLATFORM_ID, Service, inject, signal} from '@angular/core';
+import {PLATFORM_ID, Service, computed, inject, signal} from '@angular/core';
 import {LOCAL_STORAGE} from '@angular/docs';
 
 // Keep these constants in sync with the code in index.html
@@ -26,12 +26,21 @@ export class ThemeManager {
   private readonly platformId = inject(PLATFORM_ID);
 
   readonly theme = signal<Theme | null>(this.getThemeFromLocalStorageValue());
+  private readonly osScheme = signal<'dark' | 'light'>('light');
+  readonly resolvedTheme = computed<'dark' | 'light'>(() => {
+    const theme = this.theme();
+    if (theme === null) {
+      return 'light';
+    }
+    return theme === 'auto' ? this.osScheme() : theme;
+  });
 
   constructor() {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
 
+    this.osScheme.set(preferredScheme());
     this.loadThemePreference();
     this.watchPreferredColorScheme();
   }
@@ -39,7 +48,7 @@ export class ThemeManager {
   setTheme(theme: Theme): void {
     this.theme.set(theme);
     this.setThemeInLocalStorage();
-    this.setThemeBodyClasses(theme === 'auto' ? preferredScheme() : theme);
+    this.setThemeBodyClasses(this.resolvedTheme());
   }
 
   // 1. Read theme preferences stored in localStorage
@@ -49,7 +58,7 @@ export class ThemeManager {
     const useTheme = savedUserPreference ?? 'auto';
 
     this.theme.set(useTheme);
-    this.setThemeBodyClasses(useTheme === 'auto' ? preferredScheme() : useTheme);
+    this.setThemeBodyClasses(this.resolvedTheme());
   }
 
   // Set theme classes on the body element
@@ -77,11 +86,11 @@ export class ThemeManager {
 
   private watchPreferredColorScheme() {
     window.matchMedia(PREFERS_COLOR_SCHEME_DARK).addEventListener('change', (event) => {
+      this.osScheme.set(event.matches ? 'dark' : 'light');
       if (this.theme() !== 'auto') {
         return;
       }
-      const preferredScheme = event.matches ? 'dark' : 'light';
-      this.setThemeBodyClasses(preferredScheme);
+      this.setThemeBodyClasses(this.resolvedTheme());
     });
   }
 }

--- a/adev/src/app/features/home/components/code-block/code-block.ts
+++ b/adev/src/app/features/home/components/code-block/code-block.ts
@@ -34,7 +34,7 @@ export class CodeBlock {
       .codeToHtml(this.code(), {
         cssVariablePrefix: '--shiki-',
         lang: this.language(),
-        theme: this.theme.theme() === 'light' ? 'github-light' : 'github-dark',
+        theme: this.theme.resolvedTheme() === 'dark' ? 'github-dark' : 'github-light',
       })
       .then((hightlightedHtml) => {
         return this.sanitizer.bypassSecurityTrustHtml(hightlightedHtml);


### PR DESCRIPTION
On angular.dev, the code samples in the Signals / Control Flow / Deferrable Views tabs render dark on an otherwise light page.

CodeBlock picks its theme with `theme() === 'light' ? 'github-light' : 'github-dark'`. But Theme is 'dark' | 'light' | 'auto', and the value is null when nothing is in localStorage. So 'auto' (the default) and null both fall through to dark, while the page background resolves 'auto' correctly through preferredScheme(). The two disagree.

Steps to reproduce:
1. Set your OS to light mode.
2. Open angular.dev in a private window (empty localStorage). or ( localStorage.removeItem('themePreference'); location.reload();  it helps too :) )
3. Scroll to the Signals / Control Flow / Deferrable Views tabs.

The samples sit on a dark slab in a light page. Picking "Light" explicitly in the theme menu fixes it, switching back to "Auto" breaks it again.

Before:

<img width="1512" height="835" alt="image" src="https://github.com/user-attachments/assets/584a70c5-b118-4d9d-bd16-30809cc7506f" />

After:

<img width="1512" height="837" alt="image" src="https://github.com/user-attachments/assets/470eae2a-2350-4b1f-9fae-d1d8a21242cc" />