### PR TITLE
docs: import bootstrapApplication from platform-browser in the CSP example

### DIFF
--- a/adev/src/content/guide/security.md
+++ b/adev/src/content/guide/security.md
@@ -155,7 +155,8 @@ You can set the nonce for Angular in one of the following ways:
 1. Provide the nonce using the `CSP_NONCE` injection token. Use this approach if you have access to the nonce at runtime and you want to be able to cache the `index.html`.
 
 ```ts
-import {bootstrapApplication, CSP_NONCE} from '@angular/core';
+import {CSP_NONCE} from '@angular/core';
+import {bootstrapApplication} from '@angular/platform-browser';
 import {AppComponent} from './app/app.component';
 
 bootstrapApplication(AppComponent, {


### PR DESCRIPTION
The CSP nonce example on angular.dev/guide/security imports bootstrapApplication from @angular/core, which doesn't export it, so copying the snippet fails to compile. It lives in @angular/platform-browser, like every other example in the docs uses. CSP_NONCE stays on @angular/core.