### PR TITLE
fix(docs-infra): match card grid row gap to column gap

### DIFF
--- a/adev/shared-docs/styles/docs/_card.scss
+++ b/adev/shared-docs/styles/docs/_card.scss
@@ -122,7 +122,7 @@
     }
   }
 
-  :not(.docs-card-container) .docs-card {
+  :not(.docs-card-grid) > .docs-card {
     margin: 1rem 0;
   }
 


### PR DESCRIPTION
https://angular.dev/roadmap#completed-projects

The card grids on https://angular.dev/roadmap#completed-projects have rows spaced 52px apart while the columns are only 20px apart, so the cards look loosely stacked. The `:not(.docs-card-container) .docs-card` rule was meant to give only standalone cards a vertical margin, but no element has the `docs-card-container` class, so it matched every card. Cards inside a grid got the 1rem top and bottom margin on top of the 1.25rem grid gap. This limits the margin to cards that aren't direct children of a card grid, so rows and columns are both 20px apart. Standalone cards keep their margin, and grids with a header already reset it to 0, so they're unchanged.


Before:

<img width="1507" height="836" alt="Screenshot 2026-09-11 at 16 59 54" src="https://github.com/user-attachments/assets/f02ab0b0-25d6-4059-9c2c-cb4685f52c73" />

After:

<img width="1511" height="837" alt="Screenshot 2026-09-11 at 17 00 02" src="https://github.com/user-attachments/assets/898d8010-112d-4c28-8fbe-7aa4d15120f3" />

