### PR TITLE
refactor(router): Remove ActivatedRouteSnapshot from resourceContext

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -672,7 +672,6 @@ export interface ResourceContext {
     fragment: Signal<string | null>;
     params: Signal<Params>;
     queryParams: Signal<Params>;
-    snapshot: ActivatedRouteSnapshot;
 }
 
 // @public

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -61,13 +61,6 @@ export interface ResourceContext {
    * @developerPreview 22.2
    */
   data: Signal<Record<string, any>>;
-  /**
-   * The static activated route snapshot for this navigation.
-   * Useful for reading initial static configuration statically without
-   * reacting to future parameter changes on reused routes.
-   * @developerPreview 22.2
-   */
-  snapshot: ActivatedRouteSnapshot;
 }
 
 /**

--- a/packages/router/src/operators/setup_and_run_resources.ts
+++ b/packages/router/src/operators/setup_and_run_resources.ts
@@ -107,7 +107,6 @@ async function setupNewRouterResources(
     queryParams: route.queryParamsSignal,
     fragment: route.fragmentSignal,
     data: route.dataSignal,
-    snapshot: route._futureSnapshot,
   };
 
   const resourceResultRaw = runInInjectionContext(childInjector, () => resourcesFn(context));


### PR DESCRIPTION
providing the snapshot is a bit incompatible with how things are meant to work here. The snapshot is only accurate during the setup and would be out of date on followup navigations
