### PR TITLE
docs: stop the disabled aria toolbar radio group from changing selection

### DIFF
--- a/adev/src/content/examples/aria/toolbar/src/disabled/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/disabled/app/app.html
@@ -84,7 +84,6 @@
       aria-label="align left"
       class="material-symbols-outlined"
       [attr.aria-checked]="alignment() === 'left'"
-      (click)="alignment.set('left')"
       translate="no"
     >
       format_align_left
@@ -98,7 +97,6 @@
       aria-label="align center"
       class="material-symbols-outlined"
       [attr.aria-checked]="alignment() === 'center'"
-      (click)="alignment.set('center')"
       translate="no"
     >
       format_align_center
@@ -112,7 +110,6 @@
       aria-label="align right"
       class="material-symbols-outlined"
       [attr.aria-checked]="alignment() === 'right'"
-      (click)="alignment.set('right')"
       translate="no"
     >
       format_align_right

--- a/adev/src/content/examples/aria/toolbar/src/disabled/material/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/disabled/material/app/app.html
@@ -84,7 +84,6 @@
       aria-label="align left"
       class="material-symbols-outlined"
       [attr.aria-checked]="alignment() === 'left'"
-      (click)="alignment.set('left')"
       translate="no"
     >
       format_align_left
@@ -98,7 +97,6 @@
       aria-label="align center"
       class="material-symbols-outlined"
       [attr.aria-checked]="alignment() === 'center'"
-      (click)="alignment.set('center')"
       translate="no"
     >
       format_align_center
@@ -112,7 +110,6 @@
       aria-label="align right"
       class="material-symbols-outlined"
       [attr.aria-checked]="alignment() === 'right'"
-      (click)="alignment.set('right')"
       translate="no"
     >
       format_align_right

--- a/adev/src/content/examples/aria/toolbar/src/disabled/retro/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/disabled/retro/app/app.html
@@ -84,7 +84,6 @@
       aria-label="align left"
       class="material-symbols-outlined"
       [attr.aria-checked]="alignment() === 'left'"
-      (click)="alignment.set('left')"
       translate="no"
     >
       format_align_left
@@ -98,7 +97,6 @@
       aria-label="align center"
       class="material-symbols-outlined"
       [attr.aria-checked]="alignment() === 'center'"
-      (click)="alignment.set('center')"
       translate="no"
     >
       format_align_center
@@ -112,7 +110,6 @@
       aria-label="align right"
       class="material-symbols-outlined"
       [attr.aria-checked]="alignment() === 'right'"
-      (click)="alignment.set('right')"
       translate="no"
     >
       format_align_right


### PR DESCRIPTION
On next.angular.dev/guide/aria/toolbar#disabled-widgets the alignment buttons
are disabled, but clicking one still selects it. #70516 added a click handler to
each radio when it moved selection into the app, and soft-disabled widgets stay
clickable, so nothing stops it. This drops the three handlers from the disabled
group, like the disabled redo button next to it.


https://next.angular.dev/guide/aria/toolbar#disabled-widgets

Before: 
(clicking "align right" selects it even though the group is disabled):

<img width="912" height="541" alt="Screenshot 2026-09-11 at 12 55 46" src="https://github.com/user-attachments/assets/e09464b6-2b7a-438d-ab3c-c10c10935ffc" />

After: 
(focus moves, selection stays on "align left"):

<img width="924" height="517" alt="Screenshot 2026-09-11 at 12 55 34" src="https://github.com/user-attachments/assets/322773d9-0c84-4457-9f13-8c85ccdc4b69" />
