### PR TITLE
feat(language-service): add smart selection ranges for templates

### DIFF
--- a/packages/compiler-cli/src/ngtsc/perf/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/api.ts
@@ -190,6 +190,11 @@ export enum PerfPhase {
   LSSemanticClassification,
 
   /**
+   * Time spent by the Angular Language Service calculating smart selection ranges.
+   */
+  LsSmartSelection,
+
+  /**
    * Tracks the number of `PerfPhase`s, and must appear at the end of the list.
    */
   LAST,

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -58,6 +58,7 @@ import {ReferencesBuilder, RenameBuilder} from './references_and_rename';
 import {createLocationKey} from './references_and_rename_utils';
 import {getClassificationsForTemplate, TokenEncodingConsts} from './semantic_tokens';
 import {getSignatureHelp} from './signature_help';
+import {getSmartSelectionRange} from './smart_selection';
 import {
   getTargetAtPosition,
   getTcbNodesOfTemplateAtPosition,
@@ -581,6 +582,19 @@ export class LanguageService {
       }
 
       return getSignatureHelp(compiler, this.tsLS, fileName, position, options);
+    });
+  }
+
+  /**
+   * Gets the smart selection range (nested ranges used by the editor's
+   * "Expand/Shrink Selection" feature) at a position. Inside Angular templates
+   * the ranges follow the template AST, so control flow blocks (`@if`, `@for`,
+   * ...) and their bodies become selection steps. Outside templates the
+   * request is delegated to the TypeScript language service.
+   */
+  getSmartSelectionRange(fileName: string, position: number): ts.SelectionRange {
+    return this.withCompilerAndPerfTracing(PerfPhase.LsSmartSelection, (compiler) => {
+      return getSmartSelectionRange(compiler, this.tsLS, fileName, position);
     });
   }
 

--- a/packages/language-service/src/smart_selection.ts
+++ b/packages/language-service/src/smart_selection.ts
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  TmplAstBlockNode,
+  TmplAstBoundaryBlock,
+  TmplAstComponent,
+  TmplAstDeferredBlock,
+  TmplAstElement,
+  TmplAstForLoopBlock,
+  TmplAstNode,
+  TmplAstRecursiveVisitor,
+  TmplAstTemplate,
+  tmplAstVisitAll,
+} from '@angular/compiler';
+import {NgCompiler} from '@angular/compiler-cli';
+
+import ts from 'typescript';
+
+import {getTypeCheckInfoAtPosition, isTypeScriptFile} from './utils';
+
+/**
+ * Computes the smart selection range (nested ranges used by the editor's
+ * "Expand/Shrink Selection" feature) for a position inside an Angular template.
+ *
+ * The chain includes, from innermost to outermost, every template AST node that
+ * contains the position (interpolations, attributes, elements, control flow
+ * blocks, ...). For nodes delimited by braces or tags, the content between the
+ * delimiters is included as an extra step so that e.g. the body of an `@if`
+ * block can be selected before the whole block.
+ *
+ * Returns `undefined` when the position is not inside an Angular template that
+ * this language service knows about.
+ */
+export function getTemplateSelectionRange(
+  compiler: NgCompiler,
+  fileName: string,
+  position: number,
+): ts.SelectionRange | undefined {
+  const typeCheckInfo = getTypeCheckInfoAtPosition(fileName, position, compiler);
+  if (typeCheckInfo === undefined) {
+    return undefined;
+  }
+
+  const spans = SelectionSpanVisitor.getSpansContainingPosition(typeCheckInfo.nodes, position);
+  if (spans.length === 0) {
+    return undefined;
+  }
+
+  // Sort from innermost (smallest) to outermost (largest) and build the parent
+  // chain. Spans that do not fully contain the previous one are dropped to
+  // guarantee the strict nesting required for selection ranges.
+  spans.sort((a, b) => a.length - b.length);
+  let result: ts.SelectionRange | undefined = undefined;
+  let innermost: ts.SelectionRange | undefined = undefined;
+  for (const textSpan of spans) {
+    if (result !== undefined) {
+      const prev = result.textSpan;
+      const isSameSpan = textSpan.start === prev.start && textSpan.length === prev.length;
+      const containsPrev =
+        textSpan.start <= prev.start &&
+        textSpan.start + textSpan.length >= prev.start + prev.length;
+      if (isSameSpan || !containsPrev) {
+        continue;
+      }
+    }
+    const range: ts.SelectionRange = {textSpan};
+    if (result === undefined) {
+      innermost = range;
+    } else {
+      result.parent = range;
+    }
+    result = range;
+  }
+  return innermost;
+}
+
+/**
+ * Computes the smart selection range for a position in a file, merging the
+ * Angular template chain with TypeScript's own smart selection when the
+ * position is inside an inline template.
+ */
+export function getSmartSelectionRange(
+  compiler: NgCompiler,
+  tsLS: ts.LanguageService,
+  fileName: string,
+  position: number,
+): ts.SelectionRange {
+  const templateRange = getTemplateSelectionRange(compiler, fileName, position);
+
+  if (!isTypeScriptFile(fileName)) {
+    // External template: there is no TypeScript structure to merge with.
+    return templateRange ?? {textSpan: {start: position, length: 0}};
+  }
+
+  const tsRange = tsLS.getSmartSelectionRange(fileName, position);
+  if (templateRange === undefined) {
+    return tsRange;
+  }
+
+  // Graft the template chain onto the TypeScript chain: the outermost template
+  // range (the whole template) gets, as parent, the innermost TypeScript range
+  // that strictly contains it (e.g. the template string literal).
+  let outermost = templateRange;
+  while (outermost.parent !== undefined) {
+    outermost = outermost.parent;
+  }
+  const templateEnd = outermost.textSpan.start + outermost.textSpan.length;
+  let tsParent: ts.SelectionRange | undefined = tsRange;
+  while (
+    tsParent !== undefined &&
+    !(
+      tsParent.textSpan.start <= outermost.textSpan.start &&
+      tsParent.textSpan.start + tsParent.textSpan.length >= templateEnd &&
+      tsParent.textSpan.length > outermost.textSpan.length
+    )
+  ) {
+    tsParent = tsParent.parent;
+  }
+  outermost.parent = tsParent;
+  return templateRange;
+}
+
+/**
+ * Collects the source spans of all template nodes that contain a position,
+ * including the "content" spans between the delimiters of blocks and elements.
+ */
+class SelectionSpanVisitor extends TmplAstRecursiveVisitor {
+  readonly spans: ts.TextSpan[] = [];
+
+  private constructor(private readonly position: number) {
+    super();
+  }
+
+  static getSpansContainingPosition(templateNodes: TmplAstNode[], position: number): ts.TextSpan[] {
+    const visitor = new SelectionSpanVisitor(position);
+    tmplAstVisitAll(visitor, templateNodes);
+    return visitor.spans;
+  }
+
+  private addSpan(start: number, end: number): void {
+    if (start <= this.position && this.position <= end && end > start) {
+      this.spans.push({start, length: end - start});
+    }
+  }
+
+  visit(node: TmplAstNode): void {
+    const {sourceSpan} = node;
+    if (this.position < sourceSpan.start.offset || this.position > sourceSpan.end.offset) {
+      // The node does not contain the position; neither can its children.
+      return;
+    }
+    this.addSpan(sourceSpan.start.offset, sourceSpan.end.offset);
+
+    if (node instanceof TmplAstBlockNode) {
+      // The source span of for loops, deferred and boundary blocks includes
+      // their secondary blocks (@empty, @placeholder, ...). The extra
+      // selection steps should be scoped to the main block.
+      let endSpan = node.endSourceSpan;
+      if (
+        node instanceof TmplAstForLoopBlock ||
+        node instanceof TmplAstDeferredBlock ||
+        node instanceof TmplAstBoundaryBlock
+      ) {
+        this.addSpan(node.mainBlockSpan.start.offset, node.mainBlockSpan.end.offset);
+        endSpan = node.mainBlockSpan;
+      }
+      // The content between the braces of the block, e.g. the body of `@if`.
+      if (endSpan !== null) {
+        const contentEnd =
+          endSpan === node.endSourceSpan ? endSpan.start.offset : endSpan.end.offset - 1;
+        this.addSpan(node.startSourceSpan.end.offset, contentEnd);
+      }
+    } else if (
+      node instanceof TmplAstElement ||
+      node instanceof TmplAstTemplate ||
+      node instanceof TmplAstComponent
+    ) {
+      // The content between the opening and closing tags.
+      if (node.endSourceSpan !== null && node.endSourceSpan !== node.startSourceSpan) {
+        this.addSpan(node.startSourceSpan.end.offset, node.endSourceSpan.start.offset);
+      }
+    }
+
+    node.visit(this);
+  }
+}

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -224,6 +224,12 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return withFallback(fileName, (ls) => ls.getOutliningSpans(fileName)) ?? [];
   }
 
+  function getSmartSelectionRange(fileName: string, position: number): ts.SelectionRange {
+    // The Angular language service internally falls back to the TypeScript
+    // language service for positions outside of templates.
+    return ngLS.getSmartSelectionRange(fileName, position);
+  }
+
   function getTcb(fileName: string, position: number): GetTcbResponse | undefined {
     return ngLS.getTcb(fileName, position);
   }
@@ -393,6 +399,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getComponentLocationsForTemplate,
     getSignatureHelpItems,
     getOutliningSpans,
+    getSmartSelectionRange,
     getTemplateLocationForComponent,
     getTemplateDocumentSymbols,
     hasCodeFixesForErrorCode: ngLS.hasCodeFixesForErrorCode.bind(ngLS),

--- a/packages/language-service/test/smart_selection_spec.ts
+++ b/packages/language-service/test/smart_selection_spec.ts
@@ -1,0 +1,187 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+
+import {createModuleAndProjectWithDeclarations, LanguageServiceTestEnv} from '../testing';
+
+describe('smart selection ranges', () => {
+  it('should expand through control flow blocks in an external template', () => {
+    const files = {
+      'app.ts': `
+        import {Component} from '@angular/core';
+
+        @Component({
+          templateUrl: './app.html',
+          standalone: false,
+        })
+        export class AppCmp {
+          show = true;
+          name = 'name';
+        }`,
+      'app.html': '<div>@if (show) {<span>{{name}}</span>}</div>',
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.html');
+    appFile.moveCursorToText('{{na¦me}}');
+    const chain = selectionChainText(appFile.getSmartSelectionRange(), files['app.html']);
+    expect(chain).toEqual([
+      '{{name}}',
+      '<span>{{name}}</span>',
+      '@if (show) {<span>{{name}}</span>}',
+      '<div>@if (show) {<span>{{name}}</span>}</div>',
+    ]);
+  });
+
+  it('should expand nested @if blocks one step at a time', () => {
+    const template = ['@if (outer) {', '  @if (inner) {', '    <b>text</b>', '  }', '}'].join('\n');
+    const files = {
+      'app.ts': `
+        import {Component} from '@angular/core';
+
+        @Component({
+          templateUrl: './app.html',
+          standalone: false,
+        })
+        export class AppCmp {
+          outer = true;
+          inner = true;
+        }`,
+      'app.html': template,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.html');
+    appFile.moveCursorToText('te¦xt');
+    const chain = selectionChainText(appFile.getSmartSelectionRange(), template);
+    expect(chain).toEqual([
+      'text',
+      '<b>text</b>',
+      '\n    <b>text</b>\n  ',
+      '@if (inner) {\n    <b>text</b>\n  }',
+      '\n  @if (inner) {\n    <b>text</b>\n  }\n',
+      '@if (outer) {\n  @if (inner) {\n    <b>text</b>\n  }\n}',
+    ]);
+  });
+
+  it('should only include the main block of @for when expanding from its body', () => {
+    const files = {
+      'app.ts': `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '@for (item of items; track item) {<i>{{item}}</i>} @empty {none}',
+          standalone: false,
+        })
+        export class AppCmp {
+          items = ['a'];
+        }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText('{{ite¦m}}');
+    const chain = selectionChainText(appFile.getSmartSelectionRange(), files['app.ts']);
+    expect(chain).toContain('@for (item of items; track item) {<i>{{item}}</i>}');
+    expect(chain).toContain('@for (item of items; track item) {<i>{{item}}</i>} @empty {none}');
+    // The chain continues beyond the inline template into the TypeScript file.
+    expect(chain[chain.length - 1]).toContain('@Component');
+  });
+
+  it('should expand from the secondary block of @for to the whole block', () => {
+    const files = {
+      'app.ts': `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '@for (item of items; track item) {<i>{{item}}</i>} @empty {none}',
+          standalone: false,
+        })
+        export class AppCmp {
+          items = ['a'];
+        }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText('no¦ne');
+    const chain = selectionChainText(appFile.getSmartSelectionRange(), files['app.ts']);
+    expect(chain).toContain('@empty {none}');
+    expect(chain).toContain('@for (item of items; track item) {<i>{{item}}</i>} @empty {none}');
+  });
+
+  it('should expand through @switch cases', () => {
+    const template = ["@switch (status) {@case ('on') {<b>on</b>} @default {off}}"].join('\n');
+    const files = {
+      'app.ts': `
+        import {Component} from '@angular/core';
+
+        @Component({
+          templateUrl: './app.html',
+          standalone: false,
+        })
+        export class AppCmp {
+          status = 'on';
+        }`,
+      'app.html': template,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.html');
+    appFile.moveCursorToText('<b>o¦n</b>');
+    const chain = selectionChainText(appFile.getSmartSelectionRange(), template);
+    expect(chain).toContain("@case ('on') {<b>on</b>}");
+    expect(chain).toContain("@switch (status) {@case ('on') {<b>on</b>} @default {off}}");
+  });
+
+  it('should fall back to TypeScript outside of templates', () => {
+    const files = {
+      'app.ts': `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '{{greeting}}',
+          standalone: false,
+        })
+        export class AppCmp {
+          greeting = 'hello world';
+        }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText(`greeting = 'hello wor¦ld';`);
+    const chain = selectionChainText(appFile.getSmartSelectionRange(), files['app.ts']);
+    expect(chain).toContain(`greeting = 'hello world';`);
+  });
+});
+
+function selectionChainText(range: ts.SelectionRange, contents: string): string[] {
+  const result: string[] = [];
+  let current: ts.SelectionRange | undefined = range;
+  while (current !== undefined) {
+    result.push(
+      contents.substring(current.textSpan.start, current.textSpan.start + current.textSpan.length),
+    );
+    current = current.parent;
+  }
+  return result;
+}

--- a/packages/language-service/testing/src/buffer.ts
+++ b/packages/language-service/testing/src/buffer.ts
@@ -123,6 +123,10 @@ export class OpenBuffer {
     return this.ngLS.getOutliningSpans(this.scriptInfo.fileName);
   }
 
+  getSmartSelectionRange() {
+    return this.ngLS.getSmartSelectionRange(this.scriptInfo.fileName, this._cursor);
+  }
+
   getTemplateLocationForComponent() {
     return this.ngLS.getTemplateLocationForComponent(this.scriptInfo.fileName, this._cursor);
   }

--- a/vscode-ng-language-service/integration/lsp/ivy_spec.ts
+++ b/vscode-ng-language-service/integration/lsp/ivy_spec.ts
@@ -318,6 +318,50 @@ export class AppComponent {
     expect(response).toContain({startLine: 32, endLine: 33}); // empty
   });
 
+  it('provides selection ranges that follow control flow blocks', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`<div>@if (name) {<span>{{name}}</span>}</div>\`,
+})
+export class AppComponent {
+  name = 'Angular';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.SelectionRangeRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+      // Inside `name` of the `{{name}}` interpolation.
+      positions: [{line: 5, character: 40}],
+    })) as lsp.SelectionRange[];
+    expect(Array.isArray(response)).toBe(true);
+    expect(response.length).toEqual(1);
+    const chain: lsp.Range[] = [];
+    let current: lsp.SelectionRange | undefined = response[0];
+    while (current !== undefined) {
+      chain.push(current.range);
+      current = current.parent;
+    }
+    expect(chain.slice(0, 4)).toEqual([
+      // {{name}}
+      {start: {line: 5, character: 36}, end: {line: 5, character: 44}},
+      // <span>{{name}}</span>
+      {start: {line: 5, character: 30}, end: {line: 5, character: 51}},
+      // @if (name) {<span>{{name}}</span>}
+      {start: {line: 5, character: 18}, end: {line: 5, character: 52}},
+      // <div>@if (name) {<span>{{name}}</span>}</div>
+      {start: {line: 5, character: 13}, end: {line: 5, character: 58}},
+    ]);
+    // The chain continues beyond the inline template into the TypeScript file.
+    expect(chain.length).toBeGreaterThan(4);
+  });
+
   it('provides document symbols for TypeScript files (default: filtered to components)', async () => {
     openTextDocument(
       client,

--- a/vscode-ng-language-service/server/src/handlers/initialization.ts
+++ b/vscode-ng-language-service/server/src/handlers/initialization.ts
@@ -20,6 +20,7 @@ export function onInitialize(session: Session, params: lsp.InitializeParams): ls
     capabilities: {
       foldingRangeProvider: true,
       documentSymbolProvider: true,
+      selectionRangeProvider: true,
       codeLensProvider: {resolveProvider: true},
       textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
       completionProvider: {

--- a/vscode-ng-language-service/server/src/handlers/selection_range.ts
+++ b/vscode-ng-language-service/server/src/handlers/selection_range.ts
@@ -1,0 +1,47 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+import * as lsp from 'vscode-languageserver';
+import * as ts from 'typescript/lib/tsserverlibrary';
+
+import {Session} from '../session';
+import {lspPositionToTsPosition, tsTextSpanToLspRange} from '../utils';
+
+/**
+ * Handles textDocument/selectionRange requests (the editor's "Expand/Shrink
+ * Selection" feature). The Angular language service produces ranges that
+ * follow the template AST, so control flow blocks (`@if`, `@for`, `@switch`,
+ * ...) and their bodies become selection steps.
+ */
+export function onSelectionRanges(
+  session: Session,
+  params: lsp.SelectionRangeParams,
+): lsp.SelectionRange[] | null {
+  const lsInfo = session.getLSAndScriptInfo(params.textDocument);
+  if (lsInfo === null) {
+    return null;
+  }
+  const {scriptInfo, languageService} = lsInfo;
+  return params.positions.map((position) => {
+    const offset = lspPositionToTsPosition(scriptInfo, position);
+    const tsSelectionRange = languageService.getSmartSelectionRange(scriptInfo.fileName, offset);
+    return tsSelectionRangeToLsp(tsSelectionRange, scriptInfo);
+  });
+}
+
+function tsSelectionRangeToLsp(
+  selectionRange: ts.SelectionRange,
+  scriptInfo: ts.server.ScriptInfo,
+): lsp.SelectionRange {
+  return {
+    range: tsTextSpanToLspRange(scriptInfo, selectionRange.textSpan),
+    parent:
+      selectionRange.parent !== undefined
+        ? tsSelectionRangeToLsp(selectionRange.parent, scriptInfo)
+        : undefined,
+  };
+}

--- a/vscode-ng-language-service/server/src/session.ts
+++ b/vscode-ng-language-service/server/src/session.ts
@@ -46,6 +46,7 @@ import {getComponentsWithTemplateFile, onCodeLens, onCodeLensResolve} from './ha
 import {onCompletion, onCompletionResolve} from './handlers/completions';
 import {onDefinition, onTypeDefinition, onReferences} from './handlers/definitions';
 import {onFoldingRanges} from './handlers/folding';
+import {onSelectionRanges} from './handlers/selection_range';
 import {onHover} from './handlers/hover';
 import {onInitialize} from './handlers/initialization';
 import {onLinkedEditingRange} from './handlers/linked_editing_range';
@@ -258,6 +259,7 @@ export class Session {
     conn.onPrepareRename((p) => onPrepareRename(this, p));
     conn.onHover((p) => onHover(this, p));
     conn.onFoldingRanges((p) => onFoldingRanges(this, p));
+    conn.onSelectionRanges((p) => onSelectionRanges(this, p));
     conn.languages.onLinkedEditingRange((p) => onLinkedEditingRange(this, p));
     conn.onDocumentSymbol(async (p) => await onDocumentSymbol(this, p));
     conn.onCompletion((p) => onCompletion(this, p));


### PR DESCRIPTION
Implements `getSmartSelectionRange` in the Angular language service and exposes it through the `textDocument/selectionRange` LSP request in the VS Code extension server.

Addresses the Expand/Shrink Selection part of #65501. The remaining parts of that issue (Go to Bracket, Emmet wrap) are editor-side features that cannot be provided through the language server protocol.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The editor's Expand/Shrink Selection feature (Shift+Alt+Right/Left) is driven by selection ranges. Neither the built-in HTML support nor TypeScript understand Angular templates, so expanding a selection inside a template ignores its structure: `@if`, `@for`, `@switch`, `@defer` and other control flow blocks, interpolations and element boundaries are not respected.

Issue Number: #65501

## What is the new behavior?

The language service builds the selection chain from the template AST: interpolations, elements, block bodies and blocks become successive selection steps. For inline templates the chain is grafted onto TypeScript's own smart selection, so expansion keeps growing beyond the template into the component class. The VS Code extension server exposes this through the `textDocument/selectionRange` LSP request.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No