### PR TITLE
refactor(compiler): remove write-only collections from template pipeline phases

### DIFF
--- a/packages/compiler/src/template/pipeline/src/phases/slot_allocation.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/slot_allocation.ts
@@ -18,12 +18,6 @@ import type {ComponentCompilationJob} from '../compilation';
  * and propagating that number into the `Template` operations which declare embedded views.
  */
 export function allocateSlots(job: ComponentCompilationJob): void {
-  // Map of all declarations in all views within the component which require an assigned slot index.
-  // This map needs to be global (across all views within the component) since it's possible to
-  // reference a slot from one view from an expression within another (e.g. local references work
-  // this way).
-  const slotMap = new Map<ir.XrefId, number>();
-
   // Process all views in the component and assign slot indexes.
   for (const unit of job.units) {
     // Slot indices start at 0 for each view (and are not unique between views).
@@ -38,9 +32,6 @@ export function allocateSlots(job: ComponentCompilationJob): void {
       // Assign slots to this declaration starting at the current `slotCount`.
       op.handle.slot = slotCount;
 
-      // And track its assigned slot in the `slotMap`.
-      slotMap.set(op.xref, op.handle.slot);
-
       // Each declaration may use more than 1 slot, so increment `slotCount` to reserve the number
       // of slots required.
       slotCount += op.numSlotsUsed;
@@ -51,11 +42,8 @@ export function allocateSlots(job: ComponentCompilationJob): void {
     unit.decls = slotCount;
   }
 
-  // After slot assignment, `slotMap` now contains slot assignments for every declaration in the
-  // whole template, across all views. Next, look for expressions which implement
-  // `UsesSlotIndexExprTrait` and propagate the assigned slot indexes into them.
-  // Additionally, this second scan allows us to find `ir.TemplateOp`s which declare views and
-  // propagate the number of slots used for each view into the operation which declares it.
+  // After slot assignment, scan for `ir.TemplateOp`s which declare views and propagate the number
+  // of slots used for each view into the operation which declares it.
   for (const unit of job.units) {
     for (const op of unit.ops()) {
       if (

--- a/packages/compiler/src/template/pipeline/src/phases/temporary_variables.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/temporary_variables.ts
@@ -54,7 +54,6 @@ function generateTemporaries(
     // read for the final time.
     let count = 0;
     const assigned = new Set<ir.XrefId>();
-    const released = new Set<ir.XrefId>();
     const defs = new Map<ir.XrefId, string>();
     ir.visitExpressionsInOp(op, (expr, flag) => {
       if (flag & ir.VisitorContextFlag.InChildOperation) {
@@ -70,7 +69,6 @@ function generateTemporaries(
         assignName(defs, expr);
       } else if (expr instanceof ir.ReadTemporaryExpr) {
         if (finalReads.get(expr.xref) === expr) {
-          released.add(expr.xref);
           count--;
         }
         assignName(defs, expr);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?

Issue Number: N/A

Two phases in the template pipeline fill a collection that is never read:

- `allocateSlots` builds `slotMap` (xref → slot) for every declaration. The
  comment above the second scan says `slotMap` will be used to propagate slot
  indexes into expressions, but the scan never reads it. Slot indexes already
  reach expressions through the shared `op.handle`, and the scan only copies
  each view's `decls` onto the op that declares it.
- `generateTemporaries` adds each temporary to `released` on its final read,
  but nothing reads the set. Name reuse is driven by `count` alone.

## What is the new behavior?

Both collections are removed. The comment on the second scan in
`allocateSlots` now describes what it does. Emitted output is unchanged, since
neither value was ever read.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Found with a static check for collections that are only ever written, then
confirmed by reading each phase.

https://claude.ai/code/session_01ABuXgtVFhvgie5kXCPcBja