### PR TITLE
docs: fix the broken housing location template in the first-app tutorial

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing-location/housing-location.ts
@@ -13,7 +13,7 @@ import {RouterLink} from '@angular/router';
         alt="Exterior photo of {{ housingLocation().name }}"
         crossorigin
       />
-      <h2 class="listing-heading">{{ housingLocatio()).name }}</h2>
+      <h2 class="listing-heading">{{ housingLocation().name }}</h2>
       <p class="listing-location">{{ housingLocation().city }}, {{ housingLocation().state }}</p>
     </section>
   `,


### PR DESCRIPTION
Step 11 of the first-app tutorial doesn't compile: housing-location.ts has {{ housingLocatio()).name }}. Typo from the signal inputs migration (#61686). Fixed to housingLocation().name.
