### PR TITLE
Remove redundant change detection configuration & Update docs

### DIFF
--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -9,7 +9,6 @@
 import {expect} from '@angular/private/testing/matchers';
 import {
   Attribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   createComponent as coreCreateComponent,
@@ -248,7 +247,6 @@ class DirectiveNeedsChangeDetectorRef {
 @Component({
   selector: '[componentNeedsChangeDetectorRef]',
   template: '{{counter}}',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
 class PushComponentNeedsChangeDetectorRef {

--- a/packages/examples/core/ts/change_detect/change-detection.ts
+++ b/packages/examples/core/ts/change_detect/change-detection.ts
@@ -5,21 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  effect,
-  input,
-  signal,
-} from '@angular/core';
+import {ChangeDetectorRef, Component, effect, input, signal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 
 // #docregion mark-for-check
 @Component({
   selector: 'app-root',
   template: `Number of ticks: {{ numberOfTicks }}`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class AppComponent {
   numberOfTicks = 0;

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -169,20 +169,20 @@ export interface InMemoryScrollingOptions {
    * in the following example.
    *
    * ```ts
-   * class AppComponent {
-   *   movieData: any;
+   * class App {
+   *   movieData = signal<MovieData | null>(null);
+   *   private router = inject(Router);
+   *   private viewportScroller = inject(ViewportScroller);
+   *   private changeDetectorRef = inject(ChangeDetectorRef);
    *
-   *   constructor(private router: Router, private viewportScroller: ViewportScroller,
-   * changeDetectorRef: ChangeDetectorRef) {
-   *   router.events.pipe(filter((event: Event): event is Scroll => event instanceof Scroll)
+   *   constructor() {
+   *    this.router.events.pipe(filter((event: Event): event is Scroll => event instanceof Scroll)
    *     ).subscribe(e => {
    *       fetch('http://example.com/movies.json').then(response => {
-   *         this.movieData = response.json();
-   *         // update the template with the data before restoring scroll
-   *         changeDetectorRef.detectChanges();
+   *         this.movieData.set(response.json());
    *
    *         if (e.position) {
-   *           viewportScroller.scrollToPosition(e.position);
+   *           this.viewportScroller.scrollToPosition(e.position);
    *         }
    *       });
    *     });

--- a/packages/router/test/integration/integration.spec.ts
+++ b/packages/router/test/integration/integration.spec.ts
@@ -123,7 +123,6 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       @Component({
         selector: 'root-cmp',
         template: `<router-outlet></router-outlet>`,
-        changeDetection: ChangeDetectionStrategy.OnPush,
         standalone: false,
       })
       class OnPushOutlet {}

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -214,7 +214,6 @@ describe('Integration', () => {
             isActive: {{ rla.isActive }}
           </div>
         `,
-        changeDetection: ChangeDetectionStrategy.OnPush,
         standalone: false,
       })
       class OnPushComponent {}


### PR DESCRIPTION
OnPush is now the default change detection strategy, so the explicit test configuration is no longer needed. 
Also update router ts doc.
