### PR TITLE
test(core): restore OnPush change detection in view injector integrat…

### DIFF
--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -9,6 +9,7 @@
 import {expect} from '@angular/private/testing/matchers';
 import {
   Attribute,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   createComponent as coreCreateComponent,
@@ -247,6 +248,7 @@ class DirectiveNeedsChangeDetectorRef {
 @Component({
   selector: '[componentNeedsChangeDetectorRef]',
   template: '{{counter}}',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
 class PushComponentNeedsChangeDetectorRef {


### PR DESCRIPTION
…ion spec

In JIT/TestBed, components without an explicit change detection strategy default to Eager due to the @Component decorator definition. Restore explicit OnPush on PushComponentNeedsChangeDetectorRef to ensure the change detector ref tests pass.
