### PR TITLE
refactor(compiler-cli): relax nullish coalescing non nullable diagnostics on indexed access

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -13,6 +13,12 @@ import {
   ParseSourceSpan,
   TmplAstNode,
   TmplAstTemplate,
+  KeyedRead,
+  SafePropertyRead,
+  SafeKeyedRead,
+  SafeCall,
+  ParenthesizedExpression,
+  NonNullAssert,
 } from '@angular/compiler';
 import ts from 'typescript';
 
@@ -160,4 +166,24 @@ class TemplateVisitor<Code extends ErrorCode> extends CombinedRecursiveAstVisito
     this.visitAllTemplateNodes(template);
     return this.diagnostics;
   }
+}
+
+/**
+ * Checks if the given AST node originates from a KeyedRead (indexed access)
+ * by unwrapping parentheses, non-null assertions, and traversing the receivers
+ * of safe navigation operations (?. property access, ?.[] keyed access, ?.() calls).
+ */
+export function isAccessFromUncheckedIndex(node: AST): boolean {
+  if (node instanceof KeyedRead) {
+    return true;
+  } else if (
+    node instanceof SafePropertyRead ||
+    node instanceof SafeKeyedRead ||
+    node instanceof SafeCall
+  ) {
+    return isAccessFromUncheckedIndex(node.receiver);
+  } else if (node instanceof ParenthesizedExpression || node instanceof NonNullAssert) {
+    return isAccessFromUncheckedIndex(node.expression);
+  }
+  return false;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/nullish_coalescing_not_nullable/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/nullish_coalescing_not_nullable/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AST, Binary, TmplAstNode} from '@angular/compiler';
+import {AST, Binary, KeyedRead, TmplAstNode} from '@angular/compiler';
 import ts from 'typescript';
 
 import {NgCompilerOptions} from '../../../../core/api';
@@ -17,6 +17,7 @@ import {
   TemplateCheckWithVisitor,
   TemplateContext,
   formatExtendedError,
+  isAccessFromUncheckedIndex,
 } from '../../api';
 
 /**
@@ -28,12 +29,22 @@ import {
 class NullishCoalescingNotNullableCheck extends TemplateCheckWithVisitor<ErrorCode.NULLISH_COALESCING_NOT_NULLABLE> {
   override code = ErrorCode.NULLISH_COALESCING_NOT_NULLABLE as const;
 
+  constructor(private readonly noUncheckedIndexedAccess: boolean) {
+    super();
+  }
+
   override visitNode(
     ctx: TemplateContext<ErrorCode.NULLISH_COALESCING_NOT_NULLABLE>,
     component: ts.ClassDeclaration,
     node: TmplAstNode | AST,
   ): NgTemplateDiagnostic<ErrorCode.NULLISH_COALESCING_NOT_NULLABLE>[] {
     if (!(node instanceof Binary) || node.operation !== '??') return [];
+
+    // When `noUncheckedIndexedAccess` is disabled, an indexed access is not checked
+    // and may result in `undefined`.
+    if (!this.noUncheckedIndexedAccess && isAccessFromUncheckedIndex(node.left)) {
+      return [];
+    }
 
     const symbolLeft = ctx.templateTypeChecker.getSymbolOfNode(node.left, component);
     if (symbolLeft === null || symbolLeft.kind !== SymbolKind.Expression) {
@@ -86,6 +97,8 @@ export const factory: TemplateCheckFactory<
       return null;
     }
 
-    return new NullishCoalescingNotNullableCheck();
+    const noUncheckedIndexedAccess = !!options.noUncheckedIndexedAccess;
+
+    return new NullishCoalescingNotNullableCheck(noUncheckedIndexedAccess);
   },
 };

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/optional_chain_not_nullable/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/optional_chain_not_nullable/index.ts
@@ -24,6 +24,7 @@ import {
   TemplateCheckWithVisitor,
   TemplateContext,
   formatExtendedError,
+  isAccessFromUncheckedIndex,
 } from '../../api';
 
 /**
@@ -54,7 +55,7 @@ class OptionalChainNotNullableCheck extends TemplateCheckWithVisitor<ErrorCode.O
 
     // When `noUncheckedIndexedAccess` is disabled, an indexed access is not checked
     // and may result in `undefined`.
-    if (node.receiver instanceof KeyedRead && !this.noUncheckedIndexedAccess) {
+    if (!this.noUncheckedIndexedAccess && isAccessFromUncheckedIndex(node.receiver)) {
       return [];
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/nullish_coalescing_not_nullable/nullish_coalescing_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/nullish_coalescing_not_nullable/nullish_coalescing_not_nullable_spec.ts
@@ -217,6 +217,155 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(0);
     });
 
+    it('should not produce nullish coalescing warning for an indexed access if noUncheckedIndexedAccess is false', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup(
+        [
+          {
+            fileName,
+            templates: {
+              'TestCmp': `{{ arr[0] ?? 'foo' }}`,
+            },
+            source: `
+               export class TestCmp {
+                  arr: Array<string> = [];
+               }
+             `,
+          },
+        ],
+        {options: {noUncheckedIndexedAccess: false}},
+      );
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [nullishCoalescingNotNullableFactory],
+        {strictNullChecks: true} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not produce nullish coalescing warning for an indexed access if noUncheckedIndexedAccess is true', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup(
+        [
+          {
+            fileName,
+            templates: {
+              'TestCmp': `{{ arr[0] ?? 'foo' }}`,
+            },
+            source: `
+               export class TestCmp {
+                  arr: Array<string> = [];
+               }
+             `,
+          },
+        ],
+        {options: {noUncheckedIndexedAccess: true}},
+      );
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [nullishCoalescingNotNullableFactory],
+        {strictNullChecks: true} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not produce nullish coalescing warning for a SafePropertyRead off an indexed access if noUncheckedIndexedAccess is false', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup(
+        [
+          {
+            fileName,
+            templates: {
+              'TestCmp': `{{ foos[0]?.name ?? 'foo' }}`,
+            },
+            source: `
+               export class TestCmp {
+                  foos: Array<{name: string}> = [];
+               }
+             `,
+          },
+        ],
+        {options: {noUncheckedIndexedAccess: false}},
+      );
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [nullishCoalescingNotNullableFactory],
+        {strictNullChecks: true} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not produce nullish coalescing warning for a SafeKeyedRead if noUncheckedIndexedAccess is false', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup(
+        [
+          {
+            fileName,
+            templates: {
+              'TestCmp': `{{ foos?.[0] ?? 'foo' }}`,
+            },
+            source: `
+               export class TestCmp {
+                  foos: Array<string> | null = null;
+               }
+             `,
+          },
+        ],
+        {options: {noUncheckedIndexedAccess: false}},
+      );
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [nullishCoalescingNotNullableFactory],
+        {strictNullChecks: true} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not produce nullish coalescing warning for a parenthesized indexed access if noUncheckedIndexedAccess is false', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup(
+        [
+          {
+            fileName,
+            templates: {
+              'TestCmp': `{{ (foos[0]) ?? 'foo' }}`,
+            },
+            source: `
+               export class TestCmp {
+                  foos: Array<string> = [];
+               }
+             `,
+          },
+        ],
+        {options: {noUncheckedIndexedAccess: false}},
+      );
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [nullishCoalescingNotNullableFactory],
+        {strictNullChecks: true} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
     it('warns for pipe arguments which are likely configured incorrectly (?? operates on "format" here)', () => {
       const fileName = absoluteFrom('/main.ts');
       const {program, templateTypeChecker} = setup([
@@ -341,7 +490,7 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(0);
     });
 
-    it('should produce nullish coalescing warning for a non-nullable ElementAccessExpression', () => {
+    it('should not produce nullish coalescing warning for a non-nullable ElementAccessExpression when noUncheckedIndexedAccess is false', () => {
       const fileName = absoluteFrom('/main.ts');
       const {program, templateTypeChecker} = setup([
         {
@@ -362,10 +511,7 @@ runInEachFileSystem(() => {
         {strictNullChecks: true} /* options */,
       );
       const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
-      expect(diags.length).toBe(1);
-      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
-      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.NULLISH_COALESCING_NOT_NULLABLE));
-      expect(getSourceCodeForDiagnostic(diags[0])).toBe(`myDict[key] ?? 'foo'`);
+      expect(diags.length).toBe(0);
     });
 
     it('should respect configured diagnostic category', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
@@ -256,6 +256,36 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(0);
     });
 
+    it('should not produce optional chain warning for a chained safe property read off an indexed access if noUncheckedIndexedAccess is false', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup(
+        [
+          {
+            fileName,
+            templates: {
+              'TestCmp': `{{ arr[0]?.bar?.length }}`,
+            },
+            source: `
+               export class TestCmp {
+                  arr: Array<{ bar: string }> = [];
+               }
+             `,
+          },
+        ],
+        {options: {noUncheckedIndexedAccess: false}},
+      );
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [optionalChainNotNullableFactory],
+        {strictNullChecks: true} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
     it('should produce optional chain warning for an indexed access if noUncheckedIndexedAccess is true', () => {
       const fileName = absoluteFrom('/main.ts');
       const {program, templateTypeChecker} = setup(


### PR DESCRIPTION
When noUncheckedIndexedAccess is not enabled, indexed accesses do not include undefined in the type. This relaxes the check for nullish coalescing similarly to optional chaining. 

Fixes #70655