### PR TITLE
fix(docs-infra): copy code blocks as they are rendered

### DIFF
--- a/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.spec.ts
+++ b/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.spec.ts
@@ -50,6 +50,36 @@ describe('CopySourceCodeButton', () => {
     expect(copySpy.calls.argsFor(0)[0].trim()).toBe(expectedCodeToBeCopied);
   });
 
+  it('should keep blank lines and skip line numbers', async () => {
+    component.code.set(
+      '<span class="shiki-ln-number">1</span><span class="line">const a = 1;</span>\n' +
+        '<span class="shiki-ln-number">2</span><span class="line"></span>\n' +
+        '<span class="shiki-ln-number">3</span><span class="line">const b = 2;</span>',
+    );
+
+    await fixture.whenStable();
+
+    const button = fixture.debugElement.query(By.directive(CopySourceCodeButton)).nativeElement;
+    button.click();
+
+    expect(copySpy.calls.argsFor(0)[0]).toBe('const a = 1;\n\nconst b = 2;');
+  });
+
+  it('should skip hidden lines', async () => {
+    component.code.set(
+      '<span class="line">const a = 1;</span>\n' +
+        '<span class="line hidden">const b = 2;</span>\n' +
+        '<span class="line">const c = 3;</span>',
+    );
+
+    await fixture.whenStable();
+
+    const button = fixture.debugElement.query(By.directive(CopySourceCodeButton)).nativeElement;
+    button.click();
+
+    expect(copySpy.calls.argsFor(0)[0]).toBe('const a = 1;\nconst c = 3;');
+  });
+
   it(`should set ${SUCCESSFULLY_COPY_CLASS_NAME} for ${CONFIRMATION_DISPLAY_TIME_MS} ms when copy was executed properly`, async () => {
     const clock = jasmine.clock().install();
     component.code.set('example');

--- a/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.ts
+++ b/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.ts
@@ -17,7 +17,6 @@ import {
 } from '@angular/core';
 import {IconComponent} from '../icon/icon.component';
 
-export const REMOVED_LINE_CLASS_NAME = '.line.remove';
 export const CONFIRMATION_DISPLAY_TIME_MS = 2000;
 
 @Component({
@@ -58,19 +57,16 @@ export class CopySourceCodeButton {
     this.showCopySuccess.set(false);
     this.showCopyFailure.set(false);
 
-    const removedLines: NodeList = codeElement.querySelectorAll(REMOVED_LINE_CLASS_NAME);
+    const lines = Array.from(codeElement.querySelectorAll('.line:not(.hidden)'));
 
-    if (removedLines.length) {
-      // Get only those lines which are not marked as removed
-      const formattedText = Array.from(codeElement.querySelectorAll('.line:not(.remove)'))
-        .map((line) => (line as HTMLDivElement).innerText)
-        .join('\n');
-
-      return formattedText.trim();
-    } else {
-      const text: string = codeElement.innerText || '';
-      return text.replace(/\n\n\n/g, ``).trim();
+    if (lines.length) {
+      return lines
+        .map((line) => line.textContent)
+        .join('\n')
+        .trim();
     }
+
+    return (codeElement.innerText || '').trim();
   }
 
   private showResult(messageState: WritableSignal<boolean>) {


### PR DESCRIPTION
Copy button doesn't copy what's on screen. On blocks with line numbers it copies the numbers as if they were code, and it eats blank lines.

1. Line numbers, first block on https://angular.dev/best-practices/zone-pollution

Before:
```
1
import { Component, NgZone, OnInit, inject } from '@angular/core';
2
3
@Component(...)
```

After:
```
import { Component, NgZone, OnInit, inject } from '@angular/core';

@Component(...)
```

2. Blank lines, first block on https://angular.dev/guide/signals

Before:
```
const count = signal(0);
// Signals are getter functions - calling them reads their value.
console.log('The count is: ' + count());
```

After:
```
const count = signal(0);

// Signals are getter functions - calling them reads their value.
console.log('The count is: ' + count());
```

Fix grabs the visible `.line` elements and joins their text, so numbers stay out and you get the block as rendered. Tested with real clicks and clipboard reads on 63 blocks across 4 pages.
