### PR TITLE
docs: release notes for the v20.3.31 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="20.3.31"></a>
+# 20.3.31 (2026-09-09)
+### platform-server
+| Commit | Type | Description |
+| -- | -- | -- |
+| [3db26e2544](https://github.com/angular/angular/commit/3db26e2544964d07a520836ad01f02f36ec88e25) | fix | update domino to latest version |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.2.23"></a>
 # 21.2.23 (2026-09-09)
 ### platform-server


### PR DESCRIPTION
Cherry-picks the changelog from the "20.3.x" branch to the next branch (main).