### PR TITLE
fix(core): align FakeNavigation with WHATWG Navigation API spec

### DIFF
--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -61,8 +61,19 @@ describe('BrowserViewportScroller', () => {
     let scroller: BrowserViewportScroller;
 
     beforeEach(() => {
+      // Force instant scrolling so that the reset below always takes effect synchronously.
+      // Otherwise a leftover `smooth` value would make every assertion on the scroll position
+      // racy, because the scroll would still be animating once the test body runs.
+      document.documentElement.style.scrollBehavior = 'auto';
       scroller = new BrowserViewportScroller(document, window);
       scroller.scrollToPosition([0, 0]);
+    });
+
+    afterEach(() => {
+      // Undo the global mutations here rather than at the end of the individual tests, so that a
+      // failed assertion cannot leak them into whichever test happens to run next.
+      document.documentElement.style.scrollBehavior = '';
+      document.body.style.paddingBottom = '';
     });
 
     it('should scroll when element with matching id is found', () => {
@@ -141,15 +152,18 @@ describe('BrowserViewportScroller', () => {
       // Header offset
       scroller.setOffset([0, 80]);
 
-      scroller.scrollToAnchor(anchor);
+      try {
+        scroller.scrollToAnchor(anchor);
 
-      await waitFor(() => throwUnless(anchorNode.getBoundingClientRect().top).toBe(80), {
-        timeout: 1_000,
-      });
-
-      document.documentElement.style.scrollBehavior = '';
-      document.body.style.paddingBottom = '';
-      cleanup();
+        // A smooth scroll settles on a fractional pixel on displays whose device pixel ratio is
+        // not 1, so compare against the offset with a sub-pixel tolerance rather than exactly.
+        await waitFor(
+          () => throwUnless(Math.abs(anchorNode.getBoundingClientRect().top - 80)).toBeLessThan(1),
+          {timeout: 1_000},
+        );
+      } finally {
+        cleanup();
+      }
     });
 
     function createTallElement() {

--- a/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
+++ b/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
@@ -28,6 +28,36 @@ import {
 // 3p-only-end
 
 /**
+ * Options for `FakeNavigation.navigateForTesting()`.
+ *
+ * These model parts of a `NavigateEvent` that `navigation.navigate()` can never produce, because a
+ * user agent supplies them when a navigation is initiated by something other than that method (a
+ * link click, a form submission, browser UI, ...). They are exposed on a separate method so that
+ * `FakeNavigation.navigate()` keeps the exact signature of the real `Navigation.navigate()`.
+ */
+export interface FakeNavigateForTestingOptions extends NavigationNavigateOptions {
+  /**
+   * Value for `NavigateEvent.cancelable`. Always `true` for `navigation.navigate()`, but a user
+   * agent initiated navigation may be non-cancelable.
+   */
+  cancelable?: boolean;
+  /** Value for `NavigateEvent.sourceElement`, i.e. the element that initiated the navigation. */
+  sourceElement?: Element | null;
+}
+
+/**
+ * Options for the traversal methods: `traverseTo()`, `back()` and `forward()`.
+ *
+ * `hasUAVisualTransition` is a test-only extension. A real user agent sets it when it performed a
+ * visual transition for the traversal, which only happens for user agent driven traversals, so
+ * there is no way for a test to produce one otherwise.
+ */
+export interface FakeNavigationTraverseOptions extends NavigationOptions {
+  /** Value for `NavigateEvent.hasUAVisualTransition` and `PopStateEvent.hasUAVisualTransition`. */
+  hasUAVisualTransition?: boolean;
+}
+
+/**
  * Fake implementation of user agent history and navigation behavior. This is a
  * high-fidelity implementation of browser behavior that attempts to emulate
  * things like traversal delay.
@@ -162,14 +192,18 @@ export class FakeNavigation implements Navigation {
       );
     }
     const currentInitialEntry = this.entriesArr[0];
-    this.entriesArr[0] = new FakeNavigationHistoryEntry(this.eventTarget, new URL(url).toString(), {
-      index: 0,
-      key: currentInitialEntry?.key ?? String(this.nextKey++),
-      id: currentInitialEntry?.id ?? String(this.nextId++),
-      sameDocument: true,
-      historyState: options?.historyState,
-      state: options.state,
-    });
+    this.entriesArr[0] = new FakeNavigationHistoryEntry(
+      this.createEventTarget,
+      new URL(url).toString(),
+      {
+        index: 0,
+        key: currentInitialEntry?.key ?? String(this.nextKey++),
+        id: currentInitialEntry?.id ?? String(this.nextId++),
+        sameDocument: true,
+        historyState: cloneState(options?.historyState),
+        state: cloneState(options.state),
+      },
+    );
   }
 
   /** Returns whether the initial entry is still eligible to be set. */
@@ -198,8 +232,28 @@ export class FakeNavigation implements Navigation {
    * https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate
    */
   navigate(url: string, options?: NavigationNavigateOptions): FakeNavigationResult {
+    return this.navigateForTesting(url, options);
+  }
+
+  /**
+   * Test-only variant of `navigate()` which additionally accepts the parts of a `NavigateEvent`
+   * that only a user agent can supply. See `FakeNavigateForTestingOptions`.
+   */
+  navigateForTesting(url: string, options?: FakeNavigateForTestingOptions): FakeNavigationResult {
     const fromUrl = new URL(this.currentEntry.url!);
-    const toUrl = new URL(url, this.currentEntry.url!);
+    let toUrl: URL;
+    try {
+      toUrl = new URL(url, this.currentEntry.url!);
+    } catch {
+      return earlyErrorResult(new DOMException(`Failed to parse URL '${url}'`, 'SyntaxError'));
+    }
+    // > If urlRecord's scheme is "javascript", then return an early error result for a
+    // > "NotSupportedError" DOMException.
+    if (toUrl.protocol === 'javascript:') {
+      return earlyErrorResult(
+        new DOMException(`Cannot navigate to a 'javascript:' URL`, 'NotSupportedError'),
+      );
+    }
 
     let navigationType: NavigationType;
     if (!options?.history || options.history === 'auto') {
@@ -215,21 +269,29 @@ export class FakeNavigation implements Navigation {
 
     const hashChange = isHashChange(fromUrl, toUrl);
 
+    let state: unknown;
+    try {
+      state = cloneState(options?.state);
+    } catch (e: unknown) {
+      return earlyErrorResult(asDataCloneError(e));
+    }
+
     const destination = new FakeNavigationDestination({
       url: toUrl.toString(),
-      state: options?.state,
+      state,
       sameDocument: hashChange,
       historyState: null,
     });
 
     return this.performNonTraverseNavigation(destination, {
       navigationType,
-      cancelable: true,
+      cancelable: options?.cancelable ?? true,
       canIntercept: true,
       // Always false for navigate().
       userInitiated: false,
       hashChange,
       info: options?.info,
+      sourceElement: options?.sourceElement,
     });
   }
 
@@ -243,6 +305,10 @@ export class FakeNavigation implements Navigation {
     this.pushOrReplaceState('replace', data, title, url);
   }
 
+  /**
+   * Shared implementation of `history.pushState()` and `history.replaceState()`.
+   * https://html.spec.whatwg.org/multipage/nav-history-apis.html#shared-history-push/replace-state-steps
+   */
   private pushOrReplaceState(
     navigationType: NavigationType,
     data: unknown,
@@ -250,14 +316,37 @@ export class FakeNavigation implements Navigation {
     url?: string,
   ): void {
     const fromUrl = new URL(this.currentEntry.url!);
-    const toUrl = url ? new URL(url, this.currentEntry.url!) : fromUrl;
+
+    // > Let serializedData be StructuredSerializeForStorage(data). Rethrow any exceptions.
+    // This happens before the URL is parsed, so a call with both a non-serializable `data` and an
+    // invalid `url` reports the `DataCloneError` rather than the URL failure.
+    const historyState = cloneState(data);
+
+    let toUrl = fromUrl;
+    if (url) {
+      // Unlike `navigation.navigate()`, the classic history API reports URL failures as a
+      // `SecurityError` rather than a `SyntaxError`.
+      try {
+        toUrl = new URL(url, this.currentEntry.url!);
+      } catch {
+        throw new DOMException(`Failed to parse URL '${url}'`, 'SecurityError');
+      }
+      // > If document cannot have its URL rewritten to newURL, then throw a "SecurityError"
+      // > DOMException.
+      if (!canHaveUrlRewrittenTo(fromUrl, toUrl)) {
+        throw new DOMException(
+          `Cannot rewrite the document URL from '${fromUrl.href}' to '${toUrl.href}'`,
+          'SecurityError',
+        );
+      }
+    }
 
     const hashChange = isHashChange(fromUrl, toUrl);
 
     const destination = new FakeNavigationDestination({
       url: toUrl.toString(),
       sameDocument: true, // history.pushState/replaceState are always same-document
-      historyState: data,
+      historyState,
       state: undefined, // No Navigation API state directly from history.pushState
     });
 
@@ -275,7 +364,7 @@ export class FakeNavigation implements Navigation {
    * Equivalent to `navigation.traverseTo()`.
    * https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-traverseto
    */
-  traverseTo(key: string, options?: NavigationOptions): FakeNavigationResult {
+  traverseTo(key: string, options?: FakeNavigationTraverseOptions): FakeNavigationResult {
     const fromUrl = new URL(this.currentEntry.url!);
     const entry = this.findEntry(key);
     if (!entry) {
@@ -310,9 +399,10 @@ export class FakeNavigation implements Navigation {
         userInitiated: false,
         hashChange,
         info: options?.info,
+        hasUAVisualTransition: options?.hasUAVisualTransition,
       });
-      if (!intercepted) {
-        this.userAgentTraverse(this.navigateEvent!);
+      if (!intercepted && this.navigateEvent) {
+        this.userAgentTraverse(this.navigateEvent);
       }
     });
     return {
@@ -325,7 +415,7 @@ export class FakeNavigation implements Navigation {
    * Equivalent to `navigation.back()`.
    * https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-back
    */
-  back(options?: NavigationOptions): FakeNavigationResult {
+  back(options?: FakeNavigationTraverseOptions): FakeNavigationResult {
     if (this.currentEntryIndex === 0) {
       return earlyErrorResult(new DOMException('Cannot go back', 'InvalidStateError'));
     }
@@ -337,7 +427,7 @@ export class FakeNavigation implements Navigation {
    * Equivalent to `navigation.forward()`.
    * https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-forward
    */
-  forward(options?: NavigationOptions): FakeNavigationResult {
+  forward(options?: FakeNavigationTraverseOptions): FakeNavigationResult {
     if (this.currentEntryIndex === this.entriesArr.length - 1) {
       return earlyErrorResult(new DOMException('Cannot go forward', 'InvalidStateError'));
     }
@@ -378,8 +468,8 @@ export class FakeNavigation implements Navigation {
         userInitiated: false,
         hashChange,
       });
-      if (!intercepted) {
-        this.userAgentTraverse(this.navigateEvent!);
+      if (!intercepted && this.navigateEvent) {
+        this.userAgentTraverse(this.navigateEvent);
       }
     });
   }
@@ -408,8 +498,10 @@ export class FakeNavigation implements Navigation {
   ): FakeNavigationResult {
     const result = new InternalNavigationResult(this);
     const intercepted = this.userAgentNavigate(destination, result, options);
-    if (!intercepted) {
-      this.updateNavigationEntriesForSameDocumentNavigation(this.navigateEvent!);
+    // The event may have been aborted during dispatch, e.g. by a `navigate` listener starting
+    // another navigation. There is nothing left to commit in that case.
+    if (!intercepted && this.navigateEvent) {
+      this.updateNavigationEntriesForSameDocumentNavigation(this.navigateEvent);
     }
     return {
       committed: result.committed,
@@ -432,7 +524,11 @@ export class FakeNavigation implements Navigation {
       return new Promise<void>((resolve) => {
         setTimeout(() => {
           resolve();
-          traversal();
+          // A traversal queued before `dispose()` must not mutate entries or dispatch events
+          // afterwards. `dispose()` has already settled this traversal's promises.
+          if (!this.disposed) {
+            traversal();
+          }
           this.propsectiveTraversalDestinations.shift();
         });
       });
@@ -462,10 +558,34 @@ export class FakeNavigation implements Navigation {
     return this.eventTarget.dispatchEvent(event);
   }
 
-  /** Cleans up resources. */
+  /**
+   * Cleans up resources.
+   *
+   * Any in-flight or queued navigation is aborted so that its `committed`/`finished` promises
+   * settle; otherwise awaiting them during teardown would hang forever.
+   */
   dispose(): void {
+    // Abort the ongoing navigation first, so `navigateerror` is still delivered to the listeners
+    // registered before disposal.
+    if (this.navigateEvent) {
+      this.abortOngoingNavigation(this.navigateEvent, createDisposedAbortError());
+    }
+    this.navigateEvent = null;
+    for (const queuedResult of this.traversalQueue.values()) {
+      const reason = createDisposedAbortError();
+      queuedResult.abort(reason);
+      queuedResult.finishedReject(reason);
+    }
+    this.traversalQueue.clear();
+    this.propsectiveTraversalDestinations = [];
+    this._transition = null;
     // Recreate eventTarget to release current listeners.
     this.eventTarget = this.createEventTarget();
+    this._onnavigate = null;
+    this._oncurrententrychange = null;
+    this._onnavigatesuccess = null;
+    this._onnavigateerror = null;
+    handlerWrappers.get(this)?.clear();
     this.disposed = true;
   }
 
@@ -549,8 +669,10 @@ export class FakeNavigation implements Navigation {
     const oldUrl = this.currentEntry.url!;
     this.updateNavigationEntriesForSameDocumentNavigation(navigateEvent);
     // Happens as part of "updating the document" steps https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-document
+    // The state is read back off the entry that just became current so that `popstate.state` and
+    // `history.state` are the same object, as they are in a real user agent.
     const popStateEvent = createPopStateEvent({
-      state: navigateEvent.destination.getHistoryState(),
+      state: this.currentEntry.getHistoryState(),
       hasUAVisualTransition: navigateEvent.hasUAVisualTransition,
     });
     this._window.dispatchEvent(popStateEvent);
@@ -589,7 +711,7 @@ export class FakeNavigation implements Navigation {
         navigationType === 'push'
           ? String(this.nextKey++)
           : (oldCurrentNHE?.key ?? String(this.nextKey++));
-      const newNHE = new FakeNavigationHistoryEntry(this.eventTarget, destination.url, {
+      const newNHE = new FakeNavigationHistoryEntry(this.createEventTarget, destination.url, {
         id: String(this.nextId++),
         key,
         index,
@@ -632,7 +754,7 @@ export class FakeNavigation implements Navigation {
     // tslint:disable-next-line:no-any
     handler: ((this: Navigation, ev: NavigateEvent) => any) | null,
   ) {
-    this._onnavigate = setEventHandler(this, 'navigate', this._onnavigate, handler);
+    this._onnavigate = setEventHandler(this, 'navigate', handler);
   }
 
   private _oncurrententrychange:
@@ -652,12 +774,7 @@ export class FakeNavigation implements Navigation {
         ((this: Navigation, ev: NavigationCurrentEntryChangeEvent) => any)
       | null,
   ) {
-    this._oncurrententrychange = setEventHandler(
-      this,
-      'currententrychange',
-      this._oncurrententrychange,
-      handler,
-    );
+    this._oncurrententrychange = setEventHandler(this, 'currententrychange', handler);
   }
 
   private _onnavigatesuccess: ((this: Navigation, ev: Event) => any) | null = null;
@@ -672,12 +789,7 @@ export class FakeNavigation implements Navigation {
     // tslint:disable-next-line:no-any
     handler: ((this: Navigation, ev: Event) => any) | null,
   ) {
-    this._onnavigatesuccess = setEventHandler(
-      this,
-      'navigatesuccess',
-      this._onnavigatesuccess,
-      handler,
-    );
+    this._onnavigatesuccess = setEventHandler(this, 'navigatesuccess', handler);
   }
 
   private _onnavigateerror: ((this: Navigation, ev: ErrorEvent) => any) | null = null;
@@ -692,7 +804,7 @@ export class FakeNavigation implements Navigation {
     // tslint:disable-next-line:no-any
     handler: ((this: Navigation, ev: ErrorEvent) => any) | null,
   ) {
-    this._onnavigateerror = setEventHandler(this, 'navigateerror', this._onnavigateerror, handler);
+    this._onnavigateerror = setEventHandler(this, 'navigateerror', handler);
   }
 
   private _transition: NavigationTransition | null = null;
@@ -736,7 +848,13 @@ export class FakeNavigation implements Navigation {
       );
     }
 
-    const state = options && 'state' in options ? options.state : current.getState();
+    let state: unknown;
+    try {
+      state = options && 'state' in options ? cloneState(options.state) : current.getState();
+    } catch (e: unknown) {
+      return earlyErrorResult(asDataCloneError(e));
+    }
+
     const destination = new FakeNavigationDestination({
       url: current.url!,
       state,
@@ -792,11 +910,18 @@ export class FakeNavigationHistoryEntry implements NavigationHistoryEntry {
     // tslint:disable-next-line:no-any
     handler: ((this: NavigationHistoryEntry, ev: Event) => any) | null,
   ) {
-    this._ondispose = setEventHandler(this, 'dispose', this._ondispose, handler);
+    this._ondispose = setEventHandler(this, 'dispose', handler);
   }
 
+  private eventTarget: EventTarget;
+
   constructor(
-    private eventTarget: EventTarget,
+    /**
+     * Creates the `EventTarget` backing this entry. A factory rather than an instance because
+     * `dispose()` swaps in a fresh target, which must be created the same way as the original to
+     * stay compatible with the `Event` implementation in use (see `FakeNavigation`'s constructor).
+     */
+    private readonly createEventTarget: () => EventTarget,
     readonly url: string | null,
     {
       id,
@@ -814,6 +939,7 @@ export class FakeNavigationHistoryEntry implements NavigationHistoryEntry {
       state?: unknown;
     },
   ) {
+    this.eventTarget = createEventTarget();
     this.id = id;
     this.key = key;
     this.index = index;
@@ -824,6 +950,10 @@ export class FakeNavigationHistoryEntry implements NavigationHistoryEntry {
 
   /**
    * https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-getstate
+   *
+   * > Return StructuredDeserialize(this's session history entry's navigation API state).
+   *
+   * The deserialization happens per call, so each call returns a fresh object.
    */
   getState(): unknown {
     return cloneState(this.state);
@@ -834,8 +964,15 @@ export class FakeNavigationHistoryEntry implements NavigationHistoryEntry {
     this.state = state;
   }
 
+  /**
+   * The classic history API state, i.e. what `history.state` returns for this entry.
+   *
+   * Unlike `getState()`, this is deserialized once when the entry is created and the same value is
+   * returned on every read, matching `history.state`'s stable identity.
+   * https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-state
+   */
   getHistoryState(): unknown {
-    return cloneState(this.historyState);
+    return this.historyState;
   }
 
   addEventListener(
@@ -865,8 +1002,12 @@ export class FakeNavigationHistoryEntry implements NavigationHistoryEntry {
   dispose() {
     const disposeEvent = new Event('dispose');
     this.dispatchEvent(disposeEvent);
-    // release current listeners
-    this.eventTarget = null!;
+    // Swap in a fresh target to release the listeners registered on the old one. The entry stays
+    // usable afterwards, matching a real user agent where a disposed entry is still a live object.
+    // Note that `ondispose` is deliberately *not* reset: reading the IDL attribute after disposal
+    // still returns the handler that was set, as it does in a browser.
+    this.eventTarget = this.createEventTarget();
+    handlerWrappers.get(this)?.clear();
   }
 }
 
@@ -885,9 +1026,27 @@ interface InternalFakeNavigateEvent extends FakeNavigateEvent {
   scrollBehavior: 'after-transition' | 'manual' | null;
   focusResetBehavior: 'after-transition' | 'manual' | null;
 
+  /**
+   * The spec's "dispatch flag", set only while the event is being dispatched. `intercept()` may
+   * only be called while it is set.
+   * https://dom.spec.whatwg.org/#dispatch-flag
+   */
+  dispatchFlag: boolean;
+  /**
+   * The spec's "canceled flag", set when the navigation is aborted during dispatch (for example
+   * by `preventDefault()`). The "shared checks" reject calls into the event once it is set.
+   * https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigateevent-canceled-flag
+   */
+  canceledFlag: boolean;
+
   abortController: AbortController;
   abort(reason: Error): void;
 }
+
+/** `InternalFakeNavigateEvent` with the `readonly` modifiers stripped, for internal mutation. */
+type MutableInternalFakeNavigateEvent = {
+  -readonly [P in keyof InternalFakeNavigateEvent]: InternalFakeNavigateEvent[P];
+};
 
 /**
  * Create a fake equivalent of `NavigateEvent`. This is not a class because ES5
@@ -923,18 +1082,20 @@ function dispatchNavigateEvent({
   const {navigation} = result;
 
   const eventAbortController = new AbortController();
-  const event = new Event('navigate', {bubbles: false, cancelable}) as {
-    -readonly [P in keyof InternalFakeNavigateEvent]: InternalFakeNavigateEvent[P];
-  };
+  const event = new Event('navigate', {
+    bubbles: false,
+    cancelable,
+  }) as MutableInternalFakeNavigateEvent;
+
+  event.dispatchFlag = false;
+  event.canceledFlag = false;
 
   event.navigationType = navigationType;
   event.destination = destination;
   event.canIntercept = canIntercept;
   event.userInitiated = userInitiated;
   event.hashChange = hashChange;
-  if (hasUAVisualTransition) {
-    event.hasUAVisualTransition = true;
-  }
+  event.hasUAVisualTransition = hasUAVisualTransition ?? false;
   event.signal = eventAbortController.signal;
   event.abortController = eventAbortController;
   event.info = info;
@@ -952,16 +1113,38 @@ function dispatchNavigateEvent({
   > = [];
   let handlers: Array<() => PromiseLike<void> | void> = [];
 
+  /**
+   * https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigateevent-shared-checks
+   *
+   * > 1. If event's relevant global object's associated Document is not fully active, then throw
+   * >    an "InvalidStateError" DOMException.
+   * > 2. If event's canceled flag is set, then throw an "InvalidStateError" DOMException.
+   *
+   * The "fully active" check has no analogue in this fake.
+   */
+  function performSharedChecks() {
+    if (event.canceledFlag) {
+      throw new DOMException('The navigation was canceled', 'InvalidStateError');
+    }
+  }
+
   // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept
   event.intercept = function (
-    this: InternalFakeNavigateEvent,
+    this: MutableInternalFakeNavigateEvent,
     options?: NavigationInterceptOptions,
   ): void {
+    performSharedChecks();
     if (!this.canIntercept) {
       throw new DOMException(`Cannot intercept when canIntercept is 'false'`, 'SecurityError');
     }
-    this.interceptionState = 'intercepted';
-    event.sameDocument = true;
+    // > If this's dispatch flag is unset, then throw an "InvalidStateError" DOMException.
+    // i.e. `intercept()` is only valid from within a `navigate` event listener.
+    if (!this.dispatchFlag) {
+      throw new DOMException(
+        `Cannot intercept when the 'navigate' event is not being dispatched`,
+        'InvalidStateError',
+      );
+    }
     const precommitHandler = options?.precommitHandler;
     if (precommitHandler) {
       if (!this.cancelable) {
@@ -972,36 +1155,41 @@ function dispatchNavigateEvent({
       }
       precommitHandlers.push(precommitHandler);
     }
-    if (event.interceptionState !== 'none' && event.interceptionState !== 'intercepted') {
-      throw new Error('Event interceptionState should be "none" or "intercepted"');
+    // The spec asserts this rather than throwing, because the dispatch flag check above already
+    // rules it out. It is kept as a throw so that misuse of the fake surfaces loudly.
+    if (this.interceptionState !== 'none' && this.interceptionState !== 'intercepted') {
+      throw new DOMException(
+        'Event interceptionState should be "none" or "intercepted"',
+        'InvalidStateError',
+      );
     }
-    event.interceptionState = 'intercepted';
+    this.interceptionState = 'intercepted';
+    this.sameDocument = true;
     const handler = options?.handler;
     if (handler) {
       handlers.push(handler);
     }
     // override old options with new ones. UA _may_ report a console warning if new options differ from previous
-    event.focusResetBehavior = options?.focusReset ?? event.focusResetBehavior;
-    event.scrollBehavior = options?.scroll ?? event.scrollBehavior;
+    this.focusResetBehavior = options?.focusReset ?? this.focusResetBehavior;
+    this.scrollBehavior = options?.scroll ?? this.scrollBehavior;
   };
 
   // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-scroll
-  event.scroll = function (this: InternalFakeNavigateEvent): void {
-    if (event.interceptionState !== 'committed') {
+  event.scroll = function (this: MutableInternalFakeNavigateEvent): void {
+    performSharedChecks();
+    if (this.interceptionState !== 'committed') {
       throw new DOMException(
         `Failed to execute 'scroll' on 'NavigateEvent': scroll() must be ` +
           `called after commit() and interception options must specify manual scroll.`,
         'InvalidStateError',
       );
     }
-    processScrollBehavior(event);
+    processScrollBehavior(this);
   };
 
   // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationprecommitcontroller-redirect
   function redirect(url: string, options: NavigationNavigateOptions = {}) {
-    if (event.interceptionState === 'none') {
-      throw new Error('cannot redirect when event is not intercepted');
-    }
+    performSharedChecks();
     if (event.interceptionState !== 'intercepted') {
       throw new DOMException(
         `cannot redirect when event is not in 'intercepted' state`,
@@ -1010,16 +1198,38 @@ function dispatchNavigateEvent({
     }
     if (event.navigationType !== 'push' && event.navigationType !== 'replace') {
       throw new DOMException(
-        `cannot redirect when navigationType is not 'push' or 'replace`,
+        `cannot redirect when navigationType is not 'push' or 'replace'`,
         'InvalidStateError',
       );
     }
-    const destinationUrl = new URL(url, navigation.currentEntry.url!);
+
+    // > Let destinationURL be the result of parsing url given document.
+    // > If destinationURL is failure, then throw a "SyntaxError" DOMException.
+    const currentUrl = new URL(navigation.currentEntry.url!);
+    let destinationUrl: URL;
+    try {
+      destinationUrl = new URL(url, currentUrl);
+    } catch {
+      throw new DOMException(`Failed to parse URL '${url}'`, 'SyntaxError');
+    }
+
+    // > If document cannot have its URL rewritten to destinationURL, then throw a "SecurityError"
+    // > DOMException.
+    if (!canHaveUrlRewrittenTo(currentUrl, destinationUrl)) {
+      throw new DOMException(
+        `Cannot rewrite the document URL from '${currentUrl.href}' to '${destinationUrl.href}'`,
+        'SecurityError',
+      );
+    }
+
+    // > If options["history"] is "push" or "replace", then set this's event's navigationType to
+    // > options["history"].
+    // Note that "history" defaults to "auto", which deliberately leaves navigationType unchanged.
     if (options.history === 'push' || options.history === 'replace') {
       event.navigationType = options.history;
     }
     if (Object.hasOwn(options, 'state')) {
-      event.destination.state = options.state;
+      event.destination.state = cloneState(options.state);
     }
     event.destination.url = destinationUrl.href;
     if (Object.hasOwn(options, 'info')) {
@@ -1029,6 +1239,7 @@ function dispatchNavigateEvent({
 
   // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationprecommitcontroller-addhandler
   function addHandler(handler: () => PromiseLike<void> | void) {
+    performSharedChecks();
     if (event.interceptionState !== 'intercepted') {
       throw new DOMException(
         `cannot addHandler when event is not in 'intercepted' state`,
@@ -1044,7 +1255,12 @@ function dispatchNavigateEvent({
       return;
     }
     if (event !== navigation.navigateEvent) {
-      throw new Error('Event is no longer the current navigation event');
+      // The event stopped being the ongoing one without having been aborted, which happens when
+      // the `Navigation` was disposed. Settle the result so that `finished` does not stay pending
+      // forever.
+      result.abort(reason);
+      result.finishedReject(reason);
+      return;
     }
     if (event.interceptionState !== 'intercepted') {
       finishNavigationEvent(event, false);
@@ -1055,7 +1271,10 @@ function dispatchNavigateEvent({
   // https://html.spec.whatwg.org/multipage/nav-history-apis.html#commit-a-navigate-event
   // "To commit a navigate event given a NavigateEvent..."
   function commit() {
-    if (result.signal.aborted) {
+    // > If event's abort controller's signal is aborted, then return.
+    // A navigation superseded by a later one is aborted by `abortOngoingNavigation`, so this also
+    // stops a stale navigation from committing entries.
+    if (event.abortController.signal.aborted || result.signal.aborted) {
       return;
     }
     if (event.interceptionState !== 'none') {
@@ -1121,9 +1340,18 @@ function dispatchNavigateEvent({
   // Internal only.
   // https://html.spec.whatwg.org/multipage/nav-history-apis.html#abort-a-navigateevent
   // "To abort a NavigateEvent event given reason:"
-  event.abort = function (this: InternalFakeNavigateEvent, reason: Error) {
+  event.abort = function (this: MutableInternalFakeNavigateEvent, reason: Error) {
+    // > If event's dispatch flag is set, then set event's canceled flag to true.
+    if (this.dispatchFlag) {
+      this.canceledFlag = true;
+    }
     this.abortController.abort(reason);
-    navigation.navigateEvent = null;
+    result.abort(reason);
+    // The spec unconditionally clears the ongoing navigate event here because it only ever aborts
+    // the ongoing one. This fake can abort a stale event, which must not clear a newer navigation.
+    if (navigation.navigateEvent === this) {
+      navigation.navigateEvent = null;
+    }
     result.finishedReject(reason);
     const navigateerrorEvent = new Event('navigateerror', {
       bubbles: false,
@@ -1139,7 +1367,15 @@ function dispatchNavigateEvent({
 
   function dispatch() {
     navigation.navigateEvent = event;
-    const dispatchResult = navigation.eventTarget.dispatchEvent(event);
+    // `intercept()` is only callable while the event is being dispatched, so the flag is set for
+    // exactly the duration of the dispatch.
+    event.dispatchFlag = true;
+    let dispatchResult: boolean;
+    try {
+      dispatchResult = navigation.eventTarget.dispatchEvent(event);
+    } finally {
+      event.dispatchFlag = false;
+    }
 
     if (event.interceptionState === 'intercepted') {
       if (!navigation.currentEntry) {
@@ -1299,9 +1535,7 @@ function createPopStateEvent({
     cancelable: false,
   }) as {-readonly [P in keyof PopStateEvent]: PopStateEvent[P]};
   event.state = state;
-  if (hasUAVisualTransition) {
-    event.hasUAVisualTransition = true;
-  }
+  event.hasUAVisualTransition = hasUAVisualTransition ?? false;
   return event as PopStateEvent;
 }
 
@@ -1355,10 +1589,19 @@ export class FakeNavigationDestination implements NavigationDestination {
     this.index = index;
   }
 
+  /**
+   * https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationdestination-getstate
+   *
+   * > Return StructuredDeserialize(this's state).
+   */
   getState(): unknown {
-    return this.state;
+    return cloneState(this.state);
   }
 
+  /**
+   * The classic history API state for this destination. Returned by reference, because it seeds
+   * the entry's `history.state`, which has a stable identity.
+   */
   getHistoryState(): unknown {
     return this.historyState;
   }
@@ -1375,26 +1618,107 @@ function isHashChange(from: URL, to: URL): boolean {
 }
 
 /**
+ * Implementation of the spec's "can have its URL rewritten" check, shared by
+ * `history.pushState()`/`replaceState()` and `NavigationPrecommitController.redirect()`.
+ *
+ * > 1. Let documentURL be document's URL.
+ * > 2. If targetURL and documentURL differ in their scheme, username, password, host, or port
+ * >    components, then return false.
+ * > 3. If targetURL's scheme is an HTTP(S) scheme, then return true.
+ * > 4. If targetURL's scheme is "file", and targetURL and documentURL differ in their path
+ * >    component, then return false.
+ * > 5. If targetURL and documentURL differ in their path component or query components, then
+ * >    return false.
+ * > 6. Return true.
+ *
+ * https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten
+ */
+function canHaveUrlRewrittenTo(documentUrl: URL, targetUrl: URL): boolean {
+  // `URL.host` is the host and, when it is not the default for the scheme, the port. Comparing it
+  // alongside the protocol and credentials covers step 2 in full.
+  if (
+    targetUrl.protocol !== documentUrl.protocol ||
+    targetUrl.username !== documentUrl.username ||
+    targetUrl.password !== documentUrl.password ||
+    targetUrl.host !== documentUrl.host
+  ) {
+    return false;
+  }
+  if (targetUrl.protocol === 'http:' || targetUrl.protocol === 'https:') {
+    return true;
+  }
+  if (targetUrl.protocol === 'file:') {
+    return targetUrl.pathname === documentUrl.pathname;
+  }
+  return targetUrl.pathname === documentUrl.pathname && targetUrl.search === documentUrl.search;
+}
+
+const handlerWrappers = new WeakMap<object, Map<string, EventListener>>();
+
+/**
  * Sets an IDL event listener attribute, removing the old listener and adding the new one.
+ *
+ * The listener is wrapped so that `this` inside the handler is the `Navigation` or
+ * `NavigationHistoryEntry` the attribute belongs to, rather than the internal `EventTarget` that
+ * actually dispatches the event.
  */
 function setEventHandler<H extends ((...args: any[]) => any) | null>(
-  target: EventTarget,
+  target: {
+    addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+    removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+  },
   type: string,
-  current: H,
   next: H,
+  context: unknown = target,
 ): H {
-  if (current) {
-    target.removeEventListener(type, current as EventListener);
+  let targetWrappers = handlerWrappers.get(target);
+  if (!targetWrappers) {
+    targetWrappers = new Map();
+    handlerWrappers.set(target, targetWrappers);
+  }
+  const existingWrapper = targetWrappers.get(type);
+  if (existingWrapper) {
+    target.removeEventListener(type, existingWrapper);
+    targetWrappers.delete(type);
   }
   if (next) {
-    target.addEventListener(type, next as EventListener);
+    const wrapped: EventListener = function (ev: Event) {
+      return next.call(context, ev);
+    };
+    targetWrappers.set(type, wrapped);
+    target.addEventListener(type, wrapped);
   }
   return next;
 }
 
-/** Budget structured clone for state objects. */
+/**
+ * Structured clone for state objects.
+ *
+ * The spec serializes navigation state with `StructuredSerializeForStorage`, which is marginally
+ * stricter than `structuredClone()` (it additionally rejects values that cannot be persisted, such
+ * as `SharedArrayBuffer`). `structuredClone()` is the closest primitive available here, so a value
+ * that a real user agent would reject may still clone successfully in this fake.
+ *
+ * `structuredClone()` throws its own `DataCloneError` `DOMException`, which carries a more useful
+ * message than anything synthesized here, so it is deliberately left unwrapped.
+ */
 function cloneState<T>(state: T): T {
-  return state !== undefined && state !== null ? (JSON.parse(JSON.stringify(state)) as T) : state;
+  if (state === undefined || state === null) {
+    return state;
+  }
+  return structuredClone(state);
+}
+
+/** Coerces a state cloning failure into the `DataCloneError` the spec surfaces. */
+function asDataCloneError(e: unknown): DOMException {
+  return e instanceof DOMException
+    ? e
+    : new DOMException('The object could not be cloned.', 'DataCloneError');
+}
+
+/** The reason used to settle navigations that were still in flight when `dispose()` was called. */
+function createDisposedAbortError(): DOMException {
+  return new DOMException('Navigation aborted because the Navigation was disposed.', 'AbortError');
 }
 
 /**
@@ -1458,6 +1782,10 @@ class InternalNavigationResult {
     return this.abortController.signal;
   }
   private readonly abortController = new AbortController();
+
+  abort(reason?: unknown) {
+    this.abortController.abort(reason);
+  }
 
   constructor(readonly navigation: FakeNavigation) {
     this.committed = new Promise<FakeNavigationHistoryEntry>((resolve, reject) => {

--- a/packages/core/primitives/dom-navigation/testing/test/fake_platform_navigation.spec.ts
+++ b/packages/core/primitives/dom-navigation/testing/test/fake_platform_navigation.spec.ts
@@ -172,7 +172,7 @@ describe('navigation', () => {
           }),
         }),
       );
-      expect(Object.hasOwn(navigateEvent, 'hasUAVisualTransition')).toBeFalse();
+      expect(navigateEvent.hasUAVisualTransition).toBe(false);
       expect(navigateEvent.destination.getState()).toBeUndefined();
       const committedEntry = await committed;
       expect(committedEntry).toEqual(
@@ -962,7 +962,7 @@ describe('navigation', () => {
       expect(locals.popStateEvents.length).toBe(1);
       const popStateEvent = locals.popStateEvents[0];
       expect(popStateEvent.state).toBeNull();
-      expect(Object.hasOwn(popStateEvent, 'hasUAVisualTransition')).toBeFalse();
+      expect(popStateEvent.hasUAVisualTransition).toBe(false);
       expect(locals.navigation.canGoBack).toBeTrue();
       expect(locals.navigation.canGoForward).toBeTrue();
       const finishedEntry = await finished;
@@ -2176,17 +2176,90 @@ describe('navigation', () => {
       expect(committedEntry.getState()).toEqual(state);
     });
 
-    it('throws an error if navigationType is "traverse"', async () => {
+    it('throws InvalidStateError if navigationType is "traverse"', async () => {
       await setUpEntries();
+      let caughtError: any = null;
       locals.pendingInterceptOptions.push({
         precommitHandler: async (event) => {
-          expect(() => event.redirect('/redirected')).toThrowError();
+          try {
+            event.redirect('/redirected');
+          } catch (e: any) {
+            caughtError = e;
+          }
         },
       });
       // Use back() to trigger a 'traverse' navigation
       await locals.navigation.back().finished;
+      expect(caughtError).not.toBeNull();
+      expect(caughtError?.name).toBe('InvalidStateError');
+      expect(caughtError?.message).toContain(
+        "cannot redirect when navigationType is not 'push' or 'replace'",
+      );
       // Check that a navigate event occurred (it should, even if redirect fails)
       expect(locals.navigateEvents.length).toBe(1);
+    });
+
+    it('throws SecurityError when redirecting to a cross-origin URL', async () => {
+      let caughtError: any = null;
+      locals.pendingInterceptOptions.push({
+        precommitHandler: (controller) => {
+          try {
+            controller.redirect('https://evil.com');
+          } catch (e: any) {
+            caughtError = e;
+          }
+        },
+      });
+
+      await locals.navigation.navigate('/page').finished;
+      expect(caughtError).not.toBeNull();
+      expect(caughtError?.name).toBe('SecurityError');
+    });
+
+    it('throws SecurityError when redirecting to a script URL', async () => {
+      let caughtError: any = null;
+      locals.pendingInterceptOptions.push({
+        precommitHandler: (controller) => {
+          try {
+            controller.redirect('javascript:alert(1)');
+          } catch (e: any) {
+            caughtError = e;
+          }
+        },
+      });
+
+      await locals.navigation.navigate('/page').finished;
+      expect(caughtError).not.toBeNull();
+      expect(caughtError?.name).toBe('SecurityError');
+    });
+
+    it('throws SyntaxError when redirecting to an unparseable URL', async () => {
+      let caughtError: any = null;
+      locals.pendingInterceptOptions.push({
+        precommitHandler: (controller) => {
+          try {
+            controller.redirect('http://:invalid-url');
+          } catch (e: any) {
+            caughtError = e;
+          }
+        },
+      });
+
+      await locals.navigation.navigate('/page').finished;
+      expect(caughtError).not.toBeNull();
+      expect(caughtError?.name).toBe('SyntaxError');
+    });
+
+    it('synchronously clones state passed to redirect', async () => {
+      const redirectState = {count: 10};
+      locals.pendingInterceptOptions.push({
+        precommitHandler: (controller) => {
+          controller.redirect('/redirected', {state: redirectState});
+          redirectState.count = 99;
+        },
+      });
+      await locals.navigation.navigate('/page').finished;
+      expect((locals.navigation.currentEntry.getState() as any).count).toBe(10);
     });
   });
 
@@ -2336,7 +2409,7 @@ describe('navigation', () => {
     it('has default hasUAVisualTransition and sourceElement values', async () => {
       await locals.navigation.navigate('/page').finished;
       const event = locals.navigateEvents[0];
-      expect(event.hasUAVisualTransition).toBeFalsy();
+      expect(event.hasUAVisualTransition).toBe(false);
       expect(event.sourceElement).toBeNull();
     });
   });
@@ -2427,6 +2500,766 @@ describe('navigation', () => {
 
       await locals.navigation.navigate('/test').finished;
       expect(onNavigateCalled).toBeFalse();
+    });
+  });
+
+  describe('superseded navigation race condition in commit()', () => {
+    it('prevents a superseded navigation from committing after asynchronous precommit handlers resolve', async () => {
+      let resolveNav1: () => void;
+      const nav1Deferred = new Promise<void>((res) => (resolveNav1 = res));
+
+      locals.pendingInterceptOptions.push({
+        precommitHandler: () => nav1Deferred,
+      });
+
+      const nav1 = locals.navigation.navigate('/page1');
+      const nav2 = locals.navigation.navigate('/page2');
+
+      // Finish nav1 after nav2 has already started
+      resolveNav1!();
+
+      await expectAsync(nav1.committed).toBeRejected();
+      await nav2.committed;
+
+      expect(locals.navigation.currentEntry?.url).toContain('/page2');
+      expect(locals.navigation.entries().length).toBe(2); // Initial and page2
+    });
+  });
+
+  describe('isolated history entry EventTarget and disposal', () => {
+    it('isolates dispose events so entries only receive their own disposal event', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      const entry1 = locals.navigation.currentEntry!;
+      let entry1DisposedCount = 0;
+      entry1.ondispose = () => entry1DisposedCount++;
+
+      await locals.navigation.navigate('/page2').finished;
+      const entry2 = locals.navigation.currentEntry!;
+      let entry2DisposedCount = 0;
+      entry2.ondispose = () => entry2DisposedCount++;
+
+      // Replace entry 2; entry 1 must NOT receive a dispose event
+      await locals.navigation.navigate('/page3', {history: 'replace'}).finished;
+
+      expect(entry2DisposedCount).toBe(1);
+      expect(entry1DisposedCount).toBe(0);
+    });
+
+    it('does not throw when removing listeners or setting ondispose on a disposed entry', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      const entry = locals.navigation.currentEntry!;
+      const listener = () => {};
+      entry.addEventListener('dispose', listener);
+      entry.ondispose = () => {};
+
+      await locals.navigation.navigate('/page2', {history: 'replace'}).finished;
+
+      expect(() => {
+        entry.removeEventListener('dispose', listener);
+        entry.ondispose = null;
+      }).not.toThrow();
+    });
+  });
+
+  describe('hasUAVisualTransition and sourceElement propagation', () => {
+    it('propagates hasUAVisualTransition: true to NavigateEvent and PopStateEvent on back()', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      await locals.navigation.navigate('/page2').finished;
+
+      await locals.navigation.back({hasUAVisualTransition: true}).finished;
+
+      const navEvent = locals.navigateEvents[locals.navigateEvents.length - 1];
+      expect(navEvent.hasUAVisualTransition).toBe(true);
+      const popEvent = locals.popStateEvents[locals.popStateEvents.length - 1];
+      expect(popEvent.hasUAVisualTransition).toBe(true);
+    });
+
+    it('propagates hasUAVisualTransition: true on forward()', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      await locals.navigation.navigate('/page2').finished;
+      await locals.navigation.back().finished;
+
+      await locals.navigation.forward({hasUAVisualTransition: true}).finished;
+
+      expect(locals.navigateEvents[locals.navigateEvents.length - 1].hasUAVisualTransition).toBe(
+        true,
+      );
+      expect(locals.popStateEvents[locals.popStateEvents.length - 1].hasUAVisualTransition).toBe(
+        true,
+      );
+    });
+
+    it('propagates hasUAVisualTransition: true on traverseTo()', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      const target = locals.navigation.currentEntry;
+      await locals.navigation.navigate('/page2').finished;
+
+      await locals.navigation.traverseTo(target.key, {hasUAVisualTransition: true}).finished;
+
+      expect(locals.navigateEvents[locals.navigateEvents.length - 1].hasUAVisualTransition).toBe(
+        true,
+      );
+    });
+
+    it('defaults hasUAVisualTransition to false for a traversal without the option', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      await locals.navigation.navigate('/page2').finished;
+
+      await locals.navigation.back().finished;
+
+      expect(locals.navigateEvents[locals.navigateEvents.length - 1].hasUAVisualTransition).toBe(
+        false,
+      );
+      expect(locals.popStateEvents[locals.popStateEvents.length - 1].hasUAVisualTransition).toBe(
+        false,
+      );
+    });
+
+    it('propagates sourceElement to NavigateEvent via navigateForTesting()', async () => {
+      const button = document.createElement('button');
+      await locals.navigation.navigateForTesting('/page', {sourceElement: button}).finished;
+      const navEvent = locals.navigateEvents[locals.navigateEvents.length - 1];
+      expect(navEvent.sourceElement).toBe(button);
+    });
+  });
+
+  describe('NavigateEvent.intercept() state validation and check order', () => {
+    it('throws InvalidStateError when called outside of the navigate event dispatch', async () => {
+      let eventRef: FakeNavigateEvent | null = null;
+      locals.setExtraNavigateCallback((event) => {
+        eventRef = event;
+      });
+
+      // A navigation that is never intercepted, so its interceptionState stays 'none'. The only
+      // thing making a later intercept() invalid is the unset dispatch flag.
+      await locals.navigation.navigate('/page').finished;
+      expect(eventRef).not.toBeNull();
+      expect((eventRef as any).interceptionState).toBe('none');
+
+      expect(() => {
+        eventRef!.intercept({});
+      }).toThrowMatching((e: any) => e.name === 'InvalidStateError');
+
+      // The rejected call must not have mutated the event.
+      expect((eventRef as any).interceptionState).toBe('none');
+      expect((eventRef as any).sameDocument).toBe(false);
+    });
+
+    it('throws InvalidStateError when called after an intercepted navigation finished', async () => {
+      let eventRef: FakeNavigateEvent | null = null;
+      locals.pendingInterceptOptions.push({handler: () => {}});
+      locals.setExtraNavigateCallback((event) => {
+        eventRef = event;
+      });
+
+      await locals.navigation.navigate('/page').finished;
+
+      expect(() => {
+        eventRef!.intercept({});
+      }).toThrowMatching((e: any) => e.name === 'InvalidStateError');
+    });
+
+    it('rejects a precommitHandler on a non-cancelable event without mutating the event', async () => {
+      let caughtError: any = null;
+      let eventRef: FakeNavigateEvent | null = null;
+      // Checked during dispatch, which is the only point at which intercept() is valid.
+      locals.setExtraNavigateCallback((event) => {
+        eventRef = event;
+        try {
+          event.intercept({precommitHandler: () => {}});
+        } catch (e) {
+          caughtError = e;
+        }
+      });
+
+      await locals.navigation.navigateForTesting('/page', {cancelable: false}).finished;
+
+      expect(caughtError?.name).toBe('InvalidStateError');
+      // The cancelable check runs before any state is written, so the navigation stayed
+      // un-intercepted.
+      expect((eventRef as any).interceptionState).toBe('none');
+      expect((eventRef as any).sameDocument).toBe(false);
+    });
+
+    it('throws SecurityError when canIntercept is false, before the dispatch flag check', async () => {
+      // `canIntercept` is checked ahead of the dispatch flag, so a stale non-interceptable event
+      // reports SecurityError rather than InvalidStateError.
+      let eventRef: FakeNavigateEvent | null = null;
+      locals.setExtraNavigateCallback((event) => {
+        eventRef = event;
+      });
+      await locals.navigation.navigate('/page').finished;
+      (eventRef as any).canIntercept = false;
+
+      expect(() => {
+        eventRef!.intercept({});
+      }).toThrowMatching((e: any) => e.name === 'SecurityError');
+    });
+
+    it('throws InvalidStateError from intercept() once the event was canceled mid-dispatch', async () => {
+      let caughtError: any = null;
+      locals.setExtraNavigateCallback((event) => {
+        // Aborting while the event is still dispatching sets the spec's "canceled flag", which is
+        // what a nested navigation started from a `navigate` listener does.
+        (event as any).abort(new DOMException('superseded', 'AbortError'));
+        try {
+          event.intercept({});
+        } catch (e) {
+          caughtError = e;
+        }
+      });
+
+      await expectAsync(locals.navigation.navigate('/page').finished).toBeRejected();
+      expect(caughtError?.name).toBe('InvalidStateError');
+    });
+  });
+
+  describe('structuredClone state serialization', () => {
+    it('supports Date, Map, and Set objects in navigation state', async () => {
+      const testDate = new Date(2026, 0, 1);
+      const testMap = new Map([['key', 'val']]);
+      const testSet = new Set([1, 2, 3]);
+
+      await locals.navigation.navigate('/page', {
+        state: {testDate, testMap, testSet},
+      }).finished;
+
+      const state = locals.navigation.currentEntry.getState() as any;
+      expect(state.testDate instanceof Date).toBeTrue();
+      expect(state.testDate.getTime()).toBe(testDate.getTime());
+      expect(state.testMap instanceof Map).toBeTrue();
+      expect(state.testMap.get('key')).toBe('val');
+      expect(state.testSet instanceof Set).toBeTrue();
+      expect(state.testSet.has(2)).toBeTrue();
+    });
+
+    it('synchronously clones state upon navigate() call', async () => {
+      const mutableState = {counter: 1};
+      const navPromise = locals.navigation.navigate('/page', {state: mutableState});
+      mutableState.counter = 2; // Mutate immediately after navigate() call
+
+      await navPromise.finished;
+      const state = locals.navigation.currentEntry.getState() as any;
+      expect(state.counter).toBe(1);
+    });
+
+    it('clones state returned by destination.getState() and entry.getState()', async () => {
+      locals.setExtraNavigateCallback((event) => {
+        const destState = event.destination.getState() as any;
+        destState.mutated = true;
+        expect((event.destination.getState() as any).mutated).toBeUndefined();
+      });
+
+      await locals.navigation.navigate('/page', {state: {initial: true}}).finished;
+      const entryState = locals.navigation.currentEntry.getState() as any;
+      entryState.mutated = true;
+      expect((locals.navigation.currentEntry.getState() as any).mutated).toBeUndefined();
+    });
+
+    it('rejects with DataCloneError when non-cloneable objects are passed to navigate()', async () => {
+      const unclonable = {fn: () => {}};
+      const result = locals.navigation.navigate('/page', {state: unclonable});
+      await expectAsync(result.committed).toBeRejectedWith(
+        jasmine.objectContaining({name: 'DataCloneError'}),
+      );
+      await expectAsync(result.finished).toBeRejectedWith(
+        jasmine.objectContaining({name: 'DataCloneError'}),
+      );
+    });
+
+    it('throws DataCloneError when non-cloneable objects are passed to updateCurrentEntry()', () => {
+      const unclonable = {fn: () => {}};
+      expect(() => {
+        locals.navigation.updateCurrentEntry({state: unclonable});
+      }).toThrowMatching((e: any) => e.name === 'DataCloneError');
+    });
+  });
+
+  describe('IDL event handler attribute this binding', () => {
+    it('binds "this" to Navigation in IDL event handlers', async () => {
+      let onnavigateThis: any;
+      let oncurrententrychangeThis: any;
+      let onnavigatesuccessThis: any;
+
+      locals.navigation.onnavigate = function () {
+        onnavigateThis = this;
+      };
+      locals.navigation.oncurrententrychange = function () {
+        oncurrententrychangeThis = this;
+      };
+      locals.navigation.onnavigatesuccess = function () {
+        onnavigatesuccessThis = this;
+      };
+
+      await locals.navigation.navigate('/page').finished;
+
+      expect(onnavigateThis).toBe(locals.navigation);
+      expect(oncurrententrychangeThis).toBe(locals.navigation);
+      expect(onnavigatesuccessThis).toBe(locals.navigation);
+    });
+
+    it('binds "this" to Navigation in onnavigateerror', async () => {
+      let onnavigateerrorThis: any;
+      locals.navigation.onnavigate = (e) => {
+        e.intercept({
+          handler: () => {
+            throw new Error('boom');
+          },
+        });
+      };
+      locals.navigation.onnavigateerror = function () {
+        onnavigateerrorThis = this;
+      };
+
+      await expectAsync(locals.navigation.navigate('/page').finished).toBeRejected();
+      expect(onnavigateerrorThis).toBe(locals.navigation);
+    });
+
+    it('binds "this" to NavigationHistoryEntry in ondispose', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      const entry1 = locals.navigation.currentEntry!;
+      let ondisposeThis: any;
+      entry1.ondispose = function () {
+        ondisposeThis = this;
+      };
+
+      await locals.navigation.navigate('/page2', {history: 'replace'}).finished;
+      expect(ondisposeThis).toBe(entry1);
+    });
+  });
+
+  describe('navigateEvent cleanup', () => {
+    it('clears navigateEvent after unintercepted navigation completes', async () => {
+      await locals.navigation.navigate('/page').finished;
+      expect((locals.navigation as any).navigateEvent).toBeNull();
+    });
+
+    it('clears navigateEvent after unintercepted traversal completes', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      await locals.navigation.navigate('/page2').finished;
+      await locals.navigation.back().finished;
+      expect((locals.navigation as any).navigateEvent).toBeNull();
+    });
+  });
+
+  describe('post-commit handlers error handling', () => {
+    it('handles multiple rejecting post-commit handlers without unhandled rejections', async () => {
+      locals.pendingInterceptOptions.push({
+        handler: () => {
+          throw new Error('first post-commit failure');
+        },
+      });
+      locals.navigation.addEventListener('navigate', (e: Event) => {
+        (e as FakeNavigateEvent).intercept({
+          handler: () => Promise.reject(new Error('second post-commit failure')),
+        });
+      });
+
+      await expectAsync(locals.navigation.navigate('/page').finished).toBeRejected();
+    });
+  });
+
+  describe('FakeNavigation.prototype.dispose()', () => {
+    it('cleans up navigation state and event handlers', () => {
+      locals.navigation.onnavigate = () => {};
+      locals.navigation.oncurrententrychange = () => {};
+      locals.navigation.onnavigatesuccess = () => {};
+      locals.navigation.onnavigateerror = () => {};
+
+      locals.navigation.dispose();
+
+      expect(locals.navigation.isDisposed()).toBeTrue();
+      expect((locals.navigation as any).navigateEvent).toBeNull();
+      expect(locals.navigation.transition).toBeNull();
+      expect(locals.navigation.onnavigate).toBeNull();
+      expect(locals.navigation.oncurrententrychange).toBeNull();
+      expect(locals.navigation.onnavigatesuccess).toBeNull();
+      expect(locals.navigation.onnavigateerror).toBeNull();
+    });
+
+    it('settles the in-flight navigation promises', async () => {
+      let releaseHandler!: () => void;
+      locals.pendingInterceptOptions.push({
+        handler: () => new Promise<void>((resolve) => (releaseHandler = resolve)),
+      });
+      const result = locals.navigation.navigate('/page');
+      await result.committed;
+
+      locals.navigation.dispose();
+
+      // Without this, `finished` would stay pending forever and hang teardown.
+      await expectAsync(result.finished).toBeRejectedWith(
+        jasmine.objectContaining({name: 'AbortError'}),
+      );
+      releaseHandler();
+    });
+
+    it('settles queued traversal promises', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      await locals.navigation.navigate('/page2').finished;
+      // `back()` queues the traversal behind a timeout, so it is still pending here.
+      const traversal = locals.navigation.back();
+
+      locals.navigation.dispose();
+
+      await expectAsync(traversal.committed).toBeRejectedWith(
+        jasmine.objectContaining({name: 'AbortError'}),
+      );
+      await expectAsync(traversal.finished).toBeRejectedWith(
+        jasmine.objectContaining({name: 'AbortError'}),
+      );
+    });
+
+    it('does not run a queued traversal after disposal', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      await locals.navigation.navigate('/page2').finished;
+      const urlBeforeDispose = locals.navigation.currentEntry.url;
+      const traversal = locals.navigation.back();
+      traversal.finished.catch(() => {});
+
+      locals.navigation.dispose();
+      // Give the queued timeout a chance to fire.
+      await timeout(10);
+
+      expect(locals.navigation.currentEntry.url).toBe(urlBeforeDispose);
+      expect(locals.popStateEvents.length).toBe(0);
+    });
+  });
+
+  describe('navigate() URL validation', () => {
+    it('rejects with SyntaxError for an unparseable URL', async () => {
+      const result = locals.navigation.navigate('http://:invalid-url');
+
+      await expectAsync(result.committed).toBeRejectedWith(
+        jasmine.objectContaining({name: 'SyntaxError'}),
+      );
+      await expectAsync(result.finished).toBeRejectedWith(
+        jasmine.objectContaining({name: 'SyntaxError'}),
+      );
+      expect(locals.navigateEvents.length).toBe(0);
+    });
+
+    it('rejects with NotSupportedError for a javascript: URL', async () => {
+      const result = locals.navigation.navigate('javascript:alert(1)');
+
+      await expectAsync(result.committed).toBeRejectedWith(
+        jasmine.objectContaining({name: 'NotSupportedError'}),
+      );
+      await expectAsync(result.finished).toBeRejectedWith(
+        jasmine.objectContaining({name: 'NotSupportedError'}),
+      );
+      expect(locals.navigateEvents.length).toBe(0);
+    });
+  });
+
+  describe('reload() state serialization', () => {
+    it('rejects with DataCloneError for non-cloneable state', async () => {
+      const result = locals.navigation.reload({state: {fn: () => {}}});
+
+      await expectAsync(result.committed).toBeRejectedWith(
+        jasmine.objectContaining({name: 'DataCloneError'}),
+      );
+      await expectAsync(result.finished).toBeRejectedWith(
+        jasmine.objectContaining({name: 'DataCloneError'}),
+      );
+    });
+
+    it('clones state synchronously', async () => {
+      const state = {counter: 1};
+      const result = locals.navigation.reload({state});
+      state.counter = 2;
+
+      await result.finished;
+      expect((locals.navigation.currentEntry.getState() as any).counter).toBe(1);
+    });
+  });
+
+  describe('redirect() history option', () => {
+    /** Redirects the next navigation and resolves with the resulting navigationType. */
+    const redirectNextNavigation = async (
+      from: string,
+      options?: Parameters<NavigationPrecommitController['redirect']>[1],
+    ) => {
+      let navigationTypeAfterRedirect: string | undefined;
+      locals.pendingInterceptOptions.push({
+        precommitHandler: (controller) => {
+          controller.redirect('/redirected', options);
+          navigationTypeAfterRedirect =
+            locals.navigateEvents[locals.navigateEvents.length - 1].navigationType;
+        },
+      });
+      await locals.navigation.navigate(from).finished;
+      return navigationTypeAfterRedirect;
+    };
+
+    it("leaves navigationType unchanged for history: 'auto'", async () => {
+      // The spec only reassigns navigationType for 'push' and 'replace'; 'auto' (the WebIDL
+      // default) must not turn a push into a replace.
+      expect(await redirectNextNavigation('/page', {history: 'auto'})).toBe('push');
+      expect(locals.navigation.entries().length).toBe(2);
+    });
+
+    it('leaves navigationType unchanged when history is omitted', async () => {
+      expect(await redirectNextNavigation('/page')).toBe('push');
+      expect(locals.navigation.entries().length).toBe(2);
+    });
+
+    it("sets navigationType to 'replace' for history: 'replace'", async () => {
+      expect(await redirectNextNavigation('/page', {history: 'replace'})).toBe('replace');
+      expect(locals.navigation.entries().length).toBe(1);
+    });
+
+    it("keeps navigationType 'push' for history: 'push'", async () => {
+      expect(await redirectNextNavigation('/page', {history: 'push'})).toBe('push');
+      expect(locals.navigation.entries().length).toBe(2);
+    });
+  });
+
+  describe('redirect() URL rewrite check', () => {
+    /** Runs `redirect(url)` during a navigation and returns the thrown error, if any. */
+    const redirectTo = async (url: string) => {
+      let caughtError: any = null;
+      locals.pendingInterceptOptions.push({
+        precommitHandler: (controller) => {
+          try {
+            controller.redirect(url);
+          } catch (e) {
+            caughtError = e;
+          }
+        },
+      });
+      await locals.navigation.navigate('/page').finished;
+      return caughtError;
+    };
+
+    it('resolves a relative URL against the current entry', async () => {
+      expect(await redirectTo('/redirected?a=1#frag')).toBeNull();
+      expect(locals.navigation.currentEntry.url).toBe('https://test.com/redirected?a=1#frag');
+    });
+
+    it('allows a same-origin URL with a different path and query', async () => {
+      expect(await redirectTo('https://test.com/elsewhere?q=2')).toBeNull();
+      expect(locals.navigation.currentEntry.url).toBe('https://test.com/elsewhere?q=2');
+    });
+
+    it('throws SecurityError for a different host', async () => {
+      expect((await redirectTo('https://evil.com/'))?.name).toBe('SecurityError');
+    });
+
+    it('throws SecurityError for a different port', async () => {
+      expect((await redirectTo('https://test.com:8443/page'))?.name).toBe('SecurityError');
+    });
+
+    it('throws SecurityError for a different scheme', async () => {
+      expect((await redirectTo('http://test.com/page'))?.name).toBe('SecurityError');
+    });
+
+    it('throws SecurityError for a javascript: URL', async () => {
+      expect((await redirectTo('javascript:alert(1)'))?.name).toBe('SecurityError');
+    });
+
+    it('throws SecurityError when credentials are added', async () => {
+      expect((await redirectTo('https://user:pass@test.com/page'))?.name).toBe('SecurityError');
+    });
+
+    it('throws SyntaxError for an unparseable URL', async () => {
+      expect((await redirectTo('http://:invalid-url'))?.name).toBe('SyntaxError');
+    });
+  });
+
+  describe('pushState()/replaceState() validation', () => {
+    it('throws DataCloneError synchronously for non-cloneable data', () => {
+      expect(() => {
+        locals.navigation.pushState({fn: () => {}}, '', '/page');
+      }).toThrowMatching((e: any) => e.name === 'DataCloneError');
+      expect(() => {
+        locals.navigation.replaceState({fn: () => {}}, '', '/page');
+      }).toThrowMatching((e: any) => e.name === 'DataCloneError');
+      // The failed calls must not have navigated.
+      expect(locals.navigateEvents.length).toBe(0);
+    });
+
+    it('serializes data before parsing the URL', () => {
+      // Both arguments are invalid; the spec serializes first, so DataCloneError wins.
+      expect(() => {
+        locals.navigation.pushState({fn: () => {}}, '', 'http://:invalid-url');
+      }).toThrowMatching((e: any) => e.name === 'DataCloneError');
+    });
+
+    it('throws SecurityError for an unparseable URL', () => {
+      expect(() => {
+        locals.navigation.pushState(null, '', 'http://:invalid-url');
+      }).toThrowMatching((e: any) => e.name === 'SecurityError');
+    });
+
+    it('throws SecurityError for a cross-origin URL', () => {
+      expect(() => {
+        locals.navigation.pushState(null, '', 'https://evil.com/');
+      }).toThrowMatching((e: any) => e.name === 'SecurityError');
+      expect(() => {
+        locals.navigation.replaceState(null, '', 'https://evil.com/');
+      }).toThrowMatching((e: any) => e.name === 'SecurityError');
+      expect(locals.navigation.currentEntry.url).toBe('https://test.com/');
+    });
+
+    it('allows a same-origin URL with a different path', () => {
+      locals.navigation.pushState({a: 1}, '', '/elsewhere');
+      expect(locals.navigation.currentEntry.url).toBe('https://test.com/elsewhere');
+    });
+
+    it('clones data synchronously', () => {
+      const data = {counter: 1};
+      locals.navigation.pushState(data, '', '/page');
+      data.counter = 2;
+      expect((locals.navigation.currentEntry.getHistoryState() as any).counter).toBe(1);
+    });
+  });
+
+  describe('history.state identity', () => {
+    it('returns the same object from repeated getHistoryState() reads', () => {
+      locals.navigation.pushState({a: 1}, '', '/page');
+      const entry = locals.navigation.currentEntry;
+
+      // `history.state` is deserialized once per navigation, so its identity is stable.
+      expect(entry.getHistoryState()).toBe(entry.getHistoryState());
+    });
+
+    it('gives popstate the same state object as the current entry', async () => {
+      locals.navigation.pushState({a: 1}, '', '/page1');
+      locals.navigation.pushState({b: 2}, '', '/page2');
+      locals.popStateEvents.length = 0;
+
+      await locals.navigation.back().finished;
+
+      expect(locals.popStateEvents.length).toBe(1);
+      expect(locals.popStateEvents[0].state).toBe(locals.navigation.currentEntry.getHistoryState());
+      expect(locals.popStateEvents[0].state).toEqual({a: 1});
+    });
+
+    it('still returns a fresh object from repeated getState() reads', async () => {
+      await locals.navigation.navigate('/page', {state: {a: 1}}).finished;
+      const entry = locals.navigation.currentEntry;
+
+      // Unlike `history.state`, `getState()` is defined as a StructuredDeserialize per call.
+      expect(entry.getState()).not.toBe(entry.getState());
+      expect(entry.getState()).toEqual({a: 1});
+    });
+  });
+
+  describe('setInitialEntryForTesting()', () => {
+    it('clones the provided state', () => {
+      const navigation = new FakeNavigation(document, 'https://test.com');
+      const historyState = {a: 1};
+      const state = {b: 2};
+
+      navigation.setInitialEntryForTesting('https://test.com', {historyState, state});
+      historyState.a = 99;
+      state.b = 99;
+
+      expect(navigation.currentEntry.getHistoryState()).toEqual({a: 1});
+      expect(navigation.currentEntry.getState()).toEqual({b: 2});
+      navigation.dispose();
+    });
+
+    it('throws DataCloneError for non-cloneable state', () => {
+      const navigation = new FakeNavigation(document, 'https://test.com');
+      expect(() => {
+        navigation.setInitialEntryForTesting('https://test.com', {
+          historyState: null,
+          state: {fn: () => {}},
+        });
+      }).toThrowMatching((e: any) => e.name === 'DataCloneError');
+      navigation.dispose();
+    });
+  });
+
+  describe('IDL event handler attributes', () => {
+    it('returns the assigned handler from the getter', () => {
+      const handler = () => {};
+      locals.navigation.onnavigate = handler;
+      expect(locals.navigation.onnavigate).toBe(handler);
+
+      locals.navigation.onnavigate = null;
+      expect(locals.navigation.onnavigate).toBeNull();
+    });
+
+    it('replaces the previous handler rather than adding a second one', async () => {
+      let firstCalls = 0;
+      let secondCalls = 0;
+      locals.navigation.onnavigate = () => firstCalls++;
+      locals.navigation.onnavigate = () => secondCalls++;
+
+      await locals.navigation.navigate('/page').finished;
+
+      expect(firstCalls).toBe(0);
+      expect(secondCalls).toBe(1);
+    });
+
+    it('removes the listener when set to null', async () => {
+      let calls = 0;
+      locals.navigation.onnavigate = () => calls++;
+      locals.navigation.onnavigate = null;
+
+      await locals.navigation.navigate('/page').finished;
+
+      expect(calls).toBe(0);
+    });
+
+    it('does not affect listeners added with addEventListener', async () => {
+      let attributeCalls = 0;
+      let listenerCalls = 0;
+      locals.navigation.addEventListener('navigate', () => listenerCalls++);
+      locals.navigation.onnavigate = () => attributeCalls++;
+      locals.navigation.onnavigate = null;
+
+      await locals.navigation.navigate('/page').finished;
+
+      expect(attributeCalls).toBe(0);
+      expect(listenerCalls).toBe(1);
+    });
+  });
+
+  describe('FakeNavigationHistoryEntry disposal', () => {
+    it('releases listeners registered before disposal', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      const entry = locals.navigation.currentEntry;
+      let disposeCalls = 0;
+      entry.addEventListener('dispose', () => disposeCalls++);
+
+      await locals.navigation.navigate('/page2', {history: 'replace'}).finished;
+      expect(disposeCalls).toBe(1);
+
+      // The listener was released, so a second dispatch must not reach it.
+      entry.dispatchEvent(new Event('dispose'));
+      expect(disposeCalls).toBe(1);
+    });
+
+    it('can still dispatch events after disposal', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      const entry = locals.navigation.currentEntry;
+
+      await locals.navigation.navigate('/page2', {history: 'replace'}).finished;
+
+      // The replacement EventTarget must be built the same way as the original, otherwise
+      // dispatching a document-created Event throws in Domino based environments.
+      expect(() => entry.dispatchEvent(new Event('dispose'))).not.toThrow();
+      let calls = 0;
+      entry.addEventListener('dispose', () => calls++);
+      entry.dispatchEvent(new Event('dispose'));
+      expect(calls).toBe(1);
+    });
+
+    it('keeps ondispose readable after disposal', async () => {
+      await locals.navigation.navigate('/page1').finished;
+      const entry = locals.navigation.currentEntry;
+      const handler = () => {};
+      entry.ondispose = handler;
+
+      await locals.navigation.navigate('/page2', {history: 'replace'}).finished;
+
+      // A browser does not reset the IDL attribute when the entry is disposed.
+      expect(entry.ondispose).toBe(handler);
+      expect(() => (entry.ondispose = null)).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
## Summary

Brings `FakeNavigation` (the test double for the WHATWG Navigation API used by
`@angular/core/testing` and `@angular/common/testing`) into closer alignment with the
[HTML Navigation API spec](https://html.spec.whatwg.org/multipage/nav-history-apis.html),
and covers a number of edge cases the fake previously got wrong or left unhandled.

Every behavioral change below is anchored to a specific spec algorithm step, and each is
covered by new unit tests.

## Spec correctness fixes

| Area | Before | After |
| --- | --- | --- |
| `redirect()` history option | `history: 'auto'` was mapped to `'replace'` | Only `'push'`/`'replace'` reassign `navigationType`; `'auto'` (the WebIDL default) leaves it unchanged, per ["Redirect" step 9](https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-redirect) |
| URL rewrite validation | Ad-hoc same-origin check in `redirect()` only | Full ["can have its URL rewritten"](https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten) algorithm (scheme/username/password/host/port, HTTP(S) short-circuit, `file:` path rule, path+query rule), shared by `redirect()`, `pushState()` and `replaceState()` |
| `pushState()`/`replaceState()` | Parsed the URL first and surfaced a raw `TypeError` | Serializes `data` before parsing `url` (spec step 3 precedes step 5); unparseable URL or failed rewrite check throws `SecurityError` |
| `navigate()` scheme check | `javascript:` URLs navigated normally | Returns an early-error result with `NotSupportedError`, per ["Navigation.navigate()" step 3](https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate) |
| `NavigateEvent.intercept()` | Mutated event state before validating | Tracks the **dispatch flag** and **canceled flag**. Runs the spec's shared checks, then `canIntercept` (`SecurityError`), then the dispatch flag (`InvalidStateError`), then `precommitHandler`/`cancelable`, then the interception state — in that order — before mutating |
| `scroll()`, `redirect()`, `addHandler()` | No canceled-flag check | Run the shared checks (canceled flag → `InvalidStateError`) |
| `history.state` identity | A fresh clone per read, so `popstate.state !== history.state` | `getHistoryState()` returns the deserialized state by reference (cloned once on write); `getState()` still clones per call, matching the spec's `History.state` getter vs. `NavigationHistoryEntry.getState()` split |
| `dispose()` | Left in-flight and queued navigations unsettled | Aborts the ongoing navigation, rejects queued traversal results with `AbortError`, and drops pending traversals |
| Handler failure on a stale event | Returned silently, leaving the result promise pending forever | Settles the result (aborts and rejects `finished`) |
| `cloneState()` | Wrapped `structuredClone`'s `DataCloneError` and fell back to JSON | Propagates the native `DataCloneError`; the JSON fallback is gone |
| Entry `dispose()` | Reset the `ondispose` IDL attribute | Leaves the attribute alone, matching browsers |

### Bug fixes

- **`EventTarget` isolation regression.** `FakeNavigationHistoryEntry` now receives the
  `EventTarget` *factory* rather than an instance, so `dispose()` can build a replacement
  target compatible with the active document implementation. Constructing a bare
  `new EventTarget()` breaks under Domino, which cannot dispatch its own `Event` objects
  through a native target.
- **Crash on in-dispatch abort.** If a `navigate` listener aborted the event during
  dispatch, `navigateEvent` was already null while `performNonTraverseNavigation()`,
  `traverseTo()` and `go()` still dereferenced it, throwing
  `TypeError: Cannot destructure property 'destination' of 'object null'`. All three sites
  now guard.

## API changes

`navigate()` and `reload()` again match the real `Navigation` signatures. The
user-agent-only knobs were split out:

- `navigateForTesting(url, options)` accepts `FakeNavigateForTestingOptions`
  (`cancelable`, `sourceElement`).
- `hasUAVisualTransition` moved to `FakeNavigationTraverseOptions` and is accepted only by
  `traverseTo()`, `back()` and `forward()` — a UA visual transition is meaningless for a
  push/replace navigation or a reload.

Both new option interfaces are exported.

## Cleanup

- Removed the non-spec `event !== navigation.navigateEvent` clause in `commit()`; the
  abort-signal check in ["commit a navigate event" step 4](https://html.spec.whatwg.org/multipage/nav-history-apis.html#commit-a-navigate-event)
  already covers superseded navigations.
- Removed no-op `.catch(() => {})` calls and an unused `setEventHandler()` parameter.
- `intercept()`, `scroll()` and `abort()` consistently operate on `this`.

## Tests

Added coverage for each of the above in
`packages/core/primitives/dom-navigation/testing/test/fake_platform_navigation.spec.ts`:

- `redirect()` across all four `history` values, and eight URL-rewrite cases.
- `pushState()`/`replaceState()` validation (serialization order, unparseable URL,
  cross-origin, rewrite-check failure).
- `navigate()` URL validation, including `javascript:`.
- `intercept()` state validation and check order, including the in-dispatch and
  canceled-flag paths.
- `history.state` reference identity, including `popstate.state`.
- `dispose()` settling in-flight and queued navigations and skipping queued traversals.
- `hasUAVisualTransition` and `sourceElement` propagation without `as any` casts.
- IDL event handler attributes and `FakeNavigationHistoryEntry` disposal.

## Known approximations

- `StructuredSerializeForStorage` (which the spec uses for history state) is stricter than
  `structuredClone`'s `StructuredSerialize`: it also rejects `SharedArrayBuffer` and
  `WebAssembly.Memory`. This is now documented in the source.
- `Navigation.navigate()` step 5 (`history: "push"` combined with a navigation that must be
  a replace → `NotSupportedError`) remains unimplemented, as before this PR.

## Verification

```
pnpm bazel test //packages/core/primitives/dom-navigation/testing/test:test \
  //packages/core/primitives/dom-navigation/testing/test:test_web_chromium \
  //packages/core/primitives/dom-navigation/testing/test:test_web_firefox \
  //packages/core/primitives/dom-navigation:tsec_test \
  //packages/core/primitives/dom-navigation/testing:tsec_test \
  //packages/core/testing:testing_deps \
  //packages/router/test:test //packages/common/test:test
```

All pass.

---

## Second commit: de-flaking `BrowserViewportScroller`

CI's `test` job failed on `//packages/common/test:test_web_firefox` — on a *different*
`scrollToAnchor` spec on each of its three attempts. This is unrelated to the changes above;
pristine `main` reproduces it 3/3 locally.

`should honor the scroll offset when smooth scrolling` sets `scroll-behavior: smooth` and a
large bottom padding on the document, but only resets them *after* its final assertion. When
that assertion fails the resets never run, so smooth scrolling leaks into every subsequent
test: `scrollToPosition([0, 0])` in `beforeEach` becomes animated instead of instant, and the
next `scrollToAnchor` spec reads a scroll position that is still settling — hence
`Expected 2435 to equal 0`, on a varying victim depending on the Jasmine seed.

The trigger is the assertion itself, which compared `getBoundingClientRect().top` against the
offset using `toBe()`. A smooth scroll settles on a fractional pixel when the device pixel
ratio is not 1, so the exact comparison fails on such displays (locally:
`Expected 79.60000610351562 to be 80`).

Fixes:

- Restore the document styles in `afterEach`, so a failing assertion cannot leak them.
- Force `scroll-behavior: auto` in `beforeEach`, so the scroll reset is always synchronous.
- Compare the settled offset with a sub-pixel tolerance.
- Run the element cleanup in a `finally` block.

Verified with `--runs_per_test=5 --nocache_test_results`: 5/5 pass, where the same command on
the unmodified suite failed 3/3.
