### PR TITLE
test(core): fix view injector integration spec

### DIFF
--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -9,6 +9,7 @@
 import {expect} from '@angular/private/testing/matchers';
 import {
   Attribute,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   createComponent as coreCreateComponent,
@@ -247,6 +248,8 @@ class DirectiveNeedsChangeDetectorRef {
 @Component({
   selector: '[componentNeedsChangeDetectorRef]',
   template: '{{counter}}',
+  // Until #69898 lands we need to explicit OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
 class PushComponentNeedsChangeDetectorRef {


### PR DESCRIPTION
Restore ChangeDetectionStrategy.OnPush that was removed in a previous commit, causing tests to fail due to ExpressionChangedAfterItHasBeenCheckedError.
