### PR TITLE
feat(compiler): preserve parameter structure in `@error` block AST

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -377,11 +377,26 @@ export class BoundaryBlock extends BlockNode implements Node {
   }
 }
 
+export interface BoundaryErrorLetParameter {
+  type: 'let' | 'alias';
+  variables: Variable[];
+  sourceSpan: ParseSourceSpan;
+}
+
+export interface BoundaryErrorWhenParameter {
+  type: 'when';
+  expression: AST;
+  sourceSpan: ParseSourceSpan;
+}
+
+export type BoundaryErrorParameter = BoundaryErrorLetParameter | BoundaryErrorWhenParameter;
+
 export class BoundaryErrorBlock extends BlockNode implements Node {
   constructor(
     public children: Node[],
     public contextVariables: Variable[],
     public expression: AST | null,
+    public parameters: BoundaryErrorParameter[],
     nameSpan: ParseSourceSpan,
     sourceSpan: ParseSourceSpan,
     startSourceSpan: ParseSourceSpan,

--- a/packages/compiler/src/render3/r3_boundaries.ts
+++ b/packages/compiler/src/render3/r3_boundaries.ts
@@ -48,6 +48,7 @@ export function createBoundaryBlock(
       new t.Variable('$reset', '$reset', emptySpan, emptySpan, emptySpan),
     ];
     let expression: AST | null = null;
+    const parameters: t.BoundaryErrorParameter[] = [];
 
     for (const param of block.parameters) {
       const letMatch = param.expression.match(LET_PATTERN);
@@ -63,6 +64,7 @@ export function createBoundaryBlock(
               )
             : param.sourceSpan;
 
+        const variablesCountBefore = contextVariables.length;
         parseLetParameters(
           param.sourceSpan,
           expressionToParse,
@@ -86,6 +88,11 @@ export function createBoundaryBlock(
           '@error block',
           '$error',
         );
+        parameters.push({
+          type: letMatch !== null ? 'let' : 'alias',
+          variables: contextVariables.slice(variablesCountBefore),
+          sourceSpan: param.sourceSpan,
+        });
         continue;
       }
 
@@ -105,6 +112,11 @@ export function createBoundaryBlock(
             param.sourceSpan.start.offset + start,
           );
           expression = expressionAST.ast;
+          parameters.push({
+            type: 'when',
+            expression,
+            sourceSpan: param.sourceSpan,
+          });
         }
         continue;
       }
@@ -122,6 +134,7 @@ export function createBoundaryBlock(
         html.visitAll(visitor, block.children, block.children),
         contextVariables,
         expression,
+        parameters,
         block.nameSpan,
         block.sourceSpan,
         block.startSourceSpan,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.3.4
+        version: 12.3.4
       pnpm:
         specifier: 12.3.4
         version: 12.3.4
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.3.4':
+    resolution: {integrity: sha512-Rq7JokWAyYF9IFfn8zofB/q2AgnZlmoMuH5fMHB2+Ta61I9aD7sNm+woZpx6iH+5vb38chdSoYRvOtSqlH72YQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.3.4:
     resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.3.4':
     optional: true
+
+  '@pnpm/exe@12.3.4':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
 
   pnpm@12.3.4:
     optionalDependencies:


### PR DESCRIPTION
The Render3 AST `BoundaryErrorBlock` previously stripped away the ordered structure of its parameters, keeping only the extracted `contextVariables` and the `when` expression. This commit introduces a new `BoundaryErrorParameter` type and adds a `parameters` property to the `BoundaryErrorBlock`. This preserves the exact order and type (`let`, `alias`, or `when`) of the parameters as they were defined in the template. This enhancement natively exposes the structured parameters, allowing formatters like Prettier to accurately traverse and format the block parameters without having to duplicate internal string-parsing logic.
