### PR TITLE
docs: show the toggle members in the i18n conditional example

### DIFF
--- a/adev/src/content/guide/i18n/prepare.md
+++ b/adev/src/content/guide/i18n/prepare.md
@@ -35,7 +35,7 @@ The following `<div>` tag will display translated text as part of `div` and `ari
 
 <docs-code-multifile>
     <docs-code header="app.component.html" path="adev/src/content/examples/i18n/src/app/app.component.html"  region="i18n-conditional"/>
-    <docs-code header="app.component.ts" path="adev/src/content/examples/i18n/src/app/app.component.ts" visibleLines="[[14,21],[33,37]]"/>
+    <docs-code header="app.component.ts" path="adev/src/content/examples/i18n/src/app/app.component.ts" visibleLines="[[13,18],[32,34]]"/>
 </docs-code-multifile>
 
 ### Translate inline text without HTML element


### PR DESCRIPTION
On https://angular.dev/guide/i18n/prepare, open the app.component.ts tab of the example under "using conditional statement with `i18n`". The visible line ranges are off by one, because the `// #docregion` line is stripped from the rendered code. The snippet ends on `inc()`, which has nothing to do with the example, and its second range starts inside `toggleDisplay()`, so you get a method body with no signature. Fixed ranges show `toggle` and `toggleAriaLabel` plus the whole `toggleDisplay()` method, which is what the template beside it binds to.

Before:

<img width="896" height="586" alt="image" src="https://github.com/user-attachments/assets/b1c4419e-6d11-4459-88a1-76562b79d4d6" />

After:

<img width="940" height="598" alt="image" src="https://github.com/user-attachments/assets/1b0632bc-639f-4b7f-ba60-dc8576d9e4f5" />

