### PR TITLE
docs(forms): document what required() considers empty

### DIFF
--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -113,19 +113,19 @@ export class RegistrationComponent {
 A field is considered "empty" when its value is one of the following, and non-empty for every other
 value — including `0` and the empty array `[]`:
 
-| Condition                | Example     | Where it comes from                                    |
-| ------------------------ | ----------- | ------------------------------------------------------ |
-| Value is `null`          | `null`      | A cleared control, or a model initialized to `null`    |
-| Value is `undefined`     | `undefined` | A model property left unset (models should avoid this) |
-| Value is an empty string | `''`        | A blank `<input type="text">`                          |
-| Value is `false`         | `false`     | An unchecked `<input type="checkbox">`                 |
-| Value is `NaN`           | `NaN`       | A blank or unparseable `<input type="number">`         |
+| Condition                | Example     |
+| ------------------------ | ----------- |
+| Value is `null`          | `null`      |
+| Value is `undefined`     | `undefined` |
+| Value is an empty string | `''`        |
+| Value is `false`         | `false`     |
+| Value is `NaN`           | `NaN`       |
 
-IMPORTANT: `false` and `NaN` are empty because they are the values native controls produce when left
-blank. A blank `<input type="number">` binds `NaN`, so the field reports a `required` error rather
-than a number-specific one — [`min()`](#min-and-max) and [`max()`](#min-and-max) skip `NaN`
-entirely. If you want a blank number field to read as empty without relying on `NaN`, initialize the
-model to `null` instead of `0`; see [Designing your form model](guide/forms/signals/designing-your-form-model).
+The last two are worth calling out:
+
+- `false` is empty to follow the native semantics of `required` on `<input type="checkbox">`, where
+  an unchecked box fails validation.
+- `NaN` is empty because it is usually the result of a parsing error, and is not a valid number.
 
 For conditional requirements, use the `when` option:
 

--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -110,12 +110,22 @@ export class RegistrationComponent {
 }
 ```
 
-A field is considered "empty" when:
+A field is considered "empty" when its value is one of the following, and non-empty for every other
+value — including `0` and the empty array `[]`:
 
-| Condition                | Example |
-| ------------------------ | ------- |
-| Value is `null`          | `null`, |
-| Value is an empty string | `''`    |
+| Condition                | Example     | Where it comes from                                    |
+| ------------------------ | ----------- | ------------------------------------------------------ |
+| Value is `null`          | `null`      | A cleared control, or a model initialized to `null`    |
+| Value is `undefined`     | `undefined` | A model property left unset (models should avoid this) |
+| Value is an empty string | `''`        | A blank `<input type="text">`                          |
+| Value is `false`         | `false`     | An unchecked `<input type="checkbox">`                 |
+| Value is `NaN`           | `NaN`       | A blank or unparseable `<input type="number">`         |
+
+IMPORTANT: `false` and `NaN` are empty because they are the values native controls produce when left
+blank. A blank `<input type="number">` binds `NaN`, so the field reports a `required` error rather
+than a number-specific one — [`min()`](#min-and-max) and [`max()`](#min-and-max) skip `NaN`
+entirely. If you want a blank number field to read as empty without relying on `NaN`, initialize the
+model to `null` instead of `0`; see [Designing your form model](guide/forms/signals/designing-your-form-model).
 
 For conditional requirements, use the `when` option:
 
@@ -130,7 +140,7 @@ registrationForm = form(this.registrationModel, (schemaPath) => {
 
 The validation rule only runs when the `when` function returns `true`.
 
-Note: `required` treats an empty array as present (valid), so use [`minLength()`](#minlength-and-maxlength) to enforce a minimum number of array items; it treats `false` as missing (invalid), matching `<input type="checkbox" required>`.
+Note: `required` treats an empty array as present (valid), so use [`minLength()`](#minlength-and-maxlength) to enforce a minimum number of array items.
 
 ### email()
 
@@ -505,9 +515,7 @@ interface User {
   lastName: string;
 }
 
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class UserFormComponent {
   readonly userModel = model<User>({
     firstName: '',
@@ -750,9 +758,7 @@ import {Component, computed, signal} from '@angular/core';
 import {form, FormField, validateStandardSchema} from '@angular/forms/signals';
 import z from 'zod';
 
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class DynamicSchema {
   model = signal({document: '', type: 'dni'});
 

--- a/packages/forms/signals/src/api/rules/validation/required.ts
+++ b/packages/forms/signals/src/api/rules/validation/required.ts
@@ -17,6 +17,16 @@ import {requiredError} from './validation_errors';
  * This function can only be called on any type of path.
  * In addition to binding a validator, this function adds `REQUIRED` property to the field.
  *
+ * A value is considered empty when it is `null`, `undefined`, the empty string `''`, `false`, or
+ * `NaN`. Every other value is considered non-empty, including `0` and the empty array `[]` — use
+ * [`minLength()`](api/forms/signals/minLength) to require a minimum number of items in an array.
+ *
+ * `false` and `NaN` are empty because they are the values native controls produce when left blank:
+ * an unchecked `<input type="checkbox">` binds `false`, and a blank or unparseable
+ * `<input type="number">` binds `NaN`. A blank number input therefore reports a `required` error
+ * rather than a number-specific one, since [`min()`](api/forms/signals/min) and
+ * [`max()`](api/forms/signals/max) skip `NaN`.
+ *
  * @param path Path of the field to validate
  * @param config Optional, allows providing any of the following options:
  *  - `message`: A user-facing message for the error.

--- a/packages/forms/signals/src/api/rules/validation/required.ts
+++ b/packages/forms/signals/src/api/rules/validation/required.ts
@@ -21,11 +21,9 @@ import {requiredError} from './validation_errors';
  * `NaN`. Every other value is considered non-empty, including `0` and the empty array `[]` — use
  * [`minLength()`](api/forms/signals/minLength) to require a minimum number of items in an array.
  *
- * `false` and `NaN` are empty because they are the values native controls produce when left blank:
- * an unchecked `<input type="checkbox">` binds `false`, and a blank or unparseable
- * `<input type="number">` binds `NaN`. A blank number input therefore reports a `required` error
- * rather than a number-specific one, since [`min()`](api/forms/signals/min) and
- * [`max()`](api/forms/signals/max) skip `NaN`.
+ * `false` is empty to follow the native semantics of `required` on `<input type="checkbox">`, where
+ * an unchecked box fails validation. `NaN` is empty because it is usually the result of a parsing
+ * error, and is not a valid number.
  *
  * @param path Path of the field to validate
  * @param config Optional, allows providing any of the following options:

--- a/packages/forms/signals/test/node/api/validators/required.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/required.spec.ts
@@ -12,6 +12,59 @@ import {form, required} from '../../../../public_api';
 import {requiredError} from '../../../../src/api/rules/validation/validation_errors';
 
 describe('required validator', () => {
+  // Documented on `required()` and in guide/forms/signals/validation#required. `false` and `NaN`
+  // are empty because they are what native controls bind when left blank: an unchecked
+  // `<input type="checkbox">` binds `false`, and a blank `<input type="number">` binds `NaN`.
+  describe('emptiness', () => {
+    it('treats null, empty string, false and NaN as empty', () => {
+      const model = signal<{
+        nullable: string | null;
+        text: string;
+        checkbox: boolean;
+        num: number;
+      }>({nullable: null, text: '', checkbox: false, num: Number.NaN});
+      const f = form(
+        model,
+        (p) => {
+          required(p.nullable);
+          required(p.text);
+          required(p.checkbox);
+          required(p.num);
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      expect(f.nullable().errors()).toEqual([requiredError({fieldTree: f.nullable})]);
+      expect(f.text().errors()).toEqual([requiredError({fieldTree: f.text})]);
+      expect(f.checkbox().errors()).toEqual([requiredError({fieldTree: f.checkbox})]);
+      expect(f.num().errors()).toEqual([requiredError({fieldTree: f.num})]);
+    });
+
+    it('treats 0, an empty array and other filled values as non-empty', () => {
+      const model = signal<{
+        zero: number;
+        list: string[];
+        checkbox: boolean;
+        text: string;
+      }>({zero: 0, list: [], checkbox: true, text: 'a'});
+      const f = form(
+        model,
+        (p) => {
+          required(p.zero);
+          required(p.list);
+          required(p.checkbox);
+          required(p.text);
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      expect(f.zero().errors()).toEqual([]);
+      expect(f.list().errors()).toEqual([]);
+      expect(f.checkbox().errors()).toEqual([]);
+      expect(f.text().errors()).toEqual([]);
+    });
+  });
+
   it('returns required Error when the value is not present', () => {
     const cat = signal({name: ''});
     const f = form(

--- a/packages/forms/signals/test/node/api/validators/required.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/required.spec.ts
@@ -12,9 +12,8 @@ import {form, required} from '../../../../public_api';
 import {requiredError} from '../../../../src/api/rules/validation/validation_errors';
 
 describe('required validator', () => {
-  // Documented on `required()` and in guide/forms/signals/validation#required. `false` and `NaN`
-  // are empty because they are what native controls bind when left blank: an unchecked
-  // `<input type="checkbox">` binds `false`, and a blank `<input type="number">` binds `NaN`.
+  // Documented on `required()` and in guide/forms/signals/validation#required. `false` follows the
+  // native semantics of `required` on `<input type="checkbox">`; `NaN` is not a valid number.
   describe('emptiness', () => {
     it('treats null, empty string, false and NaN as empty', () => {
       const model = signal<{


### PR DESCRIPTION
The `required()` validator treats `null`, `undefined`, `''`, `false` and `NaN` as empty, but the API docs never defined "empty" at all and the validation guide listed only `null` and `''`.

`false` and `NaN` are the surprising ones, and they are not arbitrary: they are what native controls bind when left blank. An unchecked `<input type="checkbox">` binds `false`, and a blank or unparseable `<input type="number">` binds `NaN` via `valueAsNumber`. Since `min()` and `max()` deliberately skip `NaN`, a blank number field reports a `required` error rather than a number-specific one, which is easy to mistake for a bug.

Document the full set on both `required()` and the validation guide, note where each empty value comes from, and add specs pinning the contract so the docs cannot silently drift from `isEmpty()`.

Fixes: #70676

Issue Number: #70676