### PR TITLE
fix(devtools): sync settings after reconnecting

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/BUILD.bazel
@@ -50,6 +50,7 @@ ts_test_library(
         "//:node_modules/tslib",
         "//devtools/projects/ng-devtools/src/lib/application-providers:app_data",
         "//devtools/projects/ng-devtools/src/lib/application-services:frame_manager",
+        "//devtools/projects/ng-devtools/src/lib/application-services:settings",
         "//devtools/projects/ng-devtools/src/lib/application-services/test-utils:settings_mock",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs",
         "//devtools/projects/protocol",

--- a/devtools/projects/ng-devtools/src/lib/devtools.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.spec.ts
@@ -14,6 +14,7 @@ import {DevToolsTabsComponent} from './devtools-tabs/devtools-tabs.component';
 import {MessageBus} from '../../../protocol';
 import {SETTINGS_MOCK} from './application-services/test-utils/settings_mock';
 import {APP_DATA, AppData} from './application-providers/app_data';
+import {Settings} from './application-services/settings';
 
 @Component({
   selector: 'ng-devtools-tabs',
@@ -21,8 +22,15 @@ import {APP_DATA, AppData} from './application-providers/app_data';
 })
 export class MockNgDevToolsTabs {}
 
-async function configureTestingModule(appData?: Partial<AppData>) {
+async function configureTestingModule(
+  appData?: Partial<AppData>,
+  configureSettings?: (settings: Settings) => void,
+) {
   const mockMessageBus = jasmine.createSpyObj('MessageBus', ['on', 'emit', 'once']);
+  const topicToCallback: {[topic: string]: Function} = {};
+  mockMessageBus.on.and.callFake((topic: string, cb: Function) => {
+    topicToCallback[topic] = cb;
+  });
 
   TestBed.configureTestingModule({
     providers: [
@@ -50,6 +58,8 @@ async function configureTestingModule(appData?: Partial<AppData>) {
     },
   });
 
+  configureSettings?.(TestBed.inject(Settings));
+
   const fixture = TestBed.createComponent(DevToolsComponent);
   const component = fixture.componentInstance;
 
@@ -58,6 +68,8 @@ async function configureTestingModule(appData?: Partial<AppData>) {
   return {
     fixture,
     component,
+    mockMessageBus,
+    topicToCallback,
   };
 }
 
@@ -124,4 +136,27 @@ describe('DevtoolsComponent', () => {
 
     expect(fixture.nativeElement.querySelector('.loading svg')).toBeTruthy();
   });
+
+  const backendSettings = [
+    ['performanceTrack', 'enablePerformanceTrack'],
+    ['showHydrationOverlays', 'enableHydrationOverlays'],
+    ['highlightChangeDetection', 'enableCdHighlighting'],
+    ['showCdInExplorer', 'enableCdDataStream'],
+  ] as const;
+
+  for (const [settingName, enableEvent] of backendSettings) {
+    it(`should synchronize the persisted ${settingName} setting after a frame connects`, async () => {
+      const {fixture, mockMessageBus, topicToCallback} = await configureTestingModule(
+        undefined,
+        (settings) => settings[settingName].set(true),
+      );
+      mockMessageBus.emit.calls.reset();
+
+      topicToCallback['contentScriptConnected'](0, 'name', 'http://localhost:4200/');
+      topicToCallback['frameConnected'](0);
+      await fixture.whenStable();
+
+      expect(mockMessageBus.emit).toHaveBeenCalledWith(enableEvent);
+    });
+  }
 });

--- a/devtools/projects/ng-devtools/src/lib/devtools.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.ts
@@ -117,6 +117,8 @@ export class DevToolsComponent implements OnDestroy {
   private syncBackendWithSettings() {
     // Keep BE in sync with the performance track setting.
     effect(() => {
+      if (!this.frameManager.selectedFrame()) return;
+
       if (this.settings.performanceTrack()) {
         this.messageBus.emit('enablePerformanceTrack');
       } else {
@@ -126,6 +128,8 @@ export class DevToolsComponent implements OnDestroy {
 
     // Keep BE in sync with hydration visualization.
     effect(() => {
+      if (!this.frameManager.selectedFrame()) return;
+
       if (this.settings.showHydrationOverlays()) {
         this.messageBus.emit('enableHydrationOverlays');
       } else {
@@ -134,6 +138,8 @@ export class DevToolsComponent implements OnDestroy {
     });
 
     effect(() => {
+      if (!this.frameManager.selectedFrame()) return;
+
       if (this.settings.highlightChangeDetection()) {
         this.messageBus.emit('enableCdHighlighting');
       } else {
@@ -142,6 +148,8 @@ export class DevToolsComponent implements OnDestroy {
     });
 
     effect(() => {
+      if (!this.frameManager.selectedFrame()) return;
+
       if (this.settings.showCdInExplorer()) {
         this.messageBus.emit('enableCdDataStream');
       } else {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue: #70683

## What is the new behavior?

Replay persisted backend settings whenever the inspected frame reconnects.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
