### PR TITLE
fix(devtools): make tab buttons visually accessible on small viewports

### DIFF
--- a/devtools/cypress/integration/node-selection.e2e.js
+++ b/devtools/cypress/integration/node-selection.e2e.js
@@ -82,8 +82,8 @@ describe('node selection', () => {
         .last()
         .click({force: true})
         .then(() => {
-          cy.get('ng-breadcrumbs')
-            .find('.breadcrumbs')
+          cy.get('ng-breadcrumbs > ng-horizontal-scroller')
+            .find('.content')
             .then((breadcrumbsContainer) => {
               const hasOverflowX = () =>
                 breadcrumbsContainer[0].scrollWidth > breadcrumbsContainer[0].clientWidth;
@@ -98,8 +98,8 @@ describe('node selection', () => {
         .last()
         .click({force: true})
         .then(() => {
-          cy.get('ng-breadcrumbs')
-            .find('.breadcrumbs')
+          cy.get('ng-breadcrumbs > ng-horizontal-scroller')
+            .find('.content')
             .then((el) => {
               el[0].style.scrollBehavior = 'auto';
             })
@@ -107,7 +107,7 @@ describe('node selection', () => {
               const scrollLeft = () => breadcrumbsContainer[0].scrollLeft;
               expect(scrollLeft()).to.eql(0);
 
-              cy.get('ng-breadcrumbs')
+              cy.get('ng-breadcrumbs > ng-horizontal-scroller')
                 .find('.scroll-button')
                 .last()
                 .click({force: true})
@@ -124,8 +124,8 @@ describe('node selection', () => {
         .last()
         .click({force: true})
         .then(() => {
-          cy.get('ng-breadcrumbs')
-            .find('.breadcrumbs')
+          cy.get('ng-breadcrumbs > ng-horizontal-scroller')
+            .find('.content')
             .then((el) => {
               el[0].style.scrollBehavior = 'auto';
             })
@@ -133,14 +133,14 @@ describe('node selection', () => {
               const scrollLeft = () => breadcrumbsContainer[0].scrollLeft;
               expect(scrollLeft()).to.eql(0);
 
-              cy.get('ng-breadcrumbs')
+              cy.get('ng-breadcrumbs > ng-horizontal-scroller')
                 .find('.scroll-button')
                 .last()
                 .click({force: true})
                 .then(() => {
                   expect(scrollLeft()).to.be.greaterThan(0);
 
-                  cy.get('ng-breadcrumbs')
+                  cy.get('ng-breadcrumbs > ng-horizontal-scroller')
                     .find('.scroll-button')
                     .first()
                     .click({force: true})

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/BUILD.bazel
@@ -20,11 +20,9 @@ ng_project(
         ":devtools_tabs_component_styles",
     ],
     deps = [
-        "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/material",
         "//:node_modules/@types/chrome",
-        "//:node_modules/rxjs",
         "//devtools/projects/ng-devtools/src/lib/application-environment",
         "//devtools/projects/ng-devtools/src/lib/application-providers:app_data",
         "//devtools/projects/ng-devtools/src/lib/application-providers:deep_link",
@@ -39,6 +37,7 @@ ng_project(
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/tab-update",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state",
         "//devtools/projects/ng-devtools/src/lib/shared/button",
+        "//devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller",
         "//devtools/projects/protocol",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
@@ -34,19 +34,21 @@
     }
   </select>
 
-  <nav
-    mat-tab-nav-bar
-    mat-stretch-tabs="false"
-    [disablePagination]="true"
-    [color]="'accent'"
-    [tabPanel]="tabPanel"
-  >
-    @for (tab of tabs(); track $index) {
-      <a class="tab-link" mat-tab-link (click)="changeTab(tab)" [active]="activeTab() === tab">
-        {{ tab }}
-      </a>
-    }
-  </nav>
+  <ng-horizontal-scroller [scrollStep]="150" buttonHidingStrategy="display-none">
+    <nav
+      mat-tab-nav-bar
+      mat-stretch-tabs="false"
+      [disablePagination]="true"
+      [color]="'accent'"
+      [tabPanel]="tabPanel"
+    >
+      @for (tab of tabs(); track $index) {
+        <a class="tab-link" mat-tab-link (click)="changeTab(tab)" [active]="activeTab() === tab">
+          {{ tab }}
+        </a>
+      }
+    </nav>
+  </ng-horizontal-scroller>
 
   <div class="settings">
     <div class="ver-ruler"></div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
@@ -63,7 +63,13 @@ $toolbar-height: 30px;
 
     .frame-selector {
       width: 100px;
+      flex: 0 0 100px;
       margin: 0 0.5rem;
+    }
+
+    ng-horizontal-scroller {
+      --horizontal-scroller-height: #{$toolbar-height};
+      flex: 1;
     }
 
     .tab-link {
@@ -74,7 +80,6 @@ $toolbar-height: 30px;
     }
 
     .settings {
-      flex: 1;
       display: flex;
       justify-content: end;
       align-items: center;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -35,6 +35,7 @@ import {SUPPORTED_APIS} from '../application-providers/supported_apis';
 import {ButtonComponent} from '../shared/button/button.component';
 import {APP_DATA} from '../application-providers/app_data';
 import {SettingsComponent} from './settings/settings.component';
+import {HorizontalScrollerComponent} from '../shared/horizontal-scroller/horizontal-scroller.component';
 
 type Tab = 'Components' | 'Profiler' | 'Router Tree' | 'Injector Tree' | 'Transfer State';
 
@@ -58,6 +59,7 @@ type Tab = 'Components' | 'Profiler' | 'Router Tree' | 'Injector Tree' | 'Transf
     TransferStateComponent,
     SettingsComponent,
     ButtonComponent,
+    HorizontalScrollerComponent,
   ],
   providers: [TabUpdate],
   host: {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/BUILD.bazel
@@ -20,11 +20,8 @@ ng_project(
         ":breadcrumbs_component_styles",
     ],
     deps = [
-        "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
-        "//:node_modules/@angular/material",
-        "//:node_modules/rxjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source",
-        "//devtools/projects/ng-devtools/src/lib/shared/utils",
+        "//devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.html
@@ -1,12 +1,4 @@
-<button
-  class="scroll-button"
-  [class.hidden]="!showScrollLeftButton()"
-  (click)="scroll(-100)"
-  aria-label="Scroll left"
->
-  <mat-icon> chevron_left </mat-icon>
-</button>
-<div class="breadcrumbs" #breadcrumbs (scroll)="updateScrollButtonVisibility()">
+<ng-horizontal-scroller #scroller>
   @for (node of parents(); track $index) {
     <button
       (mouseover)="mouseOverNode.emit(node)"
@@ -19,12 +11,4 @@
       {{ node.original.component?.name || node.original.tagName }}
     </button>
   }
-</div>
-<button
-  class="scroll-button"
-  [class.hidden]="!showScrollRightButton()"
-  (click)="scroll(100)"
-  aria-label="Scroll right"
->
-  <mat-icon> chevron_right </mat-icon>
-</button>
+</ng-horizontal-scroller>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.scss
@@ -1,62 +1,23 @@
 @use '../../../../../styles/typography';
 
 :host {
-  width: 100%;
-  height: 24px;
-  display: flex;
-  flex-direction: row;
-  box-sizing: border-box;
+  display: block;
 
-  .scroll-button {
-    height: 100%;
-    background-color: var(--septenary-contrast);
+  .breadcrumb {
+    @extend %monospaced;
+    background-color: transparent;
+    color: var(--color-tree-node-element-name);
+    padding-inline: 0.5rem;
     border: none;
-    cursor: pointer;
-    color: var(--tertiary-contrast);
-    display: flex;
-    align-items: center;
-
-    &.hidden {
-      visibility: hidden;
-    }
-
-    mat-icon {
-      font-size: 16px;
-      width: 16px;
-      height: 16px;
-    }
-  }
-
-  .breadcrumbs {
-    overflow-x: auto;
-    overflow-y: hidden;
-    white-space: nowrap;
-    display: inline-block;
     height: 100%;
-    scroll-behavior: smooth;
-    scrollbar-width: none;
-    flex: 1;
+    cursor: pointer;
 
-    &::-webkit-scrollbar {
-      display: none;
+    &:hover {
+      background-color: var(--color-tree-node-hovered);
     }
 
-    .breadcrumb {
-      @extend %monospaced;
-      background-color: transparent;
-      color: var(--color-tree-node-element-name);
-      padding-inline: 0.5rem;
-      border: none;
-      height: 100%;
-      cursor: pointer;
-
-      &:hover {
-        background-color: var(--color-tree-node-hovered);
-      }
-
-      &.selected {
-        background-color: var(--color-tree-node-highlighted);
-      }
+    &.selected {
+      background-color: var(--color-tree-node-highlighted);
     }
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.ts
@@ -6,97 +6,33 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  afterNextRender,
-  afterRenderEffect,
-  Component,
-  computed,
-  DestroyRef,
-  ElementRef,
-  input,
-  output,
-  signal,
-  untracked,
-  viewChild,
-} from '@angular/core';
-import {MatIcon} from '@angular/material/icon';
+import {afterRenderEffect, Component, input, output, untracked, viewChild} from '@angular/core';
 
 import {FlatNode} from '../component-data-source';
-import {Debouncer} from '../../../../shared/utils/debouncer';
-
-const RESIZE_DEBOUNCE = 100;
+import {HorizontalScrollerComponent} from '../../../../shared/horizontal-scroller/horizontal-scroller.component';
 
 @Component({
   selector: 'ng-breadcrumbs',
   templateUrl: './breadcrumbs.component.html',
   styleUrls: ['./breadcrumbs.component.scss'],
-  imports: [MatIcon],
+  imports: [HorizontalScrollerComponent],
 })
 export class BreadcrumbsComponent {
-  readonly parents = input.required<FlatNode[]>();
-  readonly handleSelect = output<FlatNode>();
-  readonly mouseOverNode = output<FlatNode>();
-  readonly mouseLeaveNode = output<FlatNode>();
+  protected readonly scoller = viewChild<HorizontalScrollerComponent>('scroller');
 
-  readonly breadcrumbsScrollContent = viewChild.required<ElementRef>('breadcrumbs');
+  protected readonly parents = input.required<FlatNode[]>();
+  protected readonly handleSelect = output<FlatNode>();
+  protected readonly mouseOverNode = output<FlatNode>();
+  protected readonly mouseLeaveNode = output<FlatNode>();
 
-  readonly showScrollLeftButton = computed(() => {
-    const value = this.breadcrumbsScrollLayout();
-    return value && value.scrollLeft > 0;
-  });
-
-  readonly showScrollRightButton = computed(() => {
-    const value = this.breadcrumbsScrollLayout();
-    if (!value) {
-      return false;
-    }
-    const {clientWidth, scrollWidth, scrollLeft} = value;
-    return scrollWidth > clientWidth && scrollLeft + clientWidth < scrollWidth;
-  });
-
-  private readonly breadcrumbsScrollLayout = signal<
-    | {
-        clientWidth: number;
-        scrollWidth: number;
-        scrollLeft: number;
-      }
-    | undefined
-  >(undefined);
-
-  constructor(destroyRef: DestroyRef) {
-    const debouncer = new Debouncer();
-    const observer = new ResizeObserver(
-      debouncer.debounce(() => {
-        this.updateScrollButtonVisibility();
-      }, RESIZE_DEBOUNCE),
-    );
-
-    afterNextRender(() => {
-      observer.observe(this.breadcrumbsScrollContent().nativeElement);
-    });
-
+  constructor() {
     afterRenderEffect({
       read: () => {
         // We use the parents as a dependency to trigger a layout
         // update that would show the navigation buttons.
         this.parents();
-        untracked(() => this.updateScrollButtonVisibility());
+        untracked(() => this.scoller()?.updateScrollButtonVisibility());
       },
     });
-
-    destroyRef.onDestroy(() => {
-      debouncer.cancel();
-      observer.disconnect();
-    });
-  }
-
-  scroll(pixels: number): void {
-    this.breadcrumbsScrollContent().nativeElement.scrollLeft += pixels;
-    this.updateScrollButtonVisibility();
-  }
-
-  updateScrollButtonVisibility(): void {
-    const {clientWidth, scrollWidth, scrollLeft} = this.breadcrumbsScrollContent().nativeElement;
-    this.breadcrumbsScrollLayout.set({clientWidth, scrollWidth, scrollLeft});
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary")
+
+package(default_visibility = ["//devtools:__subpackages__"])
+
+sass_binary(
+    name = "horizontal-scroller_component_styles",
+    src = "horizontal-scroller.component.scss",
+)
+
+ng_project(
+    name = "horizontal-scroller",
+    srcs = [
+        "horizontal-scroller.component.ts",
+    ],
+    angular_assets = [
+        "horizontal-scroller.component.html",
+        ":horizontal-scroller_component_styles",
+    ],
+    deps = [
+        "//:node_modules/@angular/core",
+        "//:node_modules/@angular/material",
+        "//devtools/projects/ng-devtools/src/lib/shared/utils",
+    ],
+)

--- a/devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller/horizontal-scroller.component.html
+++ b/devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller/horizontal-scroller.component.html
@@ -1,0 +1,21 @@
+<button
+  class="scroll-button"
+  [class]="[!showScrollLeftButton() ? buttonHidingStrategy() : null]"
+  (click)="scroll(-this.scrollStep())"
+  aria-label="Scroll left"
+>
+  <mat-icon> chevron_left </mat-icon>
+</button>
+<div class="content" #content (scroll)="updateScrollButtonVisibility()">
+  <div class="content-inner">
+    <ng-content></ng-content>
+  </div>
+</div>
+<button
+  class="scroll-button"
+  [class]="[!showScrollRightButton() ? buttonHidingStrategy() : null]"
+  (click)="scroll(this.scrollStep())"
+  aria-label="Scroll right"
+>
+  <mat-icon> chevron_right </mat-icon>
+</button>

--- a/devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller/horizontal-scroller.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller/horizontal-scroller.component.scss
@@ -1,0 +1,54 @@
+:host {
+  width: 100%;
+  height: var(--horizontal-scroller-height, 24px);
+  display: flex;
+  flex-direction: row;
+  box-sizing: border-box;
+  overflow-x: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  .content {
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+    height: 100%;
+    scroll-behavior: smooth;
+    scrollbar-width: none;
+    flex: 1;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    .content-inner {
+      min-width: max-content;
+    }
+  }
+
+  .scroll-button {
+    height: 100%;
+    background-color: var(--septenary-contrast);
+    border: none;
+    cursor: pointer;
+    color: var(--tertiary-contrast);
+    display: flex;
+    align-items: center;
+
+    &.hidden {
+      visibility: hidden;
+    }
+
+    &.display-none {
+      display: none;
+    }
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+    }
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller/horizontal-scroller.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/horizontal-scroller/horizontal-scroller.component.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  afterNextRender,
+  Component,
+  computed,
+  DestroyRef,
+  ElementRef,
+  input,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {MatIcon} from '@angular/material/icon';
+import {Debouncer} from '../utils/debouncer';
+
+const RESIZE_DEBOUNCE = 100;
+const DEFAULT_SCROLL_STEP = 100; // in pixels
+
+interface ScrollLayout {
+  clientWidth: number;
+  scrollWidth: number;
+  scrollLeft: number;
+}
+
+/**
+ * Horizontal scroller with scroll arrows.
+ *
+ * Use `--horizontal-scroller-height` CSS var to adjust the height.
+ * Default: `24px`
+ */
+@Component({
+  selector: 'ng-horizontal-scroller',
+  templateUrl: './horizontal-scroller.component.html',
+  styleUrls: ['./horizontal-scroller.component.scss'],
+  imports: [MatIcon],
+})
+export class HorizontalScrollerComponent {
+  readonly scrollContent = viewChild.required<ElementRef>('content');
+
+  /** The scroll step size in pixels. Default: `100` */
+  readonly scrollStep = input<number>(DEFAULT_SCROLL_STEP);
+
+  /**
+   * Select the scroll buttons behavior when they are not visible:
+   * - `hidden` (default) – buttons take up space but are invisible/hidden
+   * - `display-none` – buttons are completely removed from the viewport
+   */
+  readonly buttonHidingStrategy = input<'hidden' | 'display-none'>('hidden');
+
+  protected readonly showScrollLeftButton = computed(() => {
+    const value = this.scrollLayout();
+    return value && value.scrollLeft > 0;
+  });
+
+  protected readonly showScrollRightButton = computed(() => {
+    const value = this.scrollLayout();
+    if (!value) {
+      return false;
+    }
+    const {clientWidth, scrollWidth, scrollLeft} = value;
+    return scrollWidth > scrollLeft + clientWidth;
+  });
+
+  private readonly scrollLayout = signal<ScrollLayout | undefined>(undefined);
+
+  constructor(destroyRef: DestroyRef) {
+    const debouncer = new Debouncer();
+    const observer = new ResizeObserver(
+      debouncer.debounce(() => {
+        this.updateScrollButtonVisibility();
+      }, RESIZE_DEBOUNCE),
+    );
+
+    afterNextRender(() => {
+      observer.observe(this.scrollContent().nativeElement);
+    });
+
+    destroyRef.onDestroy(() => {
+      debouncer.cancel();
+      observer.disconnect();
+    });
+  }
+
+  scroll(pixels: number): void {
+    this.scrollContent().nativeElement.scrollLeft += pixels;
+    this.updateScrollButtonVisibility();
+  }
+
+  updateScrollButtonVisibility(): void {
+    const {clientWidth, scrollWidth, scrollLeft} = this.scrollContent().nativeElement;
+
+    // Sometimes the values can be decimal numbers,
+    // like `scrollLeft` being always -0.5 off the total
+    // scroll width. This is why, we round up the values.
+    this.scrollLayout.set({
+      clientWidth: Math.ceil(clientWidth),
+      scrollWidth: Math.ceil(scrollWidth),
+      scrollLeft: Math.ceil(scrollLeft),
+    });
+  }
+}


### PR DESCRIPTION
Reuse breadcrumbs scroll behavior (in the form of a reusable component) for the main tabs bar.

<img width="447" height="137" alt="Screenshot 2026-09-11 at 13 31 13" src="https://github.com/user-attachments/assets/c1742824-e27c-4e7b-a131-9e4da7b56eee" />
