### PR TITLE
fix(compiler-cli): warn on uninvoked signals in @defer when triggers

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -17,6 +17,7 @@ import {
   PrefixNot,
   PropertyRead,
   TmplAstBoundAttribute,
+  TmplAstDeferredBlock,
   TmplAstElement,
   TmplAstIfBlock,
   TmplAstNode,
@@ -106,6 +107,19 @@ class InterpolatedSignalCheck extends TemplateCheckWithVisitor<ErrorCode.INTERPO
       if (expression instanceof PropertyRead) {
         return buildDiagnosticForSignal(ctx, expression, component);
       }
+    }
+    // defer blocks like `@defer (when mySignal) { ... }`
+    else if (node instanceof TmplAstDeferredBlock) {
+      return [node.triggers.when, node.prefetchTriggers.when, node.hydrateTriggers.when]
+        .filter((trigger): trigger is NonNullable<typeof trigger> => trigger !== undefined)
+        .flatMap((trigger) => {
+          const ast = trigger.value instanceof ASTWithSource ? trigger.value.ast : trigger.value;
+          const expression = ast instanceof PrefixNot ? ast.expression : ast;
+          if (expression instanceof PropertyRead) {
+            return buildDiagnosticForSignal(ctx, expression, component);
+          }
+          return [];
+        });
     }
 
     return [];

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/interpolated_signal_not_invoked_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/interpolated_signal_not_invoked_spec.ts
@@ -983,6 +983,127 @@ runInEachFileSystem(() => {
     expect(diags.length).toBe(0);
   });
 
+  it('should produce a warning when a signal is not invoked in a @defer when trigger', () => {
+    const fileName = absoluteFrom('/main.ts');
+    const {program, templateTypeChecker} = setup([
+      {
+        fileName,
+        templates: {
+          'TestCmp': `@defer (when mySignal) { <div>Show</div> }`,
+        },
+        source: `
+          import {signal} from '@angular/core';
+
+          export class TestCmp {
+            mySignal = signal(false);
+          }`,
+      },
+    ]);
+    const sf = getSourceFileOrError(program, fileName);
+    const component = getClass(sf, 'TestCmp');
+    const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+      templateTypeChecker,
+      program.getTypeChecker(),
+      [interpolatedSignalFactory],
+      {} /* options */,
+    );
+    const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+    expect(diags.length).toBe(1);
+    expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+    expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED));
+    expect(getSourceCodeForDiagnostic(diags[0])).toBe(`mySignal`);
+  });
+
+  it('should produce a warning when a signal is not invoked in a @defer prefetch when trigger', () => {
+    const fileName = absoluteFrom('/main.ts');
+    const {program, templateTypeChecker} = setup([
+      {
+        fileName,
+        templates: {
+          'TestCmp': `@defer (prefetch when mySignal) { <div>Show</div> }`,
+        },
+        source: `
+          import {signal} from '@angular/core';
+
+          export class TestCmp {
+            mySignal = signal(false);
+          }`,
+      },
+    ]);
+    const sf = getSourceFileOrError(program, fileName);
+    const component = getClass(sf, 'TestCmp');
+    const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+      templateTypeChecker,
+      program.getTypeChecker(),
+      [interpolatedSignalFactory],
+      {} /* options */,
+    );
+    const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+    expect(diags.length).toBe(1);
+    expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+    expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED));
+    expect(getSourceCodeForDiagnostic(diags[0])).toBe(`mySignal`);
+  });
+
+  it('should produce a warning when a signal is not invoked in a @defer hydrate when trigger', () => {
+    const fileName = absoluteFrom('/main.ts');
+    const {program, templateTypeChecker} = setup([
+      {
+        fileName,
+        templates: {
+          'TestCmp': `@defer (hydrate when mySignal) { <div>Show</div> }`,
+        },
+        source: `
+          import {signal} from '@angular/core';
+
+          export class TestCmp {
+            mySignal = signal(false);
+          }`,
+      },
+    ]);
+    const sf = getSourceFileOrError(program, fileName);
+    const component = getClass(sf, 'TestCmp');
+    const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+      templateTypeChecker,
+      program.getTypeChecker(),
+      [interpolatedSignalFactory],
+      {} /* options */,
+    );
+    const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+    expect(diags.length).toBe(1);
+    expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+    expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED));
+    expect(getSourceCodeForDiagnostic(diags[0])).toBe(`mySignal`);
+  });
+
+  it('should not produce a warning when a signal getter is invoked in a @defer when trigger', () => {
+    const fileName = absoluteFrom('/main.ts');
+    const {program, templateTypeChecker} = setup([
+      {
+        fileName,
+        templates: {
+          'TestCmp': `@defer (when mySignal()) { <div>Show</div> }`,
+        },
+        source: `
+          import {signal} from '@angular/core';
+
+          export class TestCmp {
+            mySignal = signal(false);
+          }`,
+      },
+    ]);
+    const sf = getSourceFileOrError(program, fileName);
+    const component = getClass(sf, 'TestCmp');
+    const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+      templateTypeChecker,
+      program.getTypeChecker(),
+      [interpolatedSignalFactory],
+      {} /* options */,
+    );
+    const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+    expect(diags.length).toBe(0);
+  });
+
   ['name', 'length', 'prototype', 'set', 'update', 'asReadonly'].forEach(
     (functionInstanceProperty) => {
       it(`should produce a warning when a property named '${functionInstanceProperty}' of a not invoked signal is used in interpolation`, () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

NG8109 already warns if you write a Signal without `()` in `{{ count }}`, `@if (count)`, and `@switch (count)`.

It stays quiet for `@defer (when count)`, `prefetch when count`, and `hydrate when count`. The checker does visit the `@defer` node, then hits `return []` because that case was never written.

A Signal is a function, so it is truthy. The defer block can sit there and never show up.

Issue Number: #70680

## What is the new behavior?

The same NG8109 check now looks at `@defer` `when` / `prefetch when` / `hydrate when`. If the expression is an uninvoked Signal (including `!count`), you get the same warning as `@if`.

Calling `count()` still does not warn.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Not the same as #70476 (that one only added `@let`).

Debugger walkthrough with screenshots is in #70680.