### PR TITLE
fix(docs-infra): raise SSR fetch limit so the menubar guide prerenders

### DIFF
--- a/adev/src/app/app.config.server.ts
+++ b/adev/src/app/app.config.server.ts
@@ -13,7 +13,7 @@ import {appConfig} from './app.config';
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(
-      {maxResponseBodySize: 2 * 1024 * 1024},
+      {maxResponseBodySize: 4 * 1024 * 1024},
       withRoutes([{path: '**', renderMode: RenderMode.Prerender}]),
     ),
   ],


### PR DESCRIPTION
https://angular.dev/guide/aria/menubar

https://github.com/user-attachments/assets/26bfe3e7-2a98-4fd7-8172-769d585de243

Opening https://angular.dev/guide/aria/menubar in a new tab, or refreshing it, lands on the 404 page. Clicking Menubar in the sidebar works, because the content is fetched in the browser. A direct load gets the prerendered HTML instead, and that was saved as a /404 redirect. The menubar content is 2.9 MB, over the 2 MiB SSR fetch limit set in #69379, so the fetch failed during prerender and the navigation error handler redirected. This raises the limit to 4 MiB. Locally, all 1598 prerendered pages now build with no 404 redirects.


