### PR TITLE
refactor(router): Remove canLoad from 1p Router

### DIFF
--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -734,6 +734,7 @@ export interface Route {
    *
    */
   canDeactivate?: Array<CanDeactivateFn<any> | DeprecatedGuard>;
+  // 3p-only-start
   /**
    * An array of `CanLoadFn` or DI tokens used to look up `CanLoad()`
    * handlers, in order to determine if the current user is allowed to
@@ -744,6 +745,7 @@ export interface Route {
    * @deprecated Use `canMatch` instead
    */
   canLoad?: Array<CanLoadFn | DeprecatedGuard>;
+  // 3p-only-end
   /**
    * Additional developer-defined data provided to the component via
    * `ActivatedRoute`. By default, no additional data is passed.

--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -234,7 +234,8 @@ export function runCanLoadGuards(
   urlSerializer: UrlSerializer,
   abortSignal?: AbortSignal,
 ): Observable<boolean> {
-  const canLoad = route.canLoad;
+  // TODO: Remove `canLoad` check once removed from 3p.
+  const canLoad = (route as any).canLoad;
   if (canLoad === undefined || canLoad.length === 0) {
     return of(true);
   }

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -151,7 +151,8 @@ export class RouterPreloader implements OnDestroy {
       // at all. Code splitting and lazy loading is separate from client-side authorization checks
       // and should not be used as a security measure to prevent loading of code.
       if (
-        (route.loadChildren && !route._loadedRoutes && route.canLoad === undefined) ||
+        // TODO: Remove `canLoad` check once removed from 3p.
+        (route.loadChildren && !route._loadedRoutes && (route as any).canLoad === undefined) ||
         (route.loadComponent && !route._loadedComponent)
       ) {
         res.push(this.preloadConfig(injectorForCurrentRoute, route));
@@ -169,7 +170,8 @@ export class RouterPreloader implements OnDestroy {
         return of(null);
       }
       let loadedChildren$: Observable<LoadedRouterConfig | null>;
-      if (route.loadChildren && route.canLoad === undefined) {
+      // TODO: Remove `canLoad` check once removed from 3p.
+      if (route.loadChildren && (route as any).canLoad === undefined) {
         loadedChildren$ = from(this.loader.loadChildren(injector, route));
       } else {
         loadedChildren$ = of(null);


### PR DESCRIPTION
This will is deprecated and will be removed. Prevent regressions internally in the meantime.
