### PR TITLE
fix(router): mark router_resource module-level symbols as side-effect…

### DIFF
--- a/packages/router/src/router_resource.ts
+++ b/packages/router/src/router_resource.ts
@@ -33,10 +33,10 @@ import {
   NavigationCancellationCode,
 } from './events';
 
-export const BLOCKING_SYMBOL: unique symbol = Symbol(
+export const BLOCKING_SYMBOL: unique symbol = /* @__PURE__ */ Symbol(
   typeof ngDevMode === 'undefined' || ngDevMode ? '__isBlocking' : '',
 );
-export const SOURCE_RESOURCE_SYMBOL: unique symbol = Symbol(
+export const SOURCE_RESOURCE_SYMBOL: unique symbol = /* @__PURE__ */ Symbol(
   typeof ngDevMode === 'undefined' || ngDevMode ? '__sourceResource' : '',
 );
 


### PR DESCRIPTION
… free

Top-level Symbol() calls in router_resource.ts lacked /* @__PURE__ */ annotations, preventing bundlers like esbuild and Rollup from tree-shaking the module and its dependencies when provideRouter() is used without withRouterResources().

Fixes #70696
