### PR TITLE
docs: fix the broken Unicode locale ID link in the i18n guide

### DIFF
--- a/adev/src/content/guide/i18n/locale-id.md
+++ b/adev/src/content/guide/i18n/locale-id.md
@@ -5,7 +5,7 @@ Angular uses the Unicode _locale identifier_ \(Unicode locale ID\) to find the c
 <docs-callout title="Unicode locale ID">
 
 - A locale ID conforms to the [Unicode Common Locale Data Repository (CLDR) core specification][UnicodeCldrDevelopmentCoreSpecification].
-  For more information about locale IDs, see [Unicode Language and Locale Identifiers][UnicodeCldrDevelopmentCoreSpecificationLocaleIDs].
+  For more information about locale IDs, see [Unicode Language and Locale Identifiers][UnicodeCldrDevelopmentCoreSpecificationLocaleID].
 
 - CLDR and Angular use [BCP 47 tags][RfcEditorInfoBcp47] as the base for the locale ID
 


### PR DESCRIPTION
The "Unicode Language and Locale Identifiers" link on https://angular.dev/guide/i18n/locale-id shows as plain text in brackets instead of a link. The label has an extra `s` that doesn't match the definition at the bottom of the page, so markdown can't resolve it. Removed the `s`.

Before:

<img width="912" height="263" alt="image" src="https://github.com/user-attachments/assets/4df9b567-390b-475d-8fec-409e8de312a8" />

After:

<img width="945" height="233" alt="image" src="https://github.com/user-attachments/assets/1124d272-ef3e-4784-97e8-0edc0049fa87" />