### PR TITLE
docs: release notes for the v21.2.23 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="21.2.23"></a>
+# 21.2.23 (2026-09-09)
+### platform-server
+| Commit | Type | Description |
+| -- | -- | -- |
+| [fc2e8fbc0b](https://github.com/angular/angular/commit/fc2e8fbc0bda2f5c11585e8a0cbd88c074f5e567) | fix | update domino to latest version |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="22.2.0-next.5"></a>
 # 22.2.0-next.5 (2026-09-02)
 ### compiler-cli


### PR DESCRIPTION
Cherry-picks the changelog from the "21.2.x" branch to the next branch (main).